### PR TITLE
fix: 30 documentation findings from production audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.4.0] - 2026-04-02
 
+v3 MDDS DataTable parsing (Timestamp cells), DST-aware timezone, gRPC flow control, header aliases for EOD. See v4.5.0 for cumulative details.
+
 ## [4.3.0] - 2026-04-02
 
 ### Added
@@ -63,6 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Supported interval presets
 
 `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`
+
+## [4.1.2] - 2026-04-01
+
+Interval format conversion (later superseded by shorthand normalization in v4.2.0).
 
 ## [4.1.1] - 2026-04-01
 
@@ -114,13 +120,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Go SDK `priceToFloat()` was fundamentally wrong -- used a switch statement instead of `value * 10^(type-10)`. Every price in the Go SDK was incorrect.
-- Python docs used `event["type"]` instead of `event["kind"]` in streaming examples
-- `Price::new()` used `assert!` in release builds -- changed to `debug_assert!` + silent clamp. Corrupt frames no longer crash production.
-- C++ `FpssClient` missing `unsubscribe_quotes()` method
-- FFI FPSS functions used `.lock().unwrap()` -- changed to poison recovery
-- WebSocket handler missing `OPEN_INTEREST` and `FULL_TRADES` dispatch
-- `Credentials.password` changed from `pub` to `pub(crate)` with accessor
 - Query builder syntax highlighter regex cross-contamination (visible `class="hl-string"` in rendered code)
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ you need to get started.
 - **maturin** - for building the PyO3 Python bindings (`pip install maturin`)
 - **Go 1.21+** - for the Go SDK
 
+Note: `protoc` is required even if you're not modifying `.proto` files, because `build.rs` compiles protos during `cargo build`.
+
 ## Development Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ No-JVM ThetaData Terminal - native Rust SDK for direct market data access.
 | [`docs/`](docs/) | Architecture, API reference, JVM deviations, reverse-engineering guide |
 | [`docs-site/`](docs-site/) | mdBook documentation site (deployed to GitHub Pages) |
 | [`notebooks/`](notebooks/) | 7 Jupyter notebooks (101-107) |
+| [`examples/`](examples/) | Example programs and test scripts |
+| [`assets/`](assets/) | Logo and static assets |
 
 ## Quick Start
 
@@ -129,6 +131,7 @@ All endpoints return fully typed native structs in every language. Zero raw JSON
 | [JVM Deviations](docs/jvm-deviations.md) | Intentional differences from the Java terminal |
 | [Reverse-Engineering Guide](docs/reverse-engineering.md) | How to decompile the terminal and extract proto definitions |
 | [Endpoint Schema](docs/endpoint-schema.md) | TOML codegen format for adding new types/columns |
+| [Java Class Mapping](docs/java-class-mapping.md) | All 588 Java terminal classes enumerated |
 | [Proto Maintenance](crates/thetadatadx/proto/MAINTENANCE.md) | Guide for ThetaData engineers updating proto files |
 
 ## Contributing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,11 +20,11 @@ for critical issues.
 | Version | Supported          | Notes |
 | ------- | ------------------ | ----- |
 | 4.5.x   | :white_check_mark: | Current release (`tdbe` + `#[repr(C)]` FFI) |
-| 4.0-4.4 | :x:                | Upgrade to 4.5.x (timezone bug in 4.0-4.3, FFI improvements in 4.5) |
+| 4.0-4.4 | :x:                | Upgrade to 4.5.x (timezone bug in 4.0-4.4, FFI improvements in 4.5) |
 | 3.x     | :x:                | Pre-`tdbe` extraction, stale API |
 | < 3.0   | :x:                | Contract wire format bug, missing endpoints |
 
-> **Important:** Versions prior to 4.4.0 contain a timezone bug that shifts ms_of_day by +1 hour
+> **Important:** Versions prior to 4.5.0 contain a timezone bug that shifts ms_of_day by +1 hour
 > for all historical data from November through March (EST period). All users should upgrade to 4.5.x.
 
 ## Security Design
@@ -105,9 +105,7 @@ unbounded memory allocation.
 
 ### Dependencies
 
-We use `cargo-deny` to audit dependencies for:
+We audit dependencies for:
 - Known vulnerabilities (RustSec advisory database)
 - License compliance
 - Duplicate crate versions
-
-See `deny.toml` for the full configuration.

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@ Backlog of outstanding work, ordered by priority.
 - [x] ~~FPSS integration test: kill TCP mid-stream, verify re-subscribe~~ — `reconnect_streaming()` implemented on ThetaDataDx (v4.1.0). Saves active subscriptions, stops, restarts with new handler, re-subscribes all per-contract and full-type subscriptions. Manual reconnection by design (documented deviation from Java auto-reconnect).
 - [x] ~~FPSS integration test: trigger `TooManyRequests`, verify 130s backoff~~ — `reconnect_delay()` returns `Some(130_000)` for RemoveReason::TooManyRequests (code 12), `None` for permanent codes (0,1,2,6,9,17,18), `Some(2_000)` for all others. Logic matches Java terminal. Cannot trigger live without burning rate limits.
 - [x] ~~MDDS integration test: terminal version negotiation (`terminal_git_commit`)~~ — sends empty string (documented deviation); server accepts it
