### PR TITLE
release: v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - 2026-04-03
+
+### Fixed
+
+- `FpssClient::connect()` now uses `DirectConfig::fpss_hosts` instead of hardcoded production servers. `dev()` and `stage()` configs now correctly connect to their respective FPSS servers. (#77)
+- Removed dead `SERVERS` constant from `protocol.rs`
+
 ## [5.0.0] - 2026-04-02
 
 ### Breaking Changes
@@ -536,6 +543,8 @@ See [TODO.md](TODO.md) for the production readiness checklist and performance ro
 - Price type range enforced with `assert!` in release builds
 
 [Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v4.5.0...v5.0.0
+[5.0.1]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v4.5.0...v5.0.0
 [4.5.0]: https://github.com/userFRM/ThetaDataDx/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/userFRM/ThetaDataDx/compare/v4.3.0...v4.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "serde_json",
  "tdbe",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "thetadatadx"
-version = "5.0.0"
+version = "5.0.1"
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

- Bump all crate versions from 5.0.0 to 5.0.1
- Update pyproject.toml, CHANGELOG with v5.0.1 entry

### Fixed

- `FpssClient::connect()` now uses `DirectConfig::fpss_hosts` instead of hardcoded production servers. `dev()` and `stage()` configs now correctly connect to their respective FPSS servers. (#77, PR #78)
- Removed dead `SERVERS` constant from `protocol.rs`

## Test plan

- [ ] CI passes on all 3 platforms
- [ ] Version strings consistent across all Cargo.toml + pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)