### PR TITLE
feat: add 3 missing FPSS methods to all SDKs

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1697,6 +1697,117 @@ pub unsafe extern "C" fn tdx_unified_subscribe_full_trades(
     }
 }
 
+/// Subscribe to all open interest for a security type on the unified client.
+/// sec_type: "STOCK", "OPTION", or "INDEX".
+#[no_mangle]
+pub unsafe extern "C" fn tdx_unified_subscribe_full_open_interest(
+    handle: *const TdxUnified,
+    sec_type: *const c_char,
+) -> i32 {
+    if handle.is_null() {
+        set_error("unified handle is null");
+        return -1;
+    }
+    let sec_type_str = match unsafe { cstr_to_str(sec_type) } {
+        Some(s) => s,
+        None => {
+            set_error("sec_type is null");
+            return -1;
+        }
+    };
+    let st = match sec_type_str.to_uppercase().as_str() {
+        "STOCK" => tdbe::types::enums::SecType::Stock,
+        "OPTION" => tdbe::types::enums::SecType::Option,
+        "INDEX" => tdbe::types::enums::SecType::Index,
+        _ => {
+            set_error("invalid sec_type: expected STOCK, OPTION, or INDEX");
+            return -1;
+        }
+    };
+    let handle = unsafe { &*handle };
+    match handle.inner.subscribe_full_open_interest(st) {
+        Ok(id) => id,
+        Err(e) => {
+            set_error(&e.to_string());
+            -1
+        }
+    }
+}
+
+/// Unsubscribe from all trades for a security type on the unified client.
+/// sec_type: "STOCK", "OPTION", or "INDEX".
+#[no_mangle]
+pub unsafe extern "C" fn tdx_unified_unsubscribe_full_trades(
+    handle: *const TdxUnified,
+    sec_type: *const c_char,
+) -> i32 {
+    if handle.is_null() {
+        set_error("unified handle is null");
+        return -1;
+    }
+    let sec_type_str = match unsafe { cstr_to_str(sec_type) } {
+        Some(s) => s,
+        None => {
+            set_error("sec_type is null");
+            return -1;
+        }
+    };
+    let st = match sec_type_str.to_uppercase().as_str() {
+        "STOCK" => tdbe::types::enums::SecType::Stock,
+        "OPTION" => tdbe::types::enums::SecType::Option,
+        "INDEX" => tdbe::types::enums::SecType::Index,
+        _ => {
+            set_error("invalid sec_type: expected STOCK, OPTION, or INDEX");
+            return -1;
+        }
+    };
+    let handle = unsafe { &*handle };
+    match handle.inner.unsubscribe_full_trades(st) {
+        Ok(id) => id,
+        Err(e) => {
+            set_error(&e.to_string());
+            -1
+        }
+    }
+}
+
+/// Unsubscribe from all open interest for a security type on the unified client.
+/// sec_type: "STOCK", "OPTION", or "INDEX".
+#[no_mangle]
+pub unsafe extern "C" fn tdx_unified_unsubscribe_full_open_interest(
+    handle: *const TdxUnified,
+    sec_type: *const c_char,
+) -> i32 {
+    if handle.is_null() {
+        set_error("unified handle is null");
+        return -1;
+    }
+    let sec_type_str = match unsafe { cstr_to_str(sec_type) } {
+        Some(s) => s,
+        None => {
+            set_error("sec_type is null");
+            return -1;
+        }
+    };
+    let st = match sec_type_str.to_uppercase().as_str() {
+        "STOCK" => tdbe::types::enums::SecType::Stock,
+        "OPTION" => tdbe::types::enums::SecType::Option,
+        "INDEX" => tdbe::types::enums::SecType::Index,
+        _ => {
+            set_error("invalid sec_type: expected STOCK, OPTION, or INDEX");
+            return -1;
+        }
+    };
+    let handle = unsafe { &*handle };
+    match handle.inner.unsubscribe_full_open_interest(st) {
+        Ok(id) => id,
+        Err(e) => {
+            set_error(&e.to_string());
+            -1
+        }
+    }
+}
+
 /// Unsubscribe from open interest data on the unified client.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_unified_unsubscribe_open_interest(
