### PR TITLE
release: v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-03-27
+
+### Fixed
+
+- **Go SDK: price encoding was fundamentally wrong** -- `priceToFloat()` used a switch-case instead of `value * 10^(price_type - 10)`. Every price returned by the Go SDK was incorrect. Now matches Rust exactly.
+- **Python docs: streaming examples used wrong event key** -- `event["type"]` changed to `event["kind"]` across README and all docs-site pages.
+- **`Price::new()` no longer panics in release** -- `assert!` replaced with `debug_assert!` + `clamp(0, 19)` with `tracing::warn!`. A corrupt frame no longer crashes production.
+- **C++ `FpssClient`: added missing `unsubscribe_quotes()`** -- was present in FFI but missing from C++ RAII wrapper.
+- **FFI FPSS: mutex poison safety** -- all 12 `.lock().unwrap()` calls replaced with `.unwrap_or_else(|e| e.into_inner())`. Prevents undefined behavior (panic across `extern "C"`) on mutex poisoning.
+- **`Credentials.password` visibility** -- changed from `pub` to `pub(crate)` with `password()` accessor. Prevents accidental credential logging by downstream code.
+- **WebSocket server: added OPEN_INTEREST + FULL_TRADES dispatch** -- previously silently dropped.
+- **C++ SDK type parity** -- `MarketValueTick` expanded from 3 to 7 fields, `CalendarDay` added `status`, `InterestRateTick` added `ms_of_day`.
+- **Python README: removed ghost methods** -- `is_authenticated()` and `server_addr()` were listed but did not exist.
+- **Root README: stock method count** -- "Stock (13)" corrected to "Stock (14)".
+
 ## [3.0.0] - 2026-03-27
 
 ### Breaking Changes
@@ -339,7 +354,8 @@ See [TODO.md](TODO.md) for the production readiness checklist and performance ro
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/userFRM/ThetaDataDx/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v1.2.2...v2.0.0
 [1.2.2]: https://github.com/userFRM/ThetaDataDx/compare/v1.2.1...v1.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "serde_json",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "disruptor",
  "prost",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "pyo3",
  "thetadatadx",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "thetadatadx"
-version = "3.0.0"
+version = "3.1.0"
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "disruptor",
  "prost",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "disruptor",
  "prost",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary
- Version bump to 3.1.0 across all crates, Python SDK, and pyproject.toml
- CHANGELOG updated with all fixes from audit round 2

## What's in 3.1.0
All fixes from dual Codex+Gemini audit:
- Go SDK price encoding fix (was returning raw integers instead of dollars)
- Python docs event key fix
- Price::new graceful fallback (no more release-mode panic)
- C++ unsubscribe_quotes, FFI mutex safety, WS dispatch, SDK type parity
- Credentials.password visibility hardening

## Test plan
- [x] 160 tests + 4 doc-tests pass
- [x] cargo fmt / clippy clean
- [x] All 4 Cargo.lock files updated
- [x] Final dual-model audit: both said SHIP IT

🤖 Generated with [Claude Code](https://claude.com/claude-code)