### PR TITLE
feat: nanosecond receive timestamp on every FPSS event

### DIFF
--- a/crates/tdbe/src/latency.rs
+++ b/crates/tdbe/src/latency.rs
@@ -1,0 +1,189 @@
+//! Wire-to-application latency computation for FPSS events.
+//!
+//! Converts the exchange-side `ms_of_day` (Eastern Time) and `event_date`
+//! (YYYYMMDD) into epoch nanoseconds, then subtracts from the local
+//! `received_at_ns` wall-clock timestamp captured at frame decode time.
+//!
+//! No external timezone crate -- uses the same civil-date math and US DST
+//! rules (Energy Policy Act 2005) as `thetadatadx::decode`.
+
+/// Compute wire-to-application latency in nanoseconds.
+///
+/// # Arguments
+///
+/// * `exchange_ms_of_day` -- milliseconds since midnight ET from the tick
+/// * `event_date` -- YYYYMMDD integer from the tick
+/// * `received_at_ns` -- nanoseconds since UNIX epoch from `FpssData.received_at_ns`
+///
+/// # Returns
+///
+/// Latency in nanoseconds. May be negative if clocks are skewed (exchange
+/// timestamp ahead of local wall clock).
+pub fn latency_ns(exchange_ms_of_day: i32, event_date: i32, received_at_ns: u64) -> i64 {
+    let exchange_epoch_ns = exchange_epoch_ns(exchange_ms_of_day, event_date);
+    received_at_ns as i64 - exchange_epoch_ns
+}
+
+/// Convert `event_date` (YYYYMMDD) + `ms_of_day` (Eastern Time) to epoch nanoseconds.
+fn exchange_epoch_ns(ms_of_day: i32, date_yyyymmdd: i32) -> i64 {
+    let year = date_yyyymmdd / 10000;
+    let month = ((date_yyyymmdd % 10000) / 100) as u32;
+    let day = (date_yyyymmdd % 100) as u32;
+
+    let days = civil_to_epoch_days(year, month, day);
+    // Midnight UTC for that civil date
+    let midnight_utc_ms = days * 86_400_000;
+
+    // The ms_of_day is in Eastern Time. We need the UTC offset for this date.
+    // Use the midday point (ms_of_day ~ 12:00) to determine DST status,
+    // since market hours (09:30-16:00 ET) are unambiguous for DST.
+    let approx_utc_ms = midnight_utc_ms + ms_of_day as i64 + 5 * 3600 * 1000; // rough EST guess
+    let offset_ms = eastern_offset_ms(approx_utc_ms as u64);
+
+    // exchange_epoch_ms = midnight_utc_ms + ms_of_day - offset_ms
+    // (offset_ms is negative, e.g. -5h for EST, so subtracting it adds hours)
+    let exchange_epoch_ms = midnight_utc_ms + ms_of_day as i64 - offset_ms;
+    exchange_epoch_ms * 1_000_000
+}
+
+// ---------------------------------------------------------------------------
+//  Civil-date / DST helpers (same algorithm as thetadatadx::decode)
+// ---------------------------------------------------------------------------
+
+/// Convert civil date to days since 1970-01-01 (Euclidean algorithm).
+fn civil_to_epoch_days(year: i32, month: u32, day: u32) -> i64 {
+    let y = if month <= 2 {
+        year as i64 - 1
+    } else {
+        year as i64
+    };
+    let m = if month <= 2 {
+        month as i64 + 9
+    } else {
+        month as i64 - 3
+    };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = (y - era * 400) as u64;
+    let doy = (153 * m as u64 + 2) / 5 + day as u64 - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe as i64 - 719468
+}
+
+/// Eastern Time UTC offset in milliseconds for a given epoch_ms.
+///
+/// US DST rule (Energy Policy Act of 2005):
+/// - EDT (UTC-4): second Sunday of March 2:00 AM local -> first Sunday of November 2:00 AM local
+/// - EST (UTC-5): rest of the year
+fn eastern_offset_ms(epoch_ms: u64) -> i64 {
+    let epoch_secs = epoch_ms as i64 / 1000;
+    let days_since_epoch = epoch_secs / 86400;
+
+    // Civil date from days since 1970-01-01.
+    let z = days_since_epoch + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let year = yoe as i32 + (era * 400) as i32;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { year + 1 } else { year };
+
+    let dst_start_utc = march_second_sunday_utc(year);
+    let dst_end_utc = november_first_sunday_utc(year);
+
+    let epoch_ms_i64 = epoch_ms as i64;
+    if epoch_ms_i64 >= dst_start_utc && epoch_ms_i64 < dst_end_utc {
+        -4 * 3600 * 1000 // EDT
+    } else {
+        -5 * 3600 * 1000 // EST
+    }
+}
+
+/// Epoch ms of the second Sunday of March at 7:00 AM UTC (= 2:00 AM EST).
+fn march_second_sunday_utc(year: i32) -> i64 {
+    let mar1 = civil_to_epoch_days(year, 3, 1);
+    let dow = ((mar1 + 3) % 7 + 7) % 7; // 0=Mon..6=Sun
+    let days_to_first_sunday = (6 - dow + 7) % 7;
+    let second_sunday = mar1 + days_to_first_sunday + 7;
+    second_sunday * 86_400_000 + 7 * 3600 * 1000
+}
+
+/// Epoch ms of the first Sunday of November at 6:00 AM UTC (= 2:00 AM EDT).
+fn november_first_sunday_utc(year: i32) -> i64 {
+    let nov1 = civil_to_epoch_days(year, 11, 1);
+    let dow = ((nov1 + 3) % 7 + 7) % 7;
+    let days_to_first_sunday = (6 - dow + 7) % 7;
+    let first_sunday = nov1 + days_to_first_sunday;
+    first_sunday * 86_400_000 + 6 * 3600 * 1000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latency_basic_est() {
+        // 2024-01-15 is a Monday in EST (UTC-5).
+        // 09:30 AM ET = 34_200_000 ms_of_day
+        // 09:30 AM ET = 14:30 UTC = 14*3600 + 30*60 = 52200 seconds since midnight UTC
+        // Epoch seconds for 2024-01-15 00:00:00 UTC:
+        let days = civil_to_epoch_days(2024, 1, 15);
+        let midnight_utc_ns = days * 86_400_000 * 1_000_000;
+        // 14:30 UTC in nanoseconds offset
+        let utc_offset_ns = (14 * 3600 + 30 * 60) as i64 * 1_000_000_000;
+        let received_at_ns = (midnight_utc_ns + utc_offset_ns) as u64;
+
+        // If received_at_ns == exchange epoch time, latency should be ~0.
+        let lat = latency_ns(34_200_000, 20240115, received_at_ns);
+        assert!(
+            lat.abs() < 1_000_000, // less than 1ms rounding
+            "expected ~0 latency, got {lat} ns"
+        );
+    }
+
+    #[test]
+    fn latency_basic_edt() {
+        // 2024-06-15 is in EDT (UTC-4).
+        // 09:30 AM ET = 34_200_000 ms_of_day
+        // 09:30 AM ET = 13:30 UTC
+        let days = civil_to_epoch_days(2024, 6, 15);
+        let midnight_utc_ns = days * 86_400_000 * 1_000_000;
+        let utc_offset_ns = (13 * 3600 + 30 * 60) as i64 * 1_000_000_000;
+        let received_at_ns = (midnight_utc_ns + utc_offset_ns) as u64;
+
+        let lat = latency_ns(34_200_000, 20240615, received_at_ns);
+        assert!(lat.abs() < 1_000_000, "expected ~0 latency, got {lat} ns");
+    }
+
+    #[test]
+    fn latency_positive_when_received_later() {
+        // Receive 100ms after the exchange timestamp.
+        let days = civil_to_epoch_days(2024, 1, 15);
+        let midnight_utc_ns = days * 86_400_000 * 1_000_000;
+        let utc_offset_ns = (14 * 3600 + 30 * 60) as i64 * 1_000_000_000;
+        let received_at_ns = (midnight_utc_ns + utc_offset_ns) as u64 + 100_000_000; // +100ms
+
+        let lat = latency_ns(34_200_000, 20240115, received_at_ns);
+        // Should be ~100ms = 100_000_000 ns
+        assert!(
+            (lat - 100_000_000).abs() < 1_000_000,
+            "expected ~100ms latency, got {lat} ns"
+        );
+    }
+
+    #[test]
+    fn latency_negative_when_clock_skewed() {
+        // Receive 50ms BEFORE the exchange timestamp (clock skew).
+        let days = civil_to_epoch_days(2024, 1, 15);
+        let midnight_utc_ns = days * 86_400_000 * 1_000_000;
+        let utc_offset_ns = (14 * 3600 + 30 * 60) as i64 * 1_000_000_000;
+        let received_at_ns = (midnight_utc_ns + utc_offset_ns) as u64 - 50_000_000; // -50ms
+
+        let lat = latency_ns(34_200_000, 20240115, received_at_ns);
+        assert!(
+            (lat + 50_000_000).abs() < 1_000_000,
+            "expected ~-50ms latency, got {lat} ns"
+        );
+    }
+}