@@ -2197,6 +2308,156 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_full_trades(
         }
     };
     match client.subscribe_full_trades(st) {
+        Ok(req_id) => req_id,
+        Err(e) => {
+            set_error(&e.to_string());
+            -1
+        }
+    }
+}
+
+/// Subscribe to all open interest for a security type (full OI stream).
+///
+/// `sec_type` must be one of: "STOCK", "OPTION", "INDEX".
+///
+/// Returns the request ID on success, or -1 on error (check `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_fpss_subscribe_full_open_interest(
+    handle: *const TdxFpssHandle,
+    sec_type: *const c_char,
+) -> i32 {
+    if handle.is_null() {
+        set_error("FPSS handle is null");
+        return -1;
+    }
+    let sec_type_str = match unsafe { cstr_to_str(sec_type) } {
+        Some(s) => s,
+        None => {
+            set_error("sec_type is null or invalid UTF-8");
+            return -1;
+        }
+    };
+    let st = match sec_type_str.to_uppercase().as_str() {
+        "STOCK" => tdbe::types::enums::SecType::Stock,
+        "OPTION" => tdbe::types::enums::SecType::Option,
+        "INDEX" => tdbe::types::enums::SecType::Index,
+        other => {
+            set_error(&format!(
+                "unknown sec_type: {other:?} (expected STOCK, OPTION, or INDEX)"
+            ));
+            return -1;
+        }
+    };
+    let handle = unsafe { &*handle };
+    let guard = handle.inner.lock().unwrap_or_else(|e| e.into_inner());
+    let client = match guard.as_ref() {
+        Some(c) => c,
+        None => {
+            set_error("FPSS client is shut down");
+            return -1;
+        }
+    };
+    match client.subscribe_full_open_interest(st) {
+        Ok(req_id) => req_id,
+        Err(e) => {
+            set_error(&e.to_string());
+            -1
+        }
+    }
+}
+
+/// Unsubscribe from all trades for a security type (full trade stream).
+///
+/// `sec_type` must be one of: "STOCK", "OPTION", "INDEX".
+///
+/// Returns the request ID on success, or -1 on error (check `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_fpss_unsubscribe_full_trades(
+    handle: *const TdxFpssHandle,
+    sec_type: *const c_char,
+) -> i32 {
+    if handle.is_null() {
+        set_error("FPSS handle is null");
+        return -1;
+    }
+    let sec_type_str = match unsafe { cstr_to_str(sec_type) } {
+        Some(s) => s,
+        None => {
+            set_error("sec_type is null or invalid UTF-8");
+            return -1;
+        }
+    };
+    let st = match sec_type_str.to_uppercase().as_str() {
+        "STOCK" => tdbe::types::enums::SecType::Stock,
+        "OPTION" => tdbe::types::enums::SecType::Option,
+        "INDEX" => tdbe::types::enums::SecType::Index,
+        other => {
+            set_error(&format!(
+                "unknown sec_type: {other:?} (expected STOCK, OPTION, or INDEX)"
+            ));
+            return -1;
+        }
+    };
+    let handle = unsafe { &*handle };
+    let guard = handle.inner.lock().unwrap_or_else(|e| e.into_inner());
+    let client = match guard.as_ref() {
+        Some(c) => c,
+        None => {
+            set_error("FPSS client is shut down");
+            return -1;
+        }
+    };
+    match client.unsubscribe_full_trades(st) {
+        Ok(req_id) => req_id,
+        Err(e) => {
+            set_error(&e.to_string());
+            -1
+        }
+    }
+}
+
+/// Unsubscribe from all open interest for a security type (full OI stream).
+///
+/// `sec_type` must be one of: "STOCK", "OPTION", "INDEX".
+///
+/// Returns the request ID on success, or -1 on error (check `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_fpss_unsubscribe_full_open_interest(
+    handle: *const TdxFpssHandle,
+    sec_type: *const c_char,
+) -> i32 {
+    if handle.is_null() {
+        set_error("FPSS handle is null");
+        return -1;
+    }
+    let sec_type_str = match unsafe { cstr_to_str(sec_type) } {
+        Some(s) => s,
+        None => {
+            set_error("sec_type is null or invalid UTF-8");
+            return -1;
+        }
+    };
+    let st = match sec_type_str.to_uppercase().as_str() {
+        "STOCK" => tdbe::types::enums::SecType::Stock,
+        "OPTION" => tdbe::types::enums::SecType::Option,
+        "INDEX" => tdbe::types::enums::SecType::Index,
+        other => {
+            set_error(&format!(
+                "unknown sec_type: {other:?} (expected STOCK, OPTION, or INDEX)"
+            ));
+            return -1;
+        }
+    };
+    let handle = unsafe { &*handle };
+    let guard = handle.inner.lock().unwrap_or_else(|e| e.into_inner());
+    let client = match guard.as_ref() {
+        Some(c) => c,
+        None => {
+            set_error("FPSS client is shut down");
+            return -1;
+        }
+    };
+    match client.unsubscribe_full_open_interest(st) {
         Ok(req_id) => req_id,
         Err(e) => {
             set_error(&e.to_string());

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -640,6 +640,15 @@ int tdx_fpss_subscribe_open_interest(const TdxFpssHandle* h, const char* symbol)
 /** Subscribe to all trades for a security type. sec_type: "STOCK", "OPTION", "INDEX". Returns request ID or -1. */
 int tdx_fpss_subscribe_full_trades(const TdxFpssHandle* h, const char* sec_type);
 
+/** Subscribe to all open interest for a security type. sec_type: "STOCK", "OPTION", "INDEX". Returns request ID or -1. */
+int tdx_fpss_subscribe_full_open_interest(const TdxFpssHandle* h, const char* sec_type);
+
+/** Unsubscribe from all trades for a security type. sec_type: "STOCK", "OPTION", "INDEX". Returns request ID or -1. */
+int tdx_fpss_unsubscribe_full_trades(const TdxFpssHandle* h, const char* sec_type);
+
+/** Unsubscribe from all open interest for a security type. sec_type: "STOCK", "OPTION", "INDEX". Returns request ID or -1. */
+int tdx_fpss_unsubscribe_full_open_interest(const TdxFpssHandle* h, const char* sec_type);
+
 /** Unsubscribe from quote data. Returns request ID or -1 on error. */
 int tdx_fpss_unsubscribe_quotes(const TdxFpssHandle* h, const char* symbol);
 

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -461,9 +461,12 @@ public:
     int subscribe_trades(const std::string& symbol);
     int subscribe_open_interest(const std::string& symbol);
     int subscribe_full_trades(const std::string& sec_type);
+    int subscribe_full_open_interest(const std::string& sec_type);
     int unsubscribe_quotes(const std::string& symbol);
     int unsubscribe_open_interest(const std::string& symbol);
     int unsubscribe_trades(const std::string& symbol);
+    int unsubscribe_full_trades(const std::string& sec_type);
+    int unsubscribe_full_open_interest(const std::string& sec_type);
 
     bool is_authenticated() const;
     std::optional<std::string> contract_lookup(int id) const;

--- a/sdks/cpp/src/thetadx.cpp
+++ b/sdks/cpp/src/thetadx.cpp
@@ -445,9 +445,12 @@ int FpssClient::subscribe_quotes(const std::string& symbol) { return tdx_fpss_su
 int FpssClient::subscribe_trades(const std::string& symbol) { return tdx_fpss_subscribe_trades(handle_.get(), symbol.c_str()); }
 int FpssClient::subscribe_open_interest(const std::string& symbol) { return tdx_fpss_subscribe_open_interest(handle_.get(), symbol.c_str()); }
 int FpssClient::subscribe_full_trades(const std::string& sec_type) { return tdx_fpss_subscribe_full_trades(handle_.get(), sec_type.c_str()); }
+int FpssClient::subscribe_full_open_interest(const std::string& sec_type) { return tdx_fpss_subscribe_full_open_interest(handle_.get(), sec_type.c_str()); }
 int FpssClient::unsubscribe_quotes(const std::string& symbol) { return tdx_fpss_unsubscribe_quotes(handle_.get(), symbol.c_str()); }
 int FpssClient::unsubscribe_open_interest(const std::string& symbol) { return tdx_fpss_unsubscribe_open_interest(handle_.get(), symbol.c_str()); }
 int FpssClient::unsubscribe_trades(const std::string& symbol) { return tdx_fpss_unsubscribe_trades(handle_.get(), symbol.c_str()); }
+int FpssClient::unsubscribe_full_trades(const std::string& sec_type) { return tdx_fpss_unsubscribe_full_trades(handle_.get(), sec_type.c_str()); }
+int FpssClient::unsubscribe_full_open_interest(const std::string& sec_type) { return tdx_fpss_unsubscribe_full_open_interest(handle_.get(), sec_type.c_str()); }
 
 bool FpssClient::is_authenticated() const { return tdx_fpss_is_authenticated(handle_.get()) != 0; }
 

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -106,9 +106,12 @@ extern int tdx_fpss_subscribe_quotes(const TdxFpssHandle* h, const char* symbol)
 extern int tdx_fpss_subscribe_trades(const TdxFpssHandle* h, const char* symbol);
 extern int tdx_fpss_subscribe_open_interest(const TdxFpssHandle* h, const char* symbol);
 extern int tdx_fpss_subscribe_full_trades(const TdxFpssHandle* h, const char* sec_type);
+extern int tdx_fpss_subscribe_full_open_interest(const TdxFpssHandle* h, const char* sec_type);
 extern int tdx_fpss_unsubscribe_quotes(const TdxFpssHandle* h, const char* symbol);
 extern int tdx_fpss_unsubscribe_trades(const TdxFpssHandle* h, const char* symbol);
 extern int tdx_fpss_unsubscribe_open_interest(const TdxFpssHandle* h, const char* symbol);
+extern int tdx_fpss_unsubscribe_full_trades(const TdxFpssHandle* h, const char* sec_type);
+extern int tdx_fpss_unsubscribe_full_open_interest(const TdxFpssHandle* h, const char* sec_type);
 extern int tdx_fpss_is_authenticated(const TdxFpssHandle* h);
 extern char* tdx_fpss_contract_lookup(const TdxFpssHandle* h, int id);
 extern char* tdx_fpss_active_subscriptions(const TdxFpssHandle* h);

--- a/sdks/go/fpss.go
+++ b/sdks/go/fpss.go
@@ -1,0 +1,191 @@
+package thetadatadx
+
+/*
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+
+// Forward declarations (already defined in thetadx.go, but CGo needs them per file).
+typedef void TdxCredentials;
+typedef void TdxConfig;
+typedef void TdxFpssHandle;
+
+extern TdxFpssHandle* tdx_fpss_connect(const TdxCredentials* creds, const TdxConfig* config);
+extern int tdx_fpss_subscribe_quotes(const TdxFpssHandle* h, const char* symbol);
+extern int tdx_fpss_subscribe_trades(const TdxFpssHandle* h, const char* symbol);
+extern int tdx_fpss_subscribe_open_interest(const TdxFpssHandle* h, const char* symbol);
+extern int tdx_fpss_subscribe_full_trades(const TdxFpssHandle* h, const char* sec_type);
+extern int tdx_fpss_subscribe_full_open_interest(const TdxFpssHandle* h, const char* sec_type);
+extern int tdx_fpss_unsubscribe_quotes(const TdxFpssHandle* h, const char* symbol);
+extern int tdx_fpss_unsubscribe_trades(const TdxFpssHandle* h, const char* symbol);
+extern int tdx_fpss_unsubscribe_open_interest(const TdxFpssHandle* h, const char* symbol);
+extern int tdx_fpss_unsubscribe_full_trades(const TdxFpssHandle* h, const char* sec_type);
+extern int tdx_fpss_unsubscribe_full_open_interest(const TdxFpssHandle* h, const char* sec_type);
+extern int tdx_fpss_is_authenticated(const TdxFpssHandle* h);
+extern char* tdx_fpss_contract_lookup(const TdxFpssHandle* h, int id);
+extern char* tdx_fpss_active_subscriptions(const TdxFpssHandle* h);
+extern char* tdx_fpss_next_event(const TdxFpssHandle* h, uint64_t timeout_ms);
+extern void tdx_fpss_shutdown(const TdxFpssHandle* h);
+extern void tdx_fpss_free(TdxFpssHandle* h);
+extern const char* tdx_last_error();
+extern void tdx_string_free(char* s);
+*/
+import "C"
+
+import (
+	"encoding/json"
+	"fmt"
+	"unsafe"
+)
+
+// FpssClient wraps the FPSS real-time streaming handle.
+type FpssClient struct {
+	handle *C.TdxFpssHandle
+}
+
+// NewFpssClient connects to the FPSS streaming servers and returns a client.
+func NewFpssClient(creds *Credentials, config *Config) (*FpssClient, error) {
+	if creds == nil || creds.handle == nil {
+		return nil, fmt.Errorf("thetadatadx: credentials handle is nil")
+	}
+	if config == nil || config.handle == nil {
+		return nil, fmt.Errorf("thetadatadx: config handle is nil")
+	}
+	h := C.tdx_fpss_connect(creds.handle, config.handle)
+	if h == nil {
+		return nil, fmt.Errorf("thetadatadx: %s", lastError())
+	}
+	return &FpssClient{handle: h}, nil
+}
+
+func (f *FpssClient) fpssCall(rc C.int) (int, error) {
+	if rc < 0 {
+		return int(rc), fmt.Errorf("thetadatadx: %s", lastError())
+	}
+	return int(rc), nil
+}
+
+// SubscribeQuotes subscribes to real-time quote data for a stock symbol.
+func (f *FpssClient) SubscribeQuotes(symbol string) (int, error) {
+	cs := C.CString(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_subscribe_quotes(f.handle, cs))
+}
+
+// SubscribeTrades subscribes to real-time trade data for a stock symbol.
+func (f *FpssClient) SubscribeTrades(symbol string) (int, error) {
+	cs := C.CString(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_subscribe_trades(f.handle, cs))
+}
+
+// SubscribeOpenInterest subscribes to open interest data for a stock symbol.
+func (f *FpssClient) SubscribeOpenInterest(symbol string) (int, error) {
+	cs := C.CString(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_subscribe_open_interest(f.handle, cs))
+}
+
+// SubscribeFullTrades subscribes to all trades for a security type ("STOCK", "OPTION", "INDEX").
+func (f *FpssClient) SubscribeFullTrades(secType string) (int, error) {
+	cs := C.CString(secType)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_subscribe_full_trades(f.handle, cs))
+}
+
+// SubscribeFullOpenInterest subscribes to all open interest for a security type ("STOCK", "OPTION", "INDEX").
+func (f *FpssClient) SubscribeFullOpenInterest(secType string) (int, error) {
+	cs := C.CString(secType)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_subscribe_full_open_interest(f.handle, cs))
+}
+
+// UnsubscribeQuotes unsubscribes from quote data for a stock symbol.
+func (f *FpssClient) UnsubscribeQuotes(symbol string) (int, error) {
+	cs := C.CString(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_unsubscribe_quotes(f.handle, cs))
+}
+
+// UnsubscribeTrades unsubscribes from trade data for a stock symbol.
+func (f *FpssClient) UnsubscribeTrades(symbol string) (int, error) {
+	cs := C.CString(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_unsubscribe_trades(f.handle, cs))
+}
+
+// UnsubscribeOpenInterest unsubscribes from open interest data for a stock symbol.
+func (f *FpssClient) UnsubscribeOpenInterest(symbol string) (int, error) {
+	cs := C.CString(symbol)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_unsubscribe_open_interest(f.handle, cs))
+}
+
+// UnsubscribeFullTrades unsubscribes from all trades for a security type ("STOCK", "OPTION", "INDEX").
+func (f *FpssClient) UnsubscribeFullTrades(secType string) (int, error) {
+	cs := C.CString(secType)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_unsubscribe_full_trades(f.handle, cs))
+}
+
+// UnsubscribeFullOpenInterest unsubscribes from all open interest for a security type ("STOCK", "OPTION", "INDEX").
+func (f *FpssClient) UnsubscribeFullOpenInterest(secType string) (int, error) {
+	cs := C.CString(secType)
+	defer C.free(unsafe.Pointer(cs))
+	return f.fpssCall(C.tdx_fpss_unsubscribe_full_open_interest(f.handle, cs))
+}
+
+// IsAuthenticated returns true if the FPSS client is currently authenticated.
+func (f *FpssClient) IsAuthenticated() bool {
+	return C.tdx_fpss_is_authenticated(f.handle) != 0
+}
+
+// ContractLookup looks up a contract by its server-assigned ID.
+func (f *FpssClient) ContractLookup(id int) (string, error) {
+	cstr := C.tdx_fpss_contract_lookup(f.handle, C.int(id))
+	if cstr == nil {
+		return "", fmt.Errorf("thetadatadx: %s", lastError())
+	}
+	goStr := C.GoString(cstr)
+	C.tdx_string_free(cstr)
+	return goStr, nil
+}
+
+// ActiveSubscriptions returns the currently active subscriptions as JSON.
+func (f *FpssClient) ActiveSubscriptions() (json.RawMessage, error) {
+	cstr := C.tdx_fpss_active_subscriptions(f.handle)
+	if cstr == nil {
+		return nil, fmt.Errorf("thetadatadx: %s", lastError())
+	}
+	goStr := C.GoString(cstr)
+	C.tdx_string_free(cstr)
+	return json.RawMessage(goStr), nil
+}
+
+// NextEvent polls for the next streaming event with the given timeout in milliseconds.
+// Returns nil if the timeout expires with no event.
+func (f *FpssClient) NextEvent(timeoutMs uint64) (json.RawMessage, error) {
+	cstr := C.tdx_fpss_next_event(f.handle, C.uint64_t(timeoutMs))
+	if cstr == nil {
+		// nil means timeout (no event), not an error
+		return nil, nil
+	}
+	goStr := C.GoString(cstr)
+	C.tdx_string_free(cstr)
+	return json.RawMessage(goStr), nil
+}
+
+// Shutdown gracefully shuts down the FPSS streaming connection.
+func (f *FpssClient) Shutdown() {
+	if f.handle != nil {
+		C.tdx_fpss_shutdown(f.handle)
+	}
+}
+
+// Close frees the FPSS handle. Call after Shutdown.
+func (f *FpssClient) Close() {
+	if f.handle != nil {
+		C.tdx_fpss_free(f.handle)
+		f.handle = nil
+	}
+}

