### PR TITLE
release: v5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.2] - 2026-04-03
+
+### Fixed
+
+- OHLCVC accumulator `volume` and `count` fields widened from `i32` to `i64` to prevent integer overflow on high-volume symbols during dev server replay. (#80)
+
 ## [5.0.1] - 2026-04-03
 
 ### Fixed
@@ -544,6 +550,7 @@ See [TODO.md](TODO.md) for the production readiness checklist and performance ro
 
 [Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.0...HEAD
 [5.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v4.5.0...v5.0.0
+[5.0.2]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v4.5.0...v5.0.0
 [4.5.0]: https://github.com/userFRM/ThetaDataDx/compare/v4.4.0...v4.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "serde_json",
  "tdbe",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "5.0.1"
+version = "5.0.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "5.0.1"
+version = "5.0.2"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "5.0.1"
+version = "5.0.2"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "thetadatadx"
-version = "5.0.1"
+version = "5.0.2"
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "5.0.1"
+version = "5.0.2"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "5.0.1"
+version = "5.0.2"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "5.0.1"
+version = "5.0.2"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

- Bump all crate versions from 5.0.1 to 5.0.2
- Update CHANGELOG with v5.0.2 entry

### Fixed

- OHLCVC accumulator `volume` and `count` widened from `i32` to `i64` to prevent integer overflow on high-volume symbols during dev server replay. (#80, PR #81)

## Test plan

- [ ] CI passes on all 3 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)