### PR TITLE
fix: FpssClient::connect() uses DirectConfig::fpss_hosts

### DIFF
--- a/crates/thetadatadx/src/fpss/connection.rs
+++ b/crates/thetadatadx/src/fpss/connection.rs
@@ -24,15 +24,15 @@ use std::time::Duration;
 use rustls::pki_types::ServerName;
 use rustls::{ClientConfig, ClientConnection, StreamOwned};
 
-use super::protocol::{CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS, SERVERS};
+use super::protocol::{CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS};
 
 /// Type alias for the TLS-wrapped TCP stream (blocking).
 pub type FpssStream = StreamOwned<ClientConnection, TcpStream>;
 
 /// Establish a TLS connection to the first reachable FPSS server.
 ///
-/// Tries each server in [`SERVERS`] in order. Returns the stream and
-/// connected server address on success, or the last error if all fail.
+/// Tries each server in order. Returns the stream and connected server
+/// address on success, or the last error if all fail.
 ///
 /// # Connection sequence (from `FPSSClient.connect()`)
 ///
@@ -42,13 +42,6 @@ pub type FpssStream = StreamOwned<ClientConnection, TcpStream>;
 /// 4. TLS handshake via system trust store
 ///
 /// Source: `FPSSClient.connect()` in decompiled terminal.