--- a/sdks/go/thetadx.go
+++ b/sdks/go/thetadx.go
@@ -153,9 +153,12 @@ extern int tdx_fpss_subscribe_quotes(const TdxFpssHandle* h, const char* symbol)
 extern int tdx_fpss_subscribe_trades(const TdxFpssHandle* h, const char* symbol);
 extern int tdx_fpss_subscribe_open_interest(const TdxFpssHandle* h, const char* symbol);
 extern int tdx_fpss_subscribe_full_trades(const TdxFpssHandle* h, const char* sec_type);
+extern int tdx_fpss_subscribe_full_open_interest(const TdxFpssHandle* h, const char* sec_type);
 extern int tdx_fpss_unsubscribe_quotes(const TdxFpssHandle* h, const char* symbol);
 extern int tdx_fpss_unsubscribe_trades(const TdxFpssHandle* h, const char* symbol);
 extern int tdx_fpss_unsubscribe_open_interest(const TdxFpssHandle* h, const char* symbol);
+extern int tdx_fpss_unsubscribe_full_trades(const TdxFpssHandle* h, const char* sec_type);
+extern int tdx_fpss_unsubscribe_full_open_interest(const TdxFpssHandle* h, const char* sec_type);
 extern int tdx_fpss_is_authenticated(const TdxFpssHandle* h);
 extern char* tdx_fpss_contract_lookup(const TdxFpssHandle* h, int id);
 extern char* tdx_fpss_active_subscriptions(const TdxFpssHandle* h);

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -854,6 +854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1577,7 @@ name = "thetadatadx"
 version = "4.5.0"
 dependencies = [
  "disruptor",
+ "paste",
  "prost",
  "prost-build",
  "prost-types",

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -32,6 +32,17 @@ fn to_py_err(e: thetadatadx::Error) -> PyErr {
     }
 }
 
