### PR TITLE
feat: fully typed returns for all 61 endpoints -- zero raw DataTable

### DIFF
--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -460,6 +460,528 @@ pub fn parse_ohlc_ticks(table: &proto::DataTable) -> Vec<OhlcTick> {
         .collect()
 }
 
+/// Helper to get an f64 from a row at a given column index, defaulting to 0.0.
+///
+/// Greeks and implied volatility columns use `Number` (f64) values in the DataTable,
+/// not `Price` cells. This helper extracts the raw f64 value.
+pub(crate) fn row_float(row: &proto::DataValueList, idx: usize) -> f64 {
+    row.values
+        .get(idx)
+        .and_then(|dv| dv.data_type.as_ref())
+        .and_then(|dt| match dt {
+            proto::data_value::DataType::Number(n) => Some(*n as f64),
+            _ => None,
+        })
+        .unwrap_or(0.0)
+}
+
+/// Helper to get a String from a row at a given column index, defaulting to empty.
+pub(crate) fn row_text(row: &proto::DataValueList, idx: usize) -> String {
+    row.values
+        .get(idx)
+        .and_then(|dv| dv.data_type.as_ref())
+        .and_then(|dt| match dt {
+            proto::data_value::DataType::Text(s) => Some(s.clone()),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// Helper to get an i64 from a row at a given column index, defaulting to 0.
+///
+/// Market value fields (market_cap, shares_outstanding, etc.) can exceed i32 range.
+pub(crate) fn row_number_i64(row: &proto::DataValueList, idx: usize) -> i64 {
+    row.values
+        .get(idx)
+        .and_then(|dv| dv.data_type.as_ref())
+        .and_then(|dt| match dt {
+            proto::data_value::DataType::Number(n) => Some(*n),
+            _ => None,
+        })
+        .unwrap_or(0)
+}
+
+/// Parse a DataTable into TradeQuoteTicks.
+///
+/// Expects headers matching the combined trade + quote schema.
+pub fn parse_trade_quote_ticks(table: &proto::DataTable) -> Vec<TradeQuoteTick> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(ms_idx) = find_header(&h, "ms_of_day") else {
+        return vec![];
+    };
+    let Some(price_idx) = find_header(&h, "price") else {
+        return vec![];
+    };
+
+    let seq_idx = find_header(&h, "sequence");
+    let ext1_idx = find_header(&h, "ext_condition1");
+    let ext2_idx = find_header(&h, "ext_condition2");
+    let ext3_idx = find_header(&h, "ext_condition3");
+    let ext4_idx = find_header(&h, "ext_condition4");
+    let cond_idx = find_header(&h, "condition");
+    let size_idx = find_header(&h, "size");
+    let exg_idx = find_header(&h, "exchange");
+    let cf_idx = find_header(&h, "condition_flags");
+    let pf_idx = find_header(&h, "price_flags");
+    let vt_idx = find_header(&h, "volume_type");
+    let rb_idx = find_header(&h, "records_back");
+    let qms_idx = find_header(&h, "quote_ms_of_day");
+    let bs_idx = find_header(&h, "bid_size");
+    let be_idx = find_header(&h, "bid_exchange");
+    let bid_idx = find_header(&h, "bid");
+    let bc_idx = find_header(&h, "bid_condition");
+    let as_idx = find_header(&h, "ask_size");
+    let ae_idx = find_header(&h, "ask_exchange");
+    let ask_idx = find_header(&h, "ask");
+    let ac_idx = find_header(&h, "ask_condition");
+    let qpt_idx = find_header(&h, "quote_price_type");
+    let pt_idx = find_header(&h, "price_type");
+    let date_idx = find_header(&h, "date");
+
+    let price_is_typed = h.contains(&"price");
+
+    fn opt_number(row: &proto::DataValueList, idx: Option<usize>) -> i32 {
+        match idx {
+            Some(i) => row_number(row, i),
+            None => 0,
+        }
+    }
+
+    table
+        .data_table
+        .iter()
+        .map(|row| {
+            let pt = if price_is_typed {
+                row_price_type(row, price_idx)
+            } else {
+                opt_number(row, pt_idx)
+            };
+
+            TradeQuoteTick {
+                ms_of_day: row_number(row, ms_idx),
+                sequence: opt_number(row, seq_idx),
+                ext_condition1: opt_number(row, ext1_idx),
+                ext_condition2: opt_number(row, ext2_idx),
+                ext_condition3: opt_number(row, ext3_idx),
+                ext_condition4: opt_number(row, ext4_idx),
+                condition: opt_number(row, cond_idx),
+                size: opt_number(row, size_idx),
+                exchange: opt_number(row, exg_idx),
+                price: if price_is_typed {
+                    row_price_value(row, price_idx)
+                } else {
+                    row_number(row, price_idx)
+                },
+                condition_flags: opt_number(row, cf_idx),
+                price_flags: opt_number(row, pf_idx),
+                volume_type: opt_number(row, vt_idx),
+                records_back: opt_number(row, rb_idx),
+                quote_ms_of_day: opt_number(row, qms_idx),
+                bid_size: opt_number(row, bs_idx),
+                bid_exchange: opt_number(row, be_idx),
+                bid: match bid_idx {
+                    Some(i) => row_price_value(row, i),
+                    None => 0,
+                },
+                bid_condition: opt_number(row, bc_idx),
+                ask_size: opt_number(row, as_idx),
+                ask_exchange: opt_number(row, ae_idx),
+                ask: match ask_idx {
+                    Some(i) => row_price_value(row, i),
+                    None => 0,
+                },
+                ask_condition: opt_number(row, ac_idx),
+                quote_price_type: opt_number(row, qpt_idx),
+                price_type: pt,
+                date: opt_number(row, date_idx),
+            }
+        })
+        .collect()
+}
+
+/// Parse a DataTable into OpenInterestTicks.
+pub fn parse_open_interest_ticks(table: &proto::DataTable) -> Vec<OpenInterestTick> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(ms_idx) = find_header(&h, "ms_of_day") else {
+        return vec![];
+    };
+
+    let oi_idx = find_header(&h, "open_interest");
+    let date_idx = find_header(&h, "date");
+
+    fn opt_number(row: &proto::DataValueList, idx: Option<usize>) -> i32 {
+        match idx {
+            Some(i) => row_number(row, i),
+            None => 0,
+        }
+    }
+
+    table
+        .data_table
+        .iter()
+        .map(|row| OpenInterestTick {
+            ms_of_day: row_number(row, ms_idx),
+            open_interest: opt_number(row, oi_idx),
+            date: opt_number(row, date_idx),
+        })
+        .collect()
+}
+
+/// Parse a DataTable into MarketValueTicks.
+pub fn parse_market_value_ticks(table: &proto::DataTable) -> Vec<MarketValueTick> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(ms_idx) = find_header(&h, "ms_of_day") else {
+        return vec![];
+    };
+
+    let mc_idx = find_header(&h, "market_cap");
+    let so_idx = find_header(&h, "shares_outstanding");
+    let ev_idx = find_header(&h, "enterprise_value");
+    let bv_idx = find_header(&h, "book_value");
+    let ff_idx = find_header(&h, "free_float");
+    let date_idx = find_header(&h, "date");
+
+    fn opt_i64(row: &proto::DataValueList, idx: Option<usize>) -> i64 {
+        match idx {
+            Some(i) => row_number_i64(row, i),
+            None => 0,
+        }
+    }
+
+    table
+        .data_table
+        .iter()
+        .map(|row| MarketValueTick {
+            ms_of_day: row_number(row, ms_idx),
+            market_cap: opt_i64(row, mc_idx),
+            shares_outstanding: opt_i64(row, so_idx),
+            enterprise_value: opt_i64(row, ev_idx),
+            book_value: opt_i64(row, bv_idx),
+            free_float: opt_i64(row, ff_idx),
+            date: date_idx.map(|i| row_number(row, i)).unwrap_or(0),
+        })
+        .collect()
+}
+
+/// Parse a DataTable into GreeksTicks.
+///
+/// Greeks columns use `Number` (f64) values in the DataTable, not `Price` cells.
+pub fn parse_greeks_ticks(table: &proto::DataTable) -> Vec<GreeksTick> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(ms_idx) = find_header(&h, "ms_of_day") else {
+        return vec![];
+    };
+
+    let iv_idx = find_header(&h, "implied_volatility");
+    let delta_idx = find_header(&h, "delta");
+    let gamma_idx = find_header(&h, "gamma");
+    let theta_idx = find_header(&h, "theta");
+    let vega_idx = find_header(&h, "vega");
+    let rho_idx = find_header(&h, "rho");
+    let ive_idx = find_header(&h, "iv_error");
+    let vanna_idx = find_header(&h, "vanna");
+    let charm_idx = find_header(&h, "charm");
+    let vomma_idx = find_header(&h, "vomma");
+    let veta_idx = find_header(&h, "veta");
+    let speed_idx = find_header(&h, "speed");
+    let zomma_idx = find_header(&h, "zomma");
+    let color_idx = find_header(&h, "color");
+    let ultima_idx = find_header(&h, "ultima");
+    let d1_idx = find_header(&h, "d1");
+    let d2_idx = find_header(&h, "d2");
+    let dd_idx = find_header(&h, "dual_delta");
+    let dg_idx = find_header(&h, "dual_gamma");
+    let eps_idx = find_header(&h, "epsilon");
+    let lam_idx = find_header(&h, "lambda");
+    let vera_idx = find_header(&h, "vera");
+    let date_idx = find_header(&h, "date");
+
+    fn opt_float(row: &proto::DataValueList, idx: Option<usize>) -> f64 {
+        match idx {
+            Some(i) => row_float(row, i),
+            None => 0.0,
+        }
+    }
+
+    fn opt_number(row: &proto::DataValueList, idx: Option<usize>) -> i32 {
+        match idx {
+            Some(i) => row_number(row, i),
+            None => 0,
+        }
+    }
+
+    table
+        .data_table
+        .iter()
+        .map(|row| GreeksTick {
+            ms_of_day: row_number(row, ms_idx),
+            implied_volatility: opt_float(row, iv_idx),
+            delta: opt_float(row, delta_idx),
+            gamma: opt_float(row, gamma_idx),
+            theta: opt_float(row, theta_idx),
+            vega: opt_float(row, vega_idx),
+            rho: opt_float(row, rho_idx),
+            iv_error: opt_float(row, ive_idx),
+            vanna: opt_float(row, vanna_idx),
+            charm: opt_float(row, charm_idx),
+            vomma: opt_float(row, vomma_idx),
+            veta: opt_float(row, veta_idx),
+            speed: opt_float(row, speed_idx),
+            zomma: opt_float(row, zomma_idx),
+            color: opt_float(row, color_idx),
+            ultima: opt_float(row, ultima_idx),
+            d1: opt_float(row, d1_idx),
+            d2: opt_float(row, d2_idx),
+            dual_delta: opt_float(row, dd_idx),
+            dual_gamma: opt_float(row, dg_idx),
+            epsilon: opt_float(row, eps_idx),
+            lambda: opt_float(row, lam_idx),
+            vera: opt_float(row, vera_idx),
+            date: opt_number(row, date_idx),
+        })
+        .collect()
+}
+
+/// Parse a DataTable into IvTicks.
+///
+/// IV columns use `Number` (f64) values in the DataTable.
+pub fn parse_iv_ticks(table: &proto::DataTable) -> Vec<IvTick> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(ms_idx) = find_header(&h, "ms_of_day") else {
+        return vec![];
+    };
+
+    let iv_idx = find_header(&h, "implied_volatility");
+    let ive_idx = find_header(&h, "iv_error");
+    let date_idx = find_header(&h, "date");
+
+    fn opt_float(row: &proto::DataValueList, idx: Option<usize>) -> f64 {
+        match idx {
+            Some(i) => row_float(row, i),
+            None => 0.0,
+        }
+    }
+
+    table
+        .data_table
+        .iter()
+        .map(|row| IvTick {
+            ms_of_day: row_number(row, ms_idx),
+            implied_volatility: opt_float(row, iv_idx),
+            iv_error: opt_float(row, ive_idx),
+            date: date_idx.map(|i| row_number(row, i)).unwrap_or(0),
+        })
+        .collect()
+}
+
+/// Parse a DataTable into PriceTicks.
+pub fn parse_price_ticks(table: &proto::DataTable) -> Vec<PriceTick> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(ms_idx) = find_header(&h, "ms_of_day") else {
+        return vec![];
+    };
+    let Some(price_idx) = find_header(&h, "price") else {
+        return vec![];
+    };
+
+    let pt_idx = find_header(&h, "price_type");
+    let date_idx = find_header(&h, "date");
+
+    let price_is_typed = h.contains(&"price");
+
+    fn opt_number(row: &proto::DataValueList, idx: Option<usize>) -> i32 {
+        match idx {
+            Some(i) => row_number(row, i),
+            None => 0,
+        }
+    }
+
+    table
+        .data_table
+        .iter()
+        .map(|row| {
+            let pt = if price_is_typed {
+                row_price_type(row, price_idx)
+            } else {
+                opt_number(row, pt_idx)
+            };
+
+            PriceTick {
+                ms_of_day: row_number(row, ms_idx),
+                price: if price_is_typed {
+                    row_price_value(row, price_idx)
+                } else {
+                    row_number(row, price_idx)
+                },
+                price_type: pt,
+                date: opt_number(row, date_idx),
+            }
+        })
+        .collect()
+}
+
+/// Parse a DataTable into CalendarDays.
+pub fn parse_calendar_days(table: &proto::DataTable) -> Vec<CalendarDay> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(date_idx) = find_header(&h, "date") else {
+        return vec![];
+    };
+
+    let open_idx = find_header(&h, "is_open");
+    let ot_idx = find_header(&h, "open_time");
+    let ct_idx = find_header(&h, "close_time");
+    let status_idx = find_header(&h, "status");
+
+    fn opt_number(row: &proto::DataValueList, idx: Option<usize>) -> i32 {
+        match idx {
+            Some(i) => row_number(row, i),
+            None => 0,
+        }
+    }
+
+    table
+        .data_table
+        .iter()
+        .map(|row| CalendarDay {
+            date: row_number(row, date_idx),
+            is_open: opt_number(row, open_idx),
+            open_time: opt_number(row, ot_idx),
+            close_time: opt_number(row, ct_idx),
+            status: opt_number(row, status_idx),
+        })
+        .collect()
+}
+
+/// Parse a DataTable into InterestRateTicks.
+pub fn parse_interest_rate_ticks(table: &proto::DataTable) -> Vec<InterestRateTick> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(ms_idx) = find_header(&h, "ms_of_day") else {
+        return vec![];
+    };
+
+    let rate_idx = find_header(&h, "rate");
+    let date_idx = find_header(&h, "date");
+
+    table
+        .data_table
+        .iter()
+        .map(|row| InterestRateTick {
+            ms_of_day: row_number(row, ms_idx),
+            rate: rate_idx.map(|i| row_float(row, i)).unwrap_or(0.0),
+            date: date_idx.map(|i| row_number(row, i)).unwrap_or(0),
+        })
+        .collect()
+}
+
+/// Parse a DataTable into OptionContracts.
+pub fn parse_option_contracts(table: &proto::DataTable) -> Vec<OptionContract> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let Some(root_idx) = find_header(&h, "root") else {
+        return vec![];
+    };
+
+    let exp_idx = find_header(&h, "expiration");
+    let strike_idx = find_header(&h, "strike");
+    let right_idx = find_header(&h, "right");
+    let spt_idx = find_header(&h, "strike_price_type");
+
+    fn opt_number(row: &proto::DataValueList, idx: Option<usize>) -> i32 {
+        match idx {
+            Some(i) => row_number(row, i),
+            None => 0,
+        }
+    }
+
+    table
+        .data_table
+        .iter()
+        .map(|row| OptionContract {
+            root: row_text(row, root_idx),
+            expiration: opt_number(row, exp_idx),
+            strike: opt_number(row, strike_idx),
+            right: opt_number(row, right_idx),
+            strike_price_type: opt_number(row, spt_idx),
+        })
+        .collect()
+}
+
+/// Parse EOD ticks from a `DataTable` using header-based column lookup.
+///
+/// Handles both Price-typed and Number-typed columns transparently.
+pub fn parse_eod_ticks(table: &proto::DataTable) -> Vec<EodTick> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+    let find = |name: &str| h.iter().position(|&s| s == name);
+
+    // EOD rows may have Price-typed cells (value + type) or plain Number cells.
+    fn eod_num(row: &proto::DataValueList, idx: usize) -> i32 {
+        row.values
+            .get(idx)
+            .and_then(|dv| dv.data_type.as_ref())
+            .and_then(|dt| match dt {
+                proto::data_value::DataType::Number(n) => Some(*n as i32),
+                proto::data_value::DataType::Price(p) => Some(p.value),
+                _ => None,
+            })
+            .unwrap_or(0)
+    }
+
+    let ms_of_day_idx = find("ms_of_day");
+    let ms_of_day2_idx = find("ms_of_day2");
+    let open_idx = find("open");
+    let high_idx = find("high");
+    let low_idx = find("low");
+    let close_idx = find("close");
+    let volume_idx = find("volume");
+    let count_idx = find("count");
+    let bid_size_idx = find("bid_size");
+    let bid_exchange_idx = find("bid_exchange");
+    let bid_idx = find("bid");
+    let bid_condition_idx = find("bid_condition");
+    let ask_size_idx = find("ask_size");
+    let ask_exchange_idx = find("ask_exchange");
+    let ask_idx = find("ask");
+    let ask_condition_idx = find("ask_condition");
+    let date_idx = find("date");
+
+    table
+        .data_table
+        .iter()
+        .map(|row| {
+            let pt = open_idx.map(|i| row_price_type(row, i)).unwrap_or(0);
+
+            EodTick {
+                ms_of_day: ms_of_day_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ms_of_day2: ms_of_day2_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                open: open_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                high: high_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                low: low_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                close: close_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                volume: volume_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                count: count_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                bid_size: bid_size_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                bid_exchange: bid_exchange_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                bid: bid_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                bid_condition: bid_condition_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ask_size: ask_size_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ask_exchange: ask_exchange_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ask: ask_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                ask_condition: ask_condition_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+                price_type: pt,
+                date: date_idx.map(|i| eod_num(row, i)).unwrap_or(0),
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -109,35 +109,6 @@ macro_rules! parsed_endpoint {
     };
 }
 
-/// Generate an endpoint that returns the raw `proto::DataTable`.
-///
-/// Used for Greeks, calendar, interest rates, and other endpoints where the
-/// column schema varies or is best consumed as a raw table.
-macro_rules! raw_endpoint {
-    (
-        $(#[$meta:meta])*
-        fn $name:ident( $($arg:ident : $arg_ty:ty),* ) -> proto::DataTable;
-        grpc: $grpc:ident;
-        request: $req:ident;
-        query: $query:ident { $($field:ident : $val:expr),* $(,)? };
-        $(dates: $($date_arg:ident),+ ;)?
-    ) => {
-        $(#[$meta])*
-        pub async fn $name(&self, $($arg : $arg_ty),*) -> Result<proto::DataTable, Error> {
-            $($(validate_date($date_arg)?;)+)?
-            tracing::debug!(endpoint = stringify!($name), "gRPC request");
-            let _permit = self.request_semaphore.acquire().await
-                .map_err(|_| Error::Fpss("request semaphore closed".into()))?;
-            let request = proto_v3::$req {
-                query_info: Some(self.query_info()),
-                params: Some(proto_v3::$query { $($field : $val),* }),
-            };
-            let stream = self.stub().$grpc(request).await?.into_inner();
-            self.collect_stream(stream).await
-        }
-    };
-}
-
 /// Generate a streaming endpoint that yields parsed ticks per-chunk via a callback,
 /// without materializing the full response in memory.
 ///
@@ -525,11 +496,11 @@ impl DirectClient {
     }
 
     // 6. GetStockSnapshotMarketValue
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get the latest market value snapshot for one or more stocks.
         ///
         /// gRPC: `BetaThetaTerminal/GetStockSnapshotMarketValue`
-        fn stock_snapshot_market_value(symbols: &[&str]) -> proto::DataTable;
+        fn stock_snapshot_market_value(symbols: &[&str]) -> Vec<MarketValueTick>;
         grpc: get_stock_snapshot_market_value;
         request: StockSnapshotMarketValueRequest;
         query: StockSnapshotMarketValueRequestQuery {
@@ -537,6 +508,7 @@ impl DirectClient {
             venue: None,
             min_time: None,
         };
+        parse: decode::parse_market_value_ticks;
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -558,7 +530,7 @@ impl DirectClient {
             start_date: start.to_string(),
             end_date: end.to_string(),
         };
-        parse: parse_eod_from_table;
+        parse: decode::parse_eod_ticks;
         dates: start, end;
     }
 
@@ -710,11 +682,11 @@ impl DirectClient {
     }
 
     // 11. GetStockHistoryTradeQuote
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch combined trade + quote ticks for a stock on a given date.
         ///
         /// gRPC: `BetaThetaTerminal/GetStockHistoryTradeQuote`
-        fn stock_history_trade_quote(symbol: &str, date: &str) -> proto::DataTable;
+        fn stock_history_trade_quote(symbol: &str, date: &str) -> Vec<TradeQuoteTick>;
         grpc: get_stock_history_trade_quote;
         request: StockHistoryTradeQuoteRequest;
         query: StockHistoryTradeQuoteRequestQuery {
@@ -727,6 +699,7 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_trade_quote_ticks;
         dates: date;
     }
 
@@ -840,15 +813,15 @@ impl DirectClient {
     }
 
     // 18. GetOptionListContracts
-    raw_endpoint! {
+    parsed_endpoint! {
         /// List all option contracts for a symbol on a given date.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionListContracts`
         ///
-        /// Returns a `DataTable` with contract details (symbol, expiration, strike, right).
+        /// Returns parsed contract details (root, expiration, strike, right).
         fn option_list_contracts(
             request_type: &str, symbol: &str, date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<OptionContract>;
         grpc: get_option_list_contracts;
         request: OptionListContractsRequest;
         query: OptionListContractsRequestQuery {
@@ -857,6 +830,7 @@ impl DirectClient {
             date: date.to_string(),
             max_dte: None,
         };
+        parse: decode::parse_option_contracts;
         dates: date;
     }
 
@@ -924,13 +898,13 @@ impl DirectClient {
     }
 
     // 22. GetOptionSnapshotOpenInterest
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get the latest open interest snapshot for option contracts.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionSnapshotOpenInterest`
         fn option_snapshot_open_interest(
             symbol: &str, expiration: &str, strike: &str, right: &str
-        ) -> proto::DataTable;
+        ) -> Vec<OpenInterestTick>;
         grpc: get_option_snapshot_open_interest;
         request: OptionSnapshotOpenInterestRequest;
         query: OptionSnapshotOpenInterestRequestQuery {
@@ -940,16 +914,17 @@ impl DirectClient {
             strike_range: None,
             min_time: None,
         };
+        parse: decode::parse_open_interest_ticks;
     }
 
     // 23. GetOptionSnapshotMarketValue
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get the latest market value snapshot for option contracts.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionSnapshotMarketValue`
         fn option_snapshot_market_value(
             symbol: &str, expiration: &str, strike: &str, right: &str
-        ) -> proto::DataTable;
+        ) -> Vec<MarketValueTick>;
         grpc: get_option_snapshot_market_value;
         request: OptionSnapshotMarketValueRequest;
         query: OptionSnapshotMarketValueRequestQuery {
@@ -959,16 +934,17 @@ impl DirectClient {
             strike_range: None,
             min_time: None,
         };
+        parse: decode::parse_market_value_ticks;
     }
 
     // 24. GetOptionSnapshotGreeksImpliedVolatility
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get implied volatility snapshot for option contracts.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionSnapshotGreeksImpliedVolatility`
         fn option_snapshot_greeks_implied_volatility(
             symbol: &str, expiration: &str, strike: &str, right: &str
-        ) -> proto::DataTable;
+        ) -> Vec<IvTick>;
         grpc: get_option_snapshot_greeks_implied_volatility;
         request: OptionSnapshotGreeksImpliedVolatilityRequest;
         query: OptionSnapshotGreeksImpliedVolatilityRequestQuery {
@@ -984,16 +960,17 @@ impl DirectClient {
             min_time: None,
             use_market_value: None,
         };
+        parse: decode::parse_iv_ticks;
     }
 
     // 25. GetOptionSnapshotGreeksAll
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get all Greeks snapshot for option contracts.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionSnapshotGreeksAll`
         fn option_snapshot_greeks_all(
             symbol: &str, expiration: &str, strike: &str, right: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_snapshot_greeks_all;
         request: OptionSnapshotGreeksAllRequest;
         query: OptionSnapshotGreeksAllRequestQuery {
@@ -1009,16 +986,17 @@ impl DirectClient {
             min_time: None,
             use_market_value: None,
         };
+        parse: decode::parse_greeks_ticks;
     }
 
     // 26. GetOptionSnapshotGreeksFirstOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get first-order Greeks snapshot (delta, theta, rho, etc.).
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionSnapshotGreeksFirstOrder`
         fn option_snapshot_greeks_first_order(
             symbol: &str, expiration: &str, strike: &str, right: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_snapshot_greeks_first_order;
         request: OptionSnapshotGreeksFirstOrderRequest;
         query: OptionSnapshotGreeksFirstOrderRequestQuery {
@@ -1034,16 +1012,17 @@ impl DirectClient {
             min_time: None,
             use_market_value: None,
         };
+        parse: decode::parse_greeks_ticks;
     }
 
     // 27. GetOptionSnapshotGreeksSecondOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get second-order Greeks snapshot (gamma, vanna, charm, etc.).
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionSnapshotGreeksSecondOrder`
         fn option_snapshot_greeks_second_order(
             symbol: &str, expiration: &str, strike: &str, right: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_snapshot_greeks_second_order;
         request: OptionSnapshotGreeksSecondOrderRequest;
         query: OptionSnapshotGreeksSecondOrderRequestQuery {
@@ -1059,16 +1038,17 @@ impl DirectClient {
             min_time: None,
             use_market_value: None,
         };
+        parse: decode::parse_greeks_ticks;
     }
 
     // 28. GetOptionSnapshotGreeksThirdOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get third-order Greeks snapshot (speed, color, ultima, etc.).
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionSnapshotGreeksThirdOrder`
         fn option_snapshot_greeks_third_order(
             symbol: &str, expiration: &str, strike: &str, right: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_snapshot_greeks_third_order;
         request: OptionSnapshotGreeksThirdOrderRequest;
         query: OptionSnapshotGreeksThirdOrderRequestQuery {
@@ -1084,6 +1064,7 @@ impl DirectClient {
             min_time: None,
             use_market_value: None,
         };
+        parse: decode::parse_greeks_ticks;
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -1109,7 +1090,7 @@ impl DirectClient {
             max_dte: None,
             strike_range: None,
         };
-        parse: parse_eod_from_table;
+        parse: decode::parse_eod_ticks;
         dates: start, end;
     }
 
@@ -1250,13 +1231,13 @@ impl DirectClient {
     }
 
     // 33. GetOptionHistoryTradeQuote
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch combined trade + quote ticks for an option contract.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryTradeQuote`
         fn option_history_trade_quote(
             symbol: &str, expiration: &str, strike: &str, right: &str, date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<TradeQuoteTick>;
         grpc: get_option_history_trade_quote;
         request: OptionHistoryTradeQuoteRequest;
         query: OptionHistoryTradeQuoteRequestQuery {
@@ -1271,17 +1252,18 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_trade_quote_ticks;
         dates: date;
     }
 
     // 34. GetOptionHistoryOpenInterest
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch open interest history for an option contract.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryOpenInterest`
         fn option_history_open_interest(
             symbol: &str, expiration: &str, strike: &str, right: &str, date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<OpenInterestTick>;
         grpc: get_option_history_open_interest;
         request: OptionHistoryOpenInterestRequest;
         query: OptionHistoryOpenInterestRequestQuery {
@@ -1293,6 +1275,7 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_open_interest_ticks;
         dates: date;
     }
 
@@ -1301,14 +1284,14 @@ impl DirectClient {
     // ═══════════════════════════════════════════════════════════════════
 
     // 35. GetOptionHistoryGreeksEod
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch end-of-day Greeks history for an option contract.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryGreeksEod`
         fn option_history_greeks_eod(
             symbol: &str, expiration: &str, strike: &str, right: &str,
             start_date: &str, end_date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_greeks_eod;
         request: OptionHistoryGreeksEodRequest;
         query: OptionHistoryGreeksEodRequestQuery {
@@ -1324,18 +1307,19 @@ impl DirectClient {
             max_dte: None,
             strike_range: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: start_date, end_date;
     }
 
     // 36. GetOptionHistoryGreeksAll
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryGreeksAll`
         fn option_history_greeks_all(
             symbol: &str, expiration: &str, strike: &str, right: &str,
             date: &str, interval: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_greeks_all;
         request: OptionHistoryGreeksAllRequest;
         query: OptionHistoryGreeksAllRequestQuery {
@@ -1353,17 +1337,18 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: date;
     }
 
     // 37. GetOptionHistoryTradeGreeksAll
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch all Greeks on each trade for an option contract.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryTradeGreeksAll`
         fn option_history_trade_greeks_all(
             symbol: &str, expiration: &str, strike: &str, right: &str, date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_trade_greeks_all;
         request: OptionHistoryTradeGreeksAllRequest;
         query: OptionHistoryTradeGreeksAllRequestQuery {
@@ -1381,18 +1366,19 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: date;
     }
 
     // 38. GetOptionHistoryGreeksFirstOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch first-order Greeks history (intraday, sampled by interval).
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryGreeksFirstOrder`
         fn option_history_greeks_first_order(
             symbol: &str, expiration: &str, strike: &str, right: &str,
             date: &str, interval: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_greeks_first_order;
         request: OptionHistoryGreeksFirstOrderRequest;
         query: OptionHistoryGreeksFirstOrderRequestQuery {
@@ -1410,17 +1396,18 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: date;
     }
 
     // 39. GetOptionHistoryTradeGreeksFirstOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch first-order Greeks on each trade for an option contract.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryTradeGreeksFirstOrder`
         fn option_history_trade_greeks_first_order(
             symbol: &str, expiration: &str, strike: &str, right: &str, date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_trade_greeks_first_order;
         request: OptionHistoryTradeGreeksFirstOrderRequest;
         query: OptionHistoryTradeGreeksFirstOrderRequestQuery {
@@ -1438,18 +1425,19 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: date;
     }
 
     // 40. GetOptionHistoryGreeksSecondOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch second-order Greeks history (intraday, sampled by interval).
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryGreeksSecondOrder`
         fn option_history_greeks_second_order(
             symbol: &str, expiration: &str, strike: &str, right: &str,
             date: &str, interval: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_greeks_second_order;
         request: OptionHistoryGreeksSecondOrderRequest;
         query: OptionHistoryGreeksSecondOrderRequestQuery {
@@ -1467,17 +1455,18 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: date;
     }
 
     // 41. GetOptionHistoryTradeGreeksSecondOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch second-order Greeks on each trade for an option contract.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryTradeGreeksSecondOrder`
         fn option_history_trade_greeks_second_order(
             symbol: &str, expiration: &str, strike: &str, right: &str, date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_trade_greeks_second_order;
         request: OptionHistoryTradeGreeksSecondOrderRequest;
         query: OptionHistoryTradeGreeksSecondOrderRequestQuery {
@@ -1495,18 +1484,19 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: date;
     }
 
     // 42. GetOptionHistoryGreeksThirdOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch third-order Greeks history (intraday, sampled by interval).
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryGreeksThirdOrder`
         fn option_history_greeks_third_order(
             symbol: &str, expiration: &str, strike: &str, right: &str,
             date: &str, interval: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_greeks_third_order;
         request: OptionHistoryGreeksThirdOrderRequest;
         query: OptionHistoryGreeksThirdOrderRequestQuery {
@@ -1524,17 +1514,18 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: date;
     }
 
     // 43. GetOptionHistoryTradeGreeksThirdOrder
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch third-order Greeks on each trade for an option contract.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryTradeGreeksThirdOrder`
         fn option_history_trade_greeks_third_order(
             symbol: &str, expiration: &str, strike: &str, right: &str, date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<GreeksTick>;
         grpc: get_option_history_trade_greeks_third_order;
         request: OptionHistoryTradeGreeksThirdOrderRequest;
         query: OptionHistoryTradeGreeksThirdOrderRequestQuery {
@@ -1552,18 +1543,19 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_greeks_ticks;
         dates: date;
     }
 
     // 44. GetOptionHistoryGreeksImpliedVolatility
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch implied volatility history (intraday, sampled by interval).
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryGreeksImpliedVolatility`
         fn option_history_greeks_implied_volatility(
             symbol: &str, expiration: &str, strike: &str, right: &str,
             date: &str, interval: &str
-        ) -> proto::DataTable;
+        ) -> Vec<IvTick>;
         grpc: get_option_history_greeks_implied_volatility;
         request: OptionHistoryGreeksImpliedVolatilityRequest;
         query: OptionHistoryGreeksImpliedVolatilityRequestQuery {
@@ -1581,17 +1573,18 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_iv_ticks;
         dates: date;
     }
 
     // 45. GetOptionHistoryTradeGreeksImpliedVolatility
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch implied volatility on each trade for an option contract.
         ///
         /// gRPC: `BetaThetaTerminal/GetOptionHistoryTradeGreeksImpliedVolatility`
         fn option_history_trade_greeks_implied_volatility(
             symbol: &str, expiration: &str, strike: &str, right: &str, date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<IvTick>;
         grpc: get_option_history_trade_greeks_implied_volatility;
         request: OptionHistoryTradeGreeksImpliedVolatilityRequest;
         query: OptionHistoryTradeGreeksImpliedVolatilityRequestQuery {
@@ -1609,6 +1602,7 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_iv_ticks;
         dates: date;
     }
 
@@ -1712,31 +1706,33 @@ impl DirectClient {
     }
 
     // 51. GetIndexSnapshotPrice
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get the latest price snapshot for one or more indices.
         ///
         /// gRPC: `BetaThetaTerminal/GetIndexSnapshotPrice`
-        fn index_snapshot_price(symbols: &[&str]) -> proto::DataTable;
+        fn index_snapshot_price(symbols: &[&str]) -> Vec<PriceTick>;
         grpc: get_index_snapshot_price;
         request: IndexSnapshotPriceRequest;
         query: IndexSnapshotPriceRequestQuery {
             symbol: symbols.iter().map(|s| s.to_string()).collect(),
             min_time: None,
         };
+        parse: decode::parse_price_ticks;
     }
 
     // 52. GetIndexSnapshotMarketValue
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get the latest market value snapshot for one or more indices.
         ///
         /// gRPC: `BetaThetaTerminal/GetIndexSnapshotMarketValue`
-        fn index_snapshot_market_value(symbols: &[&str]) -> proto::DataTable;
+        fn index_snapshot_market_value(symbols: &[&str]) -> Vec<MarketValueTick>;
         grpc: get_index_snapshot_market_value;
         request: IndexSnapshotMarketValueRequest;
         query: IndexSnapshotMarketValueRequestQuery {
             symbol: symbols.iter().map(|s| s.to_string()).collect(),
             min_time: None,
         };
+        parse: decode::parse_market_value_ticks;
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -1756,7 +1752,7 @@ impl DirectClient {
             start_date: start.to_string(),
             end_date: end.to_string(),
         };
-        parse: parse_eod_from_table;
+        parse: decode::parse_eod_ticks;
         dates: start, end;
     }
 
@@ -1783,13 +1779,13 @@ impl DirectClient {
     }
 
     // 55. GetIndexHistoryPrice
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch intraday price history for an index.
         ///
         /// gRPC: `BetaThetaTerminal/GetIndexHistoryPrice`
         fn index_history_price(
             symbol: &str, date: &str, interval: &str
-        ) -> proto::DataTable;
+        ) -> Vec<PriceTick>;
         grpc: get_index_history_price;
         request: IndexHistoryPriceRequest;
         query: IndexHistoryPriceRequestQuery {
@@ -1801,6 +1797,7 @@ impl DirectClient {
             start_date: None,
             end_date: None,
         };
+        parse: decode::parse_price_ticks;
         dates: date;
     }
 
@@ -1809,13 +1806,13 @@ impl DirectClient {
     // ═══════════════════════════════════════════════════════════════════
 
     // 56. GetIndexAtTimePrice
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch the index price at a specific time of day across a date range.
         ///
         /// gRPC: `BetaThetaTerminal/GetIndexAtTimePrice`
         fn index_at_time_price(
             symbol: &str, start_date: &str, end_date: &str, time_of_day: &str
-        ) -> proto::DataTable;
+        ) -> Vec<PriceTick>;
         grpc: get_index_at_time_price;
         request: IndexAtTimePriceRequest;
         query: IndexAtTimePriceRequestQuery {
@@ -1824,6 +1821,7 @@ impl DirectClient {
             end_date: end_date.to_string(),
             time_of_day: time_of_day.to_string(),
         };
+        parse: decode::parse_price_ticks;
         dates: start_date, end_date;
     }
 
@@ -1832,43 +1830,46 @@ impl DirectClient {
     // ═══════════════════════════════════════════════════════════════════
 
     // 57. GetCalendarOpenToday
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Check whether the market is open today.
         ///
         /// gRPC: `BetaThetaTerminal/GetCalendarOpenToday`
-        fn calendar_open_today() -> proto::DataTable;
+        fn calendar_open_today() -> Vec<CalendarDay>;
         grpc: get_calendar_open_today;
         request: CalendarOpenTodayRequest;
         query: CalendarOpenTodayRequestQuery {};
+        parse: decode::parse_calendar_days;
     }
 
     // 58. GetCalendarOnDate
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get calendar information for a specific date.
         ///
         /// gRPC: `BetaThetaTerminal/GetCalendarOnDate`
-        fn calendar_on_date(date: &str) -> proto::DataTable;
+        fn calendar_on_date(date: &str) -> Vec<CalendarDay>;
         grpc: get_calendar_on_date;
         request: CalendarOnDateRequest;
         query: CalendarOnDateRequestQuery {
             date: date.to_string(),
         };
+        parse: decode::parse_calendar_days;
         dates: date;
     }
 
     // 59. GetCalendarYear
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Get calendar information for an entire year.
         ///
         /// gRPC: `BetaThetaTerminal/GetCalendarYear`
         ///
         /// `year` is a 4-digit year string (e.g. `"2024"`).
-        fn calendar_year(year: &str) -> proto::DataTable;
+        fn calendar_year(year: &str) -> Vec<CalendarDay>;
         grpc: get_calendar_year;
         request: CalendarYearRequest;
         query: CalendarYearRequestQuery {
             year: year.to_string(),
         };
+        parse: decode::parse_calendar_days;
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -1876,13 +1877,13 @@ impl DirectClient {
     // ═══════════════════════════════════════════════════════════════════
 
     // 60. GetInterestRateHistoryEod
-    raw_endpoint! {
+    parsed_endpoint! {
         /// Fetch end-of-day interest rate history.
         ///
         /// gRPC: `BetaThetaTerminal/GetInterestRateHistoryEod`
         fn interest_rate_history_eod(
             symbol: &str, start_date: &str, end_date: &str
-        ) -> proto::DataTable;
+        ) -> Vec<InterestRateTick>;
         grpc: get_interest_rate_history_eod;
         request: InterestRateHistoryEodRequest;
         query: InterestRateHistoryEodRequestQuery {
@@ -1890,6 +1891,7 @@ impl DirectClient {
             start_date: start_date.to_string(),
             end_date: end_date.to_string(),
         };
+        parse: decode::parse_interest_rate_ticks;
         dates: start_date, end_date;
     }
 
@@ -1965,80 +1967,6 @@ fn validate_date(date: &str) -> Result<(), Error> {
     Ok(())
 }
 
-/// Parse EOD ticks from a `DataTable` using header-based column lookup.
-///
-/// Handles both Price-typed and Number-typed columns transparently.
-fn parse_eod_from_table(table: &proto::DataTable) -> Vec<EodTick> {
-    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
-    let find = |name: &str| h.iter().position(|&s| s == name);
-
-    // EOD rows may have Price-typed cells (value + type) or plain Number cells.
-    // `eod_num` tries Price.value first, then Number, matching the dual-typed
-    // columns that EOD data can return. This is distinct from `decode::row_number`
-    // which only handles Number cells (used for pure tick data).
-    fn eod_num(row: &proto::DataValueList, idx: usize) -> i32 {
-        row.values
-            .get(idx)
-            .and_then(|dv| dv.data_type.as_ref())
-            .and_then(|dt| match dt {
-                proto::data_value::DataType::Number(n) => Some(*n as i32),
-                proto::data_value::DataType::Price(p) => Some(p.value),
-                _ => None,
-            })
-            .unwrap_or(0)
-    }
-
-    // Precompute all column indices once, outside the per-row loop.
-    let ms_of_day_idx = find("ms_of_day");
-    let ms_of_day2_idx = find("ms_of_day2");
-    let open_idx = find("open");
-    let high_idx = find("high");
-    let low_idx = find("low");
-    let close_idx = find("close");
-    let volume_idx = find("volume");
-    let count_idx = find("count");
-    let bid_size_idx = find("bid_size");
-    let bid_exchange_idx = find("bid_exchange");
-    let bid_idx = find("bid");
-    let bid_condition_idx = find("bid_condition");
-    let ask_size_idx = find("ask_size");
-    let ask_exchange_idx = find("ask_exchange");
-    let ask_idx = find("ask");
-    let ask_condition_idx = find("ask_condition");
-    let date_idx = find("date");
-
-    table
-        .data_table
-        .iter()
-        .map(|row| {
-            let pt = open_idx
-                .map(|i| decode::row_price_type(row, i))
-                .unwrap_or(0);
-
-            EodTick {
-                ms_of_day: ms_of_day_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                ms_of_day2: ms_of_day2_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                open: open_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                high: high_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                low: low_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                close: close_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                volume: volume_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                count: count_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                bid_size: bid_size_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                bid_exchange: bid_exchange_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                bid: bid_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                bid_condition: bid_condition_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                ask_size: ask_size_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                ask_exchange: ask_exchange_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                ask: ask_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                ask_condition: ask_condition_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-                price_type: pt,
-                date: date_idx.map(|i| eod_num(row, i)).unwrap_or(0),
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2071,7 +1999,7 @@ mod tests {
             headers: vec!["ms_of_day".into(), "open".into(), "date".into()],
             data_table: vec![],
         };
-        let ticks = parse_eod_from_table(&table);
+        let ticks = decode::parse_eod_ticks(&table);
         assert!(ticks.is_empty());
     }
 
@@ -2101,7 +2029,7 @@ mod tests {
                 ],
             }],
         };
-        let ticks = parse_eod_from_table(&table);
+        let ticks = decode::parse_eod_ticks(&table);
         assert_eq!(ticks.len(), 1);
         assert_eq!(ticks[0].ms_of_day, 34200000);
         assert_eq!(ticks[0].open, 15000);

--- a/crates/thetadatadx/src/types/tick.rs
+++ b/crates/thetadatadx/src/types/tick.rs
@@ -236,6 +236,7 @@ pub struct TradeQuoteTick {
     pub ask_exchange: i32,
     pub ask: i32,
     pub ask_condition: i32,
+    pub quote_price_type: i32,
     // Shared
     pub price_type: i32,
     pub date: i32,
@@ -254,4 +255,106 @@ impl TradeQuoteTick {
     pub fn ask_price(&self) -> Price {
         Price::new(self.ask, self.price_type)
     }
+}
+
+/// Market value tick — 7 fields. Market capitalization and related data.
+#[derive(Debug, Clone, Copy)]
+#[repr(C, align(64))]
+pub struct MarketValueTick {
+    pub ms_of_day: i32,
+    pub market_cap: i64,
+    pub shares_outstanding: i64,
+    pub enterprise_value: i64,
+    pub book_value: i64,
+    pub free_float: i64,
+    pub date: i32,
+}
+
+/// Greeks tick — 24 fields. Full set of option greeks.
+#[derive(Debug, Clone, Copy)]
+#[repr(C, align(64))]
+pub struct GreeksTick {
+    pub ms_of_day: i32,
+    pub implied_volatility: f64,
+    pub delta: f64,
+    pub gamma: f64,
+    pub theta: f64,
+    pub vega: f64,
+    pub rho: f64,
+    pub iv_error: f64,
+    pub vanna: f64,
+    pub charm: f64,
+    pub vomma: f64,
+    pub veta: f64,
+    pub speed: f64,
+    pub zomma: f64,
+    pub color: f64,
+    pub ultima: f64,
+    pub d1: f64,
+    pub d2: f64,
+    pub dual_delta: f64,
+    pub dual_gamma: f64,
+    pub epsilon: f64,
+    pub lambda: f64,
+    pub vera: f64,
+    pub date: i32,
+}
+
+/// Implied volatility tick — 4 fields.
+#[derive(Debug, Clone, Copy)]
+#[repr(C, align(64))]
+pub struct IvTick {
+    pub ms_of_day: i32,
+    pub implied_volatility: f64,
+    pub iv_error: f64,
+    pub date: i32,
+}
+
+/// Price tick — 4 fields. Generic price data point.
+#[derive(Debug, Clone, Copy)]
+#[repr(C, align(64))]
+pub struct PriceTick {
+    pub ms_of_day: i32,
+    pub price: i32,
+    pub price_type: i32,
+    pub date: i32,
+}
+
+impl PriceTick {
+    #[inline]
+    pub fn get_price(&self) -> Price {
+        Price::new(self.price, self.price_type)
+    }
+}
+
+/// Calendar day — 5 fields. Market open/close schedule.
+#[derive(Debug, Clone, Copy)]
+#[repr(C, align(64))]
+pub struct CalendarDay {
+    pub date: i32,
+    pub is_open: i32,
+    pub open_time: i32,
+    pub close_time: i32,
+    pub status: i32,
+}
+
+/// Interest rate tick — 3 fields. End-of-day interest rate.
+#[derive(Debug, Clone, Copy)]
+#[repr(C, align(64))]
+pub struct InterestRateTick {
+    pub ms_of_day: i32,
+    pub rate: f64,
+    pub date: i32,
+}
+
+/// Option contract — 5 fields. Contract specification.
+///
+/// Cannot be `Copy` because of the `String` root field.
+#[derive(Debug, Clone)]
+pub struct OptionContract {
+    pub root: String,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -297,6 +297,7 @@ fn json_to_cstring(val: &serde_json::Value) -> *mut c_char {
 ///
 /// Each row is an array of values matching the header columns.
 /// Values are either strings (text), numbers (int64), or price objects `{"value":N,"type":T}`.
+#[allow(dead_code)]
 fn data_table_to_cstring(table: &thetadatadx::proto::DataTable) -> *mut c_char {
     let headers: Vec<serde_json::Value> = table
         .headers
@@ -536,6 +537,130 @@ fn quote_tick_to_json(t: &thetadatadx::types::tick::QuoteTick) -> serde_json::Va
     })
 }
 
+fn trade_quote_tick_to_json(t: &thetadatadx::types::tick::TradeQuoteTick) -> serde_json::Value {
+    serde_json::json!({
+        "ms_of_day": t.ms_of_day,
+        "sequence": t.sequence,
+        "condition": t.condition,
+        "size": t.size,
+        "exchange": t.exchange,
+        "price": t.trade_price().to_f64(),
+        "price_raw": t.price,
+        "price_type": t.price_type,
+        "condition_flags": t.condition_flags,
+        "price_flags": t.price_flags,
+        "volume_type": t.volume_type,
+        "records_back": t.records_back,
+        "quote_ms_of_day": t.quote_ms_of_day,
+        "bid_size": t.bid_size,
+        "bid_exchange": t.bid_exchange,
+        "bid": t.bid_price().to_f64(),
+        "bid_condition": t.bid_condition,
+        "ask_size": t.ask_size,
+        "ask_exchange": t.ask_exchange,
+        "ask": t.ask_price().to_f64(),
+        "ask_condition": t.ask_condition,
+        "quote_price_type": t.quote_price_type,
+        "date": t.date,
+    })
+}
+
+fn open_interest_tick_to_json(t: &thetadatadx::types::tick::OpenInterestTick) -> serde_json::Value {
+    serde_json::json!({
+        "ms_of_day": t.ms_of_day,
+        "open_interest": t.open_interest,
+        "date": t.date,
+    })
+}
+
+fn market_value_tick_to_json(t: &thetadatadx::types::tick::MarketValueTick) -> serde_json::Value {
+    serde_json::json!({
+        "ms_of_day": t.ms_of_day,
+        "market_cap": t.market_cap,
+        "shares_outstanding": t.shares_outstanding,
+        "enterprise_value": t.enterprise_value,
+        "book_value": t.book_value,
+        "free_float": t.free_float,
+        "date": t.date,
+    })
+}
+
+fn greeks_tick_to_json(t: &thetadatadx::types::tick::GreeksTick) -> serde_json::Value {
+    serde_json::json!({
+        "ms_of_day": t.ms_of_day,
+        "implied_volatility": t.implied_volatility,
+        "delta": t.delta,
+        "gamma": t.gamma,
+        "theta": t.theta,
+        "vega": t.vega,
+        "rho": t.rho,
+        "iv_error": t.iv_error,
+        "vanna": t.vanna,
+        "charm": t.charm,
+        "vomma": t.vomma,
+        "veta": t.veta,
+        "speed": t.speed,
+        "zomma": t.zomma,
+        "color": t.color,
+        "ultima": t.ultima,
+        "d1": t.d1,
+        "d2": t.d2,
+        "dual_delta": t.dual_delta,
+        "dual_gamma": t.dual_gamma,
+        "epsilon": t.epsilon,
+        "lambda": t.lambda,
+        "vera": t.vera,
+        "date": t.date,
+    })
+}
+
+fn iv_tick_to_json(t: &thetadatadx::types::tick::IvTick) -> serde_json::Value {
+    serde_json::json!({
+        "ms_of_day": t.ms_of_day,
+        "implied_volatility": t.implied_volatility,
+        "iv_error": t.iv_error,
+        "date": t.date,
+    })
+}
+
+fn price_tick_to_json(t: &thetadatadx::types::tick::PriceTick) -> serde_json::Value {
+    serde_json::json!({
+        "ms_of_day": t.ms_of_day,
+        "price": t.get_price().to_f64(),
+        "price_raw": t.price,
+        "price_type": t.price_type,
+        "date": t.date,
+    })
+}
+
+fn calendar_day_to_json(t: &thetadatadx::types::tick::CalendarDay) -> serde_json::Value {
+    serde_json::json!({
+        "date": t.date,
+        "is_open": t.is_open,
+        "open_time": t.open_time,
+        "close_time": t.close_time,
+        "status": t.status,
+    })
+}
+
+fn interest_rate_tick_to_json(t: &thetadatadx::types::tick::InterestRateTick) -> serde_json::Value {
+    serde_json::json!({
+        "ms_of_day": t.ms_of_day,
+        "rate": t.rate,
+        "date": t.date,
+    })
+}
+
+fn option_contract_to_json(t: &thetadatadx::types::tick::OptionContract) -> serde_json::Value {
+    serde_json::json!({
+        "root": t.root,
+        "expiration": t.expiration,
+        "strike": t.strike,
+        "right": t.right,
+        "strike_price_type": t.strike_price_type,
+    })
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 //  FFI macros — eliminate boilerplate across all endpoint wrappers
 // ═══════════════════════════════════════════════════════════════════════
@@ -659,49 +784,6 @@ macro_rules! ffi_snapshot_endpoint {
     };
 }
 
-/// FFI wrapper for raw snapshot endpoints (return DataTable as JSON).
-macro_rules! ffi_snapshot_raw_endpoint {
-    (
-        $(#[$meta:meta])*
-        $ffi_name:ident => $method:ident
-    ) => {
-        $(#[$meta])*
-        #[no_mangle]
-        pub unsafe extern "C" fn $ffi_name(
-            client: *const TdxClient,
-            symbols_json: *const c_char,
-        ) -> *mut c_char {
-            if client.is_null() {
-                set_error("client handle is null");
-                return ptr::null_mut();
-            }
-            let client = unsafe { &*client };
-            let json_str = match unsafe { cstr_to_str(symbols_json) } {
-                Some(s) => s,
-                None => {
-                    set_error("symbols_json is null or invalid UTF-8");
-                    return ptr::null_mut();
-                }
-            };
-            let symbols: Vec<String> = match serde_json::from_str(json_str) {
-                Ok(s) => s,
-                Err(e) => {
-                    set_error(&format!("invalid symbols JSON: {}", e));
-                    return ptr::null_mut();
-                }
-            };
-            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-            match runtime().block_on(client.inner.$method(&refs)) {
-                Ok(table) => data_table_to_cstring(&table),
-                Err(e) => {
-                    set_error(&e.to_string());
-                    ptr::null_mut()
-                }
-            }
-        }
-    };
-}
-
 /// FFI wrapper for parsed tick endpoints with C string params.
 macro_rules! ffi_parsed_endpoint {
     (
@@ -743,48 +825,11 @@ macro_rules! ffi_parsed_endpoint {
     };
 }
 
-/// FFI wrapper for raw DataTable endpoints with C string params.
-macro_rules! ffi_raw_endpoint {
+/// FFI wrapper for parsed endpoints with no params.
+macro_rules! ffi_parsed_endpoint_no_params {
     (
         $(#[$meta:meta])*
-        $ffi_name:ident => $method:ident ( $($param:ident),+ )
-    ) => {
-        $(#[$meta])*
-        #[no_mangle]
-        pub unsafe extern "C" fn $ffi_name(
-            client: *const TdxClient,
-            $($param: *const c_char),+
-        ) -> *mut c_char {
-            if client.is_null() {
-                set_error("client handle is null");
-                return ptr::null_mut();
-            }
-            let client = unsafe { &*client };
-            $(
-                let $param = match unsafe { cstr_to_str($param) } {
-                    Some(s) => s,
-                    None => {
-                        set_error(concat!(stringify!($param), " is null or invalid UTF-8"));
-                        return ptr::null_mut();
-                    }
-                };
-            )+
-            match runtime().block_on(client.inner.$method($($param),+)) {
-                Ok(table) => data_table_to_cstring(&table),
-                Err(e) => {
-                    set_error(&e.to_string());
-                    ptr::null_mut()
-                }
-            }
-        }
-    };
-}
-
-/// FFI wrapper for raw DataTable endpoints with no params.
-macro_rules! ffi_raw_endpoint_no_params {
-    (
-        $(#[$meta:meta])*
-        $ffi_name:ident => $method:ident
+        $ffi_name:ident => $method:ident, $tick_to_json:ident
     ) => {
         $(#[$meta])*
         #[no_mangle]
@@ -795,7 +840,11 @@ macro_rules! ffi_raw_endpoint_no_params {
             }
             let client = unsafe { &*client };
             match runtime().block_on(client.inner.$method()) {
-                Ok(table) => data_table_to_cstring(&table),
+                Ok(ticks) => {
+                    let json =
+                        serde_json::Value::Array(ticks.iter().map($tick_to_json).collect());
+                    json_to_cstring(&json)
+                }
                 Err(e) => {
                     set_error(&e.to_string());
                     ptr::null_mut()
@@ -844,9 +893,9 @@ ffi_snapshot_endpoint! {
 }
 
 // 6. stock_snapshot_market_value
-ffi_snapshot_raw_endpoint! {
-    /// Get latest market value snapshot. symbols_json is JSON array. Returns JSON DataTable.
-    tdx_stock_snapshot_market_value => stock_snapshot_market_value
+ffi_snapshot_endpoint! {
+    /// Get latest market value snapshot. symbols_json is JSON array. Returns JSON array.
+    tdx_stock_snapshot_market_value => stock_snapshot_market_value, market_value_tick_to_json
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -884,9 +933,9 @@ ffi_parsed_endpoint! {
 }
 
 // 11. stock_history_trade_quote
-ffi_raw_endpoint! {
-    /// Fetch combined trade + quote ticks. Returns JSON DataTable.
-    tdx_stock_history_trade_quote => stock_history_trade_quote(symbol, date)
+ffi_parsed_endpoint! {
+    /// Fetch combined trade + quote ticks. Returns JSON array.
+    tdx_stock_history_trade_quote => stock_history_trade_quote, trade_quote_tick_to_json(symbol, date)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -934,9 +983,9 @@ ffi_list_endpoint! {
 }
 
 // 18. option_list_contracts
-ffi_raw_endpoint! {
-    /// List all option contracts for a symbol on a date. Returns JSON DataTable.
-    tdx_option_list_contracts => option_list_contracts(request_type, symbol, date)
+ffi_parsed_endpoint! {
+    /// List all option contracts for a symbol on a date. Returns JSON array.
+    tdx_option_list_contracts => option_list_contracts, option_contract_to_json(request_type, symbol, date)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -962,45 +1011,45 @@ ffi_parsed_endpoint! {
 }
 
 // 22. option_snapshot_open_interest
-ffi_raw_endpoint! {
-    /// Get latest open interest snapshot for options. Returns JSON DataTable.
-    tdx_option_snapshot_open_interest => option_snapshot_open_interest(symbol, expiration, strike, right)
+ffi_parsed_endpoint! {
+    /// Get latest open interest snapshot for options. Returns JSON array.
+    tdx_option_snapshot_open_interest => option_snapshot_open_interest, open_interest_tick_to_json(symbol, expiration, strike, right)
 }
 
 // 23. option_snapshot_market_value
-ffi_raw_endpoint! {
-    /// Get latest market value snapshot for options. Returns JSON DataTable.
-    tdx_option_snapshot_market_value => option_snapshot_market_value(symbol, expiration, strike, right)
+ffi_parsed_endpoint! {
+    /// Get latest market value snapshot for options. Returns JSON array.
+    tdx_option_snapshot_market_value => option_snapshot_market_value, market_value_tick_to_json(symbol, expiration, strike, right)
 }
 
 // 24. option_snapshot_greeks_implied_volatility
-ffi_raw_endpoint! {
-    /// Get IV snapshot for options. Returns JSON DataTable.
-    tdx_option_snapshot_greeks_implied_volatility => option_snapshot_greeks_implied_volatility(symbol, expiration, strike, right)
+ffi_parsed_endpoint! {
+    /// Get IV snapshot for options. Returns JSON array.
+    tdx_option_snapshot_greeks_implied_volatility => option_snapshot_greeks_implied_volatility, iv_tick_to_json(symbol, expiration, strike, right)
 }
 
 // 25. option_snapshot_greeks_all
-ffi_raw_endpoint! {
-    /// Get all Greeks snapshot for options. Returns JSON DataTable.
-    tdx_option_snapshot_greeks_all => option_snapshot_greeks_all(symbol, expiration, strike, right)
+ffi_parsed_endpoint! {
+    /// Get all Greeks snapshot for options. Returns JSON array.
+    tdx_option_snapshot_greeks_all => option_snapshot_greeks_all, greeks_tick_to_json(symbol, expiration, strike, right)
 }
 
 // 26. option_snapshot_greeks_first_order
-ffi_raw_endpoint! {
-    /// Get first-order Greeks snapshot. Returns JSON DataTable.
-    tdx_option_snapshot_greeks_first_order => option_snapshot_greeks_first_order(symbol, expiration, strike, right)
+ffi_parsed_endpoint! {
+    /// Get first-order Greeks snapshot. Returns JSON array.
+    tdx_option_snapshot_greeks_first_order => option_snapshot_greeks_first_order, greeks_tick_to_json(symbol, expiration, strike, right)
 }
 
 // 27. option_snapshot_greeks_second_order
-ffi_raw_endpoint! {
-    /// Get second-order Greeks snapshot. Returns JSON DataTable.
-    tdx_option_snapshot_greeks_second_order => option_snapshot_greeks_second_order(symbol, expiration, strike, right)
+ffi_parsed_endpoint! {
+    /// Get second-order Greeks snapshot. Returns JSON array.
+    tdx_option_snapshot_greeks_second_order => option_snapshot_greeks_second_order, greeks_tick_to_json(symbol, expiration, strike, right)
 }
 
 // 28. option_snapshot_greeks_third_order
-ffi_raw_endpoint! {
-    /// Get third-order Greeks snapshot. Returns JSON DataTable.
-    tdx_option_snapshot_greeks_third_order => option_snapshot_greeks_third_order(symbol, expiration, strike, right)
+ffi_parsed_endpoint! {
+    /// Get third-order Greeks snapshot. Returns JSON array.
+    tdx_option_snapshot_greeks_third_order => option_snapshot_greeks_third_order, greeks_tick_to_json(symbol, expiration, strike, right)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1032,15 +1081,15 @@ ffi_parsed_endpoint! {
 }
 
 // 33. option_history_trade_quote
-ffi_raw_endpoint! {
-    /// Fetch combined trade + quote ticks for an option contract. Returns JSON DataTable.
-    tdx_option_history_trade_quote => option_history_trade_quote(symbol, expiration, strike, right, date)
+ffi_parsed_endpoint! {
+    /// Fetch combined trade + quote ticks for an option contract. Returns JSON array.
+    tdx_option_history_trade_quote => option_history_trade_quote, trade_quote_tick_to_json(symbol, expiration, strike, right, date)
 }
 
 // 34. option_history_open_interest
-ffi_raw_endpoint! {
-    /// Fetch open interest history for an option contract. Returns JSON DataTable.
-    tdx_option_history_open_interest => option_history_open_interest(symbol, expiration, strike, right, date)
+ffi_parsed_endpoint! {
+    /// Fetch open interest history for an option contract. Returns JSON array.
+    tdx_option_history_open_interest => option_history_open_interest, open_interest_tick_to_json(symbol, expiration, strike, right, date)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1048,69 +1097,69 @@ ffi_raw_endpoint! {
 // ═══════════════════════════════════════════════════════════════════════
 
 // 35. option_history_greeks_eod
-ffi_raw_endpoint! {
-    /// Fetch EOD Greeks history. Returns JSON DataTable.
-    tdx_option_history_greeks_eod => option_history_greeks_eod(symbol, expiration, strike, right, start_date, end_date)
+ffi_parsed_endpoint! {
+    /// Fetch EOD Greeks history. Returns JSON array.
+    tdx_option_history_greeks_eod => option_history_greeks_eod, greeks_tick_to_json(symbol, expiration, strike, right, start_date, end_date)
 }
 
 // 36. option_history_greeks_all
-ffi_raw_endpoint! {
-    /// Fetch all Greeks history (intraday). Returns JSON DataTable.
-    tdx_option_history_greeks_all => option_history_greeks_all(symbol, expiration, strike, right, date, interval)
+ffi_parsed_endpoint! {
+    /// Fetch all Greeks history (intraday). Returns JSON array.
+    tdx_option_history_greeks_all => option_history_greeks_all, greeks_tick_to_json(symbol, expiration, strike, right, date, interval)
 }
 
 // 37. option_history_trade_greeks_all
-ffi_raw_endpoint! {
-    /// Fetch all Greeks on each trade. Returns JSON DataTable.
-    tdx_option_history_trade_greeks_all => option_history_trade_greeks_all(symbol, expiration, strike, right, date)
+ffi_parsed_endpoint! {
+    /// Fetch all Greeks on each trade. Returns JSON array.
+    tdx_option_history_trade_greeks_all => option_history_trade_greeks_all, greeks_tick_to_json(symbol, expiration, strike, right, date)
 }
 
 // 38. option_history_greeks_first_order
-ffi_raw_endpoint! {
-    /// Fetch first-order Greeks history. Returns JSON DataTable.
-    tdx_option_history_greeks_first_order => option_history_greeks_first_order(symbol, expiration, strike, right, date, interval)
+ffi_parsed_endpoint! {
+    /// Fetch first-order Greeks history. Returns JSON array.
+    tdx_option_history_greeks_first_order => option_history_greeks_first_order, greeks_tick_to_json(symbol, expiration, strike, right, date, interval)
 }
 
 // 39. option_history_trade_greeks_first_order
-ffi_raw_endpoint! {
-    /// Fetch first-order Greeks on each trade. Returns JSON DataTable.
-    tdx_option_history_trade_greeks_first_order => option_history_trade_greeks_first_order(symbol, expiration, strike, right, date)
+ffi_parsed_endpoint! {
+    /// Fetch first-order Greeks on each trade. Returns JSON array.
+    tdx_option_history_trade_greeks_first_order => option_history_trade_greeks_first_order, greeks_tick_to_json(symbol, expiration, strike, right, date)
 }
 
 // 40. option_history_greeks_second_order
-ffi_raw_endpoint! {
-    /// Fetch second-order Greeks history. Returns JSON DataTable.
-    tdx_option_history_greeks_second_order => option_history_greeks_second_order(symbol, expiration, strike, right, date, interval)
+ffi_parsed_endpoint! {
+    /// Fetch second-order Greeks history. Returns JSON array.
+    tdx_option_history_greeks_second_order => option_history_greeks_second_order, greeks_tick_to_json(symbol, expiration, strike, right, date, interval)
 }
 
 // 41. option_history_trade_greeks_second_order
-ffi_raw_endpoint! {
-    /// Fetch second-order Greeks on each trade. Returns JSON DataTable.
-    tdx_option_history_trade_greeks_second_order => option_history_trade_greeks_second_order(symbol, expiration, strike, right, date)
+ffi_parsed_endpoint! {
+    /// Fetch second-order Greeks on each trade. Returns JSON array.
+    tdx_option_history_trade_greeks_second_order => option_history_trade_greeks_second_order, greeks_tick_to_json(symbol, expiration, strike, right, date)
 }
 
 // 42. option_history_greeks_third_order
-ffi_raw_endpoint! {
-    /// Fetch third-order Greeks history. Returns JSON DataTable.
-    tdx_option_history_greeks_third_order => option_history_greeks_third_order(symbol, expiration, strike, right, date, interval)
+ffi_parsed_endpoint! {
+    /// Fetch third-order Greeks history. Returns JSON array.
+    tdx_option_history_greeks_third_order => option_history_greeks_third_order, greeks_tick_to_json(symbol, expiration, strike, right, date, interval)
 }
 
 // 43. option_history_trade_greeks_third_order
-ffi_raw_endpoint! {
-    /// Fetch third-order Greeks on each trade. Returns JSON DataTable.
-    tdx_option_history_trade_greeks_third_order => option_history_trade_greeks_third_order(symbol, expiration, strike, right, date)
+ffi_parsed_endpoint! {
+    /// Fetch third-order Greeks on each trade. Returns JSON array.
+    tdx_option_history_trade_greeks_third_order => option_history_trade_greeks_third_order, greeks_tick_to_json(symbol, expiration, strike, right, date)
 }
 
 // 44. option_history_greeks_implied_volatility
-ffi_raw_endpoint! {
-    /// Fetch IV history (intraday). Returns JSON DataTable.
-    tdx_option_history_greeks_implied_volatility => option_history_greeks_implied_volatility(symbol, expiration, strike, right, date, interval)
+ffi_parsed_endpoint! {
+    /// Fetch IV history (intraday). Returns JSON array.
+    tdx_option_history_greeks_implied_volatility => option_history_greeks_implied_volatility, iv_tick_to_json(symbol, expiration, strike, right, date, interval)
 }
 
 // 45. option_history_trade_greeks_implied_volatility
-ffi_raw_endpoint! {
-    /// Fetch IV on each trade. Returns JSON DataTable.
-    tdx_option_history_trade_greeks_implied_volatility => option_history_trade_greeks_implied_volatility(symbol, expiration, strike, right, date)
+ffi_parsed_endpoint! {
+    /// Fetch IV on each trade. Returns JSON array.
+    tdx_option_history_trade_greeks_implied_volatility => option_history_trade_greeks_implied_volatility, iv_tick_to_json(symbol, expiration, strike, right, date)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1156,15 +1205,15 @@ ffi_snapshot_endpoint! {
 }
 
 // 51. index_snapshot_price
-ffi_snapshot_raw_endpoint! {
-    /// Get latest price snapshot for indices. Returns JSON DataTable.
-    tdx_index_snapshot_price => index_snapshot_price
+ffi_snapshot_endpoint! {
+    /// Get latest price snapshot for indices. Returns JSON array.
+    tdx_index_snapshot_price => index_snapshot_price, price_tick_to_json
 }
 
 // 52. index_snapshot_market_value
-ffi_snapshot_raw_endpoint! {
-    /// Get latest market value snapshot for indices. Returns JSON DataTable.
-    tdx_index_snapshot_market_value => index_snapshot_market_value
+ffi_snapshot_endpoint! {
+    /// Get latest market value snapshot for indices. Returns JSON array.
+    tdx_index_snapshot_market_value => index_snapshot_market_value, market_value_tick_to_json
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1184,9 +1233,9 @@ ffi_parsed_endpoint! {
 }
 
 // 55. index_history_price
-ffi_raw_endpoint! {
-    /// Fetch intraday price history for an index. Returns JSON DataTable.
-    tdx_index_history_price => index_history_price(symbol, date, interval)
+ffi_parsed_endpoint! {
+    /// Fetch intraday price history for an index. Returns JSON array.
+    tdx_index_history_price => index_history_price, price_tick_to_json(symbol, date, interval)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1194,9 +1243,9 @@ ffi_raw_endpoint! {
 // ═══════════════════════════════════════════════════════════════════════
 
 // 56. index_at_time_price
-ffi_raw_endpoint! {
-    /// Fetch index price at a specific time across a date range. Returns JSON DataTable.
-    tdx_index_at_time_price => index_at_time_price(symbol, start_date, end_date, time_of_day)
+ffi_parsed_endpoint! {
+    /// Fetch index price at a specific time across a date range. Returns JSON array.
+    tdx_index_at_time_price => index_at_time_price, price_tick_to_json(symbol, start_date, end_date, time_of_day)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1204,21 +1253,21 @@ ffi_raw_endpoint! {
 // ═══════════════════════════════════════════════════════════════════════
 
 // 57. calendar_open_today
-ffi_raw_endpoint_no_params! {
-    /// Check whether the market is open today. Returns JSON DataTable.
-    tdx_calendar_open_today => calendar_open_today
+ffi_parsed_endpoint_no_params! {
+    /// Check whether the market is open today. Returns JSON array.
+    tdx_calendar_open_today => calendar_open_today, calendar_day_to_json
 }
 
 // 58. calendar_on_date
-ffi_raw_endpoint! {
-    /// Get calendar information for a specific date. Returns JSON DataTable.
-    tdx_calendar_on_date => calendar_on_date(date)
+ffi_parsed_endpoint! {
+    /// Get calendar information for a specific date. Returns JSON array.
+    tdx_calendar_on_date => calendar_on_date, calendar_day_to_json(date)
 }
 
 // 59. calendar_year
-ffi_raw_endpoint! {
-    /// Get calendar information for an entire year. Returns JSON DataTable.
-    tdx_calendar_year => calendar_year(year)
+ffi_parsed_endpoint! {
+    /// Get calendar information for an entire year. Returns JSON array.
+    tdx_calendar_year => calendar_year, calendar_day_to_json(year)
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1226,9 +1275,9 @@ ffi_raw_endpoint! {
 // ═══════════════════════════════════════════════════════════════════════
 
 // 60. interest_rate_history_eod
-ffi_raw_endpoint! {
-    /// Fetch EOD interest rate history. Returns JSON DataTable.
-    tdx_interest_rate_history_eod => interest_rate_history_eod(symbol, start_date, end_date)
+ffi_parsed_endpoint! {
+    /// Fetch EOD interest rate history. Returns JSON array.
+    tdx_interest_rate_history_eod => interest_rate_history_eod, interest_rate_tick_to_json(symbol, start_date, end_date)
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -161,10 +161,112 @@ fn eod_tick_to_dict(py: Python<'_>, e: &tick::EodTick) -> Py<PyAny> {
     dict.into_any().unbind()
 }
 
+fn trade_quote_tick_to_dict(py: Python<'_>, t: &tick::TradeQuoteTick) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("ms_of_day", t.ms_of_day).unwrap();
+    dict.set_item("sequence", t.sequence).unwrap();
+    dict.set_item("condition", t.condition).unwrap();
+    dict.set_item("size", t.size).unwrap();
+    dict.set_item("exchange", t.exchange).unwrap();
+    dict.set_item("price", t.trade_price().to_f64()).unwrap();
+    dict.set_item("bid", t.bid_price().to_f64()).unwrap();
+    dict.set_item("bid_size", t.bid_size).unwrap();
+    dict.set_item("ask", t.ask_price().to_f64()).unwrap();
+    dict.set_item("ask_size", t.ask_size).unwrap();
+    dict.set_item("date", t.date).unwrap();
+    dict.into_any().unbind()
+}
+
+fn open_interest_tick_to_dict(py: Python<'_>, t: &tick::OpenInterestTick) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("ms_of_day", t.ms_of_day).unwrap();
+    dict.set_item("open_interest", t.open_interest).unwrap();
+    dict.set_item("date", t.date).unwrap();
+    dict.into_any().unbind()
+}
+
+fn market_value_tick_to_dict(py: Python<'_>, t: &tick::MarketValueTick) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("ms_of_day", t.ms_of_day).unwrap();
+    dict.set_item("market_cap", t.market_cap).unwrap();
+    dict.set_item("shares_outstanding", t.shares_outstanding)
+        .unwrap();
+    dict.set_item("enterprise_value", t.enterprise_value)
+        .unwrap();
+    dict.set_item("book_value", t.book_value).unwrap();
+    dict.set_item("free_float", t.free_float).unwrap();
+    dict.set_item("date", t.date).unwrap();
+    dict.into_any().unbind()
+}
+
+fn greeks_tick_to_dict(py: Python<'_>, t: &tick::GreeksTick) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("ms_of_day", t.ms_of_day).unwrap();
+    dict.set_item("implied_volatility", t.implied_volatility)
+        .unwrap();
+    dict.set_item("delta", t.delta).unwrap();
+    dict.set_item("gamma", t.gamma).unwrap();
+    dict.set_item("theta", t.theta).unwrap();
+    dict.set_item("vega", t.vega).unwrap();
+    dict.set_item("rho", t.rho).unwrap();
+    dict.set_item("iv_error", t.iv_error).unwrap();
+    dict.set_item("date", t.date).unwrap();
+    dict.into_any().unbind()
+}
+
+fn iv_tick_to_dict(py: Python<'_>, t: &tick::IvTick) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("ms_of_day", t.ms_of_day).unwrap();
+    dict.set_item("implied_volatility", t.implied_volatility)
+        .unwrap();
+    dict.set_item("iv_error", t.iv_error).unwrap();
+    dict.set_item("date", t.date).unwrap();
+    dict.into_any().unbind()
+}
+
+fn price_tick_to_dict(py: Python<'_>, t: &tick::PriceTick) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("ms_of_day", t.ms_of_day).unwrap();
+    dict.set_item("price", t.get_price().to_f64()).unwrap();
+    dict.set_item("price_type", t.price_type).unwrap();
+    dict.set_item("date", t.date).unwrap();
+    dict.into_any().unbind()
+}
+
+fn calendar_day_to_dict(py: Python<'_>, d: &tick::CalendarDay) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("date", d.date).unwrap();
+    dict.set_item("is_open", d.is_open).unwrap();
+    dict.set_item("open_time", d.open_time).unwrap();
+    dict.set_item("close_time", d.close_time).unwrap();
+    dict.set_item("status", d.status).unwrap();
+    dict.into_any().unbind()
+}
+
+fn interest_rate_tick_to_dict(py: Python<'_>, t: &tick::InterestRateTick) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("ms_of_day", t.ms_of_day).unwrap();
+    dict.set_item("rate", t.rate).unwrap();
+    dict.set_item("date", t.date).unwrap();
+    dict.into_any().unbind()
+}
+
+fn option_contract_to_dict(py: Python<'_>, c: &tick::OptionContract) -> Py<PyAny> {
+    let dict = PyDict::new(py);
+    dict.set_item("root", &c.root).unwrap();
+    dict.set_item("expiration", c.expiration).unwrap();
+    dict.set_item("strike", c.strike).unwrap();
+    dict.set_item("right", c.right).unwrap();
+    dict.set_item("strike_price_type", c.strike_price_type)
+        .unwrap();
+    dict.into_any().unbind()
+}
+
 /// Convert a `proto::DataTable` into a Python list of dicts.
 ///
 /// Each dict has the column headers as keys and the corresponding row
 /// values as values (strings, ints, or nested dicts for price/timestamp).
+#[allow(dead_code)]
 fn data_table_to_dicts(py: Python<'_>, table: &thetadatadx::proto::DataTable) -> Vec<Py<PyAny>> {
     use thetadatadx::proto::data_value::DataType;
 
@@ -996,12 +1098,15 @@ impl ThetaDataDx {
         symbols: Vec<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.stock_snapshot_market_value(&refs))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| market_value_tick_to_dict(py, t))
+            .collect())
     }
 
     // Stock — History (5 + bonus)
@@ -1085,12 +1190,15 @@ impl ThetaDataDx {
         symbol: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.stock_history_trade_quote(symbol, date))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| trade_quote_tick_to_dict(py, t))
+            .collect())
     }
 
     // Stock — At-Time (2)
@@ -1152,10 +1260,13 @@ impl ThetaDataDx {
     ) -> PyResult<Vec<String>> {
         py.detach(|| {
             runtime()
-                .block_on(
-                    self.tdx
-                        .option_list_dates(request_type, symbol, expiration, strike, right),
-                )
+                .block_on(self.tdx.option_list_dates(
+                    request_type,
+                    symbol,
+                    expiration,
+                    strike,
+                    right,
+                ))
                 .map_err(to_py_err)
         })
     }
@@ -1185,12 +1296,15 @@ impl ThetaDataDx {
         symbol: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_list_contracts(request_type, symbol, date))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| option_contract_to_dict(py, t))
+            .collect())
     }
 
     // Option — Snapshot (10)
@@ -1257,7 +1371,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1265,7 +1379,10 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| open_interest_tick_to_dict(py, t))
+            .collect())
     }
     fn option_snapshot_market_value(
         &self,
@@ -1275,7 +1392,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1283,7 +1400,10 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| market_value_tick_to_dict(py, t))
+            .collect())
     }
     fn option_snapshot_greeks_implied_volatility(
         &self,
@@ -1293,14 +1413,15 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
-            runtime()
-                .block_on(self.tdx.option_snapshot_greeks_implied_volatility(
-                    symbol, expiration, strike, right,
-                ))
-                .map_err(to_py_err)
-        })?;
-        Ok(data_table_to_dicts(py, &table))
+        let ticks =
+            py.detach(|| {
+                runtime()
+                    .block_on(self.tdx.option_snapshot_greeks_implied_volatility(
+                        symbol, expiration, strike, right,
+                    ))
+                    .map_err(to_py_err)
+            })?;
+        Ok(ticks.iter().map(|t| iv_tick_to_dict(py, t)).collect())
     }
     fn option_snapshot_greeks_all(
         &self,
@@ -1310,7 +1431,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1318,7 +1439,7 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_snapshot_greeks_first_order(
         &self,
@@ -1328,7 +1449,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1336,7 +1457,7 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_snapshot_greeks_second_order(
         &self,
@@ -1346,7 +1467,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1354,7 +1475,7 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_snapshot_greeks_third_order(
         &self,
@@ -1364,7 +1485,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1372,7 +1493,7 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
 
     // Option — History (6)
@@ -1387,13 +1508,14 @@ impl ThetaDataDx {
         start_date: &str,
         end_date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let ticks = py.detach(|| {
-            runtime()
-                .block_on(self.tdx.option_history_eod(
-                    symbol, expiration, strike, right, start_date, end_date,
-                ))
-                .map_err(to_py_err)
-        })?;
+        let ticks =
+            py.detach(|| {
+                runtime()
+                    .block_on(self.tdx.option_history_eod(
+                        symbol, expiration, strike, right, start_date, end_date,
+                    ))
+                    .map_err(to_py_err)
+            })?;
         Ok(ticks.iter().map(|t| eod_tick_to_dict(py, t)).collect())
     }
     fn option_history_ohlc(
@@ -1464,7 +1586,7 @@ impl ThetaDataDx {
         right: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1472,7 +1594,10 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| trade_quote_tick_to_dict(py, t))
+            .collect())
     }
     fn option_history_open_interest(
         &self,
@@ -1483,7 +1608,7 @@ impl ThetaDataDx {
         right: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1491,7 +1616,10 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| open_interest_tick_to_dict(py, t))
+            .collect())
     }
 
     // Option — History Greeks (11)
@@ -1506,14 +1634,14 @@ impl ThetaDataDx {
         start_date: &str,
         end_date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_greeks_eod(
                     symbol, expiration, strike, right, start_date, end_date,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_greeks_all(
         &self,
@@ -1525,14 +1653,15 @@ impl ThetaDataDx {
         date: &str,
         interval: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
-            runtime()
-                .block_on(self.tdx.option_history_greeks_all(
-                    symbol, expiration, strike, right, date, interval,
-                ))
-                .map_err(to_py_err)
-        })?;
-        Ok(data_table_to_dicts(py, &table))
+        let ticks =
+            py.detach(|| {
+                runtime()
+                    .block_on(self.tdx.option_history_greeks_all(
+                        symbol, expiration, strike, right, date, interval,
+                    ))
+                    .map_err(to_py_err)
+            })?;
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_trade_greeks_all(
         &self,
@@ -1543,7 +1672,7 @@ impl ThetaDataDx {
         right: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1551,7 +1680,7 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_greeks_first_order(
         &self,
@@ -1563,14 +1692,14 @@ impl ThetaDataDx {
         date: &str,
         interval: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_greeks_first_order(
                     symbol, expiration, strike, right, date, interval,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_trade_greeks_first_order(
         &self,
@@ -1581,14 +1710,14 @@ impl ThetaDataDx {
         right: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_trade_greeks_first_order(
                     symbol, expiration, strike, right, date,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_greeks_second_order(
         &self,
@@ -1600,14 +1729,14 @@ impl ThetaDataDx {
         date: &str,
         interval: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_greeks_second_order(
                     symbol, expiration, strike, right, date, interval,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_trade_greeks_second_order(
         &self,
@@ -1618,14 +1747,14 @@ impl ThetaDataDx {
         right: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_trade_greeks_second_order(
                     symbol, expiration, strike, right, date,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_greeks_third_order(
         &self,
@@ -1637,14 +1766,14 @@ impl ThetaDataDx {
         date: &str,
         interval: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_greeks_third_order(
                     symbol, expiration, strike, right, date, interval,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_trade_greeks_third_order(
         &self,
@@ -1655,14 +1784,14 @@ impl ThetaDataDx {
         right: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_trade_greeks_third_order(
                     symbol, expiration, strike, right, date,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| greeks_tick_to_dict(py, t)).collect())
     }
     fn option_history_greeks_implied_volatility(
         &self,
@@ -1674,14 +1803,14 @@ impl ThetaDataDx {
         date: &str,
         interval: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_greeks_implied_volatility(
                     symbol, expiration, strike, right, date, interval,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| iv_tick_to_dict(py, t)).collect())
     }
     fn option_history_trade_greeks_implied_volatility(
         &self,
@@ -1692,14 +1821,14 @@ impl ThetaDataDx {
         right: &str,
         date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.option_history_trade_greeks_implied_volatility(
                     symbol, expiration, strike, right, date,
                 ))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| iv_tick_to_dict(py, t)).collect())
     }
 
     // Option — At-Time (2)
@@ -1797,12 +1926,12 @@ impl ThetaDataDx {
         symbols: Vec<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.index_snapshot_price(&refs))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| price_tick_to_dict(py, t)).collect())
     }
     fn index_snapshot_market_value(
         &self,
@@ -1810,12 +1939,15 @@ impl ThetaDataDx {
         symbols: Vec<String>,
     ) -> PyResult<Vec<Py<PyAny>>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.index_snapshot_market_value(&refs))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| market_value_tick_to_dict(py, t))
+            .collect())
     }
 
     // Index — History (3)
@@ -1859,12 +1991,12 @@ impl ThetaDataDx {
         date: &str,
         interval: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.index_history_price(symbol, date, interval))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| price_tick_to_dict(py, t)).collect())
     }
 
     // Index — At-Time (1)
@@ -1877,7 +2009,7 @@ impl ThetaDataDx {
         end_date: &str,
         time_of_day: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1885,34 +2017,34 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| price_tick_to_dict(py, t)).collect())
     }
 
     // Calendar (3)
 
     fn calendar_open_today(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.calendar_open_today())
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| calendar_day_to_dict(py, t)).collect())
     }
     fn calendar_on_date(&self, py: Python<'_>, date: &str) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.calendar_on_date(date))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| calendar_day_to_dict(py, t)).collect())
     }
     fn calendar_year(&self, py: Python<'_>, year: &str) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(self.tdx.calendar_year(year))
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks.iter().map(|t| calendar_day_to_dict(py, t)).collect())
     }
 
     // Interest Rate (1)
@@ -1924,7 +2056,7 @@ impl ThetaDataDx {
         start_date: &str,
         end_date: &str,
     ) -> PyResult<Vec<Py<PyAny>>> {
-        let table = py.detach(|| {
+        let ticks = py.detach(|| {
             runtime()
                 .block_on(
                     self.tdx
@@ -1932,7 +2064,10 @@ impl ThetaDataDx {
                 )
                 .map_err(to_py_err)
         })?;
-        Ok(data_table_to_dicts(py, &table))
+        Ok(ticks
+            .iter()
+            .map(|t| interest_rate_tick_to_dict(py, t))
+            .collect())
     }
 
     // ── DataFrame convenience wrappers ──

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -215,8 +215,8 @@ async fn dispatch_endpoint(
         }
         "stock_snapshot_market_value" => {
             let syms = parse_symbols(get_arg(m, "symbols"));
-            let table = client.stock_snapshot_market_value(&syms).await?;
-            render_data_table(&table, fmt);
+            let ticks = client.stock_snapshot_market_value(&syms).await?;
+            render_market_value(&ticks, fmt);
         }
 
         // ── Stock History ───────────────────────────────────────────
@@ -260,8 +260,8 @@ async fn dispatch_endpoint(
         "stock_history_trade_quote" => {
             let sym = get_arg(m, "symbol");
             let date = get_arg(m, "date");
-            let table = client.stock_history_trade_quote(sym, date).await?;
-            render_data_table(&table, fmt);
+            let ticks = client.stock_history_trade_quote(sym, date).await?;
+            render_trade_quotes(&ticks, fmt);
         }
 
         // ── Stock At-Time ───────────────────────────────────────────
@@ -313,8 +313,8 @@ async fn dispatch_endpoint(
             let rt = get_arg(m, "request_type");
             let sym = get_arg(m, "symbol");
             let date = get_arg(m, "date");
-            let table = client.option_list_contracts(rt, sym, date).await?;
-            render_data_table(&table, fmt);
+            let contracts = client.option_list_contracts(rt, sym, date).await?;
+            render_option_contracts(&contracts, fmt);
         }
 
         // ── Option Snapshot ─────────────────────────────────────────
@@ -339,52 +339,52 @@ async fn dispatch_endpoint(
         }
         "option_snapshot_open_interest" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
-            let table = client
+            let ticks = client
                 .option_snapshot_open_interest(sym, exp, strike, right)
                 .await?;
-            render_data_table(&table, fmt);
+            render_open_interest(&ticks, fmt);
         }
         "option_snapshot_market_value" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
-            let table = client
+            let ticks = client
                 .option_snapshot_market_value(sym, exp, strike, right)
                 .await?;
-            render_data_table(&table, fmt);
+            render_market_value(&ticks, fmt);
         }
         "option_snapshot_greeks_implied_volatility" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_implied_volatility(sym, exp, strike, right)
                 .await?;
-            render_data_table(&table, fmt);
+            render_iv(&ticks, fmt);
         }
         "option_snapshot_greeks_all" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_all(sym, exp, strike, right)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_snapshot_greeks_first_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_first_order(sym, exp, strike, right)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_snapshot_greeks_second_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_second_order(sym, exp, strike, right)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_snapshot_greeks_third_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_third_order(sym, exp, strike, right)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
 
         // ── Option History ──────────────────────────────────────────
@@ -426,18 +426,18 @@ async fn dispatch_endpoint(
         "option_history_trade_quote" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
-            let table = client
+            let ticks = client
                 .option_history_trade_quote(sym, exp, strike, right, date)
                 .await?;
-            render_data_table(&table, fmt);
+            render_trade_quotes(&ticks, fmt);
         }
         "option_history_open_interest" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
-            let table = client
+            let ticks = client
                 .option_history_open_interest(sym, exp, strike, right, date)
                 .await?;
-            render_data_table(&table, fmt);
+            render_open_interest(&ticks, fmt);
         }
 
         // ── Option History Greeks ───────────────────────────────────
@@ -445,95 +445,95 @@ async fn dispatch_endpoint(
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let start = get_arg(m, "start_date");
             let end = get_arg(m, "end_date");
-            let table = client
+            let ticks = client
                 .option_history_greeks_eod(sym, exp, strike, right, start, end)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_greeks_all" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
             let interval = get_arg(m, "interval");
-            let table = client
+            let ticks = client
                 .option_history_greeks_all(sym, exp, strike, right, date, interval)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_trade_greeks_all" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_all(sym, exp, strike, right, date)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_greeks_first_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
             let interval = get_arg(m, "interval");
-            let table = client
+            let ticks = client
                 .option_history_greeks_first_order(sym, exp, strike, right, date, interval)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_trade_greeks_first_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_first_order(sym, exp, strike, right, date)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_greeks_second_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
             let interval = get_arg(m, "interval");
-            let table = client
+            let ticks = client
                 .option_history_greeks_second_order(sym, exp, strike, right, date, interval)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_trade_greeks_second_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_second_order(sym, exp, strike, right, date)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_greeks_third_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
             let interval = get_arg(m, "interval");
-            let table = client
+            let ticks = client
                 .option_history_greeks_third_order(sym, exp, strike, right, date, interval)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_trade_greeks_third_order" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_third_order(sym, exp, strike, right, date)
                 .await?;
-            render_data_table(&table, fmt);
+            render_greeks(&ticks, fmt);
         }
         "option_history_greeks_implied_volatility" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
             let interval = get_arg(m, "interval");
-            let table = client
+            let ticks = client
                 .option_history_greeks_implied_volatility(sym, exp, strike, right, date, interval)
                 .await?;
-            render_data_table(&table, fmt);
+            render_iv(&ticks, fmt);
         }
         "option_history_trade_greeks_implied_volatility" => {
             let (sym, exp, strike, right) = option_contract_args(m)?;
             let date = get_arg(m, "date");
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_implied_volatility(sym, exp, strike, right, date)
                 .await?;
-            render_data_table(&table, fmt);
+            render_iv(&ticks, fmt);
         }
 
         // ── Option At-Time ──────────────────────────────────────────
@@ -577,13 +577,13 @@ async fn dispatch_endpoint(
         }
         "index_snapshot_price" => {
             let syms = parse_symbols(get_arg(m, "symbols"));
-            let table = client.index_snapshot_price(&syms).await?;
-            render_data_table(&table, fmt);
+            let ticks = client.index_snapshot_price(&syms).await?;
+            render_price(&ticks, fmt);
         }
         "index_snapshot_market_value" => {
             let syms = parse_symbols(get_arg(m, "symbols"));
-            let table = client.index_snapshot_market_value(&syms).await?;
-            render_data_table(&table, fmt);
+            let ticks = client.index_snapshot_market_value(&syms).await?;
+            render_market_value(&ticks, fmt);
         }
 
         // ── Index History ───────────────────────────────────────────
@@ -606,8 +606,8 @@ async fn dispatch_endpoint(
             let sym = get_arg(m, "symbol");
             let date = get_arg(m, "date");
             let interval = get_arg(m, "interval");
-            let table = client.index_history_price(sym, date, interval).await?;
-            render_data_table(&table, fmt);
+            let ticks = client.index_history_price(sym, date, interval).await?;
+            render_price(&ticks, fmt);
         }
 
         // ── Index At-Time ───────────────────────────────────────────
@@ -616,24 +616,24 @@ async fn dispatch_endpoint(
             let start = get_arg(m, "start_date");
             let end = get_arg(m, "end_date");
             let tod = get_arg(m, "time_of_day");
-            let table = client.index_at_time_price(sym, start, end, tod).await?;
-            render_data_table(&table, fmt);
+            let ticks = client.index_at_time_price(sym, start, end, tod).await?;
+            render_price(&ticks, fmt);
         }
 
         // ── Calendar ────────────────────────────────────────────────
         "calendar_open_today" => {
-            let table = client.calendar_open_today().await?;
-            render_data_table(&table, fmt);
+            let days = client.calendar_open_today().await?;
+            render_calendar(&days, fmt);
         }
         "calendar_on_date" => {
             let date = get_arg(m, "date");
-            let table = client.calendar_on_date(date).await?;
-            render_data_table(&table, fmt);
+            let days = client.calendar_on_date(date).await?;
+            render_calendar(&days, fmt);
         }
         "calendar_year" => {
             let year = get_arg(m, "year");
-            let table = client.calendar_year(year).await?;
-            render_data_table(&table, fmt);
+            let days = client.calendar_year(year).await?;
+            render_calendar(&days, fmt);
         }
 
         // ── Interest Rate ───────────────────────────────────────────
@@ -641,8 +641,8 @@ async fn dispatch_endpoint(
             let sym = get_arg(m, "symbol");
             let start = get_arg(m, "start_date");
             let end = get_arg(m, "end_date");
-            let table = client.interest_rate_history_eod(sym, start, end).await?;
-            render_data_table(&table, fmt);
+            let ticks = client.interest_rate_history_eod(sym, start, end).await?;
+            render_interest_rates(&ticks, fmt);
         }
 
         other => {
@@ -842,6 +842,7 @@ impl TabularData {
 /// they render as proper `null`.
 const NULL_SENTINEL: &str = "\x00NULL\x00";
 
+#[allow(dead_code)]
 fn render_data_table(table: &thetadatadx::proto::DataTable, fmt: &OutputFormat) {
     let headers: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
     let mut td = TabularData::new(headers);
@@ -1020,6 +1021,177 @@ fn render_string_list(items: &[String], header: &str, fmt: &OutputFormat) {
     let mut td = TabularData::new(vec![header]);
     for s in items {
         td.push(vec![s.clone()]);
+    }
+    td.render(fmt);
+}
+
+fn render_trade_quotes(ticks: &[thetadatadx::types::tick::TradeQuoteTick], fmt: &OutputFormat) {
+    let mut td = TabularData::new(vec![
+        "date",
+        "time",
+        "price",
+        "size",
+        "exchange",
+        "condition",
+        "sequence",
+        "quote_time",
+        "bid",
+        "bid_size",
+        "ask",
+        "ask_size",
+    ]);
+    for t in ticks {
+        td.push(vec![
+            format_date(t.date),
+            format_ms(t.ms_of_day),
+            format_price(t.price, t.price_type),
+            format!("{}", t.size),
+            format!("{}", t.exchange),
+            format!("{}", t.condition),
+            format!("{}", t.sequence),
+            format_ms(t.quote_ms_of_day),
+            format_price(t.bid, t.price_type),
+            format!("{}", t.bid_size),
+            format_price(t.ask, t.price_type),
+            format!("{}", t.ask_size),
+        ]);
+    }
+    td.render(fmt);
+}
+
+fn render_open_interest(ticks: &[thetadatadx::types::tick::OpenInterestTick], fmt: &OutputFormat) {
+    let mut td = TabularData::new(vec!["date", "ms_of_day", "open_interest"]);
+    for t in ticks {
+        td.push(vec![
+            format_date(t.date),
+            format_ms(t.ms_of_day),
+            format!("{}", t.open_interest),
+        ]);
+    }
+    td.render(fmt);
+}
+
+fn render_market_value(ticks: &[thetadatadx::types::tick::MarketValueTick], fmt: &OutputFormat) {
+    let mut td = TabularData::new(vec![
+        "date",
+        "ms_of_day",
+        "market_cap",
+        "shares_outstanding",
+        "enterprise_value",
+        "book_value",
+        "free_float",
+    ]);
+    for t in ticks {
+        td.push(vec![
+            format_date(t.date),
+            format_ms(t.ms_of_day),
+            format!("{}", t.market_cap),
+            format!("{}", t.shares_outstanding),
+            format!("{}", t.enterprise_value),
+            format!("{}", t.book_value),
+            format!("{}", t.free_float),
+        ]);
+    }
+    td.render(fmt);
+}
+
+fn render_greeks(ticks: &[thetadatadx::types::tick::GreeksTick], fmt: &OutputFormat) {
+    let mut td = TabularData::new(vec![
+        "date",
+        "ms_of_day",
+        "iv",
+        "delta",
+        "gamma",
+        "theta",
+        "vega",
+        "rho",
+    ]);
+    for t in ticks {
+        td.push(vec![
+            format_date(t.date),
+            format_ms(t.ms_of_day),
+            format!("{:.6}", t.implied_volatility),
+            format!("{:.6}", t.delta),
+            format!("{:.6}", t.gamma),
+            format!("{:.6}", t.theta),
+            format!("{:.6}", t.vega),
+            format!("{:.6}", t.rho),
+        ]);
+    }
+    td.render(fmt);
+}
+
+fn render_iv(ticks: &[thetadatadx::types::tick::IvTick], fmt: &OutputFormat) {
+    let mut td = TabularData::new(vec!["date", "ms_of_day", "implied_volatility", "iv_error"]);
+    for t in ticks {
+        td.push(vec![
+            format_date(t.date),
+            format_ms(t.ms_of_day),
+            format!("{:.6}", t.implied_volatility),
+            format!("{:.6}", t.iv_error),
+        ]);
+    }
+    td.render(fmt);
+}
+
+fn render_price(ticks: &[thetadatadx::types::tick::PriceTick], fmt: &OutputFormat) {
+    let mut td = TabularData::new(vec!["date", "ms_of_day", "price", "price_type"]);
+    for t in ticks {
+        td.push(vec![
+            format_date(t.date),
+            format_ms(t.ms_of_day),
+            format_price(t.price, t.price_type),
+            format!("{}", t.price_type),
+        ]);
+    }
+    td.render(fmt);
+}
+
+fn render_calendar(days: &[thetadatadx::types::tick::CalendarDay], fmt: &OutputFormat) {
+    let mut td = TabularData::new(vec!["date", "is_open", "open_time", "close_time", "status"]);
+    for d in days {
+        td.push(vec![
+            format_date(d.date),
+            format!("{}", d.is_open),
+            format_ms(d.open_time),
+            format_ms(d.close_time),
+            format!("{}", d.status),
+        ]);
+    }
+    td.render(fmt);
+}
+
+fn render_interest_rates(ticks: &[thetadatadx::types::tick::InterestRateTick], fmt: &OutputFormat) {
+    let mut td = TabularData::new(vec!["date", "ms_of_day", "rate"]);
+    for t in ticks {
+        td.push(vec![
+            format_date(t.date),
+            format_ms(t.ms_of_day),
+            format!("{:.6}", t.rate),
+        ]);
+    }
+    td.render(fmt);
+}
+
+fn render_option_contracts(
+    contracts: &[thetadatadx::types::tick::OptionContract],
+    fmt: &OutputFormat,
+) {
+    let mut td = TabularData::new(vec![
+        "root",
+        "expiration",
+        "strike",
+        "right",
+        "strike_price_type",
+    ]);
+    for c in contracts {
+        td.push(vec![
+            c.root.clone(),
+            format!("{}", c.expiration),
+            format!("{}", c.strike),
+            format!("{}", c.right),
+            format!("{}", c.strike_price_type),
+        ]);
     }
     td.render(fmt);
 }

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -219,12 +219,16 @@ fn sanitize_error(msg: &str) -> String {
         // Email pattern: contains @ with word chars on both sides
         } else if bytes[i] == b'@' && i > 0 && is_email_boundary(&result, bytes, i, len) {
             // Walk back to erase the local part we already pushed
-            while result.ends_with(|c: char| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' || c == '+') {
+            while result.ends_with(|c: char| {
+                c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-' || c == '+'
+            }) {
                 result.pop();
             }
             // Skip forward past the domain part
             i += 1; // skip @
-            while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'.' || bytes[i] == b'-') {
+            while i < len
+                && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'.' || bytes[i] == b'-')
+            {
                 i += 1;
             }
             result.push_str("[REDACTED]");
@@ -424,6 +428,7 @@ fn tool_definitions() -> Vec<Value> {
 //  Serialization helpers
 // ═══════════════════════════════════════════════════════════════════════════
 
+#[allow(dead_code)]
 fn serialize_data_table(table: &thetadatadx::proto::DataTable) -> Value {
     let headers: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
     let rows: Vec<Value> = table
@@ -539,6 +544,129 @@ fn serialize_quote_ticks(ticks: &[thetadatadx::types::tick::QuoteTick]) -> Value
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
+}
+
+fn serialize_trade_quote_ticks(ticks: &[thetadatadx::types::tick::TradeQuoteTick]) -> Value {
+    let rows: Vec<Value> = ticks
+        .iter()
+        .map(|t| {
+            json!({
+                "date": t.date,
+                "ms_of_day": t.ms_of_day,
+                "price": t.trade_price().to_f64(),
+                "size": t.size,
+                "exchange": t.exchange,
+                "condition": t.condition,
+                "sequence": t.sequence,
+                "bid": t.bid_price().to_f64(),
+                "bid_size": t.bid_size,
+                "ask": t.ask_price().to_f64(),
+                "ask_size": t.ask_size,
+            })
+        })
+        .collect();
+    json!({ "ticks": rows, "count": rows.len() })
+}
+
+fn serialize_open_interest_ticks(ticks: &[thetadatadx::types::tick::OpenInterestTick]) -> Value {
+    let rows: Vec<Value> = ticks
+        .iter()
+        .map(
+            |t| json!({"date": t.date, "ms_of_day": t.ms_of_day, "open_interest": t.open_interest}),
+        )
+        .collect();
+    json!({ "ticks": rows, "count": rows.len() })
+}
+
+fn serialize_market_value_ticks(ticks: &[thetadatadx::types::tick::MarketValueTick]) -> Value {
+    let rows: Vec<Value> = ticks
+        .iter()
+        .map(|t| {
+            json!({
+                "date": t.date, "ms_of_day": t.ms_of_day,
+                "market_cap": t.market_cap, "shares_outstanding": t.shares_outstanding,
+                "enterprise_value": t.enterprise_value, "book_value": t.book_value,
+                "free_float": t.free_float,
+            })
+        })
+        .collect();
+    json!({ "ticks": rows, "count": rows.len() })
+}
+
+fn serialize_greeks_ticks(ticks: &[thetadatadx::types::tick::GreeksTick]) -> Value {
+    let rows: Vec<Value> = ticks
+        .iter()
+        .map(|t| {
+            json!({
+                "date": t.date, "ms_of_day": t.ms_of_day,
+                "implied_volatility": t.implied_volatility, "delta": t.delta,
+                "gamma": t.gamma, "theta": t.theta, "vega": t.vega, "rho": t.rho,
+                "iv_error": t.iv_error,
+            })
+        })
+        .collect();
+    json!({ "ticks": rows, "count": rows.len() })
+}
+
+fn serialize_iv_ticks(ticks: &[thetadatadx::types::tick::IvTick]) -> Value {
+    let rows: Vec<Value> = ticks
+        .iter()
+        .map(|t| {
+            json!({
+                "date": t.date, "ms_of_day": t.ms_of_day,
+                "implied_volatility": t.implied_volatility, "iv_error": t.iv_error,
+            })
+        })
+        .collect();
+    json!({ "ticks": rows, "count": rows.len() })
+}
+
+fn serialize_price_ticks(ticks: &[thetadatadx::types::tick::PriceTick]) -> Value {
+    let rows: Vec<Value> = ticks
+        .iter()
+        .map(|t| {
+            json!({
+                "date": t.date, "ms_of_day": t.ms_of_day,
+                "price": t.get_price().to_f64(),
+            })
+        })
+        .collect();
+    json!({ "ticks": rows, "count": rows.len() })
+}
+
+fn serialize_calendar_days(days: &[thetadatadx::types::tick::CalendarDay]) -> Value {
+    let rows: Vec<Value> = days
+        .iter()
+        .map(|d| {
+            json!({
+                "date": d.date, "is_open": d.is_open,
+                "open_time": d.open_time, "close_time": d.close_time,
+                "status": d.status,
+            })
+        })
+        .collect();
+    json!({ "days": rows, "count": rows.len() })
+}
+
+fn serialize_interest_rate_ticks(ticks: &[thetadatadx::types::tick::InterestRateTick]) -> Value {
+    let rows: Vec<Value> = ticks
+        .iter()
+        .map(|t| json!({"date": t.date, "ms_of_day": t.ms_of_day, "rate": t.rate}))
+        .collect();
+    json!({ "ticks": rows, "count": rows.len() })
+}
+
+fn serialize_option_contracts(contracts: &[thetadatadx::types::tick::OptionContract]) -> Value {
+    let rows: Vec<Value> = contracts
+        .iter()
+        .map(|c| {
+            json!({
+                "root": c.root, "expiration": c.expiration,
+                "strike": c.strike, "right": c.right,
+            })
+        })
+        .collect();
+    json!({ "contracts": rows, "count": rows.len() })
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -733,8 +861,8 @@ async fn execute_tool(
         "stock_snapshot_market_value" => {
             let syms_str = param!(arg_symbol(args, "symbols"));
             let syms = parse_symbols(syms_str);
-            let table = api!(client.stock_snapshot_market_value(&syms).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.stock_snapshot_market_value(&syms).await);
+            Ok(serialize_market_value_ticks(&ticks))
         }
 
         // ── Stock History ───────────────────────────────────────────
@@ -780,8 +908,8 @@ async fn execute_tool(
         "stock_history_trade_quote" => {
             let sym = param!(arg_symbol(args, "symbol"));
             let date = param!(arg_date(args, "date"));
-            let table = api!(client.stock_history_trade_quote(sym, date).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.stock_history_trade_quote(sym, date).await);
+            Ok(serialize_trade_quote_ticks(&ticks))
         }
 
         // ── Stock At-Time ───────────────────────────────────────────
@@ -831,8 +959,8 @@ async fn execute_tool(
             let rt = param!(arg_str(args, "request_type"));
             let sym = param!(arg_symbol(args, "symbol"));
             let date = param!(arg_date(args, "date"));
-            let table = api!(client.option_list_contracts(rt, sym, date).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.option_list_contracts(rt, sym, date).await);
+            Ok(serialize_option_contracts(&ticks))
         }
 
         // ── Option Snapshot ─────────────────────────────────────────
@@ -864,60 +992,60 @@ async fn execute_tool(
                     Ok(serialize_quote_ticks(&ticks))
                 }
                 "option_snapshot_open_interest" => {
-                    let table = api!(
+                    let ticks = api!(
                         client
                             .option_snapshot_open_interest(sym, exp, strike, right)
                             .await
                     );
-                    Ok(serialize_data_table(&table))
+                    Ok(serialize_open_interest_ticks(&ticks))
                 }
                 "option_snapshot_market_value" => {
-                    let table = api!(
+                    let ticks = api!(
                         client
                             .option_snapshot_market_value(sym, exp, strike, right)
                             .await
                     );
-                    Ok(serialize_data_table(&table))
+                    Ok(serialize_market_value_ticks(&ticks))
                 }
                 "option_snapshot_greeks_implied_volatility" => {
-                    let table = api!(
+                    let ticks = api!(
                         client
                             .option_snapshot_greeks_implied_volatility(sym, exp, strike, right)
                             .await
                     );
-                    Ok(serialize_data_table(&table))
+                    Ok(serialize_iv_ticks(&ticks))
                 }
                 "option_snapshot_greeks_all" => {
-                    let table = api!(
+                    let ticks = api!(
                         client
                             .option_snapshot_greeks_all(sym, exp, strike, right)
                             .await
                     );
-                    Ok(serialize_data_table(&table))
+                    Ok(serialize_greeks_ticks(&ticks))
                 }
                 "option_snapshot_greeks_first_order" => {
-                    let table = api!(
+                    let ticks = api!(
                         client
                             .option_snapshot_greeks_first_order(sym, exp, strike, right)
                             .await
                     );
-                    Ok(serialize_data_table(&table))
+                    Ok(serialize_greeks_ticks(&ticks))
                 }
                 "option_snapshot_greeks_second_order" => {
-                    let table = api!(
+                    let ticks = api!(
                         client
                             .option_snapshot_greeks_second_order(sym, exp, strike, right)
                             .await
                     );
-                    Ok(serialize_data_table(&table))
+                    Ok(serialize_greeks_ticks(&ticks))
                 }
                 "option_snapshot_greeks_third_order" => {
-                    let table = api!(
+                    let ticks = api!(
                         client
                             .option_snapshot_greeks_third_order(sym, exp, strike, right)
                             .await
                     );
-                    Ok(serialize_data_table(&table))
+                    Ok(serialize_greeks_ticks(&ticks))
                 }
                 _ => unreachable!(),
             }
@@ -985,12 +1113,12 @@ async fn execute_tool(
             let strike = param!(arg_str(args, "strike"));
             let right = param!(arg_right(args, "right"));
             let date = param!(arg_date(args, "date"));
-            let table = api!(
+            let ticks = api!(
                 client
                     .option_history_trade_quote(sym, exp, strike, right, date)
                     .await
             );
-            Ok(serialize_data_table(&table))
+            Ok(serialize_trade_quote_ticks(&ticks))
         }
         "option_history_open_interest" => {
             let sym = param!(arg_symbol(args, "symbol"));
@@ -998,12 +1126,12 @@ async fn execute_tool(
             let strike = param!(arg_str(args, "strike"));
             let right = param!(arg_right(args, "right"));
             let date = param!(arg_date(args, "date"));
-            let table = api!(
+            let ticks = api!(
                 client
                     .option_history_open_interest(sym, exp, strike, right, date)
                     .await
             );
-            Ok(serialize_data_table(&table))
+            Ok(serialize_open_interest_ticks(&ticks))
         }
 
         // ── Option History Greeks ───────────────────────────────────
@@ -1014,26 +1142,25 @@ async fn execute_tool(
             let right = param!(arg_right(args, "right"));
             let start = param!(arg_date(args, "start_date"));
             let end = param!(arg_date(args, "end_date"));
-            let table = api!(
+            let ticks = api!(
                 client
                     .option_history_greeks_eod(sym, exp, strike, right, start, end)
                     .await
             );
-            Ok(serialize_data_table(&table))
+            Ok(serialize_greeks_ticks(&ticks))
         }
-        // Greeks with interval (6 endpoints)
+        // Greeks with interval (4 endpoints)
         "option_history_greeks_all"
         | "option_history_greeks_first_order"
         | "option_history_greeks_second_order"
-        | "option_history_greeks_third_order"
-        | "option_history_greeks_implied_volatility" => {
+        | "option_history_greeks_third_order" => {
             let sym = param!(arg_symbol(args, "symbol"));
             let exp = param!(arg_date(args, "expiration"));
             let strike = param!(arg_str(args, "strike"));
             let right = param!(arg_right(args, "right"));
             let date = param!(arg_date(args, "date"));
             let interval = param!(arg_interval(args, "interval"));
-            let table = match name {
+            let ticks = match name {
                 "option_history_greeks_all" => api!(
                     client
                         .option_history_greeks_all(sym, exp, strike, right, date, interval)
@@ -1046,7 +1173,9 @@ async fn execute_tool(
                 ),
                 "option_history_greeks_second_order" => api!(
                     client
-                        .option_history_greeks_second_order(sym, exp, strike, right, date, interval)
+                        .option_history_greeks_second_order(
+                            sym, exp, strike, right, date, interval,
+                        )
                         .await
                 ),
                 "option_history_greeks_third_order" => api!(
@@ -1054,29 +1183,37 @@ async fn execute_tool(
                         .option_history_greeks_third_order(sym, exp, strike, right, date, interval)
                         .await
                 ),
-                "option_history_greeks_implied_volatility" => api!(
-                    client
-                        .option_history_greeks_implied_volatility(
-                            sym, exp, strike, right, date, interval
-                        )
-                        .await
-                ),
                 _ => unreachable!(),
             };
-            Ok(serialize_data_table(&table))
+            Ok(serialize_greeks_ticks(&ticks))
         }
-        // Trade Greeks (5 endpoints, no interval)
-        "option_history_trade_greeks_all"
-        | "option_history_trade_greeks_first_order"
-        | "option_history_trade_greeks_second_order"
-        | "option_history_trade_greeks_third_order"
-        | "option_history_trade_greeks_implied_volatility" => {
+        "option_history_greeks_implied_volatility" => {
             let sym = param!(arg_symbol(args, "symbol"));
             let exp = param!(arg_date(args, "expiration"));
             let strike = param!(arg_str(args, "strike"));
             let right = param!(arg_right(args, "right"));
             let date = param!(arg_date(args, "date"));
-            let table = match name {
+            let interval = param!(arg_interval(args, "interval"));
+            let ticks = api!(
+                client
+                    .option_history_greeks_implied_volatility(
+                        sym, exp, strike, right, date, interval,
+                    )
+                    .await
+            );
+            Ok(serialize_iv_ticks(&ticks))
+        }
+        // Trade Greeks (4 endpoints, no interval)
+        "option_history_trade_greeks_all"
+        | "option_history_trade_greeks_first_order"
+        | "option_history_trade_greeks_second_order"
+        | "option_history_trade_greeks_third_order" => {
+            let sym = param!(arg_symbol(args, "symbol"));
+            let exp = param!(arg_date(args, "expiration"));
+            let strike = param!(arg_str(args, "strike"));
+            let right = param!(arg_right(args, "right"));
+            let date = param!(arg_date(args, "date"));
+            let ticks = match name {
                 "option_history_trade_greeks_all" => api!(
                     client
                         .option_history_trade_greeks_all(sym, exp, strike, right, date)
@@ -1097,16 +1234,22 @@ async fn execute_tool(
                         .option_history_trade_greeks_third_order(sym, exp, strike, right, date)
                         .await
                 ),
-                "option_history_trade_greeks_implied_volatility" => api!(
-                    client
-                        .option_history_trade_greeks_implied_volatility(
-                            sym, exp, strike, right, date
-                        )
-                        .await
-                ),
                 _ => unreachable!(),
             };
-            Ok(serialize_data_table(&table))
+            Ok(serialize_greeks_ticks(&ticks))
+        }
+        "option_history_trade_greeks_implied_volatility" => {
+            let sym = param!(arg_symbol(args, "symbol"));
+            let exp = param!(arg_date(args, "expiration"));
+            let strike = param!(arg_str(args, "strike"));
+            let right = param!(arg_right(args, "right"));
+            let date = param!(arg_date(args, "date"));
+            let ticks = api!(
+                client
+                    .option_history_trade_greeks_implied_volatility(sym, exp, strike, right, date)
+                    .await
+            );
+            Ok(serialize_iv_ticks(&ticks))
         }
 
         // ── Option At-Time ──────────────────────────────────────────
@@ -1162,14 +1305,14 @@ async fn execute_tool(
         "index_snapshot_price" => {
             let syms_str = param!(arg_symbol(args, "symbols"));
             let syms = parse_symbols(syms_str);
-            let table = api!(client.index_snapshot_price(&syms).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.index_snapshot_price(&syms).await);
+            Ok(serialize_price_ticks(&ticks))
         }
         "index_snapshot_market_value" => {
             let syms_str = param!(arg_symbol(args, "symbols"));
             let syms = parse_symbols(syms_str);
-            let table = api!(client.index_snapshot_market_value(&syms).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.index_snapshot_market_value(&syms).await);
+            Ok(serialize_market_value_ticks(&ticks))
         }
 
         // ── Index History ───────────────────────────────────────────
@@ -1192,8 +1335,8 @@ async fn execute_tool(
             let sym = param!(arg_symbol(args, "symbol"));
             let date = param!(arg_date(args, "date"));
             let interval = param!(arg_interval(args, "interval"));
-            let table = api!(client.index_history_price(sym, date, interval).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.index_history_price(sym, date, interval).await);
+            Ok(serialize_price_ticks(&ticks))
         }
 
         // ── Index At-Time ───────────────────────────────────────────
@@ -1202,24 +1345,24 @@ async fn execute_tool(
             let start = param!(arg_date(args, "start_date"));
             let end = param!(arg_date(args, "end_date"));
             let tod = param!(arg_str(args, "time_of_day"));
-            let table = api!(client.index_at_time_price(sym, start, end, tod).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.index_at_time_price(sym, start, end, tod).await);
+            Ok(serialize_price_ticks(&ticks))
         }
 
         // ── Calendar ────────────────────────────────────────────────
         "calendar_open_today" => {
-            let table = api!(client.calendar_open_today().await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.calendar_open_today().await);
+            Ok(serialize_calendar_days(&ticks))
         }
         "calendar_on_date" => {
             let date = param!(arg_date(args, "date"));
-            let table = api!(client.calendar_on_date(date).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.calendar_on_date(date).await);
+            Ok(serialize_calendar_days(&ticks))
         }
         "calendar_year" => {
             let year = param!(arg_str(args, "year"));
-            let table = api!(client.calendar_year(year).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.calendar_year(year).await);
+            Ok(serialize_calendar_days(&ticks))
         }
 
         // ── Interest Rate ───────────────────────────────────────────
@@ -1227,8 +1370,8 @@ async fn execute_tool(
             let sym = param!(arg_symbol(args, "symbol"));
             let start = param!(arg_date(args, "start_date"));
             let end = param!(arg_date(args, "end_date"));
-            let table = api!(client.interest_rate_history_eod(sym, start, end).await);
-            Ok(serialize_data_table(&table))
+            let ticks = api!(client.interest_rate_history_eod(sym, start, end).await);
+            Ok(serialize_interest_rate_ticks(&ticks))
         }
 
         _ => Err(ToolError::InvalidParams(format!("unknown tool: {name}"))),

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -151,10 +151,179 @@ pub fn quote_ticks_to_json(ticks: &[QuoteTick]) -> Vec<sonic_rs::Value> {
         .collect()
 }
 
+/// Convert trade+quote ticks to JSON array.
+pub fn trade_quote_ticks_to_json(ticks: &[TradeQuoteTick]) -> Vec<sonic_rs::Value> {
+    ticks
+        .iter()
+        .map(|t| {
+            sonic_rs::json!({
+                "ms_of_day": t.ms_of_day,
+                "sequence": t.sequence,
+                "size": t.size,
+                "condition": t.condition,
+                "price": fmt_price(t.price, t.price_type),
+                "exchange": t.exchange,
+                "quote_ms_of_day": t.quote_ms_of_day,
+                "bid_size": t.bid_size,
+                "bid_exchange": t.bid_exchange,
+                "bid": fmt_price(t.bid, t.price_type),
+                "bid_condition": t.bid_condition,
+                "ask_size": t.ask_size,
+                "ask_exchange": t.ask_exchange,
+                "ask": fmt_price(t.ask, t.price_type),
+                "ask_condition": t.ask_condition,
+                "date": t.date
+            })
+        })
+        .collect()
+}
+
+/// Convert open interest ticks to JSON array.
+pub fn open_interest_ticks_to_json(ticks: &[OpenInterestTick]) -> Vec<sonic_rs::Value> {
+    ticks
+        .iter()
+        .map(|t| {
+            sonic_rs::json!({
+                "ms_of_day": t.ms_of_day,
+                "open_interest": t.open_interest,
+                "date": t.date
+            })
+        })
+        .collect()
+}
+
+/// Convert market value ticks to JSON array.
+pub fn market_value_ticks_to_json(ticks: &[MarketValueTick]) -> Vec<sonic_rs::Value> {
+    ticks
+        .iter()
+        .map(|t| {
+            sonic_rs::json!({
+                "ms_of_day": t.ms_of_day,
+                "market_cap": t.market_cap,
+                "shares_outstanding": t.shares_outstanding,
+                "enterprise_value": t.enterprise_value,
+                "book_value": t.book_value,
+                "free_float": t.free_float,
+                "date": t.date
+            })
+        })
+        .collect()
+}
+
+/// Convert greeks ticks to JSON array.
+pub fn greeks_ticks_to_json(ticks: &[GreeksTick]) -> Vec<sonic_rs::Value> {
+    ticks
+        .iter()
+        .map(|t| {
+            sonic_rs::json!({
+                "ms_of_day": t.ms_of_day,
+                "implied_volatility": t.implied_volatility,
+                "delta": t.delta,
+                "gamma": t.gamma,
+                "theta": t.theta,
+                "vega": t.vega,
+                "rho": t.rho,
+                "iv_error": t.iv_error,
+                "vanna": t.vanna,
+                "charm": t.charm,
+                "vomma": t.vomma,
+                "veta": t.veta,
+                "speed": t.speed,
+                "zomma": t.zomma,
+                "color": t.color,
+                "ultima": t.ultima,
+                "d1": t.d1,
+                "d2": t.d2,
+                "dual_delta": t.dual_delta,
+                "dual_gamma": t.dual_gamma,
+                "epsilon": t.epsilon,
+                "lambda": t.lambda,
+                "vera": t.vera,
+                "date": t.date
+            })
+        })
+        .collect()
+}
+
+/// Convert IV ticks to JSON array.
+pub fn iv_ticks_to_json(ticks: &[IvTick]) -> Vec<sonic_rs::Value> {
+    ticks
+        .iter()
+        .map(|t| {
+            sonic_rs::json!({
+                "ms_of_day": t.ms_of_day,
+                "implied_volatility": t.implied_volatility,
+                "iv_error": t.iv_error,
+                "date": t.date
+            })
+        })
+        .collect()
+}
+
+/// Convert price ticks to JSON array.
+pub fn price_ticks_to_json(ticks: &[PriceTick]) -> Vec<sonic_rs::Value> {
+    ticks
+        .iter()
+        .map(|t| {
+            sonic_rs::json!({
+                "ms_of_day": t.ms_of_day,
+                "price": fmt_price(t.price, t.price_type),
+                "date": t.date
+            })
+        })
+        .collect()
+}
+
+/// Convert calendar days to JSON array.
+pub fn calendar_days_to_json(days: &[CalendarDay]) -> Vec<sonic_rs::Value> {
+    days.iter()
+        .map(|d| {
+            sonic_rs::json!({
+                "date": d.date,
+                "is_open": d.is_open,
+                "open_time": d.open_time,
+                "close_time": d.close_time,
+                "status": d.status
+            })
+        })
+        .collect()
+}
+
+/// Convert interest rate ticks to JSON array.
+pub fn interest_rate_ticks_to_json(ticks: &[InterestRateTick]) -> Vec<sonic_rs::Value> {
+    ticks
+        .iter()
+        .map(|t| {
+            sonic_rs::json!({
+                "ms_of_day": t.ms_of_day,
+                "rate": t.rate,
+                "date": t.date
+            })
+        })
+        .collect()
+}
+
+/// Convert option contracts to JSON array.
+pub fn option_contracts_to_json(contracts: &[OptionContract]) -> Vec<sonic_rs::Value> {
+    contracts
+        .iter()
+        .map(|c| {
+            sonic_rs::json!({
+                "root": c.root,
+                "expiration": c.expiration,
+                "strike": c.strike,
+                "right": c.right,
+                "strike_price_type": c.strike_price_type
+            })
+        })
+        .collect()
+}
+
 /// Convert a raw `DataTable` to a JSON array of objects.
 ///
 /// Proto `DataValue.data_type` oneof variants:
 /// - `Text(String)`, `Number(i64)`, `Price(Price)`, `Timestamp(ZonedDateTime)`, `NullValue(i32)`
+#[allow(dead_code)]
 pub fn data_table_to_json(table: &proto::DataTable) -> Vec<sonic_rs::Value> {
     table
         .data_table
@@ -203,10 +372,7 @@ pub fn json_to_csv(response: &[sonic_rs::Value]) -> Option<String> {
     let first = response.first()?;
     let obj = first.as_object()?;
     let null_val = sonic_rs::Value::default();
-    let keys: Vec<&str> = obj
-        .iter()
-        .map(|(k, _)| k)
-        .collect();
+    let keys: Vec<&str> = obj.iter().map(|(k, _)| k).collect();
     if keys.is_empty() {
         return None;
     }

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -112,9 +112,11 @@ pub async fn generic(
         Ok(json_val) => {
             if use_csv {
                 // Extract the "response" array and convert to CSV.
-                if let Some(arr) = json_val.get("response").and_then(|v: &sonic_rs::Value| v.as_array()) {
-                    let items: Vec<sonic_rs::Value> =
-                        arr.iter().cloned().collect();
+                if let Some(arr) = json_val
+                    .get("response")
+                    .and_then(|v: &sonic_rs::Value| v.as_array())
+                {
+                    let items: Vec<sonic_rs::Value> = arr.iter().cloned().collect();
                     if let Some(csv) = format::json_to_csv(&items) {
                         return (
                             StatusCode::OK,
@@ -164,11 +166,19 @@ async fn dispatch(
     let date = || get_param(params, "date", "date");
     let interval = || {
         let v = get_param(params, "interval", "ivl");
-        if v.is_empty() { "60000".to_string() } else { v }
+        if v.is_empty() {
+            "60000".to_string()
+        } else {
+            v
+        }
     };
     let interval_quote = || {
         let v = get_param(params, "interval", "ivl");
-        if v.is_empty() { "0".to_string() } else { v }
+        if v.is_empty() {
+            "0".to_string()
+        } else {
+            v
+        }
     };
     let exp = || get_param(params, "expiration", "exp");
     let strike = || get_param(params, "strike", "strike");
@@ -210,8 +220,10 @@ async fn dispatch(
         "stock_snapshot_market_value" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let table = client.stock_snapshot_market_value(&syms).await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            let ticks = client.stock_snapshot_market_value(&syms).await?;
+            Ok(format::ok_envelope(format::market_value_ticks_to_json(
+                &ticks,
+            )))
         }
 
         // ── Stock History (6) ───────────────────────────────────────
@@ -242,8 +254,10 @@ async fn dispatch(
             Ok(format::ok_envelope(format::quote_ticks_to_json(&ticks)))
         }
         "stock_history_trade_quote" => {
-            let table = client.stock_history_trade_quote(&sym(), &date()).await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            let ticks = client.stock_history_trade_quote(&sym(), &date()).await?;
+            Ok(format::ok_envelope(format::trade_quote_ticks_to_json(
+                &ticks,
+            )))
         }
 
         // ── Stock At-Time (2) ───────────────────────────────────────
@@ -280,10 +294,12 @@ async fn dispatch(
             Ok(format::list_envelope(&items))
         }
         "option_list_contracts" => {
-            let table = client
+            let ticks = client
                 .option_list_contracts(&request_type(), &sym(), &date())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::option_contracts_to_json(
+                &ticks,
+            )))
         }
 
         // ── Option Snapshot (10) ────────────────────────────────────
@@ -306,46 +322,50 @@ async fn dispatch(
             Ok(format::ok_envelope(format::quote_ticks_to_json(&ticks)))
         }
         "option_snapshot_open_interest" => {
-            let table = client
+            let ticks = client
                 .option_snapshot_open_interest(&sym(), &exp(), &strike(), &right())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::open_interest_ticks_to_json(
+                &ticks,
+            )))
         }
         "option_snapshot_market_value" => {
-            let table = client
+            let ticks = client
                 .option_snapshot_market_value(&sym(), &exp(), &strike(), &right())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::market_value_ticks_to_json(
+                &ticks,
+            )))
         }
         "option_snapshot_greeks_implied_volatility" => {
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_implied_volatility(&sym(), &exp(), &strike(), &right())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::iv_ticks_to_json(&ticks)))
         }
         "option_snapshot_greeks_all" => {
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_all(&sym(), &exp(), &strike(), &right())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_snapshot_greeks_first_order" => {
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_first_order(&sym(), &exp(), &strike(), &right())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_snapshot_greeks_second_order" => {
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_second_order(&sym(), &exp(), &strike(), &right())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_snapshot_greeks_third_order" => {
-            let table = client
+            let ticks = client
                 .option_snapshot_greeks_third_order(&sym(), &exp(), &strike(), &right())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
 
         // ── Option History (6) ──────────────────────────────────────
@@ -381,27 +401,31 @@ async fn dispatch(
             Ok(format::ok_envelope(format::quote_ticks_to_json(&ticks)))
         }
         "option_history_trade_quote" => {
-            let table = client
+            let ticks = client
                 .option_history_trade_quote(&sym(), &exp(), &strike(), &right(), &date())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::trade_quote_ticks_to_json(
+                &ticks,
+            )))
         }
         "option_history_open_interest" => {
-            let table = client
+            let ticks = client
                 .option_history_open_interest(&sym(), &exp(), &strike(), &right(), &date())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::open_interest_ticks_to_json(
+                &ticks,
+            )))
         }
 
         // ── Option History Greeks (12) ──────────────────────────────
         "option_history_greeks_eod" => {
-            let table = client
+            let ticks = client
                 .option_history_greeks_eod(&sym(), &exp(), &strike(), &right(), &start(), &end())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_greeks_all" => {
-            let table = client
+            let ticks = client
                 .option_history_greeks_all(
                     &sym(),
                     &exp(),
@@ -411,16 +435,16 @@ async fn dispatch(
                     &interval(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_trade_greeks_all" => {
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_all(&sym(), &exp(), &strike(), &right(), &date())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_greeks_first_order" => {
-            let table = client
+            let ticks = client
                 .option_history_greeks_first_order(
                     &sym(),
                     &exp(),
@@ -430,10 +454,10 @@ async fn dispatch(
                     &interval(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_trade_greeks_first_order" => {
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_first_order(
                     &sym(),
                     &exp(),
@@ -442,10 +466,10 @@ async fn dispatch(
                     &date(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_greeks_second_order" => {
-            let table = client
+            let ticks = client
                 .option_history_greeks_second_order(
                     &sym(),
                     &exp(),
@@ -455,10 +479,10 @@ async fn dispatch(
                     &interval(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_trade_greeks_second_order" => {
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_second_order(
                     &sym(),
                     &exp(),
@@ -467,10 +491,10 @@ async fn dispatch(
                     &date(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_greeks_third_order" => {
-            let table = client
+            let ticks = client
                 .option_history_greeks_third_order(
                     &sym(),
                     &exp(),
@@ -480,10 +504,10 @@ async fn dispatch(
                     &interval(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_trade_greeks_third_order" => {
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_third_order(
                     &sym(),
                     &exp(),
@@ -492,10 +516,10 @@ async fn dispatch(
                     &date(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_history_greeks_implied_volatility" => {
-            let table = client
+            let ticks = client
                 .option_history_greeks_implied_volatility(
                     &sym(),
                     &exp(),
@@ -505,10 +529,10 @@ async fn dispatch(
                     &interval(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::iv_ticks_to_json(&ticks)))
         }
         "option_history_trade_greeks_implied_volatility" => {
-            let table = client
+            let ticks = client
                 .option_history_trade_greeks_implied_volatility(
                     &sym(),
                     &exp(),
@@ -517,7 +541,7 @@ async fn dispatch(
                     &date(),
                 )
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::iv_ticks_to_json(&ticks)))
         }
 
         // ── Option At-Time (2) ──────────────────────────────────────
@@ -570,14 +594,16 @@ async fn dispatch(
         "index_snapshot_price" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let table = client.index_snapshot_price(&syms).await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            let ticks = client.index_snapshot_price(&syms).await?;
+            Ok(format::ok_envelope(format::price_ticks_to_json(&ticks)))
         }
         "index_snapshot_market_value" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let table = client.index_snapshot_market_value(&syms).await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            let ticks = client.index_snapshot_market_value(&syms).await?;
+            Ok(format::ok_envelope(format::market_value_ticks_to_json(
+                &ticks,
+            )))
         }
 
         // ── Index History (3) ───────────────────────────────────────
@@ -592,40 +618,42 @@ async fn dispatch(
             Ok(format::ok_envelope(format::ohlc_ticks_to_json(&ticks)))
         }
         "index_history_price" => {
-            let table = client
+            let ticks = client
                 .index_history_price(&sym(), &date(), &interval())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::price_ticks_to_json(&ticks)))
         }
 
         // ── Index At-Time (1) ───────────────────────────────────────
         "index_at_time_price" => {
-            let table = client
+            let ticks = client
                 .index_at_time_price(&sym(), &start(), &end(), &time_of_day())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::price_ticks_to_json(&ticks)))
         }
 
         // ── Calendar (3) ────────────────────────────────────────────
         "calendar_open_today" => {
-            let table = client.calendar_open_today().await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            let ticks = client.calendar_open_today().await?;
+            Ok(format::ok_envelope(format::calendar_days_to_json(&ticks)))
         }
         "calendar_on_date" => {
-            let table = client.calendar_on_date(&date()).await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            let ticks = client.calendar_on_date(&date()).await?;
+            Ok(format::ok_envelope(format::calendar_days_to_json(&ticks)))
         }
         "calendar_year" => {
-            let table = client.calendar_year(&year()).await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            let ticks = client.calendar_year(&year()).await?;
+            Ok(format::ok_envelope(format::calendar_days_to_json(&ticks)))
         }
 
         // ── Interest Rate (1) ───────────────────────────────────────
         "interest_rate_history_eod" => {
-            let table = client
+            let ticks = client
                 .interest_rate_history_eod(&sym(), &start(), &end())
                 .await?;
-            Ok(format::ok_envelope(format::data_table_to_json(&table)))
+            Ok(format::ok_envelope(format::interest_rate_ticks_to_json(
+                &ticks,
+            )))
         }
 
         _ => Err(thetadatadx::Error::Config(format!(
@@ -652,10 +680,7 @@ pub async fn system_fpss_status(State(state): State<AppState>) -> Response {
 }
 
 /// GET /v2/system/shutdown -- requires `X-Shutdown-Token` header.
-pub async fn system_shutdown(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-) -> Response {
+pub async fn system_shutdown(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let token = headers
         .get("X-Shutdown-Token")
         .and_then(|v| v.to_str().ok())

--- a/tools/server/src/router.rs
+++ b/tools/server/src/router.rs
@@ -98,12 +98,13 @@ pub fn build(state: AppState) -> Router {
         if let Some(path) = endpoint_to_path(ep) {
             let ep_arc: &'static EndpointMeta = ep;
             let ep_shared = Arc::new(ep_arc);
-            let handler_fn =
-                move |s: axum::extract::State<AppState>,
-                      q: axum::extract::Query<std::collections::HashMap<String, String>>| {
-                    let ep = Arc::clone(&ep_shared);
-                    async move { handler::generic(s, q, &ep).await }
-                };
+            let handler_fn = move |s: axum::extract::State<AppState>,
+                                   q: axum::extract::Query<
+                std::collections::HashMap<String, String>,
+            >| {
+                let ep = Arc::clone(&ep_shared);
+                async move { handler::generic(s, q, &ep).await }
+            };
             app = app.route(&path, get(handler_fn));
             registered += 1;
             tracing::debug!(endpoint = ep.name, path = %path, "registered route");
@@ -117,7 +118,10 @@ pub fn build(state: AppState) -> Router {
         }
     }
 
-    tracing::info!(count = registered, "registered endpoint routes from registry");
+    tracing::info!(
+        count = registered,
+        "registered endpoint routes from registry"
+    );
 
     // System routes
     app = app

--- a/tools/server/src/state.rs
+++ b/tools/server/src/state.rs
@@ -8,10 +8,10 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use tokio::sync::broadcast;
 use thetadatadx::direct::DirectClient;
 use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::ThetaDataDx;
+use tokio::sync::broadcast;
 
 /// Capacity of the broadcast channel used to fan out FPSS events to WebSocket
 /// clients.  4096 is chosen because:


### PR DESCRIPTION
## Summary
All 31 endpoints that returned raw `proto::DataTable` now return typed Rust structs. The `raw_endpoint!` macro has been removed entirely.

- 9 new tick types in `types/tick.rs`
- 10 parse functions in `decode.rs` 
- All FFI, CLI, Server, MCP, Python SDK updated

Every endpoint in every SDK (Rust, Python, C++, Go) now returns native typed structures. Zero raw JSON or protobuf in the public API.

## Test plan
- [x] 160 tests pass
- [x] cargo fmt / clippy clean
- [x] All downstream crates compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)