--- a/crates/tdbe/src/lib.rs
+++ b/crates/tdbe/src/lib.rs
@@ -17,6 +17,7 @@ pub mod codec;
 pub mod error;
 pub mod flags;
 pub mod greeks;
+pub mod latency;
 pub mod types;
 
 // Convenience re-exports at crate root

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -132,6 +132,8 @@ pub enum FpssData {
         ask_condition: i32,
         price_type: i32,
         date: i32,
+        /// Wall-clock nanoseconds since UNIX epoch, captured at frame decode time.
+        received_at_ns: u64,
     },
     /// Decoded trade tick (code 22). 16 FIT fields + contract_id.
     Trade {
@@ -152,6 +154,8 @@ pub enum FpssData {
         records_back: i32,
         price_type: i32,
         date: i32,
+        /// Wall-clock nanoseconds since UNIX epoch, captured at frame decode time.
+        received_at_ns: u64,
     },
     /// Decoded open interest tick (code 23). 3 FIT fields + contract_id.
     OpenInterest {
@@ -159,6 +163,8 @@ pub enum FpssData {
         ms_of_day: i32,
         open_interest: i32,
         date: i32,
+        /// Wall-clock nanoseconds since UNIX epoch, captured at frame decode time.
+        received_at_ns: u64,
     },
     /// Decoded OHLCVC bar (code 24 or trade-derived).
     Ohlcvc {
@@ -172,6 +178,8 @@ pub enum FpssData {
         count: i32,
         price_type: i32,
         date: i32,
+        /// Wall-clock nanoseconds since UNIX epoch, captured at frame decode time.
+        received_at_ns: u64,
     },
 }
 
@@ -1313,6 +1321,12 @@ fn decode_frame(
     delta_state: &mut DeltaState,
     derive_ohlcvc: bool,
 ) -> (Option<FpssEvent>, Option<FpssEvent>) {
+    // Capture wall-clock timestamp once per frame for all data variants.
+    let received_at_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64;
+
     match code {
         StreamMsgType::Metadata => {
             // Can arrive again after reconnection
@@ -1370,6 +1384,7 @@ fn decode_frame(
                         ask_condition: f[8],
                         price_type: f[9],
                         date: f[10],
+                        received_at_ns,
                     })),
                     None,
                 ),
@@ -1410,6 +1425,7 @@ fn decode_frame(
                         records_back: f[13],
                         price_type,
                         date,
+                        received_at_ns,
                     });
                     // Derive OHLCVC from trade (Java: OHLCVC.processTrade).
                     // Only if enabled AND the server has already seeded a bar.
@@ -1429,6 +1445,7 @@ fn decode_frame(
                                     count: acc.count,
                                     price_type: acc.price_type,
                                     date: acc.date,
+                                    received_at_ns,
                                 }))
                             } else {
                                 None
@@ -1462,6 +1479,7 @@ fn decode_frame(
                         ms_of_day: f[0],
                         open_interest: f[1],
                         date: f[2],
+                        received_at_ns,
                     })),
                     None,
                 ),
