### PR TITLE
fix: all 12 Codex audit findings (#11)

### DIFF
--- a/crates/thetadatadx/src/auth/nexus.rs
+++ b/crates/thetadatadx/src/auth/nexus.rs
@@ -174,6 +174,13 @@ pub async fn authenticate(creds: &Credentials) -> Result<AuthResponse, Error> {
         .map_err(|e| Error::Auth(format!("Nexus API request failed: {e}")))?;
 
     let status = resp.status();
+    // Java special-cases 401 and 404 as "invalid credentials".
+    // Source: AuthenticationManager.authenticateViaCloud() in decompiled terminal.
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::NOT_FOUND {
+        return Err(Error::Auth(
+            "invalid credentials (server returned 401/404)".into(),
+        ));
+    }
     if !status.is_success() {
         let body_text = resp
             .text()

--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -137,37 +137,68 @@ pub fn extract_price_column(
 }
 
 /// Helper to get a number from a row at a given column index, defaulting to 0.
-fn row_number(row: &proto::DataValueList, idx: usize) -> i32 {
+///
+/// Returns 0 for missing cells, `NullValue` cells, or non-Number types.
+/// Tick schemas don't have nullable fields in practice — NullValue only appears
+/// in column-oriented endpoints like Greeks/calendar which use `extract_number_column`
+/// (which returns `Option`). For tick parsing, defaulting to 0 is correct and
+/// matches the Java terminal's behavior.
+pub(crate) fn row_number(row: &proto::DataValueList, idx: usize) -> i32 {
     row.values
         .get(idx)
         .and_then(|dv| dv.data_type.as_ref())
         .and_then(|dt| match dt {
             proto::data_value::DataType::Number(n) => Some(*n as i32),
-            _ => None,
+            other => {
+                tracing::trace!(
+                    column = idx,
+                    data_type = ?other,
+                    "unexpected cell type in tick row, defaulting to 0"
+                );
+                None
+            }
         })
         .unwrap_or(0)
 }
 
 /// Helper to get a price value from a row at a given column index.
-fn row_price_value(row: &proto::DataValueList, idx: usize) -> i32 {
+///
+/// See [`row_number`] for null/missing cell handling rationale.
+pub(crate) fn row_price_value(row: &proto::DataValueList, idx: usize) -> i32 {
     row.values
         .get(idx)
         .and_then(|dv| dv.data_type.as_ref())
         .and_then(|dt| match dt {
             proto::data_value::DataType::Price(p) => Some(p.value),
-            _ => None,
+            other => {
+                tracing::trace!(
+                    column = idx,
+                    data_type = ?other,
+                    "unexpected cell type in tick row (expected Price), defaulting to 0"
+                );
+                None
+            }
         })
         .unwrap_or(0)
 }
 
 /// Helper to get price type from a row at a given column index.
-fn row_price_type(row: &proto::DataValueList, idx: usize) -> i32 {
+///
+/// See [`row_number`] for null/missing cell handling rationale.
+pub(crate) fn row_price_type(row: &proto::DataValueList, idx: usize) -> i32 {
     row.values
         .get(idx)
         .and_then(|dv| dv.data_type.as_ref())
         .and_then(|dt| match dt {
             proto::data_value::DataType::Price(p) => Some(p.r#type),
-            _ => None,
+            other => {
+                tracing::trace!(
+                    column = idx,
+                    data_type = ?other,
+                    "unexpected cell type in tick row (expected Price type), defaulting to 0"
+                );
+                None
+            }
         })
         .unwrap_or(0)
 }
@@ -350,4 +381,158 @@ pub fn parse_ohlc_ticks(table: &proto::DataTable) -> Vec<OhlcTick> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a DataValue containing a Number.
+    fn dv_number(n: i64) -> proto::DataValue {
+        proto::DataValue {
+            data_type: Some(proto::data_value::DataType::Number(n)),
+        }
+    }
+
+    /// Build a DataValue containing a Price.
+    fn dv_price(value: i32, r#type: i32) -> proto::DataValue {
+        proto::DataValue {
+            data_type: Some(proto::data_value::DataType::Price(proto::Price {
+                value,
+                r#type,
+            })),
+        }
+    }
+
+    /// Build a DataValue containing NullValue.
+    fn dv_null() -> proto::DataValue {
+        proto::DataValue {
+            data_type: Some(proto::data_value::DataType::NullValue(0)),
+        }
+    }
+
+    /// Build a DataValue with no data_type set (missing).
+    fn dv_missing() -> proto::DataValue {
+        proto::DataValue { data_type: None }
+    }
+
+    fn row_of(values: Vec<proto::DataValue>) -> proto::DataValueList {
+        proto::DataValueList { values }
+    }
+
+    #[test]
+    fn row_number_returns_value_for_number_cell() {
+        let row = row_of(vec![dv_number(42)]);
+        assert_eq!(row_number(&row, 0), 42);
+    }
+
+    #[test]
+    fn row_number_returns_0_for_null_cell() {
+        let row = row_of(vec![dv_null()]);
+        assert_eq!(row_number(&row, 0), 0);
+    }
+
+    #[test]
+    fn row_number_returns_0_for_missing_cell() {
+        let row = row_of(vec![dv_missing()]);
+        assert_eq!(row_number(&row, 0), 0);
+    }
+
+    #[test]
+    fn row_number_returns_0_for_out_of_bounds() {
+        let row = row_of(vec![]);
+        assert_eq!(row_number(&row, 5), 0);
+    }
+
+    #[test]
+    fn row_price_value_returns_value_for_price_cell() {
+        let row = row_of(vec![dv_price(12345, 10)]);
+        assert_eq!(row_price_value(&row, 0), 12345);
+    }
+
+    #[test]
+    fn row_price_value_returns_0_for_null_cell() {
+        let row = row_of(vec![dv_null()]);
+        assert_eq!(row_price_value(&row, 0), 0);
+    }
+
+    #[test]
+    fn row_price_type_returns_type_for_price_cell() {
+        let row = row_of(vec![dv_price(12345, 10)]);
+        assert_eq!(row_price_type(&row, 0), 10);
+    }
+
+    #[test]
+    fn row_price_type_returns_0_for_null_cell() {
+        let row = row_of(vec![dv_null()]);
+        assert_eq!(row_price_type(&row, 0), 0);
+    }
+
+    #[test]
+    fn null_cells_dont_corrupt_trade_ticks() {
+        // Build a minimal DataTable with one row that has a NullValue in a field.
+        // Note: "price" header triggers Price-typed extraction, so we use a Price cell.
+        let table = proto::DataTable {
+            headers: vec![
+                "ms_of_day".into(),
+                "sequence".into(),
+                "ext_condition1".into(),
+                "ext_condition2".into(),
+                "ext_condition3".into(),
+                "ext_condition4".into(),
+                "condition".into(),
+                "size".into(),
+                "exchange".into(),
+                "price".into(),
+                "condition_flags".into(),
+                "price_flags".into(),
+                "volume_type".into(),
+                "records_back".into(),
+                "date".into(),
+            ],
+            data_table: vec![row_of(vec![
+                dv_number(34200000), // ms_of_day
+                dv_number(1),        // sequence
+                dv_null(),           // ext_condition1 = NullValue
+                dv_number(0),        // ext_condition2
+                dv_number(0),        // ext_condition3
+                dv_number(0),        // ext_condition4
+                dv_number(0),        // condition
+                dv_number(100),      // size
+                dv_number(4),        // exchange
+                dv_price(15000, 10), // price (Price-typed because header is "price")
+                dv_number(0),        // condition_flags
+                dv_number(0),        // price_flags
+                dv_number(0),        // volume_type
+                dv_number(0),        // records_back
+                dv_number(20240301), // date
+            ])],
+        };
+
+        let ticks = parse_trade_ticks(&table);
+        assert_eq!(ticks.len(), 1);
+        let tick = &ticks[0];
+        assert_eq!(tick.ms_of_day, 34200000);
+        // NullValue should default to 0, not corrupt subsequent fields.
+        assert_eq!(tick.ext_condition1, 0);
+        assert_eq!(tick.size, 100);
+        assert_eq!(tick.price, 15000);
+        assert_eq!(tick.price_type, 10);
+        assert_eq!(tick.date, 20240301);
+    }
+
+    #[test]
+    fn extract_number_column_returns_none_for_null() {
+        let table = proto::DataTable {
+            headers: vec!["val".into()],
+            data_table: vec![
+                row_of(vec![dv_number(10)]),
+                row_of(vec![dv_null()]),
+                row_of(vec![dv_number(30)]),
+            ],
+        };
+
+        let col = extract_number_column(&table, "val");
+        assert_eq!(col, vec![Some(10), None, Some(30)]);
+    }
 }

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -239,6 +239,10 @@ impl DirectClient {
             }),
             query_parameters,
             client_type: CLIENT_TYPE.to_string(),
+            // Intentional divergence from Java (see jvm-deviations.md):
+            // Java fills this with the terminal's build git commit hash.
+            // We are not the Java terminal and have no git commit to report,
+            // so we leave it empty. The server accepts empty strings here.
             terminal_git_commit: String::new(),
             terminal_version: TERMINAL_VERSION.to_string(),
         };
@@ -1805,24 +1809,17 @@ fn parse_eod_from_table(table: &proto::DataTable) -> Vec<EodTick> {
     let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
     let find = |name: &str| h.iter().position(|&s| s == name);
 
-    fn num(row: &proto::DataValueList, idx: usize) -> i32 {
+    // EOD rows may have Price-typed cells (value + type) or plain Number cells.
+    // `eod_num` tries Price.value first, then Number, matching the dual-typed
+    // columns that EOD data can return. This is distinct from `decode::row_number`
+    // which only handles Number cells (used for pure tick data).
+    fn eod_num(row: &proto::DataValueList, idx: usize) -> i32 {
         row.values
             .get(idx)
             .and_then(|dv| dv.data_type.as_ref())
             .and_then(|dt| match dt {
                 proto::data_value::DataType::Number(n) => Some(*n as i32),
                 proto::data_value::DataType::Price(p) => Some(p.value),
-                _ => None,
-            })
-            .unwrap_or(0)
-    }
-
-    fn price_type(row: &proto::DataValueList, idx: usize) -> i32 {
-        row.values
-            .get(idx)
-            .and_then(|dv| dv.data_type.as_ref())
-            .and_then(|dt| match dt {
-                proto::data_value::DataType::Price(p) => Some(p.r#type),
                 _ => None,
             })
             .unwrap_or(0)
@@ -1851,27 +1848,29 @@ fn parse_eod_from_table(table: &proto::DataTable) -> Vec<EodTick> {
         .data_table
         .iter()
         .map(|row| {
-            let pt = open_idx.map(|i| price_type(row, i)).unwrap_or(0);
+            let pt = open_idx
+                .map(|i| decode::row_price_type(row, i))
+                .unwrap_or(0);
 
             EodTick {
-                ms_of_day: ms_of_day_idx.map(|i| num(row, i)).unwrap_or(0),
-                ms_of_day2: ms_of_day2_idx.map(|i| num(row, i)).unwrap_or(0),
-                open: open_idx.map(|i| num(row, i)).unwrap_or(0),
-                high: high_idx.map(|i| num(row, i)).unwrap_or(0),
-                low: low_idx.map(|i| num(row, i)).unwrap_or(0),
-                close: close_idx.map(|i| num(row, i)).unwrap_or(0),
-                volume: volume_idx.map(|i| num(row, i)).unwrap_or(0),
-                count: count_idx.map(|i| num(row, i)).unwrap_or(0),
-                bid_size: bid_size_idx.map(|i| num(row, i)).unwrap_or(0),
-                bid_exchange: bid_exchange_idx.map(|i| num(row, i)).unwrap_or(0),
-                bid: bid_idx.map(|i| num(row, i)).unwrap_or(0),
-                bid_condition: bid_condition_idx.map(|i| num(row, i)).unwrap_or(0),
-                ask_size: ask_size_idx.map(|i| num(row, i)).unwrap_or(0),
-                ask_exchange: ask_exchange_idx.map(|i| num(row, i)).unwrap_or(0),
-                ask: ask_idx.map(|i| num(row, i)).unwrap_or(0),
-                ask_condition: ask_condition_idx.map(|i| num(row, i)).unwrap_or(0),
+                ms_of_day: ms_of_day_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ms_of_day2: ms_of_day2_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                open: open_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                high: high_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                low: low_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                close: close_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                volume: volume_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                count: count_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                bid_size: bid_size_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                bid_exchange: bid_exchange_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                bid: bid_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                bid_condition: bid_condition_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ask_size: ask_size_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ask_exchange: ask_exchange_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ask: ask_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ask_condition: ask_condition_idx.map(|i| eod_num(row, i)).unwrap_or(0),
                 price_type: pt,
-                date: date_idx.map(|i| num(row, i)).unwrap_or(0),
+                date: date_idx.map(|i| eod_num(row, i)).unwrap_or(0),
             }
         })
         .collect()
@@ -1901,5 +1900,49 @@ mod tests {
         assert!(validate_date("").is_err());
         // Whitespace
         assert!(validate_date("2024 101").is_err());
+    }
+
+    #[test]
+    fn parse_eod_handles_empty_table() {
+        let table = proto::DataTable {
+            headers: vec!["ms_of_day".into(), "open".into(), "date".into()],
+            data_table: vec![],
+        };
+        let ticks = parse_eod_from_table(&table);
+        assert!(ticks.is_empty());
+    }
+
+    #[test]
+    fn parse_eod_handles_number_typed_columns() {
+        let table = proto::DataTable {
+            headers: vec![
+                "ms_of_day".into(),
+                "open".into(),
+                "close".into(),
+                "date".into(),
+            ],
+            data_table: vec![proto::DataValueList {
+                values: vec![
+                    proto::DataValue {
+                        data_type: Some(proto::data_value::DataType::Number(34200000)),
+                    },
+                    proto::DataValue {
+                        data_type: Some(proto::data_value::DataType::Number(15000)),
+                    },
+                    proto::DataValue {
+                        data_type: Some(proto::data_value::DataType::Number(15100)),
+                    },
+                    proto::DataValue {
+                        data_type: Some(proto::data_value::DataType::Number(20240301)),
+                    },
+                ],
+            }],
+        };
+        let ticks = parse_eod_from_table(&table);
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(ticks[0].ms_of_day, 34200000);
+        assert_eq!(ticks[0].open, 15000);
+        assert_eq!(ticks[0].close, 15100);
+        assert_eq!(ticks[0].date, 20240301);
     }
 }

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -1181,20 +1181,23 @@ fn ping_loop(
     let interval = Duration::from_millis(PING_INTERVAL_MS);
     let ping_payload = build_ping_payload();
 
-    // Java: scheduleAtFixedRate(..., 2000L, 100L) — initial delay before first ping.
+    // Java: scheduleAtFixedRate(task, 2000L, 100L) — first execution at 2000ms,
+    // then every 100ms. scheduleAtFixedRate sends THEN waits, so the first ping
+    // fires at exactly 2000ms.
     thread::sleep(Duration::from_millis(2000));
 
     loop {
-        thread::sleep(interval);
-
         if shutdown.load(Ordering::Relaxed) {
             break;
         }
         if !authenticated.load(Ordering::Relaxed) {
             // Don't send pings if not authenticated
+            thread::sleep(interval);
             continue;
         }
 
+        // Send ping FIRST, then sleep — matches Java's scheduleAtFixedRate
+        // which executes the task then waits the interval.
         let cmd = IoCommand::WriteFrame {
             code: StreamMsgType::Ping,
             payload: ping_payload.clone(),
@@ -1203,6 +1206,8 @@ fn ping_loop(
             // I/O thread has exited
             break;
         }
+
+        thread::sleep(interval);
     }
 
     tracing::debug!("fpss-ping thread exiting");
@@ -1270,9 +1275,19 @@ where
 /// Determine the reconnect delay based on the disconnect reason.
 ///
 /// Source: `FPSSClient.java` -- reconnect logic checks `RemoveReason` to decide delay.
+///
+/// # Intentional divergence from Java (see jvm-deviations.md)
+///
+/// Java only treats `AccountAlreadyConnected` (code 6) as a permanent error,
+/// retrying forever on invalid credentials — which burns rate limits and never
+/// succeeds. We treat all 7 credential/account error codes as permanent because
+/// no amount of retrying will fix bad credentials. This is a deliberate
+/// improvement over the Java behavior.
 pub fn reconnect_delay(reason: RemoveReason) -> Option<u64> {
     match reason {
         // Permanent errors -- no amount of reconnection will fix bad credentials.
+        // Java only checks AccountAlreadyConnected here; we extend this to all
+        // credential errors. See jvm-deviations.md "Permanent Disconnect".
         RemoveReason::AccountAlreadyConnected
         | RemoveReason::InvalidCredentials
         | RemoveReason::InvalidLoginValues

--- a/crates/thetadatadx/src/fpss/protocol.rs
+++ b/crates/thetadatadx/src/fpss/protocol.rs
@@ -177,26 +177,35 @@ impl Contract {
     /// [exp_date: i32 BE] [is_call: u8] [strike: i32 BE]
     /// ```
     ///
-    /// `total_size` counts everything after itself (root_len + root + sec_type + option fields).
+    /// `total_size` counts the entire buffer including itself, matching Java's
+    /// `Contract.toBytes()` exactly:
+    ///   - Stock: `3 + root.length()` = size(1) + root_len(1) + root(N) + sec_type(1)
+    ///   - Option: `12 + root.length()` = size(1) + root_len(1) + root(N) + sec_type(1) + exp(4) + is_call(1) + strike(4)
+    ///
+    /// Java's `fromBytes()` validates `len == size`, confirming the size byte
+    /// counts itself.
     pub fn to_bytes(&self) -> Vec<u8> {
         let root_bytes = self.root.as_bytes();
         assert!(
-            root_bytes.len() <= 244,
-            "contract root too long: {} bytes (max 244 to fit in u8 total_size with option fields)",
+            root_bytes.len() <= 16,
+            "contract root too long: {} bytes (max 16 to match Java Contract.toBytes())",
             root_bytes.len()
         );
         let root_len = root_bytes.len() as u8;
 
-        // Base size: root_len(1) + root(N) + sec_type(1)
-        let base_size = 1 + root_bytes.len() + 1;
-
         let is_option = self.sec_type == SecType::Option;
-        // Option adds: exp_date(4) + is_call(1) + strike(4) = 9
-        let total_size = if is_option { base_size + 9 } else { base_size };
 
-        let mut buf = Vec::with_capacity(1 + total_size);
+        // Java: `3 + root.length()` for non-option, `12 + root.length()` for option.
+        // The size byte counts itself: size(1) + root_len(1) + root(N) + sec_type(1) [+ option fields(9)]
+        let total_size = if is_option {
+            12 + root_bytes.len()
+        } else {
+            3 + root_bytes.len()
+        };
 
-        // total_size byte (everything after this byte)
+        let mut buf = Vec::with_capacity(total_size);
+
+        // total_size byte (includes itself — matches Java's Contract.toBytes())
         buf.push(total_size as u8);
         // root_len
         buf.push(root_len);
@@ -227,18 +236,21 @@ impl Contract {
             return Err(ContractParseError::TooShort);
         }
 
+        // Java's size byte counts itself: the total buffer length equals the size byte value.
+        // Java fromBytes: `if (len != size) throw ...` where len is the total span including size.
         let total_size = data[0] as usize;
-        let needed = 1 + total_size;
-        if data.len() < needed {
+        if data.len() < total_size {
             return Err(ContractParseError::TooShort);
         }
 
-        if total_size < 2 {
+        // Minimum: size(1) + root_len(1) + root(>=0) + sec_type(1) = 3
+        if total_size < 3 {
             return Err(ContractParseError::InvalidSize(total_size));
         }
 
         let root_len = data[1] as usize;
-        if total_size < 1 + root_len + 1 {
+        // Validate: size(1) + root_len(1) + root(N) + sec_type(1) <= total_size
+        if total_size < 2 + root_len + 1 {
             return Err(ContractParseError::InvalidSize(total_size));
         }
 
@@ -281,7 +293,7 @@ impl Contract {
                     is_call: Some(is_call),
                     strike: Some(strike),
                 },
-                needed,
+                total_size,
             ))
         } else {
             Ok((
@@ -292,7 +304,7 @@ impl Contract {
                     is_call: None,
                     strike: None,
                 },
-                needed,
+                total_size,
             ))
         }
     }
@@ -585,9 +597,9 @@ mod tests {
     fn stock_contract_roundtrip() {
         let c = Contract::stock("AAPL");
         let bytes = c.to_bytes();
-        // total_size(1) + root_len(1) + "AAPL"(4) + sec_type(1) = 7
+        // Java: 3 + root.length() = 3 + 4 = 7 total bytes, size byte = 7
         assert_eq!(bytes.len(), 7);
-        assert_eq!(bytes[0], 6); // total_size = 1+4+1 = 6
+        assert_eq!(bytes[0], 7); // total_size includes itself (Java: `3 + root.length()`)
 
         let (parsed, consumed) = Contract::from_bytes(&bytes).unwrap();
         assert_eq!(consumed, 7);
@@ -598,9 +610,9 @@ mod tests {
     fn option_contract_roundtrip() {
         let c = Contract::option("SPY", 20261218, true, 60000);
         let bytes = c.to_bytes();
-        // total_size(1) + root_len(1) + "SPY"(3) + sec_type(1) + exp(4) + is_call(1) + strike(4) = 15
+        // Java: 12 + root.length() = 12 + 3 = 15 total bytes, size byte = 15
         assert_eq!(bytes.len(), 15);
-        assert_eq!(bytes[0], 14); // total_size = 1+3+1+9 = 14
+        assert_eq!(bytes[0], 15); // total_size includes itself (Java: `12 + root.length()`)
 
         let (parsed, consumed) = Contract::from_bytes(&bytes).unwrap();
         assert_eq!(consumed, 15);
@@ -627,9 +639,9 @@ mod tests {
 
     #[test]
     fn contract_from_bytes_invalid_size() {
-        // total_size = 1, but need at least root_len + 1 byte root + sec_type
-        let err = Contract::from_bytes(&[1, 0]).unwrap_err();
-        assert_eq!(err, ContractParseError::InvalidSize(1));
+        // total_size = 2, but minimum valid is 3 (size + root_len + sec_type with root_len=0)
+        let err = Contract::from_bytes(&[2, 0]).unwrap_err();
+        assert_eq!(err, ContractParseError::InvalidSize(2));
     }
 
     #[test]
@@ -767,5 +779,65 @@ mod tests {
             SubscriptionKind::OpenInterest.unsubscribe_code(),
             StreamMsgType::RemoveOpenInterest
         );
+    }
+
+    // ── Java wire-format parity tests ──────────────────────────────────
+    // These verify byte-for-byte compatibility with Java's Contract.toBytes().
+
+    #[test]
+    fn java_parity_stock_aapl() {
+        // Java: root="AAPL" (4 bytes), sec=STOCK
+        // Java allocates: 3 + 4 = 7 bytes
+        // Wire: [7, 4, 'A', 'A', 'P', 'L', sec_type_code]
+        let c = Contract::stock("AAPL");
+        let bytes = c.to_bytes();
+        assert_eq!(bytes[0], 7); // size byte = 3 + root.length()
+        assert_eq!(bytes[1], 4); // root_len
+        assert_eq!(&bytes[2..6], b"AAPL");
+        assert_eq!(bytes[6], SecType::Stock as u8);
+        assert_eq!(bytes.len(), 7);
+    }
+
+    #[test]
+    fn java_parity_option_spy() {
+        // Java: root="SPY" (3 bytes), sec=OPTION, exp=20261218, isCall=true, strike=60000
+        // Java allocates: 12 + 3 = 15 bytes
+        // Wire: [15, 3, 'S','P','Y', sec_type, exp(4), is_call(1), strike(4)]
+        let c = Contract::option("SPY", 20261218, true, 60000);
+        let bytes = c.to_bytes();
+        assert_eq!(bytes[0], 15); // size byte = 12 + root.length()
+        assert_eq!(bytes[1], 3); // root_len
+        assert_eq!(&bytes[2..5], b"SPY");
+        assert_eq!(bytes[5], SecType::Option as u8);
+        // exp_date = 20261218 big-endian
+        assert_eq!(&bytes[6..10], &20261218i32.to_be_bytes());
+        assert_eq!(bytes[10], 1); // is_call = true
+                                  // strike = 60000 big-endian
+        assert_eq!(&bytes[11..15], &60000i32.to_be_bytes());
+    }
+
+    #[test]
+    fn java_parity_index_spx() {
+        // Java: root="SPX" (3 bytes), sec=INDEX
+        // Java allocates: 3 + 3 = 6 bytes
+        let c = Contract::index("SPX");
+        let bytes = c.to_bytes();
+        assert_eq!(bytes[0], 6);
+        assert_eq!(bytes[1], 3);
+        assert_eq!(&bytes[2..5], b"SPX");
+        assert_eq!(bytes[5], SecType::Index as u8);
+        assert_eq!(bytes.len(), 6);
+    }
+
+    #[test]
+    fn java_parity_single_char_root() {
+        // Edge case: root="A" (1 byte), sec=STOCK
+        // Java allocates: 3 + 1 = 4 bytes
+        let c = Contract::stock("A");
+        let bytes = c.to_bytes();
+        assert_eq!(bytes[0], 4);
+        assert_eq!(bytes[1], 1);
+        assert_eq!(bytes[2], b'A');
+        assert_eq!(bytes.len(), 4);
     }
 }

--- a/crates/thetadatadx/src/greeks.rs
+++ b/crates/thetadatadx/src/greeks.rs
@@ -180,6 +180,30 @@ pub fn lambda(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> 
     realize(delta(s, x, v, r, q, t, is_call) * s / value(s, x, v, r, q, t, is_call))
 }
 
+/// Vera (rho-vega cross-Greek).
+///
+/// Java: `Math.pow(-x * t * Math.E, -r * t) * f1(d2 * (d1 / v))`
+///
+/// Note: the Java code computes `(-x * t * e)^(-r*t)`. For typical inputs
+/// the base is negative, and `pow(negative, non-integer)` returns NaN.
+/// Java catches the resulting exception and returns 0.0. We replicate this
+/// by checking for NaN/Inf.
+pub fn vera(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, _is_call: bool) -> f64 {
+    if is_degenerate(v, t) {
+        return 0.0;
+    }
+    let d1_val = d1(s, x, v, r, q, t);
+    let d2_val = d2(s, x, v, r, q, t);
+    // Java: Math.pow(-x * t * Math.E, -r * t) * f1(d2 * (d1 / v))
+    let base = -x * t * std::f64::consts::E;
+    let result = base.powf(-r * t) * f1(d2_val * (d1_val / v));
+    if result.is_nan() || result.is_infinite() {
+        0.0
+    } else {
+        result
+    }
+}
+
 pub fn gamma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     if is_degenerate(v, t) {
         return 0.0;
@@ -226,10 +250,14 @@ pub fn veta(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     }
     let d1_val = d1(s, x, v, r, q, t);
     let d2_val = d2(s, x, v, r, q, t);
+    // Java: -s * e^(-qt) * f1(d1) * sqrt(t) * (q + (r-q)*d1/v*sqrt(t) - (1+d1*d2)/2.0*t)
+    // Java operator precedence (left-to-right for * and /):
+    //   (r-q)*d1/v*sqrt(t) = ((r-q)*d1/v)*sqrt(t) = (r-q)*d1*sqrt(t)/v
+    //   (1+d1*d2)/2.0*t    = ((1+d1*d2)/2.0)*t     = (1+d1*d2)*t/2
     -s * (-q * t).exp()
         * f1(d1_val)
         * t.sqrt()
-        * (q + (r - q) * d1_val / (v * t.sqrt()) - (1.0 + d1_val * d2_val) / (2.0 * t))
+        * (q + (r - q) * d1_val * t.sqrt() / v - (1.0 + d1_val * d2_val) * t / 2.0)
 }
 
 pub fn speed(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
@@ -237,7 +265,11 @@ pub fn speed(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
         return 0.0;
     }
     let d1_val = d1(s, x, v, r, q, t);
-    -(-q * t).exp() * f1(d1_val) / (s * s * v * t.sqrt()) * (d1_val / (v * t.sqrt()) + 1.0)
+    // Java: -e^(-qt) * f1(d1) / s^2 * v * sqrt(t) * (d1/v*sqrt(t) + 1)
+    // Java operator precedence (left-to-right):
+    //   prefix: -e^(-qt)*f1(d1)/s^2 * v*sqrt(t)  = -e^(-qt)*f1(d1)*v*sqrt(t)/s^2
+    //   inner:  d1/v*sqrt(t)                       = d1*sqrt(t)/v
+    -(-q * t).exp() * f1(d1_val) * v * t.sqrt() / (s * s) * (d1_val * t.sqrt() / v + 1.0)
 }
 
 pub fn zomma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
@@ -246,7 +278,11 @@ pub fn zomma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     }
     let d1_val = d1(s, x, v, r, q, t);
     let d2_val = d2(s, x, v, r, q, t);
-    (-q * t).exp() * f1(d1_val) * (d1_val * d2_val - 1.0) / (s * v * v * t.sqrt())
+    // Java: e^(-qt) * f1(d1) * (d1*d2 - 1) / s * v * v * sqrt(t)
+    // Java operator precedence (left-to-right):
+    //   e^(-qt)*f1(d1)*(d1*d2-1) / s * v^2 * sqrt(t)
+    //   = e^(-qt)*f1(d1)*(d1*d2-1)*v^2*sqrt(t) / s
+    (-q * t).exp() * f1(d1_val) * (d1_val * d2_val - 1.0) * v * v * t.sqrt() / s
 }
 
 pub fn color(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
@@ -255,10 +291,13 @@ pub fn color(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     }
     let d1_val = d1(s, x, v, r, q, t);
     let d2_val = d2(s, x, v, r, q, t);
-    -(-q * t).exp() * f1(d1_val) / (2.0 * s * t * v * t.sqrt())
-        * (2.0 * q * t
-            + 1.0
-            + (2.0 * (r - q) * t - d2_val * v * t.sqrt()) / (v * t.sqrt()) * d1_val)
+    // Java: -e^(-qt) * f1(d1) / 2.0 * s * t * v * sqrt(t) * (2qt + 1 + 2(r-q)t - d2*v*sqrt(t)/v*sqrt(t)*d1)
+    // Java operator precedence (left-to-right):
+    //   prefix: -e^(-qt)*f1(d1)/2.0 * s*t*v*sqrt(t)  = -e^(-qt)*f1(d1)*s*t*v*sqrt(t)/2
+    //   inner last term: d2*v*sqrt(t)/v*sqrt(t)*d1     = d2*sqrt(t)*sqrt(t)*d1 = d1*d2*t
+    //   inner: 2qt + 1 + 2(r-q)t - d1*d2*t
+    -(-q * t).exp() * f1(d1_val) * s * t * v * t.sqrt() / 2.0
+        * (2.0 * q * t + 1.0 + 2.0 * (r - q) * t - d1_val * d2_val * t)
 }
 
 pub fn ultima(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
@@ -289,7 +328,10 @@ pub fn dual_gamma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
         return 0.0;
     }
     let d2_val = d2(s, x, v, r, q, t);
-    (-r * t).exp() * f1(d2_val) / (x * v * t.sqrt())
+    // Java: e^(-rt) * f1(d2) / x * v * sqrt(t)
+    // Java operator precedence (left-to-right):
+    //   e^(-rt)*f1(d2) / x * v*sqrt(t) = e^(-rt)*f1(d2)*v*sqrt(t)/x
+    (-r * t).exp() * f1(d2_val) * v * t.sqrt() / x
 }
 
 /// Implied volatility solver using bisection. Returns `(iv, error)`.
@@ -383,6 +425,7 @@ pub struct GreeksResult {
     pub dual_gamma: f64,
     pub epsilon: f64,
     pub lambda: f64,
+    pub vera: f64,
 }
 
 /// Compute all Greeks at once.
@@ -426,6 +469,7 @@ pub fn all_greeks(
             dual_gamma: 0.0,
             epsilon: 0.0,
             lambda: 0.0,
+            vera: 0.0,
         };
     }
 
@@ -505,22 +549,22 @@ pub fn all_greeks(
     // Vomma
     let vomma_val = vega_val * (d1_val * d2_val / v);
 
-    // Veta
+    // Veta (matches Java operator precedence)
     let veta_val = -s
         * exp_neg_qt
         * f1_d1
         * sqrt_t
-        * (q + (r - q) * d1_val / (v * sqrt_t) - (1.0 + d1_val * d2_val) / (2.0 * t));
+        * (q + (r - q) * d1_val * sqrt_t / v - (1.0 + d1_val * d2_val) * t / 2.0);
 
-    // Speed
-    let speed_val = -exp_neg_qt * f1_d1 / (s * s * v * sqrt_t) * (d1_val / (v * sqrt_t) + 1.0);
+    // Speed (matches Java operator precedence)
+    let speed_val = -exp_neg_qt * f1_d1 * v * sqrt_t / (s * s) * (d1_val * sqrt_t / v + 1.0);
 
-    // Zomma
-    let zomma_val = exp_neg_qt * f1_d1 * (d1_val * d2_val - 1.0) / (s * v * v * sqrt_t);
+    // Zomma (matches Java operator precedence)
+    let zomma_val = exp_neg_qt * f1_d1 * (d1_val * d2_val - 1.0) * v * v * sqrt_t / s;
 
-    // Color
-    let color_val = -exp_neg_qt * f1_d1 / (2.0 * s * t * v * sqrt_t)
-        * (2.0 * q * t + 1.0 + (2.0 * (r - q) * t - d2_val * v * sqrt_t) / (v * sqrt_t) * d1_val);
+    // Color (matches Java operator precedence)
+    let color_val = -exp_neg_qt * f1_d1 * s * t * v * sqrt_t / 2.0
+        * (2.0 * q * t + 1.0 + 2.0 * (r - q) * t - d1_val * d2_val * t);
 
     // Ultima
     let ultima_raw = -vega_val / (v * v)
@@ -534,9 +578,18 @@ pub fn all_greeks(
         exp_neg_rt * n_neg_d2
     };
 
-    // Dual gamma
+    // Dual gamma (matches Java operator precedence: e^(-rt)*f1(d2)/x * v*sqrt(t))
     let f1_d2 = f1(d2_val);
-    let dual_gamma_val = exp_neg_rt * f1_d2 / (x * v * sqrt_t);
+    let dual_gamma_val = exp_neg_rt * f1_d2 * v * sqrt_t / x;
+
+    // Vera
+    let vera_base = -x * t * std::f64::consts::E;
+    let vera_raw = vera_base.powf(-r * t) * f1(d2_val * (d1_val / v));
+    let vera_val = if vera_raw.is_nan() || vera_raw.is_infinite() {
+        0.0
+    } else {
+        vera_raw
+    };
 
     GreeksResult {
         value: value_val,
@@ -561,6 +614,7 @@ pub fn all_greeks(
         dual_gamma: dual_gamma_val,
         epsilon: epsilon_val,
         lambda: lambda_val,
+        vera: vera_val,
     }
 }
 
@@ -754,5 +808,109 @@ mod tests {
         );
         assert!((g.d1 - d1(s, x, v, r, q, t)).abs() < eps, "d1 mismatch");
         assert!((g.d2 - d2(s, x, v, r, q, t)).abs() < eps, "d2 mismatch");
+    }
+
+    // ── Java formula parity tests ──────────────────────────────────────
+    // These compute the same inputs through the Java operator-precedence formulas
+    // (transcribed inline) and the Rust functions, verifying they match.
+
+    /// Reproduce the exact Java formula for a Greek inline, then compare to our function.
+    /// Uses the same test inputs throughout: SPY $450, strike $450, vol 20%, r 5%, q 1.5%, 30 days.
+    fn java_test_params() -> (f64, f64, f64, f64, f64, f64) {
+        (450.0, 450.0, 0.20, 0.05, 0.015, 30.0 / 365.0)
+    }
+
+    #[test]
+    fn java_parity_veta() {
+        let (s, x, v, r, q, t) = java_test_params();
+        let d1v = d1(s, x, v, r, q, t);
+        let d2v = d2(s, x, v, r, q, t);
+        // Java: -s * e^(-qt) * f1(d1) * sqrt(t) * (q + (r-q)*d1/v*sqrt(t) - (1+d1*d2)/2.0*t)
+        // Java precedence: /v*sqrt(t) = *sqrt(t)/v; /2.0*t = *t/2
+        let java_val = -s
+            * (-q * t).exp()
+            * f1(d1v)
+            * t.sqrt()
+            * (q + (r - q) * d1v * t.sqrt() / v - (1.0 + d1v * d2v) * t / 2.0);
+        let rust_val = veta(s, x, v, r, q, t);
+        assert!(
+            (java_val - rust_val).abs() < 1e-10,
+            "veta: java={java_val}, rust={rust_val}"
+        );
+    }
+
+    #[test]
+    fn java_parity_speed() {
+        let (s, x, v, r, q, t) = java_test_params();
+        let d1v = d1(s, x, v, r, q, t);
+        // Java: -e^(-qt) * f1(d1) / s^2 * v * sqrt(t) * (d1/v*sqrt(t) + 1)
+        let java_val =
+            -(-q * t).exp() * f1(d1v) / (s * s) * v * t.sqrt() * (d1v / v * t.sqrt() + 1.0);
+        let rust_val = speed(s, x, v, r, q, t);
+        assert!(
+            (java_val - rust_val).abs() < 1e-10,
+            "speed: java={java_val}, rust={rust_val}"
+        );
+    }
+
+    #[test]
+    fn java_parity_zomma() {
+        let (s, x, v, r, q, t) = java_test_params();
+        let d1v = d1(s, x, v, r, q, t);
+        let d2v = d2(s, x, v, r, q, t);
+        // Java: e^(-qt) * f1(d1) * (d1*d2 - 1) / s * v * v * sqrt(t)
+        let java_val = (-q * t).exp() * f1(d1v) * (d1v * d2v - 1.0) / s * v * v * t.sqrt();
+        let rust_val = zomma(s, x, v, r, q, t);
+        assert!(
+            (java_val - rust_val).abs() < 1e-10,
+            "zomma: java={java_val}, rust={rust_val}"
+        );
+    }
+
+    #[test]
+    fn java_parity_color() {
+        let (s, x, v, r, q, t) = java_test_params();
+        let d1v = d1(s, x, v, r, q, t);
+        let d2v = d2(s, x, v, r, q, t);
+        // Java: -e^(-qt) * f1(d1) / 2.0 * s * t * v * sqrt(t) *
+        //       (2qt + 1 + 2(r-q)t - d2*v*sqrt(t)/v*sqrt(t)*d1)
+        // The inner term simplifies: d2*v*sqrt(t)/v*sqrt(t)*d1 = d1*d2*t
+        let java_val = -(-q * t).exp() * f1(d1v) / 2.0
+            * s
+            * t
+            * v
+            * t.sqrt()
+            * (2.0 * q * t + 1.0 + 2.0 * (r - q) * t - d2v * v * t.sqrt() / v * t.sqrt() * d1v);
+        let rust_val = color(s, x, v, r, q, t);
+        assert!(
+            (java_val - rust_val).abs() < 1e-10,
+            "color: java={java_val}, rust={rust_val}"
+        );
+    }
+
+    #[test]
+    fn java_parity_dual_gamma() {
+        let (s, x, v, r, q, t) = java_test_params();
+        let d2v = d2(s, x, v, r, q, t);
+        // Java: e^(-rt) * f1(d2) / x * v * sqrt(t)
+        let java_val = (-r * t).exp() * f1(d2v) / x * v * t.sqrt();
+        let rust_val = dual_gamma(s, x, v, r, q, t);
+        assert!(
+            (java_val - rust_val).abs() < 1e-10,
+            "dual_gamma: java={java_val}, rust={rust_val}"
+        );
+    }
+
+    #[test]
+    fn vera_returns_finite_or_zero() {
+        let (s, x, v, r, q, t) = java_test_params();
+        // vera typically returns 0.0 due to NaN from negative base pow
+        let v_val = vera(s, x, v, r, q, t, true);
+        assert!(v_val.is_finite(), "vera must be finite, got {v_val}");
+    }
+
+    #[test]
+    fn vera_degenerate_returns_zero() {
+        assert_eq!(vera(100.0, 100.0, 0.0, 0.05, 0.01, 0.0, true), 0.0);
     }
 }


### PR DESCRIPTION
Closes #11

## What
Fixes all 12 findings from the Codex (GPT-5.4) full audit against the decompiled Java terminal.

## Key fixes
- **CRITICAL**: Contract wire format size byte was off-by-one vs Java
- **HIGH**: 6 Greeks formulas had operator precedence bugs (Java left-to-right `a/b*c` != Rust `a/(b*c)`). Added missing `vera()`.
- **MEDIUM**: Ping timing, auth 401/404 handling, null documentation
- **LOW**: Tracing on unexpected types, removed code duplication

## Test plan
- [x] 150 tests pass (18 new: wire format parity, Greeks formula parity, null handling)
- [x] cargo clippy -- -D warnings: zero
- [x] cargo fmt: clean