-- [x] ~~Optional RPS rate limiter in `DirectConfig`~~ — implemented as `request_semaphore` with `2^tier` concurrent requests from the auth response subscription tier. Matches Java's concurrency model. Bailey confirmed during call that server-side protection is their priority, not client-side.
+- [x] ~~Optional RPS rate limiter in `DirectConfig`~~ — implemented as `request_semaphore` with `2^tier` concurrent requests from the auth response subscription tier. Matches Java's concurrency model. ThetaData confirmed server-side protection is their priority.
 
 ## Low Priority
 

--- a/crates/tdbe/README.md
+++ b/crates/tdbe/README.md
@@ -13,6 +13,7 @@ The `thetadatadx` client crate depends on `tdbe` for type definitions.
 | `codec` | FIT nibble decoder and FIE string encoder used by FPSS tick compression |
 | `greeks` | Full Black-Scholes calculator: 22 Greeks + IV bisection solver |
 | `flags` | Bit flags and condition codes for market data records |
+| `latency` | Wire-to-application latency computation (`latency_ns`) |
 | `error` | Encoding-layer error types |
 
 ## Quick start

--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -160,7 +160,7 @@ export default defineConfig({
                 collapsed: true,
                 items: [
                   { text: 'Trade', link: '/historical/option/at-time/trade' },
-                  { text: 'OHLC', link: '/historical/option/at-time/ohlc' },
+                  { text: 'Quote', link: '/historical/option/at-time/ohlc' },
                 ],
               },
             ],

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -36,7 +36,7 @@ defer client.Close()
 ```
 ```cpp [C++]
 auto creds = tdx::Credentials::from_file("creds.txt");
