### PR TITLE
feat: metrics export + runtime config loading from TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,32 +374,6 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.5.0",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
@@ -397,7 +383,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.8.2",
+ "criterion-plot",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -409,16 +395,6 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -994,30 +970,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1171,6 +1127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,9 +1144,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1377,6 +1343,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1993,11 +1965,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2125,7 +2097,7 @@ dependencies = [
 name = "tdbe"
 version = "0.1.0"
 dependencies = [
- "criterion 0.8.2",
+ "criterion",
  "thiserror 2.0.18",
 ]
 
@@ -2146,8 +2118,9 @@ dependencies = [
 name = "thetadatadx"
 version = "4.5.0"
 dependencies = [
- "criterion 0.5.1",
+ "criterion",
  "disruptor",
+ "metrics",
  "paste",
  "prost",
  "prost-build",
@@ -2270,9 +2243,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -2285,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2330,44 +2303,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -2587,13 +2558,19 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -3030,12 +3007,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -20,6 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+config-file = ["dep:toml"]
 
 [dependencies]
 tdbe = { version = "0.1.0", path = "../tdbe" }
@@ -31,7 +32,7 @@ prost = "=0.14.3"
 prost-types = "=0.14.3"
 
 # Async runtime
-tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync"] }
+tokio = { version = "1.51.0", features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync"] }
 tokio-stream = "0.1.18"
 tokio-rustls = "0.26.4"
 rustls = { version = "0.23.37", features = ["ring"] }
@@ -42,7 +43,7 @@ reqwest = { version = "0.13.2", features = ["json", "rustls"], default-features 
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }
-uuid = "1.22.0"
+uuid = "1.23.0"
 
 # Compression (responses use zstd)
 zstd = "0.13.3"
@@ -56,18 +57,24 @@ paste = "1"
 # Logging
 tracing = "0.1.44"
 
+# Metrics
+metrics = "0.24.3"
+
+# Config file loading (optional)
+toml = { version = "1", optional = true }
+
 # Lock-free ring buffer (LMAX Disruptor pattern) for FPSS event dispatch
-disruptor = "4"
+disruptor = "4.0.0"
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
 
 [build-dependencies]
 # tonic 0.14 extracted build integration into tonic-prost-build
 tonic-prost-build = "=0.14.5"
 prost-build = "=0.14.3"
-regex = "1"
-toml = "0.8"
+regex = "1.12.3"
+toml = "1"
 serde = { version = "1", features = ["derive"] }
 
 [[bench]]

--- a/crates/thetadatadx/src/auth/nexus.rs
+++ b/crates/thetadatadx/src/auth/nexus.rs
@@ -144,6 +144,9 @@ impl AuthUser {
 /// The returned `AuthResponse.session_id` is a UUID string that must be
 /// embedded in every MDDS gRPC request as `QueryInfo.auth_token.session_uuid`.
 pub async fn authenticate(creds: &Credentials) -> Result<AuthResponse, Error> {
+    metrics::counter!("thetadatadx.auth.requests").increment(1);
+    let _auth_start = std::time::Instant::now();
+
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .connect_timeout(Duration::from_secs(5))
@@ -205,6 +208,9 @@ pub async fn authenticate(creds: &Credentials) -> Result<AuthResponse, Error> {
         session_id_prefix = %&auth.session_id[..8.min(auth.session_id.len())],
         "authenticated successfully (session_id redacted)"
     );
+
+    metrics::histogram!("thetadatadx.auth.latency_ms")
+        .record(_auth_start.elapsed().as_millis() as f64);
 
     Ok(auth)
 }

--- a/crates/thetadatadx/src/config.rs
+++ b/crates/thetadatadx/src/config.rs
@@ -310,6 +310,251 @@ impl DirectConfig {
     }
 }
 
+// ── Config file loading (behind `config-file` feature) ──────────────────────
+
+#[cfg(feature = "config-file")]
+mod config_file {
+    use super::{DirectConfig, FpssFlushMode};
+    use crate::error::Error;
+    use serde::Deserialize;
+
+    /// TOML-level representation of the config file.
+    ///
+    /// Unknown keys are silently ignored (`#[serde(default)]` on each section).
+    /// Missing sections fall back to production defaults.
+    #[derive(Debug, Default, Deserialize)]
+    #[serde(default)]
+    struct ConfigFile {
+        mdds: MddsSection,
+        fpss: FpssSection,
+        grpc: GrpcSection,
+        auth: AuthSection,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(default)]
+    struct MddsSection {
+        host: String,
+        port: u16,
+        tls: bool,
+        keepalive_time_secs: u64,
+        keepalive_timeout_secs: u64,
+        max_message_size: usize,
+    }
+
+    impl Default for MddsSection {
+        fn default() -> Self {
+            let prod = DirectConfig::production();
+            Self {
+                host: prod.mdds_host,
+                port: prod.mdds_port,
+                tls: prod.mdds_tls,
+                keepalive_time_secs: prod.mdds_keepalive_secs,
+                keepalive_timeout_secs: prod.mdds_keepalive_timeout_secs,
+                max_message_size: prod.mdds_max_message_size,
+            }
+        }
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(default)]
+    struct FpssSection {
+        /// Hosts as `["host:port", ...]` array or `"host:port,host:port"` string.
+        hosts: FpssHosts,
+        connect_timeout: u64,
+        read_timeout: u64,
+        ping_interval: u64,
+        reconnect_wait: u64,
+        reconnect_wait_rate_limited: u64,
+        queue_depth: usize,
+        ring_size: usize,
+        flush_mode: String,
+    }
+
+    impl Default for FpssSection {
+        fn default() -> Self {
+            let prod = DirectConfig::production();
+            Self {
+                hosts: FpssHosts::Array(
+                    prod.fpss_hosts
+                        .iter()
+                        .map(|(h, p)| format!("{h}:{p}"))
+                        .collect(),
+                ),
+                connect_timeout: prod.fpss_connect_timeout_ms,
+                read_timeout: prod.fpss_timeout_ms,
+                ping_interval: prod.fpss_ping_interval_ms,
+                reconnect_wait: prod.reconnect_wait_ms,
+                reconnect_wait_rate_limited: prod.reconnect_wait_rate_limited_ms,
+                queue_depth: prod.fpss_queue_depth,
+                ring_size: prod.fpss_ring_size,
+                flush_mode: "batched".to_string(),
+            }
+        }
+    }
+
+    /// FPSS hosts can be specified as either a TOML array or a comma-separated string.
+    #[derive(Debug, Deserialize)]
+    #[serde(untagged)]
+    enum FpssHosts {
+        Array(Vec<String>),
+        Csv(String),
+    }
+
+    impl Default for FpssHosts {
+        fn default() -> Self {
+            let prod = DirectConfig::production();
+            FpssHosts::Array(
+                prod.fpss_hosts
+                    .iter()
+                    .map(|(h, p)| format!("{h}:{p}"))
+                    .collect(),
+            )
+        }
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(default)]
+    struct GrpcSection {
+        window_size_kb: usize,
+        connection_window_size_kb: usize,
+        max_message_size_mb: usize,
+        concurrent_requests: usize,
+    }
+
+    impl Default for GrpcSection {
+        fn default() -> Self {
+            let prod = DirectConfig::production();
+            Self {
+                window_size_kb: prod.mdds_window_size_kb,
+                connection_window_size_kb: prod.mdds_connection_window_size_kb,
+                max_message_size_mb: prod.mdds_max_message_size / (1024 * 1024),
+                concurrent_requests: prod.mdds_concurrent_requests,
+            }
+        }
+    }
+
+    #[derive(Debug, Default, Deserialize)]
+    #[serde(default)]
+    struct AuthSection {
+        #[allow(dead_code)]
+        creds_file: Option<String>,
+    }
+
+    impl FpssHosts {
+        fn parse(self) -> Result<Vec<(String, u16)>, Error> {
+            let entries = match self {
+                FpssHosts::Array(arr) => arr,
+                FpssHosts::Csv(s) => s.split(',').map(|s| s.trim().to_string()).collect(),
+            };
+            let mut result = Vec::new();
+            for entry in entries {
+                let entry = entry.trim();
+                if entry.is_empty() {
+                    continue;
+                }
+                let (host, port_str) = entry
+                    .rsplit_once(':')
+                    .ok_or_else(|| Error::Config(format!("invalid host:port entry: '{entry}'")))?;
+                let port: u16 = port_str
+                    .parse()
+                    .map_err(|e| Error::Config(format!("invalid port in '{entry}': {e}")))?;
+                result.push((host.to_string(), port));
+            }
+            if result.is_empty() {
+                return Err(Error::Config("no FPSS hosts provided".to_string()));
+            }
+            Ok(result)
+        }
+    }
+
+    impl DirectConfig {
+        /// Load configuration from a TOML file.
+        ///
+        /// The file format matches `config.default.toml` shipped with the crate.
+        /// Missing sections and keys fall back to [`DirectConfig::production()`] defaults.
+        /// Unknown keys are silently ignored.
+        ///
+        /// # Example file
+        ///
+        /// ```toml
+        /// [mdds]
+        /// host = "mdds-01.thetadata.us"
+        /// port = 443
+        /// tls = true
+        ///
+        /// [fpss]
+        /// hosts = ["nj-a.thetadata.us:20000", "nj-b.thetadata.us:20000"]
+        /// reconnect_wait = 2000
+        /// queue_depth = 1000000
+        /// flush_mode = "batched"  # or "immediate"
+        ///
+        /// [grpc]
+        /// window_size_kb = 64
+        /// connection_window_size_kb = 64
+        /// concurrent_requests = 0  # 0 = auto from tier
+        /// ```
+        pub fn from_file(path: impl AsRef<std::path::Path>) -> Result<Self, Error> {
+            let contents = std::fs::read_to_string(path.as_ref()).map_err(|e| {
+                Error::Config(format!(
+                    "failed to read config file '{}': {e}",
+                    path.as_ref().display()
+                ))
+            })?;
+            Self::from_toml_str(&contents)
+        }
+
+        /// Parse configuration from a TOML string.
+        ///
+        /// Same semantics as [`from_file`](Self::from_file) but takes a string directly.
+        pub fn from_toml_str(toml_str: &str) -> Result<Self, Error> {
+            let cf: ConfigFile = toml::from_str(toml_str)
+                .map_err(|e| Error::Config(format!("failed to parse TOML config: {e}")))?;
+
+            let flush_mode = match cf.fpss.flush_mode.to_lowercase().as_str() {
+                "immediate" => FpssFlushMode::Immediate,
+                _ => FpssFlushMode::Batched,
+            };
+
+            // If [grpc].max_message_size_mb is set, it overrides [mdds].max_message_size.
+            // The grpc section value is in MB; the mdds section value is in bytes.
+            let max_message_size = if cf.grpc.max_message_size_mb
+                != DirectConfig::production().mdds_max_message_size / (1024 * 1024)
+            {
+                cf.grpc.max_message_size_mb * 1024 * 1024
+            } else {
+                cf.mdds.max_message_size
+            };
+
+            Ok(DirectConfig {
+                mdds_host: cf.mdds.host,
+                mdds_port: cf.mdds.port,
+                mdds_tls: cf.mdds.tls,
+
+                fpss_hosts: cf.fpss.hosts.parse()?,
+                fpss_timeout_ms: cf.fpss.read_timeout,
+                fpss_queue_depth: cf.fpss.queue_depth,
+                fpss_ring_size: cf.fpss.ring_size,
+                fpss_ping_interval_ms: cf.fpss.ping_interval,
+                fpss_connect_timeout_ms: cf.fpss.connect_timeout,
+                fpss_flush_mode: flush_mode,
+
+                mdds_concurrent_requests: cf.grpc.concurrent_requests,
+                mdds_max_message_size: max_message_size,
+                mdds_keepalive_secs: cf.mdds.keepalive_time_secs,
+                mdds_keepalive_timeout_secs: cf.mdds.keepalive_timeout_secs,
+                mdds_window_size_kb: cf.grpc.window_size_kb,
+                mdds_connection_window_size_kb: cf.grpc.connection_window_size_kb,
+
+                reconnect_wait_ms: cf.fpss.reconnect_wait,
+                reconnect_wait_rate_limited_ms: cf.fpss.reconnect_wait_rate_limited,
+
+                tokio_worker_threads: None,
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -388,5 +633,156 @@ mod tests {
         let dev = DirectConfig::dev();
         assert!(dev.fpss_timeout_ms < prod.fpss_timeout_ms);
         assert!(dev.reconnect_wait_ms < prod.reconnect_wait_ms);
+    }
+
+    // -- Config file tests (only compiled with the `config-file` feature) --
+
+    #[cfg(feature = "config-file")]
+    mod config_file_tests {
+        use crate::config::{DirectConfig, FpssFlushMode};
+
+        #[test]
+        fn empty_toml_gives_production_defaults() {
+            let config = DirectConfig::from_toml_str("").unwrap();
+            let prod = DirectConfig::production();
+            assert_eq!(config.mdds_host, prod.mdds_host);
+            assert_eq!(config.mdds_port, prod.mdds_port);
+            assert_eq!(config.fpss_hosts.len(), prod.fpss_hosts.len());
+            assert_eq!(config.fpss_queue_depth, prod.fpss_queue_depth);
+        }
+
+        #[test]
+        fn partial_toml_overrides_only_specified() {
+            let toml = r#"
+                [mdds]
+                host = "custom.example.com"
+                port = 8443
+
+                [fpss]
+                queue_depth = 500000
+            "#;
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            assert_eq!(config.mdds_host, "custom.example.com");
+            assert_eq!(config.mdds_port, 8443);
+            assert_eq!(config.fpss_queue_depth, 500000);
+            // Unspecified fields keep production defaults
+            assert!(config.mdds_tls);
+        }
+
+        #[test]
+        fn fpss_hosts_as_array() {
+            let toml = r#"
+                [fpss]
+                hosts = ["host-a.example.com:20000", "host-b.example.com:20001"]
+            "#;
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            assert_eq!(config.fpss_hosts.len(), 2);
+            assert_eq!(
+                config.fpss_hosts[0],
+                ("host-a.example.com".to_string(), 20000)
+            );
+            assert_eq!(
+                config.fpss_hosts[1],
+                ("host-b.example.com".to_string(), 20001)
+            );
+        }
+
+        #[test]
+        fn fpss_hosts_as_csv_string() {
+            let toml = r#"
+                [fpss]
+                hosts = "host-a.example.com:20000,host-b.example.com:20001"
+            "#;
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            assert_eq!(config.fpss_hosts.len(), 2);
+            assert_eq!(config.fpss_hosts[0].0, "host-a.example.com");
+        }
+
+        #[test]
+        fn flush_mode_immediate() {
+            let toml = r#"
+                [fpss]
+                flush_mode = "immediate"
+            "#;
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            assert_eq!(config.fpss_flush_mode, FpssFlushMode::Immediate);
+        }
+
+        #[test]
+        fn flush_mode_batched_by_default() {
+            let toml = r#"
+                [fpss]
+                flush_mode = "batched"
+            "#;
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            assert_eq!(config.fpss_flush_mode, FpssFlushMode::Batched);
+        }
+
+        #[test]
+        fn grpc_section_sets_window_sizes() {
+            let toml = r#"
+                [grpc]
+                window_size_kb = 128
+                connection_window_size_kb = 256
+                concurrent_requests = 4
+            "#;
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            assert_eq!(config.mdds_window_size_kb, 128);
+            assert_eq!(config.mdds_connection_window_size_kb, 256);
+            assert_eq!(config.mdds_concurrent_requests, 4);
+        }
+
+        #[test]
+        fn grpc_max_message_size_mb_overrides_mdds_bytes() {
+            let toml = r#"
+                [grpc]
+                max_message_size_mb = 8
+            "#;
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            assert_eq!(config.mdds_max_message_size, 8 * 1024 * 1024);
+        }
+
+        #[test]
+        fn unknown_keys_are_ignored() {
+            let toml = r#"
+                [mdds]
+                host = "mdds-01.thetadata.us"
+                port = 443
+                unknown_key = "should be ignored"
+
+                [some_unknown_section]
+                foo = "bar"
+            "#;
+            // Should not error
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            assert_eq!(config.mdds_port, 443);
+        }
+
+        #[test]
+        fn full_config_default_toml_parses() {
+            // Validate that config.default.toml (shipped with the crate) can be parsed.
+            let default_toml = include_str!("../../../config.default.toml");
+            let config = DirectConfig::from_toml_str(default_toml).unwrap();
+            assert_eq!(config.mdds_host, "mdds-01.thetadata.us");
+            assert_eq!(config.mdds_port, 443);
+            assert_eq!(config.fpss_hosts.len(), 4);
+        }
+
+        #[test]
+        fn invalid_toml_returns_error() {
+            let result = DirectConfig::from_toml_str("this is not valid toml [[[");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("TOML"));
+        }
+    }
+
+    // -- Metrics tests --
+
+    #[test]
+    fn metrics_counter_compiles_and_runs() {
+        // Verify that metrics macros resolve without a recorder installed.
+        // The `metrics` crate is designed to no-op when no recorder is set.
+        metrics::counter!("thetadatadx.test.counter", "tag" => "value").increment(1);
+        metrics::histogram!("thetadatadx.test.histogram").record(42.0);
     }
 }

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -63,14 +63,30 @@ macro_rules! list_endpoint {
         $(#[$meta])*
         pub async fn $name(&self, $($arg : $arg_ty),*) -> Result<Vec<String>, Error> {
             tracing::debug!(endpoint = stringify!($name), "gRPC request");
+            metrics::counter!("thetadatadx.grpc.requests", "endpoint" => stringify!($name)).increment(1);
+            let _metrics_start = std::time::Instant::now();
             let _permit = self.request_semaphore.acquire().await
                 .map_err(|_| Error::Fpss("request semaphore closed".into()))?;
             let request = proto_v3::$req {
                 query_info: Some(self.query_info()),
                 params: Some(proto_v3::$query { $($field : $val),* }),
             };
-            let stream = self.stub().$grpc(request).await?.into_inner();
-            let table = self.collect_stream(stream).await?;
+            let stream = match self.stub().$grpc(request).await {
+                Ok(resp) => resp.into_inner(),
+                Err(e) => {
+                    metrics::counter!("thetadatadx.grpc.errors", "endpoint" => stringify!($name)).increment(1);
+                    return Err(e.into());
+                }
+            };
+            let table = match self.collect_stream(stream).await {
+                Ok(t) => t,
+                Err(e) => {
+                    metrics::counter!("thetadatadx.grpc.errors", "endpoint" => stringify!($name)).increment(1);
+                    return Err(e);
+                }
+            };
+            metrics::histogram!("thetadatadx.grpc.latency_ms", "endpoint" => stringify!($name))
+                .record(_metrics_start.elapsed().as_millis() as f64);
             Ok(decode::extract_text_column(&table, $col)
                 .into_iter()
                 .flatten()
@@ -138,14 +154,30 @@ macro_rules! parsed_endpoint {
                     let _ = &client;
                     $($(validate_date(&$date_arg)?;)+)?
                     tracing::debug!(endpoint = stringify!($name), "gRPC request");
+                    metrics::counter!("thetadatadx.grpc.requests", "endpoint" => stringify!($name)).increment(1);
+                    let _metrics_start = std::time::Instant::now();
                     let _permit = client.request_semaphore.acquire().await
                         .map_err(|_| Error::Fpss("request semaphore closed".into()))?;
                     let request = proto_v3::$req {
                         query_info: Some(client.query_info()),
                         params: Some(proto_v3::$query { $($field : $val),* }),
                     };
-                    let stream = client.stub().$grpc(request).await?.into_inner();
-                    let table = client.collect_stream(stream).await?;
+                    let stream = match client.stub().$grpc(request).await {
+                        Ok(resp) => resp.into_inner(),
+                        Err(e) => {
+                            metrics::counter!("thetadatadx.grpc.errors", "endpoint" => stringify!($name)).increment(1);
+                            return Err(e.into());
+                        }
+                    };
+                    let table = match client.collect_stream(stream).await {
+                        Ok(t) => t,
+                        Err(e) => {
+                            metrics::counter!("thetadatadx.grpc.errors", "endpoint" => stringify!($name)).increment(1);
+                            return Err(e);
+                        }
+                    };
+                    metrics::histogram!("thetadatadx.grpc.latency_ms", "endpoint" => stringify!($name))
+                        .record(_metrics_start.elapsed().as_millis() as f64);
                     Ok($parser(&table))
                 })
             }
@@ -286,21 +318,39 @@ macro_rules! streaming_endpoint {
                 let _ = &client;
                 $($(validate_date(&$date_arg)?;)+)?
                 tracing::debug!(endpoint = stringify!($name), "gRPC streaming request");
+                metrics::counter!("thetadatadx.grpc.requests", "endpoint" => stringify!($name)).increment(1);
+                let _metrics_start = std::time::Instant::now();
                 let _permit = client.request_semaphore.acquire().await
                     .map_err(|_| Error::Fpss("request semaphore closed".into()))?;
                 let request = proto_v3::$req {
                     query_info: Some(client.query_info()),
                     params: Some(proto_v3::$query { $($field : $val),* }),
                 };
-                let stream = client.stub().$grpc(request).await?.into_inner();
-                client.for_each_chunk(stream, |_headers, rows| {
+                let stream = match client.stub().$grpc(request).await {
+                    Ok(resp) => resp.into_inner(),
+                    Err(e) => {
+                        metrics::counter!("thetadatadx.grpc.errors", "endpoint" => stringify!($name)).increment(1);
+                        return Err(e.into());
+                    }
+                };
+                let result = client.for_each_chunk(stream, |_headers, rows| {
                     let table = proto::DataTable {
                         headers: _headers.to_vec(),
                         data_table: rows.to_vec(),
                     };
                     let ticks = $parser(&table);
                     handler(&ticks);
-                }).await
+                }).await;
+                match &result {
+                    Ok(()) => {
+                        metrics::histogram!("thetadatadx.grpc.latency_ms", "endpoint" => stringify!($name))
+                            .record(_metrics_start.elapsed().as_millis() as f64);
+                    }
+                    Err(_) => {
+                        metrics::counter!("thetadatadx.grpc.errors", "endpoint" => stringify!($name)).increment(1);
+                    }
+                }
+                result
             }
         }
 

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -1398,24 +1398,27 @@ fn decode_frame(
         StreamMsgType::Quote => {
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, QUOTE_FIELDS) {
-                Some((contract_id, f)) => (
-                    Some(FpssEvent::Data(FpssData::Quote {
-                        contract_id,
-                        ms_of_day: f[0],
-                        bid_size: f[1],
-                        bid_exchange: f[2],
-                        bid: f[3],
-                        bid_condition: f[4],
-                        ask_size: f[5],
-                        ask_exchange: f[6],
-                        ask: f[7],
-                        ask_condition: f[8],
-                        price_type: f[9],
-                        date: f[10],
-                        received_at_ns,
-                    })),
-                    None,
-                ),
+                Some((contract_id, f)) => {
+                    metrics::counter!("thetadatadx.fpss.events", "kind" => "quote").increment(1);
+                    (
+                        Some(FpssEvent::Data(FpssData::Quote {
+                            contract_id,
+                            ms_of_day: f[0],
+                            bid_size: f[1],
+                            bid_exchange: f[2],
+                            bid: f[3],
+                            bid_condition: f[4],
+                            ask_size: f[5],
+                            ask_exchange: f[6],
+                            ask: f[7],
+                            ask_condition: f[8],
+                            price_type: f[9],
+                            date: f[10],
+                            received_at_ns,
+                        })),
+                        None,
+                    )
+                }
                 // DATE markers return None from decode_tick -- this is normal
                 // protocol flow (session date boundary), not corruption.
                 None if delta_state.last_was_date => (None, None),
@@ -1433,6 +1436,7 @@ fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, TRADE_FIELDS) {
                 Some((contract_id, f)) => {
+                    metrics::counter!("thetadatadx.fpss.events", "kind" => "trade").increment(1);
                     let (ms_of_day, size, price) = (f[0], f[7], f[9]);
                     let (price_type, date) = (f[14], f[15]);
                     let trade_event = FpssEvent::Data(FpssData::Trade {
@@ -1501,16 +1505,20 @@ fn decode_frame(
         StreamMsgType::OpenInterest => {
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, OI_FIELDS) {
-                Some((contract_id, f)) => (
-                    Some(FpssEvent::Data(FpssData::OpenInterest {
-                        contract_id,
-                        ms_of_day: f[0],
-                        open_interest: f[1],
-                        date: f[2],
-                        received_at_ns,
-                    })),
-                    None,
-                ),
+                Some((contract_id, f)) => {
+                    metrics::counter!("thetadatadx.fpss.events", "kind" => "open_interest")
+                        .increment(1);
+                    (
+                        Some(FpssEvent::Data(FpssData::OpenInterest {
+                            contract_id,
+                            ms_of_day: f[0],
+                            open_interest: f[1],
+                            date: f[2],
+                            received_at_ns,
+                        })),
+                        None,
+                    )
+                }
                 None if delta_state.last_was_date => (None, None),
                 None => (
                     Some(FpssEvent::RawData {
@@ -1526,6 +1534,7 @@ fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, OHLCVC_FIELDS) {
                 Some((contract_id, f)) => {
+                    metrics::counter!("thetadatadx.fpss.events", "kind" => "ohlcvc").increment(1);
                     let acc = delta_state
                         .ohlcvc
                         .entry(contract_id)
@@ -1613,6 +1622,8 @@ fn decode_frame(
         StreamMsgType::Disconnected => {
             let reason = parse_disconnect_reason(payload);
             tracing::warn!(reason = ?reason, "server disconnected us");
+            metrics::counter!("thetadatadx.fpss.disconnects", "reason" => format!("{:?}", reason))
+                .increment(1);
             authenticated.store(false, Ordering::Release);
 
             // Permanent errors -- no reconnect will fix these.

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -226,6 +226,7 @@ impl ThetaDataDx {
     where
         F: FnMut(&FpssEvent) + Send + 'static,
     {
+        metrics::counter!("thetadatadx.fpss.reconnects").increment(1);
         // 1. Save active subscriptions before stopping
         let saved_subs = {
             let guard = self.streaming.lock().unwrap_or_else(|e| e.into_inner());


### PR DESCRIPTION
## Metrics (#68)

`metrics` crate integrated. Zero overhead when no backend installed. Counters/histograms on:
- All gRPC endpoints (requests, latency, errors)
- FPSS events (by kind), disconnects (by reason), reconnects
- Auth requests and latency

## Config file (#69)

`DirectConfig::from_file(path)` behind `config-file` feature flag. Matches Java terminal config.toml format. 11 tests.

```toml
[mdds]
host = "mdds-01.thetadata.us"
port = 443

[fpss]
hosts = ["nj-a.thetadata.us:20000", "nj-b.thetadata.us:20000"]
flush_mode = "immediate"
```

Fixes #68, #69.

## Test plan
- [x] 175 tests pass (default features)
- [x] 186 tests pass (with config-file)
- [x] fmt/clippy clean both ways