+fn parse_sec_type(sec_type: &str) -> PyResult<tdbe::types::enums::SecType> {
+    match sec_type.to_uppercase().as_str() {
+        "STOCK" => Ok(tdbe::types::enums::SecType::Stock),
+        "OPTION" => Ok(tdbe::types::enums::SecType::Option),
+        "INDEX" => Ok(tdbe::types::enums::SecType::Index),
+        other => Err(PyValueError::new_err(format!(
+            "unknown sec_type: {other:?} (expected STOCK, OPTION, or INDEX)"
+        ))),
+    }
+}
+
 // ── Credentials ──
 
 #[pyclass(from_py_object)]
@@ -905,17 +916,26 @@ impl ThetaDataDx {
 
     /// Subscribe to all trades for a security type (full trade stream).
     fn subscribe_full_trades(&self, sec_type: &str) -> PyResult<i32> {
-        let st = match sec_type.to_uppercase().as_str() {
-            "STOCK" => tdbe::types::enums::SecType::Stock,
-            "OPTION" => tdbe::types::enums::SecType::Option,
-            "INDEX" => tdbe::types::enums::SecType::Index,
-            other => {
-                return Err(PyValueError::new_err(format!(
-                    "unknown sec_type: {other:?} (expected STOCK, OPTION, or INDEX)"
-                )))
-            }
-        };
+        let st = parse_sec_type(sec_type)?;
         self.tdx.subscribe_full_trades(st).map_err(to_py_err)
+    }
+
+    /// Subscribe to all open interest for a security type (full OI stream).
+    fn subscribe_full_open_interest(&self, sec_type: &str) -> PyResult<i32> {
+        let st = parse_sec_type(sec_type)?;
+        self.tdx.subscribe_full_open_interest(st).map_err(to_py_err)
+    }
+
+    /// Unsubscribe from all trades for a security type (full trade stream).
+    fn unsubscribe_full_trades(&self, sec_type: &str) -> PyResult<i32> {
+        let st = parse_sec_type(sec_type)?;
+        self.tdx.unsubscribe_full_trades(st).map_err(to_py_err)
+    }
+
+    /// Unsubscribe from all open interest for a security type (full OI stream).
+    fn unsubscribe_full_open_interest(&self, sec_type: &str) -> PyResult<i32> {
+        let st = parse_sec_type(sec_type)?;
+        self.tdx.unsubscribe_full_open_interest(st).map_err(to_py_err)
     }
 
     /// Unsubscribe from quote data for a stock symbol.
@@ -1111,10 +1131,9 @@ impl ThetaDataDx {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
         let ticks = py.detach(|| {
             runtime()
-                .block_on(
-                    self.tdx
-                        .stock_snapshot_market_value(&refs),
-                )
+                .block_on(async {
+                    self.tdx.stock_snapshot_market_value(&refs).await
+                })
                 .map_err(to_py_err)
         })?;
         Ok(ticks
@@ -2064,10 +2083,9 @@ impl ThetaDataDx {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
         let ticks = py.detach(|| {
             runtime()
-                .block_on(
-                    self.tdx
-                        .index_snapshot_market_value(&refs),
-                )
+                .block_on(async {
+                    self.tdx.index_snapshot_market_value(&refs).await
+                })
                 .map_err(to_py_err)
         })?;
         Ok(ticks
@@ -2102,10 +2120,9 @@ impl ThetaDataDx {
     ) -> PyResult<Vec<Py<PyAny>>> {
         let ticks = py.detach(|| {
             runtime()
-                .block_on(
-                    self.tdx
-                        .index_history_ohlc(symbol, start_date, end_date, interval),
-                )
+                .block_on(async {
+                    self.tdx.index_history_ohlc(symbol, start_date, end_date, interval).await
+                })
                 .map_err(to_py_err)
         })?;
         Ok(ticks.iter().map(|t| ohlc_tick_to_dict(py, t)).collect())
@@ -2141,10 +2158,9 @@ impl ThetaDataDx {
     ) -> PyResult<Vec<Py<PyAny>>> {
         let ticks = py.detach(|| {
             runtime()
-                .block_on(
-                    self.tdx
-                        .index_at_time_price(symbol, start_date, end_date, time_of_day),
-                )
+                .block_on(async {
+                    self.tdx.index_at_time_price(symbol, start_date, end_date, time_of_day).await
+                })
                 .map_err(to_py_err)
         })?;
         Ok(ticks.iter().map(|t| price_tick_to_dict(py, t)).collect())
@@ -2188,10 +2204,9 @@ impl ThetaDataDx {
     ) -> PyResult<Vec<Py<PyAny>>> {
         let ticks = py.detach(|| {
             runtime()
-                .block_on(
-                    self.tdx
-                        .interest_rate_history_eod(symbol, start_date, end_date),
-                )
+                .block_on(async {
+                    self.tdx.interest_rate_history_eod(symbol, start_date, end_date).await
+                })
                 .map_err(to_py_err)
         })?;
         Ok(ticks


### PR DESCRIPTION
## Problem

`subscribe_full_open_interest`, `unsubscribe_full_trades`, `unsubscribe_full_open_interest` exist in Rust core but were missing from FFI, Python, C++, Go SDKs.

Also: 5 Python SDK endpoints had broken async blocks from the builder pattern refactor.

## Solution

Added all 3 methods to FFI (6 functions: standalone + unified handles), Python, C++, Go. Fixed Python async wrapping.

Fixes #56.

## Test plan
- [x] cargo fmt/clippy/check/test all pass
- [x] Python SDK compiles cleanly
- [x] Go FpssClient type added (was documented but missing)