-auto client = tdx::ThetaDataDx::connect(creds, tdx::Config::production());
+auto client = tdx::Client::connect(creds, tdx::Config::production());
 ```
 :::
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,130 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.0] - 2026-04-02
+
+### Breaking Changes
+
+- **FFI: `#[repr(C)]` typed struct arrays replace JSON** -- all 60 data endpoints now return native struct arrays across the FFI boundary. C++ and Go SDKs read fields directly, zero JSON serialization. FPSS streaming events remain JSON (variable schemas).
+- C++ `OptionContract` now uses `std::string root` (was `const char*`)
+- Go SDK gains 9 previously missing Greeks endpoints
+
+### Added
+
+- **DST-aware timezone conversion** -- `eastern_offset_ms()` correctly handles EST/EDT transitions using US Energy Policy Act 2005 rules. Historical data from November-March now has correct ms_of_day values. (#32)
+- **gRPC flow control config** -- `DirectConfig` gained `mdds_window_size_kb` and `mdds_connection_window_size_kb`, wired into tonic channel builder. (#36)
+- Go SDK: `OptionSnapshotGreeksFirstOrder`, `OptionSnapshotGreeksSecondOrder`, `OptionSnapshotGreeksThirdOrder`, `OptionHistoryGreeksFirstOrder/SecondOrder/ThirdOrder`, `OptionHistoryTradeGreeksFirstOrder/SecondOrder/ThirdOrder` (#39)
+- Go SDK: `SnapshotTradeTick` type and converter
+- Go SDK: `Vera` field on `GreeksTick`
+- FFI: 13 typed tick array types (`TdxEodTickArray`, `TdxOhlcTickArray`, etc.) with `from_vec`/`free`
+- FFI: `TdxStringArray` for list endpoints, `TdxOptionContractArray` for contracts
+- C++ header: `thetadx.h` with all `#[repr(C)]` struct definitions and function signatures
+
+### Fixed
+
+- **Timezone hardcoded UTC-4** -- was producing ms_of_day shifted +1 hour for all Nov-Mar historical data. Now DST-aware with 5 unit tests. (#32)
+- **EOD parser divergent alias system** -- unified to shared `find_header()`. (#34)
+- **reconnect_wait_ms** -- changed from 1000 to 2000 to match Java terminal. (#35)
+- **C++ OptionContract use-after-free** -- root string was dangling after array free. Now deep-copies to `std::string`. (#39)
+- **Active subscriptions not cleared on explicit shutdown** -- `shutdown()` clears, involuntary disconnect preserves for reconnect. (#38)
+- Mermaid diagram syntax in architecture.md (#30)
+
+### Documented
+
+- Price type per-row variation as known limitation in jvm-deviations.md (#37)
+- FPSS ring buffer capacity monitoring as known limitation
+
+## [4.4.0] - 2026-04-02
+
+## [4.3.0] - 2026-04-02
+
+### Added
+
+- **`start_time` and `end_time` parameters** exposed on all 25 endpoints that support time filtering. Pass `Some("04:00:00")` for pre-market, `Some("20:00:00")` for extended hours, or `None` for RTH defaults (09:30:00-16:00:00). Affects stock history/snapshot/at-time, option history, and index history endpoints.
+
+### Fixed
+
+- Version pins in README and getting-started docs updated to `"4.2"`
+- Default venue `"nqb"` (NASDAQ Best) documented in jvm-deviations.md
+
+## [4.2.0] - 2026-04-01
+
+### Fixed (battle-tested against live MDDS -- all 61 endpoints verified)
+
+- **Interval conversion**: MDDS server accepts preset shorthand (`1m`, `5m`, `1h`), not raw milliseconds. `normalize_interval()` now converts `"60000"` -> `"1m"`, `"300000"` -> `"5m"`, etc. Sub-second presets supported: `"100"` -> `"100ms"`, `"500"` -> `"500ms"`. Users can pass either milliseconds or shorthand directly.
+- **Default start_time/end_time**: the Java terminal defaults these to `"09:30:00"` and `"16:00:00"`. Our SDK left them as None, causing `"Invalid time format: Expected hh:mm:ss.SSS"` on trade/quote/greeks endpoints. Now defaults to RTH.
+- **extract_text_column**: now handles Number and Price DataTable values. `option_list_strikes` was returning 0 results because strikes come as Number values, not Text.
+- **FPSS TLS certificate**: ThetaData's FPSS servers have certificates expired since Jan 2024. Skip certificate verification for FPSS connections (matching Java terminal behavior).
+
+### Supported interval presets
+
+`100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`
+
+## [4.1.1] - 2026-04-01
+
+### Fixed
+
+- PyPI publish workflow: add `skip-existing: true` to prevent duplicate upload failures on tag re-push
+
+## [4.1.0] - 2026-04-01
+
+### Added
+
+- `subscribe_full_open_interest(sec_type)` -- firehose open interest subscription (was missing, Java terminal has it)
+- `unsubscribe_full_trades(sec_type)` -- firehose trade unsubscribe (was missing)
+- `unsubscribe_full_open_interest(sec_type)` -- firehose OI unsubscribe (was missing)
+- `reconnect_streaming(handler)` on `ThetaDataDx` -- saves active subscriptions, stops streaming, restarts with new handler, re-subscribes all per-contract and full-type subscriptions automatically
+- `active_full_subscriptions()` accessor for full-type subscription tracking
+- `docs/java-class-mapping.md` -- complete enumeration of all 588 Java terminal classes with Rust equivalents or justification for exclusion
+
+### Fixed
+
+- DNS hostname resolution in FPSS connection -- `SocketAddr::parse()` replaced with `ToSocketAddrs` to resolve hostnames like `nj-a.thetadata.us` (was silently failing)
+
+### Documented
+
+- Greeks operator precedence (veta, speed, zomma, color, dual_gamma) -- Java decompiler may have lost parenthesization, Rust follows textbook Black-Scholes formulas
+- FPSS ring buffer capacity monitoring -- documented as known limitation (disruptor-rs v4 has no fill-level API)
+
+## [4.0.0] - 2026-04-01
+
+### Breaking Changes
+
+- **`tdbe` crate extracted** -- all data types, codecs, greeks, price, enums, and flags moved to standalone `tdbe` crate with zero networking dependencies. Users must add `tdbe` as a dependency and change imports: `use tdbe::{Price, TradeTick, EodTick}`.
+- `thetadatadx` no longer exports `types/`, `codec/`, `greeks.rs`. These modules live in `tdbe`.
+
+### Added
+
+- **`tdbe` crate** (`crates/tdbe/`) -- pure data-format crate. Single dependency (`thiserror`). Contains:
+  - 14 hand-written tick structs (no build.rs codegen)
+  - FIT/FIE nibble codecs
+  - Price fixed-point encoding
+  - 22 Black-Scholes Greeks + IV solver
+  - All enums (SecType, DataType, StreamMsgType, etc.)
+  - Error types (Decode, Encode, Conversion, Io)
+  - Flags module (trade conditions, price flags, volume types)
+  - 6 criterion benchmarks
+- **Interactive Query Builder** on docs site -- 13 real-world recipes (GEX, vol surface, option chains, live trade tape, etc.) with symbol autocomplete, dynamic dates, and copy-paste code generation for Rust and Python
+- **Inline credential construction** -- all SDK examples now show both `from_file("creds.txt")` and `Credentials::new("email", "password")` patterns
+- **serde_json vs sonic_rs benchmark** (`bench_json`) -- criterion benchmark covering FPSS events, REST responses, DataTable serialization, and JSON parsing
+
+### Fixed
+
+- Go SDK `priceToFloat()` was fundamentally wrong -- used a switch statement instead of `value * 10^(type-10)`. Every price in the Go SDK was incorrect.
+- Python docs used `event["type"]` instead of `event["kind"]` in streaming examples
+- `Price::new()` used `assert!` in release builds -- changed to `debug_assert!` + silent clamp. Corrupt frames no longer crash production.
+- C++ `FpssClient` missing `unsubscribe_quotes()` method
+- FFI FPSS functions used `.lock().unwrap()` -- changed to poison recovery
+- WebSocket handler missing `OPEN_INTEREST` and `FULL_TRADES` dispatch
+- `Credentials.password` changed from `pub` to `pub(crate)` with accessor
+- Query builder syntax highlighter regex cross-contamination (visible `class="hl-string"` in rendered code)
+
+### Changed
+
+- Tick types in `tdbe` are hand-written (no `include!()`, no `endpoint_schema.toml` codegen). IDE-navigable, visible in source.
+- Magic numbers in `TradeTick` impl replaced with `tdbe::flags::` named constants
+- Documentation updated across 17+ files for new import paths
+
 ## [3.2.2] - 2026-03-30
 
 ### Fixed

--- a/docs-site/docs/configuration.md
+++ b/docs-site/docs/configuration.md
@@ -58,13 +58,13 @@ By default, the number of concurrent gRPC requests is auto-detected from your su
 ::: code-group
 ```rust [Rust]
 let config = DirectConfig {
-    mdds_concurrent_requests: Some(8),  // manual override
-    ..DirectConfig::production()        // None = auto from tier
+    mdds_concurrent_requests: 8,        // manual override
+    ..DirectConfig::production()        // 0 = auto from tier
 };
 ```
 ```python [Python]
 config = Config.production()
-config.mdds_concurrent_requests = 8  # manual override; None = auto from tier
+config.mdds_concurrent_requests = 8  # manual override; 0 = auto from tier
 ```
 :::
 
@@ -92,10 +92,10 @@ pub struct DirectConfig {
     pub reconnect_wait_rate_limited_ms: u64,// rate-limit delay (130000ms)
 
     // Concurrency
-    pub mdds_concurrent_requests: Option<usize>,  // None = auto (2^tier)
+    pub mdds_concurrent_requests: usize,           // 0 = auto (2^tier)
 
     // Threading
-    pub tokio_worker_threads: Option<usize>,// Tokio runtime thread count
+    pub tokio_worker_threads: usize,       // Tokio runtime thread count (0 = auto)
 }
 ```
 
@@ -118,7 +118,7 @@ The `mdds_concurrent_requests` field controls the maximum number of in-flight gR
 
 | Setting | Behavior |
 |---------|----------|
-| `None` / not set (default) | Auto-detected from subscription tier: `2^tier` |
+| `0` / not set (default) | Auto-detected from subscription tier: `2^tier` |
 | Explicit value | Fixed at `n` concurrent requests |
 
 ::: tip

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ description: Install ThetaDataDx for Rust, Python, Go, or C++.
 ```toml [Rust]
 # Add to your Cargo.toml
 [dependencies]
-thetadatadx = "3.2"
+thetadatadx = "4.5"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 ```bash [Python]

--- a/docs-site/docs/historical/option/at-time/ohlc.md
+++ b/docs-site/docs/historical/option/at-time/ohlc.md
@@ -1,9 +1,9 @@
 ---
-title: option_at_time_ohlc
+title: option_at_time_quote
 description: Quote at a specific time of day across a date range for an option contract.
 ---
 
-# option_at_time_ohlc
+# option_at_time_quote
 
 <TierBadge tier="free" />
 

--- a/docs-site/docs/streaming.md
+++ b/docs-site/docs/streaming.md
@@ -410,6 +410,12 @@ match thetadatadx::fpss::reconnect_delay(reason) {
 | `unsubscribe_quotes(contract)` | Unsubscribe from quotes |
 | `unsubscribe_trades(contract)` | Unsubscribe from trades |
 | `unsubscribe_open_interest(contract)` | Unsubscribe from OI |
+| `reconnect_streaming(handler)` | Reconnect with new handler, re-subscribe all |
+| `start_streaming_no_ohlcvc(handler)` | Start without OHLCVC derivation |
+| `is_streaming()` | Check if FPSS is active |
+| `contract_lookup(id)` | Look up contract by ID |
+| `active_subscriptions()` | Get active per-contract subs |
+| `active_full_subscriptions()` | Get active firehose subs |
 | `contract_map()` | Get current contract ID mapping |
 | `stop_streaming()` | Stop the streaming connection |
 
@@ -421,6 +427,13 @@ match thetadatadx::fpss::reconnect_delay(reason) {
 | `subscribe_quotes(symbol)` | Subscribe to quote data |
 | `subscribe_trades(symbol)` | Subscribe to trade data |
 | `subscribe_open_interest(symbol)` | Subscribe to open interest |
+| `subscribe_full_trades(sec_type)` | Subscribe to all trades for a security type |
+| `subscribe_full_open_interest(sec_type)` | Subscribe to all OI for a security type |
+| `unsubscribe_quotes(symbol)` | Unsubscribe from quotes |
+| `unsubscribe_trades(symbol)` | Unsubscribe from trades |
+| `unsubscribe_open_interest(symbol)` | Unsubscribe from OI |
+| `unsubscribe_full_trades(sec_type)` | Unsubscribe from all trades for a security type |
+| `unsubscribe_full_open_interest(sec_type)` | Unsubscribe from all OI for a security type |
 | `next_event(timeout_ms=5000)` | Poll next event (dict or `None`) |
 | `stop_streaming()` | Graceful shutdown of streaming |
 
@@ -432,9 +445,12 @@ match thetadatadx::fpss::reconnect_delay(reason) {
 | `SubscribeTrades` | `(symbol string) (int, error)` | Subscribe to trades |
 | `SubscribeOpenInterest` | `(symbol string) (int, error)` | Subscribe to OI |
 | `SubscribeFullTrades` | `(secType string) (int, error)` | Subscribe to all trades for a security type |
+| `SubscribeFullOpenInterest` | `(secType string) (int, error)` | Subscribe to all OI for a security type |
 | `UnsubscribeQuotes` | `(symbol string) (int, error)` | Unsubscribe from quotes |
 | `UnsubscribeTrades` | `(symbol string) (int, error)` | Unsubscribe from trades |
 | `UnsubscribeOpenInterest` | `(symbol string) (int, error)` | Unsubscribe from OI |
+| `UnsubscribeFullTrades` | `(secType string) (int, error)` | Unsubscribe from all trades for a security type |
+| `UnsubscribeFullOpenInterest` | `(secType string) (int, error)` | Unsubscribe from all OI for a security type |
 | `NextEvent` | `(timeoutMs uint64) (json.RawMessage, error)` | Poll next event |
 | `IsAuthenticated` | `() bool` | Check FPSS auth status |
 | `ContractLookup` | `(id int) (string, error)` | Look up contract by server-assigned ID |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -592,44 +592,64 @@ let table = tdx.raw_query(|mut stub| {
 
 ### Streaming `_stream` Endpoint Variants
 
-These variants process gRPC response chunks via callback without materializing the full response in memory. Ideal for endpoints returning millions of rows.
+These variants process gRPC response chunks via callback without materializing the full response in memory. Ideal for endpoints returning millions of rows. Each returns a builder that is finalized with `.stream()`.
 
 ```rust
-pub async fn stock_history_trade_stream<F>(
-    &self, symbol: &str, date: &str, handler: F,
-) -> Result<(), Error>
-where F: FnMut(Vec<TradeTick>) -> Result<(), Error>
+pub fn stock_history_trade_stream(&self, symbol: &str, date: &str) -> StreamBuilder<TradeTick>
 ```
 
 Process all trades for a stock on a given date, one chunk at a time. gRPC: `GetStockHistoryTrade`
 
 ```rust
-pub async fn stock_history_quote_stream<F>(
-    &self, symbol: &str, date: &str, interval: &str, handler: F,
-) -> Result<(), Error>
-where F: FnMut(Vec<QuoteTick>) -> Result<(), Error>
+let builder = tdx.stock_history_trade_stream("AAPL", "20260401");
+builder.stream(|chunk: &[TradeTick]| {
+    // process chunk
+})?;
+```
+
+```rust
+pub fn stock_history_quote_stream(&self, symbol: &str, date: &str) -> StreamBuilder<QuoteTick>
 ```
 
 Process quotes for a stock, one chunk at a time. gRPC: `GetStockHistoryQuote`
 
 ```rust
-pub async fn option_history_trade_stream<F>(
-    &self, symbol: &str, expiration: &str, strike: &str, right: &str, date: &str, handler: F,
-) -> Result<(), Error>
-where F: FnMut(Vec<TradeTick>) -> Result<(), Error>
+let builder = tdx.stock_history_quote_stream("AAPL", "20260401");
+builder.stream(|chunk: &[QuoteTick]| {
+    // process chunk
+})?;
+```
+
+```rust
+pub fn option_history_trade_stream(
+    &self, symbol: &str, expiration: &str, strike: &str, right: &str, date: &str,
+) -> StreamBuilder<TradeTick>
 ```
 
 Process all trades for an option contract, one chunk at a time. gRPC: `GetOptionHistoryTrade`
 
 ```rust
-pub async fn option_history_quote_stream<F>(
+let builder = tdx.option_history_trade_stream("SPY", "20261220", "500000", "C", "20260401");
+builder.stream(|chunk: &[TradeTick]| {
+    // process chunk
+})?;
+```
+
+```rust
+pub fn option_history_quote_stream(
     &self, symbol: &str, expiration: &str, strike: &str, right: &str,
-    date: &str, interval: &str, handler: F,
-) -> Result<(), Error>
-where F: FnMut(Vec<QuoteTick>) -> Result<(), Error>
+    date: &str, interval: &str,
+) -> StreamBuilder<QuoteTick>
 ```
 
 Process quotes for an option contract, one chunk at a time. gRPC: `GetOptionHistoryQuote`
+
+```rust
+let builder = tdx.option_history_quote_stream("SPY", "20261220", "500000", "C", "20260401", "1m");
+builder.stream(|chunk: &[QuoteTick]| {
+    // process chunk
+})?;
+```
 
 ### Auth Error Behavior
 
@@ -1502,9 +1522,9 @@ pub struct DirectConfig {
     pub reconnect_wait_ms: u64,
     pub reconnect_wait_rate_limited_ms: u64,
     // Concurrency
-    pub mdds_concurrent_requests: Option<usize>,  // max in-flight gRPC requests
-                                                   // None = auto from tier (2^tier)
-                                                   // Some(n) = manual override
+    pub mdds_concurrent_requests: usize,  // max in-flight gRPC requests
+                                         // 0 = auto from tier (2^tier)
+                                         // n = manual override
     // Threading
     pub tokio_worker_threads: Option<usize>,
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -483,13 +483,14 @@ graph TD
         end
 
         subgraph tdbe_types["types/"]
-            T_ENUM["enums.rs<br/><i>80+ DataType codes</i>"]
+            T_ENUM["enums.rs<br/><i>91 DataType codes</i>"]
             T_PRICE["price.rs<br/><i>fixed-point Price</i>"]
             T_TICK["tick.rs<br/><i>14 tick types (generated)<br/>TradeTick, QuoteTick, OhlcTick,<br/>EodTick, OpenInterestTick,<br/>SnapshotTradeTick, TradeQuoteTick,<br/>MarketValueTick, GreeksTick,<br/>IvTick, PriceTick, CalendarDay,<br/>InterestRateTick,<br/>OptionContract</i>"]
         end
 
         TDBE_GREEKS["greeks.rs<br/><i>22 Greeks + IV</i>"]
         TDBE_FLAGS["flags.rs<br/><i>condition codes</i>"]
+        TDBE_LATENCY["latency.rs<br/><i>wire-to-app latency</i>"]
         TDBE_ERROR["error.rs<br/><i>encoding errors</i>"]
     end
 
@@ -508,6 +509,7 @@ graph TD
             F_CONN["connection.rs<br/><i>TLS/TCP failover</i>"]
             F_FRAME["framing.rs<br/><i>wire frames</i>"]
             F_PROTO["protocol.rs<br/><i>contracts, messages</i>"]
+            F_RING["ring.rs<br/><i>Disruptor ring buffer</i>"]
         end
 
         UNIFIED["unified.rs<br/><i>ThetaDataDx — unified entry point<br/>Deref to DirectClient</i>"]

--- a/docs/java-class-mapping.md
+++ b/docs/java-class-mapping.md
@@ -30,11 +30,11 @@ Complete enumeration of all 588 Java classes in ThetaTerminal v202603181 and the
 | Java Class | Rust Equivalent |
 |-----------|----------------|
 | `enums/StreamMsgType.java` | `tdbe::types::enums::StreamMsgType` (21 values, exact match) |
-| `enums/DataType.java` | `tdbe::types::enums::DataType` (75 values, exact match) |
+| `enums/DataType.java` | `tdbe::types::enums::DataType` (91 values, exact match) |
 | `enums/RemoveReason.java` | `tdbe::types::enums::RemoveReason` (18 values, exact match) |
 | `enums/SecType.java` | `tdbe::types::enums::SecType` (4 values; Java has IGNORE(-1), not needed) |
 | `enums/StreamResponseType.java` | `tdbe::types::enums::StreamResponseType` (4 values, exact match) |
-| `enums/ReqType.java` | `tdbe::types::enums::ReqType` (28 values, exact match) |
+| `enums/ReqType.java` | `tdbe::types::enums::ReqType` (39 values, exact match) |
 | `enums/RateType.java` | `tdbe::types::enums::RateType` (12 values, exact match) |
 | `enums/AccountType.java` | Parsed as `i32` tier in `AuthUser` (functional match) |
 | `enums/CalendarType.java` | Not needed (Java REST-layer enum, Rust sends values directly in gRPC) |
@@ -57,7 +57,7 @@ Complete enumeration of all 588 Java classes in ThetaTerminal v202603181 and the
 | `types/tick/PriceableTick.java` | `get_price()` / `bid_price()` / `ask_price()` methods on tick structs |
 | `types/Price.java` | `tdbe::Price` |
 | `types/Right.java` | `tdbe::types::enums::Right` |
-| `types/Venue.java` | `tdbe::types::enums::Venue` (if present) |
+| `types/Venue.java` | `tdbe::types::enums::Venue` (Nqb, UtpCta) |
 | `types/ResultsFormat.java` | Not needed (JSON/CSV/HTML enum for REST layer) |
 | `types/MarketHoliday.java` | `tdbe::CalendarDay` |
 

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -33,15 +33,50 @@ All 61 endpoints are available as `tdx_stock_*`, `tdx_option_*`, `tdx_index_*`, 
 
 `tdx_unified_historical()` returns a borrowed `*const TdxClient` from a unified handle - same session, no double auth.
 
-### Streaming (via TdxUnified or TdxFpssHandle)
+### Streaming (via TdxUnified)
 
 | Function | Description |
 |----------|-------------|
 | `tdx_unified_start_streaming` | Start FPSS on the unified handle |
+| `tdx_unified_start_streaming_no_ohlcvc` | Start FPSS without derived OHLCVC |
 | `tdx_unified_subscribe_quotes` | Subscribe to quote stream |
 | `tdx_unified_subscribe_trades` | Subscribe to trade stream |
+| `tdx_unified_subscribe_open_interest` | Subscribe to open interest stream |
+| `tdx_unified_subscribe_full_trades` | Subscribe to firehose trade stream |
+| `tdx_unified_subscribe_full_open_interest` | Subscribe to firehose open interest stream |
+| `tdx_unified_unsubscribe_quotes` | Unsubscribe from quote stream |
+| `tdx_unified_unsubscribe_trades` | Unsubscribe from trade stream |
+| `tdx_unified_unsubscribe_open_interest` | Unsubscribe from open interest stream |
+| `tdx_unified_unsubscribe_full_trades` | Unsubscribe from firehose trade stream |
+| `tdx_unified_unsubscribe_full_open_interest` | Unsubscribe from firehose open interest stream |
+| `tdx_unified_is_streaming` | Check if FPSS connection is live |
+| `tdx_unified_contract_lookup` | Look up contract by ID |
+| `tdx_unified_active_subscriptions` | List active subscriptions (JSON) |
 | `tdx_unified_next_event` | Poll for next event (JSON, blocks with timeout) |
 | `tdx_unified_stop_streaming` | Stop streaming, historical stays alive |
+| `tdx_unified_free` | Free the unified handle |
+
+### Streaming (via TdxFpssHandle, standalone)
+
+| Function | Description |
+|----------|-------------|
+| `tdx_fpss_connect` | Connect standalone FPSS client |
+| `tdx_fpss_subscribe_quotes` | Subscribe to quote stream |
+| `tdx_fpss_subscribe_trades` | Subscribe to trade stream |
+| `tdx_fpss_subscribe_open_interest` | Subscribe to open interest stream |
+| `tdx_fpss_subscribe_full_trades` | Subscribe to firehose trade stream |
+| `tdx_fpss_subscribe_full_open_interest` | Subscribe to firehose open interest stream |
+| `tdx_fpss_unsubscribe_quotes` | Unsubscribe from quote stream |
+| `tdx_fpss_unsubscribe_trades` | Unsubscribe from trade stream |
+| `tdx_fpss_unsubscribe_open_interest` | Unsubscribe from open interest stream |
+| `tdx_fpss_unsubscribe_full_trades` | Unsubscribe from firehose trade stream |
+| `tdx_fpss_unsubscribe_full_open_interest` | Unsubscribe from firehose open interest stream |
+| `tdx_fpss_is_authenticated` | Check if FPSS is authenticated |
+| `tdx_fpss_contract_lookup` | Look up contract by ID |
+| `tdx_fpss_active_subscriptions` | List active subscriptions (JSON) |
+| `tdx_fpss_next_event` | Poll for next event (JSON, blocks with timeout) |
+| `tdx_fpss_shutdown` | Shut down FPSS client |
+| `tdx_fpss_free` | Free the FPSS handle |
 
 ### Error handling
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -121,7 +121,7 @@ A fully interactive, live-updating option chain rendered inside the notebook:
 - One-click and auto-refresh modes
 - IV smile plot and multi-expiration term structure visualization
 
-Requires `ipywidgets`. For a richer standalone GUI with tabbed expirations and configurable display, see the [Streamlit live-chain app](../tools/live-chain/).
+Requires `ipywidgets`. For a richer standalone GUI with tabbed expirations and configurable display, see the [Streamlit live-chain app](live-chain/).
 
 ### 107 - Full Trade Stream
 

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -9,7 +9,7 @@ Multi-language SDKs for ThetaDataDx. All powered by the Rust core via FFI - thes
 | **Python** | `pip install thetadatadx` | 61 endpoints | `ThetaDataDx` | `all_greeks()`, `to_polars()` / `to_dataframe()` | [sdks/python/](python/) |
 | **Go** | `go get github.com/userFRM/thetadatadx/sdks/go` | 61 endpoints | `FpssClient` | via FFI | [sdks/go/](go/) |
 | **C++** | CMake `find_library` | 61 endpoints | `FpssClient` | via FFI | [sdks/cpp/](cpp/) |
-| **C FFI** | `cargo build --release -p thetadatadx-ffi` | 61 endpoints | 7 functions | `tdx_all_greeks` | [ffi/](../ffi/) |
+| **C FFI** | `cargo build --release -p thetadatadx-ffi` | 61 endpoints | 17 functions | `tdx_all_greeks` | [ffi/](../ffi/) |
 
 ## Architecture
 
@@ -159,7 +159,7 @@ The library exposes opaque handle types and `extern "C"` functions:
 | **Config** | `tdx_config_production`, `tdx_config_dev`, `tdx_config_free` |
 | **Client** | `tdx_client_connect`, `tdx_client_free` |
 | **Greeks** | `tdx_all_greeks`, `tdx_implied_volatility` |
-| **FPSS Streaming** | `tdx_fpss_connect`, `tdx_fpss_subscribe_quotes`, `tdx_fpss_subscribe_trades`, `tdx_fpss_unsubscribe_quotes`, `tdx_fpss_next_event`, `tdx_fpss_shutdown`, `tdx_fpss_free` |
+| **FPSS Streaming** | 17 functions: `tdx_fpss_connect`, `tdx_fpss_subscribe_quotes`, `tdx_fpss_subscribe_trades`, `tdx_fpss_subscribe_open_interest`, `tdx_fpss_subscribe_full_trades`, `tdx_fpss_subscribe_full_open_interest`, `tdx_fpss_unsubscribe_quotes`, `tdx_fpss_unsubscribe_trades`, `tdx_fpss_unsubscribe_open_interest`, `tdx_fpss_unsubscribe_full_trades`, `tdx_fpss_unsubscribe_full_open_interest`, `tdx_fpss_is_authenticated`, `tdx_fpss_contract_lookup`, `tdx_fpss_active_subscriptions`, `tdx_fpss_next_event`, `tdx_fpss_shutdown`, `tdx_fpss_free` |
 | **Memory** | `tdx_*_array_free` (per tick type), `tdx_string_array_free`, `tdx_string_free`, `tdx_last_error` |
 
 All historical data endpoints (61 total) are accessed through `tdx_client_connect`. Results are returned as typed `#[repr(C)]` struct arrays (e.g. `TdxEodTickArray`, `TdxOhlcTickArray`) that must be freed with the corresponding `tdx_*_array_free` function. List endpoints return `TdxStringArray`. See the [FFI source](../ffi/src/lib.rs) for the full API and safety contract.

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -319,6 +319,9 @@ func main() {
 | `UnsubscribeQuotes(symbol)` | `(int, error)` | Unsubscribe from quotes |
 | `UnsubscribeTrades(symbol)` | `(int, error)` | Unsubscribe from trades |
 | `UnsubscribeOpenInterest(symbol)` | `(int, error)` | Unsubscribe from open interest |
+| `SubscribeFullOpenInterest(secType)` | `(int, error)` | Subscribe to all OI for a security type |
+| `UnsubscribeFullTrades(secType)` | `(int, error)` | Unsubscribe from all trades for a security type |
+| `UnsubscribeFullOpenInterest(secType)` | `(int, error)` | Unsubscribe from all OI for a security type |
 | `IsAuthenticated()` | `bool` | Check if FPSS client is authenticated |
 | `ContractLookup(id)` | `(string, error)` | Look up contract by server-assigned ID |
 | `ActiveSubscriptions()` | `(json.RawMessage, error)` | List currently active subscriptions |

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -982,6 +982,20 @@ impl ThetaDataDx {
         self.tdx.unsubscribe_trades(&contract).map_err(to_py_err)
     }
 
+    /// Unsubscribe from open interest data for an option contract.
+    fn unsubscribe_option_open_interest(
+        &self,
+        symbol: &str,
+        exp_date: i32,
+        is_call: bool,
+        strike: i32,
+    ) -> PyResult<i32> {
+        let contract = fpss::protocol::Contract::option(symbol, exp_date, is_call, strike);
+        self.tdx
+            .unsubscribe_open_interest(&contract)
+            .map_err(to_py_err)
+    }
+
     /// Get the current contract map (server-assigned IDs -> contract strings).
     fn contract_map(&self) -> PyResult<std::collections::HashMap<i32, String>> {
         self.tdx

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -34,10 +34,10 @@ tdx auth --creds creds.txt
 tdx stock list_symbols
 tdx stock list_dates EOD AAPL
 tdx stock history_eod AAPL 20240101 20240301
-tdx stock history_ohlc AAPL 20240315 60000           # 1-min bars
-tdx stock history_ohlc_range AAPL 20240101 20240301 60000
+tdx stock history_ohlc AAPL 20240315 1m              # 1-min bars
+tdx stock history_ohlc_range AAPL 20240101 20240301 1m
 tdx stock history_trade AAPL 20240315
-tdx stock history_quote AAPL 20240315 60000
+tdx stock history_quote AAPL 20240315 1m
 tdx stock history_trade_quote AAPL 20240315
 tdx stock snapshot_ohlc AAPL,MSFT,GOOGL
 tdx stock snapshot_trade AAPL,MSFT,GOOGL
@@ -53,9 +53,9 @@ tdx option list_strikes SPY 20240419
 tdx option list_dates EOD SPY 20240419 500000 C
 tdx option list_contracts EOD SPY 20240315
 tdx option history_trade SPY 20240419 500000 C 20240315
-tdx option history_quote SPY 20240419 500000 C 20240315 60000
+tdx option history_quote SPY 20240419 500000 C 20240315 1m
 tdx option history_eod SPY 20240419 500000 C 20240101 20240301
-tdx option history_ohlc SPY 20240419 500000 C 20240315 60000
+tdx option history_ohlc SPY 20240419 500000 C 20240315 1m
 tdx option history_trade_quote SPY 20240419 500000 C 20240315
 tdx option history_open_interest SPY 20240419 500000 C 20240315
 
@@ -73,15 +73,15 @@ tdx option snapshot_greeks_third_order SPY 20240419 500000 C
 
 # Option Greeks history
 tdx option history_greeks_eod SPY 20240419 500000 C 20240101 20240301
-tdx option history_greeks_all SPY 20240419 500000 C 20240315 60000
+tdx option history_greeks_all SPY 20240419 500000 C 20240315 1m
 tdx option history_trade_greeks_all SPY 20240419 500000 C 20240315
-tdx option history_greeks_first_order SPY 20240419 500000 C 20240315 60000
+tdx option history_greeks_first_order SPY 20240419 500000 C 20240315 1m
 tdx option history_trade_greeks_first_order SPY 20240419 500000 C 20240315
-tdx option history_greeks_second_order SPY 20240419 500000 C 20240315 60000
+tdx option history_greeks_second_order SPY 20240419 500000 C 20240315 1m
 tdx option history_trade_greeks_second_order SPY 20240419 500000 C 20240315
-tdx option history_greeks_third_order SPY 20240419 500000 C 20240315 60000
+tdx option history_greeks_third_order SPY 20240419 500000 C 20240315 1m
 tdx option history_trade_greeks_third_order SPY 20240419 500000 C 20240315
-tdx option history_greeks_implied_volatility SPY 20240419 500000 C 20240315 60000
+tdx option history_greeks_implied_volatility SPY 20240419 500000 C 20240315 1m
 tdx option history_trade_greeks_implied_volatility SPY 20240419 500000 C 20240315
 
 # Option at-time queries
@@ -92,8 +92,8 @@ tdx option at_time_quote SPY 20240419 500000 C 20240101 20240301 34200000
 tdx index list_symbols
 tdx index list_dates SPX
 tdx index history_eod SPX 20240101 20240301
-tdx index history_ohlc SPX 20240101 20240301 60000
-tdx index history_price SPX 20240315 60000
+tdx index history_ohlc SPX 20240101 20240301 1m
+tdx index history_price SPX 20240315 1m
 tdx index snapshot_ohlc SPX,NDX,RUT
 tdx index snapshot_price SPX,NDX,RUT
 tdx index snapshot_market_value SPX,NDX,RUT


### PR DESCRIPTION
All 30 findings from the final production audit fixed across 22 files. 10 HIGH (broken code examples, phantom endpoints, wrong versions), 11 MEDIUM (incomplete tables, stale counts), 9 LOW (style, paths, naming). Fixes #62.