@@ -1497,6 +1515,7 @@ fn decode_frame(
                             count: f[6],
                             price_type: f[7],
                             date: f[8],
+                            received_at_ns,
                         })),
                         None,
                     )
@@ -1864,6 +1883,7 @@ mod tests {
             records_back: 0,
             price_type: 8,
             date: 20240315,
+            received_at_ns: 0,
         });
         match &data_evt {
             FpssEvent::Data(FpssData::Trade {

--- a/crates/thetadatadx/src/fpss/ring.rs
+++ b/crates/thetadatadx/src/fpss/ring.rs
@@ -262,6 +262,7 @@ mod tests {
                 ask_condition: 0,
                 price_type: 8,
                 date: 20240315,
+                received_at_ns: 0,
             }));
         });
 
@@ -356,6 +357,7 @@ mod tests {
                     ask_condition: 0,
                     price_type: 0,
                     date: 0,
+                    received_at_ns: 0,
                 }));
             });
         }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -142,6 +142,7 @@ fn fpss_event_to_ffi(event: &thetadatadx::fpss::FpssEvent) -> FfiBufferedEvent {
             ask_condition,
             price_type,
             date,
+            received_at_ns,
         }) => serde_json::json!({
             "kind": "quote",
             "contract_id": contract_id,
@@ -155,6 +156,7 @@ fn fpss_event_to_ffi(event: &thetadatadx::fpss::FpssEvent) -> FfiBufferedEvent {
             "ask": ffi_price_to_f64(*ask, *price_type),
             "ask_condition": ask_condition,
             "date": date,
+            "received_at_ns": received_at_ns,
         }),
         FpssEvent::Data(FpssData::Trade {
             contract_id,
@@ -170,6 +172,7 @@ fn fpss_event_to_ffi(event: &thetadatadx::fpss::FpssEvent) -> FfiBufferedEvent {
             records_back,
             price_type,
             date,
+            received_at_ns,
             ..
         }) => serde_json::json!({
             "kind": "trade",
@@ -187,18 +190,21 @@ fn fpss_event_to_ffi(event: &thetadatadx::fpss::FpssEvent) -> FfiBufferedEvent {
             "volume_type": volume_type,
             "records_back": records_back,
             "date": date,
+            "received_at_ns": received_at_ns,
         }),
         FpssEvent::Data(FpssData::OpenInterest {
             contract_id,
             ms_of_day,
             open_interest,
             date,
+            received_at_ns,
         }) => serde_json::json!({
             "kind": "open_interest",
             "contract_id": contract_id,
             "ms_of_day": ms_of_day,
             "open_interest": open_interest,
             "date": date,
+            "received_at_ns": received_at_ns,
         }),
         FpssEvent::Data(FpssData::Ohlcvc {
             contract_id,
@@ -211,6 +217,7 @@ fn fpss_event_to_ffi(event: &thetadatadx::fpss::FpssEvent) -> FfiBufferedEvent {
             count,
             price_type,
             date,
+            received_at_ns,
         }) => serde_json::json!({
             "kind": "ohlcvc",
             "contract_id": contract_id,
@@ -222,6 +229,7 @@ fn fpss_event_to_ffi(event: &thetadatadx::fpss::FpssEvent) -> FfiBufferedEvent {
             "volume": volume,
             "count": count,
             "date": date,
+            "received_at_ns": received_at_ns,
         }),
         FpssEvent::RawData { code, payload } => {
             use std::fmt::Write;

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1550,7 +1550,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 name = "tdbe"
 version = "0.1.0"
 dependencies = [
- "tracing",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "3.2.2"
+version = "4.5.0"
 dependencies = [
  "disruptor",
  "prost",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "3.2.2"
+version = "4.5.0"
 dependencies = [
  "pyo3",
  "tdbe",

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -417,6 +417,7 @@ enum BufferedEvent {
         ask: f64,
         ask_condition: i32,
         date: i32,
+        received_at_ns: u64,
     },
     /// Trade tick with decoded fields.
     Trade {
@@ -434,6 +435,7 @@ enum BufferedEvent {
         volume_type: i32,
         records_back: i32,
         date: i32,
+        received_at_ns: u64,
     },
     /// Open interest tick.
     OpenInterest {
@@ -441,6 +443,7 @@ enum BufferedEvent {
         ms_of_day: i32,
         open_interest: i32,
         date: i32,
+        received_at_ns: u64,
     },
     /// OHLCVC bar with decoded fields.
     Ohlcvc {
@@ -453,6 +456,7 @@ enum BufferedEvent {
         volume: i32,
         count: i32,
         date: i32,
+        received_at_ns: u64,
     },
     /// Raw undecoded data (fallback).
     RawData { code: u8, payload: Vec<u8> },
@@ -485,6 +489,7 @@ fn fpss_event_to_buffered(event: &fpss::FpssEvent) -> BufferedEvent {
                 ask_condition,
                 price_type,
                 date,
+                received_at_ns,
             } => BufferedEvent::Quote {
                 contract_id: *contract_id,
                 ms_of_day: *ms_of_day,
@@ -497,6 +502,7 @@ fn fpss_event_to_buffered(event: &fpss::FpssEvent) -> BufferedEvent {
                 ask: price_to_f64(*ask, *price_type),
                 ask_condition: *ask_condition,
                 date: *date,
+                received_at_ns: *received_at_ns,
             },
             fpss::FpssData::Trade {
                 contract_id,
@@ -512,6 +518,7 @@ fn fpss_event_to_buffered(event: &fpss::FpssEvent) -> BufferedEvent {
                 records_back,
                 price_type,
                 date,
+                received_at_ns,
                 ..
             } => BufferedEvent::Trade {
                 contract_id: *contract_id,
@@ -528,17 +535,20 @@ fn fpss_event_to_buffered(event: &fpss::FpssEvent) -> BufferedEvent {
                 volume_type: *volume_type,
                 records_back: *records_back,
                 date: *date,
+                received_at_ns: *received_at_ns,
             },
             fpss::FpssData::OpenInterest {
                 contract_id,
                 ms_of_day,
                 open_interest,
                 date,
+                received_at_ns,
             } => BufferedEvent::OpenInterest {
                 contract_id: *contract_id,
                 ms_of_day: *ms_of_day,
                 open_interest: *open_interest,
                 date: *date,
+                received_at_ns: *received_at_ns,
             },
             fpss::FpssData::Ohlcvc {
                 contract_id,
@@ -551,6 +561,7 @@ fn fpss_event_to_buffered(event: &fpss::FpssEvent) -> BufferedEvent {
                 count,
                 price_type,
                 date,
+                received_at_ns,
             } => BufferedEvent::Ohlcvc {
                 contract_id: *contract_id,
                 ms_of_day: *ms_of_day,
@@ -561,6 +572,7 @@ fn fpss_event_to_buffered(event: &fpss::FpssEvent) -> BufferedEvent {
                 volume: *volume,
                 count: *count,
                 date: *date,
+                received_at_ns: *received_at_ns,
             },
             _ => BufferedEvent::Simple {
                 kind: "unknown_data".to_string(),
@@ -642,6 +654,7 @@ fn buffered_event_to_py(py: Python<'_>, event: &BufferedEvent) -> Py<PyAny> {
             ask,
             ask_condition,
             date,
+            received_at_ns,
         } => {
             dict.set_item("kind", "quote").unwrap();
             dict.set_item("contract_id", contract_id).unwrap();
@@ -655,6 +668,7 @@ fn buffered_event_to_py(py: Python<'_>, event: &BufferedEvent) -> Py<PyAny> {
             dict.set_item("ask", ask).unwrap();
             dict.set_item("ask_condition", ask_condition).unwrap();
             dict.set_item("date", date).unwrap();
+            dict.set_item("received_at_ns", received_at_ns).unwrap();
         }
         BufferedEvent::Trade {
             contract_id,
@@ -671,6 +685,7 @@ fn buffered_event_to_py(py: Python<'_>, event: &BufferedEvent) -> Py<PyAny> {
             volume_type,
             records_back,
             date,
+            received_at_ns,
         } => {
             dict.set_item("kind", "trade").unwrap();
             dict.set_item("contract_id", contract_id).unwrap();
@@ -687,18 +702,21 @@ fn buffered_event_to_py(py: Python<'_>, event: &BufferedEvent) -> Py<PyAny> {
             dict.set_item("volume_type", volume_type).unwrap();
             dict.set_item("records_back", records_back).unwrap();
             dict.set_item("date", date).unwrap();
+            dict.set_item("received_at_ns", received_at_ns).unwrap();
         }
         BufferedEvent::OpenInterest {
             contract_id,
             ms_of_day,
             open_interest,
             date,
+            received_at_ns,
         } => {
             dict.set_item("kind", "open_interest").unwrap();
             dict.set_item("contract_id", contract_id).unwrap();
             dict.set_item("ms_of_day", ms_of_day).unwrap();
             dict.set_item("open_interest", open_interest).unwrap();
             dict.set_item("date", date).unwrap();
+            dict.set_item("received_at_ns", received_at_ns).unwrap();
         }
         BufferedEvent::Ohlcvc {
             contract_id,
@@ -710,6 +728,7 @@ fn buffered_event_to_py(py: Python<'_>, event: &BufferedEvent) -> Py<PyAny> {
             volume,
             count,
             date,
+            received_at_ns,
         } => {
             dict.set_item("kind", "ohlcvc").unwrap();
             dict.set_item("contract_id", contract_id).unwrap();
@@ -721,6 +740,7 @@ fn buffered_event_to_py(py: Python<'_>, event: &BufferedEvent) -> Py<PyAny> {
             dict.set_item("volume", volume).unwrap();
             dict.set_item("count", count).unwrap();
             dict.set_item("date", date).unwrap();
+            dict.set_item("received_at_ns", received_at_ns).unwrap();
         }
         BufferedEvent::RawData { code, payload } => {
             dict.set_item("kind", "raw_data").unwrap();

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -1951,7 +1951,7 @@ dependencies = [
 name = "tdbe"
 version = "0.1.0"
 dependencies = [
- "tracing",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "3.2.2"
+version = "4.5.0"
 dependencies = [
  "disruptor",
  "prost",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "3.2.2"
+version = "4.5.0"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/src/ws.rs
+++ b/tools/server/src/ws.rs
@@ -291,6 +291,7 @@ fn fpss_event_to_ws_json(
                     ask_condition,
                     price_type,
                     date,
+                    received_at_ns,
                 } => (
                     "QUOTE",
                     *contract_id,
@@ -305,6 +306,7 @@ fn fpss_event_to_ws_json(
                         "ask": Price::new(*ask, *price_type).to_f64(),
                         "ask_condition": ask_condition,
                         "date": date,
+                        "received_at_ns": received_at_ns,
                     }),
                 ),
                 FpssData::Trade {
@@ -317,6 +319,7 @@ fn fpss_event_to_ws_json(
                     price,
                     price_type,
                     date,
+                    received_at_ns,
                     ..
                 } => (
                     "TRADE",
@@ -329,6 +332,7 @@ fn fpss_event_to_ws_json(
                         "exchange": exchange,
                         "price": Price::new(*price, *price_type).to_f64(),
                         "date": date,
+                        "received_at_ns": received_at_ns,
                     }),
                 ),
                 FpssData::Ohlcvc {
@@ -342,6 +346,7 @@ fn fpss_event_to_ws_json(
                     count,
                     price_type,
                     date,
+                    received_at_ns,
                 } => (
                     "OHLC",
                     *contract_id,
@@ -354,6 +359,7 @@ fn fpss_event_to_ws_json(
                         "volume": volume,
                         "count": count,
                         "date": date,
+                        "received_at_ns": received_at_ns,
                     }),
                 ),
                 FpssData::OpenInterest {
@@ -361,6 +367,7 @@ fn fpss_event_to_ws_json(
                     ms_of_day,
                     open_interest,
                     date,
+                    received_at_ns,
                 } => (
                     "OPEN_INTEREST",
                     *contract_id,
@@ -368,6 +375,7 @@ fn fpss_event_to_ws_json(
                         "ms_of_day": ms_of_day,
                         "open_interest": open_interest,
                         "date": date,
+                        "received_at_ns": received_at_ns,
                     }),
                 ),
                 _ => return None,


### PR DESCRIPTION
## Summary

Every `FpssData` variant now carries `received_at_ns: u64` -- wall-clock nanoseconds captured at frame decode in the I/O thread.

New utility: `tdbe::latency::latency_ns(exchange_ms_of_day, event_date, received_at_ns)` computes wire-to-application latency in nanoseconds with DST-aware ET timezone handling.

## Impact

- Users can measure per-tick latency out of the box
- Enables latency histograms for benchmarking
- Zero meaningful overhead (~20ns syscall per frame)
- Propagated to all SDKs: Rust (field), Python (dict key), FFI (JSON key), WebSocket (JSON key)

Fixes #44.

## Test plan
- [x] 169 tests pass (4 new latency tests)
- [x] cargo fmt/clippy/check clean