### PR TITLE
feat: expose DirectConfig::stage() in all SDKs

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -370,11 +370,19 @@ pub extern "C" fn tdx_config_production() -> *mut TdxConfig {
     }))
 }
 
-/// Create a dev config (shorter timeouts).
+/// Create a dev config (FPSS dev servers, port 20200, infinite replay).
 #[no_mangle]
 pub extern "C" fn tdx_config_dev() -> *mut TdxConfig {
     Box::into_raw(Box::new(TdxConfig {
         inner: thetadatadx::DirectConfig::dev(),
+    }))
+}
+
+/// Create a stage config (FPSS stage servers, port 20100, unstable).
+#[no_mangle]
+pub extern "C" fn tdx_config_stage() -> *mut TdxConfig {
+    Box::into_raw(Box::new(TdxConfig {
+        inner: thetadatadx::DirectConfig::stage(),
     }))
 }
 

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -74,6 +74,7 @@ int main() {
 
 - `Config::production()` - ThetaData NJ production servers
 - `Config::dev()` - Dev FPSS servers (port 20200, infinite historical replay)
+- `Config.stage()` / `StageConfig()` / `Config::stage()` - Stage FPSS servers (port 20100, testing, unstable)
 
 ### Client
 

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -296,8 +296,11 @@ void tdx_credentials_free(TdxCredentials* creds);
 /** Create a production config (ThetaData NJ datacenter). */
 TdxConfig* tdx_config_production(void);
 
-/** Create a dev config (shorter timeouts). */
+/** Create a dev FPSS config (port 20200, infinite historical replay). */
 TdxConfig* tdx_config_dev(void);
+
+/** Create a stage FPSS config (port 20100, testing, unstable). */
+TdxConfig* tdx_config_stage(void);
 
 /** Free a config handle. */
 void tdx_config_free(TdxConfig* config);

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -187,8 +187,11 @@ public:
     /** Production config (ThetaData NJ datacenter). */
     static Config production();
 
-    /** Dev config (shorter timeouts). */
+    /** Dev FPSS config (port 20200, infinite historical replay). */
     static Config dev();
+
+    /** Stage FPSS config (port 20100, testing, unstable). */
+    static Config stage();
 
     /** Get the raw handle. */
     TdxConfig* get() const { return handle_.get(); }

--- a/sdks/cpp/src/thetadx.cpp
+++ b/sdks/cpp/src/thetadx.cpp
@@ -46,6 +46,7 @@ Credentials Credentials::from_email(const std::string& email, const std::string&
 
 Config Config::production() { return Config(tdx_config_production()); }
 Config Config::dev() { return Config(tdx_config_dev()); }
+Config Config::stage() { return Config(tdx_config_stage()); }
 
 // ── Client ──
 

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -77,6 +77,7 @@ func main() {
 ### Config
 - `ProductionConfig()` - ThetaData NJ production servers
 - `DevConfig()` - Dev FPSS servers (port 20200, infinite historical replay)
+- `Config.stage()` / `StageConfig()` / `Config::stage()` - Stage FPSS servers (port 20100, testing, unstable)
 
 ### Client (Historical Data)
 

--- a/sdks/go/thetadx.go
+++ b/sdks/go/thetadx.go
@@ -24,6 +24,7 @@ extern void tdx_credentials_free(TdxCredentials* creds);
 // ── Config ──
 extern TdxConfig* tdx_config_production();
 extern TdxConfig* tdx_config_dev();
+extern TdxConfig* tdx_config_stage();
 extern void tdx_config_free(TdxConfig* config);
 
 // ── Client ──
@@ -266,9 +267,14 @@ func ProductionConfig() *Config {
 	return &Config{handle: C.tdx_config_production()}
 }
 
-// DevConfig returns the dev server config (shorter timeouts).
+// DevConfig returns the dev FPSS config (port 20200, infinite historical replay).
 func DevConfig() *Config {
 	return &Config{handle: C.tdx_config_dev()}
+}
+
+// StageConfig returns the stage FPSS config (port 20100, testing, unstable).
+func StageConfig() *Config {
+	return &Config{handle: C.tdx_config_stage()}
 }
 
 // Close frees the config handle.

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +821,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,9 +838,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1468,11 +1490,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1577,6 +1599,7 @@ name = "thetadatadx"
 version = "4.5.0"
 dependencies = [
  "disruptor",
+ "metrics",
  "paste",
  "prost",
  "prost-build",
@@ -1677,9 +1700,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -1692,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1737,44 +1760,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -1976,13 +1997,19 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2419,12 +2446,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -78,6 +78,7 @@ iv, err = implied_volatility(450.0, 455.0, 0.05, 0.015, 30/365, 8.50, True)
 ### `Config`
 - `Config.production()` - ThetaData NJ production servers
 - `Config.dev()` - Dev FPSS servers (port 20200, infinite historical replay)
+- `Config.stage()` / `StageConfig()` / `Config::stage()` - Stage FPSS servers (port 20100, testing, unstable)
 
 ### `ThetaDataDx(creds, config)`
 

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -91,11 +91,19 @@ impl Config {
         }
     }
 
-    /// Dev configuration (shorter timeouts).
+    /// Dev FPSS configuration (port 20200, infinite historical replay).
     #[staticmethod]
     fn dev() -> Self {
         Self {
             inner: config::DirectConfig::dev(),
+        }
+    }
+
+    /// Stage FPSS configuration (port 20100, testing, unstable).
+    #[staticmethod]
+    fn stage() -> Self {
+        Self {
+            inner: config::DirectConfig::stage(),
         }
     }
 


### PR DESCRIPTION
stage() added to FFI, Python, C++, Go. All dev() docstrings fixed. READMEs updated. Fixes #74.