### PR TITLE
docs: show inline credential construction in all SDK examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ use thetadatadx::{ThetaDataDx, Credentials, DirectConfig};
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
+    // Or inline: let creds = Credentials::new("user@example.com", "your-password");
     let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 
     let eod = tdx.stock_history_eod("AAPL", "20240101", "20240301").await?;
@@ -73,6 +74,7 @@ pip install thetadatadx
 from thetadatadx import Credentials, Config, ThetaDataDx
 
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 tdx = ThetaDataDx(creds, Config.production())
 
 eod = tdx.stock_history_eod("AAPL", "20240101", "20240301")

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -29,6 +29,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), thetadatadx::Error> {
 //!     let creds = Credentials::from_file("creds.txt")?;
+//!     // Or inline: let creds = Credentials::new("user@example.com", "your-password");
 //!
 //!     // Connect -- authenticates once, historical ready immediately
 //!     let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
@@ -61,6 +62,7 @@
 //! use thetadatadx::{ThetaDataDx, Credentials, DirectConfig};
 //!
 //! let creds = Credentials::from_file("creds.txt")?;
+//! // Or inline: let creds = Credentials::new("user@example.com", "your-password");
 //! let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 //! let ticks = tdx.stock_history_eod("AAPL", "20240101", "20240301").await?;
 //! ```

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -9,6 +9,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), thetadatadx::Error> {
 //!     // One connect, one auth. FPSS is NOT connected yet.
+//!     // Or inline: Credentials::new("user@example.com", "your-password")
 //!     let tdx = ThetaDataDx::connect(
 //!         &Credentials::from_file("creds.txt")?,
 //!         DirectConfig::production(),

--- a/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
+++ b/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
@@ -590,6 +590,7 @@ function pyHeader(): string {
   return `from thetadatadx import ThetaDataDx, Credentials, Config
 
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 tdx = ThetaDataDx(creds, Config.production())`
 }
 
@@ -603,6 +604,7 @@ function rustMain(body: string): string {
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
+    // Or inline: let creds = Credentials::new("user@example.com", "your-password");
     let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 
 ${body}
@@ -1246,6 +1248,7 @@ use std::sync::{Arc, Mutex};
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
+    // Or inline: let creds = Credentials::new("user@example.com", "your-password");
     let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 
     let contracts: Arc<Mutex<HashMap<i32, String>>> = Arc::new(Mutex::new(HashMap::new()));
@@ -1290,6 +1293,7 @@ use std::sync::{Arc, Mutex};
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
+    // Or inline: let creds = Credentials::new("user@example.com", "your-password");
     let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 
     let contracts: Arc<Mutex<HashMap<i32, String>>> = Arc::new(Mutex::new(HashMap::new()));
@@ -1334,6 +1338,7 @@ use std::sync::{Arc, Mutex};
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
+    // Or inline: let creds = Credentials::new("user@example.com", "your-password");
     let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 
     let min_size: u32 = ${minSize()};
@@ -1377,6 +1382,7 @@ use std::sync::{Arc, Mutex};
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
+    // Or inline: let creds = Credentials::new("user@example.com", "your-password");
     let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 
     let symbol = "${sym()}";

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -85,6 +85,7 @@ use thetadatadx::{ThetaDataDx, Credentials, DirectConfig};
 async fn main() -> Result<(), thetadatadx::Error> {
     // Load credentials
     let creds = Credentials::from_file("creds.txt")?;
+    // Or inline: let creds = Credentials::new("user@example.com", "your-password");
 
     // Connect to ThetaData (authenticates automatically)
     let client = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
@@ -122,6 +123,7 @@ from thetadatadx import Credentials, Config, ThetaDataDx
 
 # Authenticate and connect
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 client = ThetaDataDx(creds, Config.production())
 
 # Fetch end-of-day stock data
@@ -156,6 +158,7 @@ import (
 func main() {
     // Load credentials
     creds, err := thetadatadx.CredentialsFromFile("creds.txt")
+    // Or inline: creds, err := thetadatadx.NewCredentials("user@example.com", "your-password")
     if err != nil {
         log.Fatal(err)
     }
@@ -197,6 +200,7 @@ func main() {
 int main() {
     // Load credentials
     auto creds = tdx::Credentials::from_file("creds.txt");
+    // Or inline: auto creds = tdx::Credentials("user@example.com", "your-password");
 
     // Connect
     auto client = tdx::Client::connect(creds, tdx::Config::production());
@@ -257,6 +261,7 @@ The Python SDK provides convenience methods that return pandas DataFrames direct
 from thetadatadx import Credentials, Config, ThetaDataDx, to_dataframe
 
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 client = ThetaDataDx(creds, Config.production())
 
 # Option 1: explicit conversion
@@ -279,6 +284,7 @@ All Go SDK objects that wrap FFI handles must be closed when no longer needed:
 
 ```go
 creds, _ := thetadatadx.CredentialsFromFile("creds.txt")
+// Or inline: creds, _ := thetadatadx.NewCredentials("user@example.com", "your-password")
 defer creds.Close()  // frees the Rust-side allocation
 
 config := thetadatadx.ProductionConfig()

--- a/docs-site/docs/streaming.md
+++ b/docs-site/docs/streaming.md
@@ -23,6 +23,7 @@ use thetadatadx::fpss::{FpssData, FpssControl, FpssEvent};
 use thetadatadx::fpss::protocol::Contract;
 
 let creds = Credentials::from_file("creds.txt")?;
+// Or inline: let creds = Credentials::new("user@example.com", "your-password");
 let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 
 tdx.start_streaming(|event: &FpssEvent| {
@@ -44,12 +45,14 @@ tdx.start_streaming(|event: &FpssEvent| {
 from thetadatadx import Credentials, Config, ThetaDataDx
 
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 tdx = ThetaDataDx(creds, Config.production())
 
 tdx.start_streaming()
 ```
 ```go [Go]
 creds, _ := thetadatadx.CredentialsFromFile("creds.txt")
+// Or inline: creds, _ := thetadatadx.NewCredentials("user@example.com", "your-password")
 defer creds.Close()
 
 config := thetadatadx.ProductionConfig()
@@ -60,6 +63,7 @@ defer fpss.Close()
 ```
 ```cpp [C++]
 auto creds = tdx::Credentials::from_file("creds.txt");
+// Or inline: auto creds = tdx::Credentials("user@example.com", "your-password");
 auto config = tdx::Config::production();
 tdx::FpssClient fpss(creds, config);
 ```
@@ -487,6 +491,7 @@ use std::sync::{Arc, Mutex};
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
+    // Or inline: let creds = Credentials::new("user@example.com", "your-password");
     let tdx = ThetaDataDx::connect(&creds, DirectConfig::production()).await?;
 
     let contracts: Arc<Mutex<HashMap<i32, Contract>>> = Arc::new(Mutex::new(HashMap::new()));
@@ -533,6 +538,7 @@ import signal
 import sys
 
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 tdx = ThetaDataDx(creds, Config.production())
 
 # Start streaming
@@ -583,6 +589,7 @@ import (
 
 func main() {
     creds, _ := thetadatadx.CredentialsFromFile("creds.txt")
+    // Or inline: creds, _ := thetadatadx.NewCredentials("user@example.com", "your-password")
     defer creds.Close()
 
     config := thetadatadx.ProductionConfig()
@@ -628,6 +635,7 @@ func main() {
 
 int main() {
     auto creds = tdx::Credentials::from_file("creds.txt");
+    // Or inline: auto creds = tdx::Credentials("user@example.com", "your-password");
     auto config = tdx::Config::production();
 
     // Historical client

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -42,6 +42,7 @@ Run the example:
 
 int main() {
     auto creds = tdx::Credentials::from_file("creds.txt");
+    // Or inline: auto creds = tdx::Credentials("user@example.com", "your-password");
     auto client = tdx::Client::connect(creds, tdx::Config::production());
 
     // Fetch EOD stock data
@@ -260,6 +261,7 @@ Real-time market data via ThetaData's FPSS servers. Streaming uses a **separate 
 
 int main() {
     auto creds = tdx::Credentials::from_file("creds.txt");
+    // Or inline: auto creds = tdx::Credentials("user@example.com", "your-password");
     auto config = tdx::Config::production();
 
     // Create a streaming client (separate from the historical Client)

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -42,6 +42,7 @@ import (
 
 func main() {
     creds, err := thetadatadx.CredentialsFromFile("creds.txt")
+    // Or inline: creds, err := thetadatadx.NewCredentials("user@example.com", "your-password")
     if err != nil {
         log.Fatal(err)
     }
@@ -267,6 +268,7 @@ import (
 
 func main() {
     creds, err := thetadatadx.CredentialsFromFile("creds.txt")
+    // Or inline: creds, err := thetadatadx.NewCredentials("user@example.com", "your-password")
     if err != nil {
         log.Fatal(err)
     }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -33,6 +33,7 @@ from thetadatadx import Credentials, Config, ThetaDataDx
 
 # Authenticate and connect
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 tdx = ThetaDataDx(creds, Config.production())
 
 # Fetch end-of-day data
@@ -279,6 +280,7 @@ Real-time market data via ThetaData's FPSS servers:
 from thetadatadx import Credentials, Config, ThetaDataDx
 
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 tdx = ThetaDataDx(creds, Config.production())
 
 # Start streaming and subscribe to real-time data
@@ -307,6 +309,7 @@ Convert any result to a pandas DataFrame:
 from thetadatadx import Credentials, Config, ThetaDataDx, to_dataframe
 
 creds = Credentials.from_file("creds.txt")
+# Or inline: creds = Credentials("user@example.com", "your-password")
 tdx = ThetaDataDx(creds, Config.production())
 
 # Option 1: convert an existing result


### PR DESCRIPTION
## Summary

- Every Quick Start and Connect section now shows both credential patterns
- `from_file("creds.txt")` remains the default, inline is shown as a comment alternative
- Updated: root README, Python/Go/C++ READMEs, docs-site pages, crate docs, query builder

Fixes #26.

## Test plan
- [x] cargo fmt clean
- [x] 4 doc-tests pass
- [x] No existing examples broken (inline shown as comment only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)