-pub fn connect() -> Result<(FpssStream, String), crate::error::Error> {
-    connect_to_servers(SERVERS)
-}
-
-/// Connect to a specific server list (for testing or custom endpoints).
-///
-/// Same behavior as [`connect`] but accepts an arbitrary server list.
 pub fn connect_to_servers(
     servers: &[(&str, u16)],
 ) -> Result<(FpssStream, String), crate::error::Error> {
@@ -200,13 +193,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn server_list_has_four_entries() {
-        // Sanity check: the hardcoded server list from Java has 4 entries.
-        assert_eq!(SERVERS.len(), 4);
-        assert_eq!(SERVERS[0], ("nj-a.thetadata.us", 20000));
-        assert_eq!(SERVERS[1], ("nj-a.thetadata.us", 20001));
-        assert_eq!(SERVERS[2], ("nj-b.thetadata.us", 20000));
-        assert_eq!(SERVERS[3], ("nj-b.thetadata.us", 20001));
+    fn production_config_has_four_fpss_hosts() {
+        let config = crate::config::DirectConfig::production();
+        assert_eq!(config.fpss_hosts.len(), 4);
+        assert_eq!(
+            config.fpss_hosts[0],
+            ("nj-a.thetadata.us".to_string(), 20000)
+        );
+        assert_eq!(
+            config.fpss_hosts[1],
+            ("nj-a.thetadata.us".to_string(), 20001)
+        );
+        assert_eq!(
+            config.fpss_hosts[2],
+            ("nj-b.thetadata.us".to_string(), 20000)
+        );
+        assert_eq!(
+            config.fpss_hosts[3],
+            ("nj-b.thetadata.us".to_string(), 20001)
+        );
     }
 
     #[test]

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -28,7 +28,8 @@
 //! # use thetadatadx::auth::Credentials;
 //! # fn example() -> Result<(), thetadatadx::error::Error> {
 //! let creds = Credentials::new("user@example.com", "pw");
-//! let client = FpssClient::connect(&creds, 4096, Default::default(), |event: &FpssEvent| {
+//! let hosts = thetadatadx::config::DirectConfig::production().fpss_hosts;
+//! let client = FpssClient::connect(&creds, &hosts, 4096, Default::default(), |event: &FpssEvent| {
 //!     // Runs on the Disruptor consumer thread -- keep it fast.
 //!     // Push to your own queue for heavy processing.
 //!     match event {
@@ -297,7 +298,7 @@ impl FpssClient {
     ///
     /// # Sequence (from `FPSSClient.java`)
     ///
-    /// 1. Try each server in `SERVERS` until one connects (blocking TLS over TCP)
+    /// 1. Try each server in `hosts` until one connects (blocking TLS over TCP)
     /// 2. Send CREDENTIALS (code 0) with email + password
     /// 3. Wait for METADATA (code 3) = login success, or DISCONNECTED (code 12) = failure
     /// 4. Start ping heartbeat (100ms interval, std::thread with sleep loop)
@@ -305,8 +306,12 @@ impl FpssClient {
     ///
     /// Source: `FPSSClient.connect()` and `FPSSClient.sendCredentials()`.
     /// Connect with default settings (OHLCVC derivation enabled).
+    ///
+    /// `hosts` is the FPSS server list from [`DirectConfig::fpss_hosts`].
+    /// Servers are tried in order until one connects.
     pub fn connect<F>(
         creds: &Credentials,
+        hosts: &[(String, u16)],
         ring_size: usize,
         flush_mode: FpssFlushMode,
         handler: F,
@@ -314,7 +319,8 @@ impl FpssClient {
     where
         F: FnMut(&FpssEvent) + Send + 'static,
     {
-        let (stream, server_addr) = connection::connect()?;
+        let borrowed: Vec<(&str, u16)> = hosts.iter().map(|(h, p)| (h.as_str(), *p)).collect();
+        let (stream, server_addr) = connection::connect_to_servers(&borrowed)?;
         Self::connect_with_stream(
             creds,
             stream,
@@ -332,8 +338,11 @@ impl FpssClient {
     /// `FpssData::Ohlcvc` events after each trade. You still receive
     /// server-sent OHLCVC frames. This reduces throughput overhead by
     /// eliminating one extra event per trade.
+    ///
+    /// `hosts` is the FPSS server list from [`DirectConfig::fpss_hosts`].
     pub fn connect_no_ohlcvc<F>(
         creds: &Credentials,
+        hosts: &[(String, u16)],
         ring_size: usize,
         flush_mode: FpssFlushMode,
         handler: F,
@@ -341,7 +350,8 @@ impl FpssClient {
     where
         F: FnMut(&FpssEvent) + Send + 'static,
     {
-        let (stream, server_addr) = connection::connect()?;
+        let borrowed: Vec<(&str, u16)> = hosts.iter().map(|(h, p)| (h.as_str(), *p)).collect();
+        let (stream, server_addr) = connection::connect_to_servers(&borrowed)?;
         Self::connect_with_stream(
             creds,
             stream,
@@ -1719,6 +1729,7 @@ fn ping_loop(
 /// Source: `FPSSClient.java` reconnection logic in the main loop.
 pub fn reconnect<F>(
     creds: &Credentials,
+    hosts: &[(String, u16)],
     previous_subs: Vec<(SubscriptionKind, Contract)>,
     previous_full_subs: Vec<(SubscriptionKind, tdbe::types::enums::SecType)>,
     delay_ms: u64,
@@ -1732,7 +1743,7 @@ where
     tracing::info!(delay_ms, "waiting before FPSS reconnection");
     thread::sleep(Duration::from_millis(delay_ms));
 
-    let client = FpssClient::connect(creds, ring_size, flush_mode, handler)?;
+    let client = FpssClient::connect(creds, hosts, ring_size, flush_mode, handler)?;
 
     // Re-subscribe all previous per-contract subscriptions with req_id = -1
     // Source: FPSSClient.java -- reconnect logic uses req_id = -1 for re-subscriptions

--- a/crates/thetadatadx/src/fpss/protocol.rs
+++ b/crates/thetadatadx/src/fpss/protocol.rs
@@ -70,16 +70,6 @@ pub const CONNECT_TIMEOUT_MS: u64 = 2_000;
 /// Source: `FPSSClient.java` — `socket.setSoTimeout(10000)`.
 pub const READ_TIMEOUT_MS: u64 = 10_000;
 
-/// FPSS server endpoints.
-///
-/// Source: `FPSSClient.java` — `SERVERS` array, four entries across two sites.
-pub const SERVERS: &[(&str, u16)] = &[
-    ("nj-a.thetadata.us", 20000),
-    ("nj-a.thetadata.us", 20001),
-    ("nj-b.thetadata.us", 20000),
-    ("nj-b.thetadata.us", 20001),
-];
-
 // ---------------------------------------------------------------------------
 // Contract
 // ---------------------------------------------------------------------------

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -87,9 +87,13 @@ impl ThetaDataDx {
             return Err(Error::Fpss("streaming already started".into()));
         }
         let config = self.historical.config();
-        let ring_size = config.fpss_ring_size;
-        let flush_mode = config.fpss_flush_mode;
-        let client = FpssClient::connect(&self.creds, ring_size, flush_mode, handler)?;
+        let client = FpssClient::connect(
+            &self.creds,
+            &config.fpss_hosts,
+            config.fpss_ring_size,
+            config.fpss_flush_mode,
+            handler,
+        )?;
         *guard = Some(client);
         Ok(())
     }
@@ -104,9 +108,13 @@ impl ThetaDataDx {
             return Err(Error::Fpss("streaming already started".into()));
         }
         let config = self.historical.config();
-        let ring_size = config.fpss_ring_size;
-        let flush_mode = config.fpss_flush_mode;
-        let client = FpssClient::connect_no_ohlcvc(&self.creds, ring_size, flush_mode, handler)?;
+        let client = FpssClient::connect_no_ohlcvc(
+            &self.creds,
+            &config.fpss_hosts,
+            config.fpss_ring_size,
+            config.fpss_flush_mode,
+            handler,
+        )?;
         *guard = Some(client);
         Ok(())
     }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2026,6 +2026,7 @@ pub unsafe extern "C" fn tdx_fpss_connect(
 
     let client = match thetadatadx::fpss::FpssClient::connect(
         &creds.inner,
+        &config.inner.fpss_hosts,
         config.inner.fpss_ring_size,
         config.inner.fpss_flush_mode,
         move |event: &thetadatadx::fpss::FpssEvent| {


### PR DESCRIPTION
## Summary

- `FpssClient::connect()` and `connect_no_ohlcvc()` now accept `hosts: &[(String, u16)]` from the config instead of using a hardcoded `SERVERS` constant
- `ThetaDataDx::start_streaming()` passes `config.fpss_hosts` through
- FFI `tdx_fpss_connect()` passes `config.fpss_hosts` through
- `reconnect()` accepts hosts parameter
- Removed dead `SERVERS` constant from `protocol.rs` and dead `connection::connect()` wrapper

Closes #77

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green on all 3 platforms
- [ ] Live test: `DirectConfig::dev()` connects to port 20200

🤖 Generated with [Claude Code](https://claude.com/claude-code)