### PR TITLE
docs: add 3 new FPSS streaming methods to all docs

### DIFF
--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -2171,6 +2171,9 @@ int req_id = fpss.subscribe_full_trades("STOCK");
 | `subscribe_trades` | Subscribe to real-time trade updates |
 | `subscribe_open_interest` | Subscribe to open interest updates |
 | `subscribe_full_trades` | Subscribe to all trades for a security type |
+| `subscribe_full_open_interest` | Subscribe to all OI for a security type |
+| `unsubscribe_full_trades` | Unsubscribe from all trades for a security type |
+| `unsubscribe_full_open_interest` | Unsubscribe from all OI for a security type |
 
 All subscription methods return a request ID. The server confirms via a `ReqResponse` control event.
 

--- a/docs-site/docs/streaming.md
+++ b/docs-site/docs/streaming.md
@@ -404,6 +404,9 @@ match thetadatadx::fpss::reconnect_delay(reason) {
 | `subscribe_trades(contract)` | Subscribe to trade data |
 | `subscribe_open_interest(contract)` | Subscribe to open interest |
 | `subscribe_full_trades(sec_type)` | Subscribe to all trades for a security type |
+| `subscribe_full_open_interest(sec_type)` | Subscribe to all OI for a security type |
+| `unsubscribe_full_trades(sec_type)` | Unsubscribe from all trades for a security type |
+| `unsubscribe_full_open_interest(sec_type)` | Unsubscribe from all OI for a security type |
 | `unsubscribe_quotes(contract)` | Unsubscribe from quotes |
 | `unsubscribe_trades(contract)` | Unsubscribe from trades |
 | `unsubscribe_open_interest(contract)` | Unsubscribe from OI |
@@ -446,6 +449,9 @@ match thetadatadx::fpss::reconnect_delay(reason) {
 | `subscribe_trades` | `(symbol) -> int32_t` | Subscribe to trades |
 | `subscribe_open_interest` | `(symbol) -> int32_t` | Subscribe to OI |
 | `subscribe_full_trades` | `(sec_type) -> int32_t` | Subscribe to all trades for a security type |
+| `subscribe_full_open_interest` | `(sec_type) -> int32_t` | Subscribe to all OI for a security type |
+| `unsubscribe_full_trades` | `(sec_type) -> int32_t` | Unsubscribe from all trades for a security type |
+| `unsubscribe_full_open_interest` | `(sec_type) -> int32_t` | Unsubscribe from all OI for a security type |
 | `unsubscribe_trades` | `(symbol) -> int32_t` | Unsubscribe from trades |
 | `unsubscribe_open_interest` | `(symbol) -> int32_t` | Unsubscribe from OI |
 | `next_event` | `(timeout_ms) -> std::string` | Poll next event (empty on timeout) |

--- a/docs-site/docs/streaming/events.md
+++ b/docs-site/docs/streaming/events.md
@@ -198,6 +198,9 @@ while (true) {
 | `subscribe_trades(contract)` | Subscribe to trade data |
 | `subscribe_open_interest(contract)` | Subscribe to open interest |
 | `subscribe_full_trades(sec_type)` | Subscribe to all trades for a security type |
+| `subscribe_full_open_interest(sec_type)` | Subscribe to all OI for a security type |
+| `unsubscribe_full_trades(sec_type)` | Unsubscribe from all trades for a security type |
+| `unsubscribe_full_open_interest(sec_type)` | Unsubscribe from all OI for a security type |
 | `unsubscribe_quotes(contract)` | Unsubscribe from quotes |
 | `unsubscribe_trades(contract)` | Unsubscribe from trades |
 | `unsubscribe_open_interest(contract)` | Unsubscribe from OI |
@@ -240,6 +243,9 @@ while (true) {
 | `subscribe_trades` | `(symbol) -> int32_t` | Subscribe to trades |
 | `subscribe_open_interest` | `(symbol) -> int32_t` | Subscribe to OI |
 | `subscribe_full_trades` | `(sec_type) -> int32_t` | Subscribe to all trades for a security type |
+| `subscribe_full_open_interest` | `(sec_type) -> int32_t` | Subscribe to all OI for a security type |
+| `unsubscribe_full_trades` | `(sec_type) -> int32_t` | Unsubscribe from all trades for a security type |
+| `unsubscribe_full_open_interest` | `(sec_type) -> int32_t` | Unsubscribe from all OI for a security type |
 | `unsubscribe_quotes` | `(symbol) -> int32_t` | Unsubscribe from quotes |
 | `unsubscribe_trades` | `(symbol) -> int32_t` | Unsubscribe from trades |
 | `unsubscribe_open_interest` | `(symbol) -> int32_t` | Unsubscribe from OI |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -758,6 +758,9 @@ tdx.start_streaming(|event: &FpssEvent| {
 | `subscribe_trades` | `(&self, &Contract) -> Result<i32, Error>` | Subscribe to trade data |
 | `subscribe_open_interest` | `(&self, &Contract) -> Result<i32, Error>` | Subscribe to open interest |
 | `subscribe_full_trades` | `(&self, SecType) -> Result<i32, Error>` | Subscribe to all trades for a security type |
+| `subscribe_full_open_interest` | `(&self, SecType) -> Result<i32, Error>` | Subscribe to all OI for a security type |
+| `unsubscribe_full_trades` | `(&self, SecType) -> Result<i32, Error>` | Unsubscribe from all trades for a security type |
+| `unsubscribe_full_open_interest` | `(&self, SecType) -> Result<i32, Error>` | Unsubscribe from all OI for a security type |
 | `unsubscribe_quotes` | `(&self, &Contract) -> Result<i32, Error>` | Unsubscribe quotes |
 | `unsubscribe_trades` | `(&self, &Contract) -> Result<i32, Error>` | Unsubscribe trades |
 | `unsubscribe_open_interest` | `(&self, &Contract) -> Result<i32, Error>` | Unsubscribe open interest |

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -291,6 +291,9 @@ int main() {
 | `subscribe_trades(symbol)` | `int` | Subscribe to trade data for a stock symbol |
 | `subscribe_open_interest(symbol)` | `int` | Subscribe to open interest data for a stock symbol |
 | `subscribe_full_trades(sec_type)` | `int` | Subscribe to all trades for a security type (`"STOCK"`, `"OPTION"`, `"INDEX"`) |
+| `subscribe_full_open_interest(sec_type)` | `int` | Subscribe to all OI for a security type |
+| `unsubscribe_full_trades(sec_type)` | `int` | Unsubscribe from all trades for a security type |
+| `unsubscribe_full_open_interest(sec_type)` | `int` | Unsubscribe from all OI for a security type |
 | `unsubscribe_quotes(symbol)` | `int` | Unsubscribe from quote data |
 | `unsubscribe_trades(symbol)` | `int` | Unsubscribe from trade data |
 | `unsubscribe_open_interest(symbol)` | `int` | Unsubscribe from open interest data |

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -198,6 +198,9 @@ Real-time streaming is accessed through the same `ThetaDataDx` instance.
 | Method | Description |
 |--------|-------------|
 | `subscribe_full_trades(sec_type)` | Subscribe to ALL trades for a security type (`"STOCK"`, `"OPTION"`, `"INDEX"`) |
+| `subscribe_full_open_interest(sec_type)` | Subscribe to ALL OI for a security type |
+| `unsubscribe_full_trades(sec_type)` | Unsubscribe from ALL trades for a security type |
+| `unsubscribe_full_open_interest(sec_type)` | Unsubscribe from ALL OI for a security type |
 
 **Full trade stream behavior:** When subscribed via `subscribe_full_trades("OPTION")`, the ThetaData FPSS server sends a **bundle** for every trade across ALL option contracts:
 


### PR DESCRIPTION
Add subscribe_full_open_interest, unsubscribe_full_trades, unsubscribe_full_open_interest to all 6 streaming API reference docs. Fixes #58.