### PR TITLE
feat: contract identification fields on all option tick types

### DIFF
--- a/crates/tdbe/src/types/tick.rs
+++ b/crates/tdbe/src/types/tick.rs
@@ -34,6 +34,14 @@ pub struct EodTick {
     pub ask_condition: i32,
     pub price_type: i32,
     pub date: i32,
+    /// Contract expiration (YYYYMMDD). Populated on wildcard queries, 0 otherwise.
+    pub expiration: i32,
+    /// Contract strike (price-encoded). Use `strike_price()` for f64.
+    pub strike: i32,
+    /// Contract right (C=67, P=80 ASCII). 0 on single-contract queries.
+    pub right: i32,
+    /// Strike price type for decoding `strike`.
+    pub strike_price_type: i32,
 }
 
 /// Greeks tick. Full set of option greeks.
@@ -64,6 +72,10 @@ pub struct GreeksTick {
     pub lambda: f64,
     pub vera: f64,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 
 /// Interest rate tick.
@@ -83,6 +95,10 @@ pub struct IvTick {
     pub implied_volatility: f64,
     pub iv_error: f64,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 
 /// Market value tick.
@@ -96,6 +112,10 @@ pub struct MarketValueTick {
     pub book_value: i64,
     pub free_float: i64,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 
 /// OHLC tick. Aggregated bar data.
@@ -111,6 +131,10 @@ pub struct OhlcTick {
     pub count: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 
 /// Open interest tick.
@@ -120,6 +144,10 @@ pub struct OpenInterestTick {
     pub ms_of_day: i32,
     pub open_interest: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 
 /// Option contract specification.
@@ -157,6 +185,10 @@ pub struct QuoteTick {
     pub ask_condition: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 
 /// Snapshot trade tick. Abbreviated trade for snapshots.
@@ -170,6 +202,10 @@ pub struct SnapshotTradeTick {
     pub price: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 
 /// Combined trade + quote tick.
@@ -202,6 +238,10 @@ pub struct TradeQuoteTick {
     pub quote_price_type: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 
 /// Trade tick. Core unit of trade data.
@@ -224,7 +264,56 @@ pub struct TradeTick {
     pub records_back: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Contract identification helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+macro_rules! impl_contract_id {
+    ($ty:ident) => {
+        impl $ty {
+            /// Decode strike as `f64` using the accompanying `strike_price_type`.
+            #[inline]
+            pub fn strike_price(&self) -> f64 {
+                if self.strike_price_type == 0 && self.strike == 0 {
+                    return 0.0;
+                }
+                Price::new(self.strike, self.strike_price_type).to_f64()
+            }
+            /// `true` when `right` == 'C' (ASCII 67).
+            #[inline]
+            pub fn is_call(&self) -> bool {
+                self.right == 67
+            }
+            /// `true` when `right` == 'P' (ASCII 80).
+            #[inline]
+            pub fn is_put(&self) -> bool {
+                self.right == 80
+            }
+            /// `true` when the server populated contract identification fields.
+            #[inline]
+            pub fn has_contract_id(&self) -> bool {
+                self.expiration != 0
+            }
+        }
+    };
+}
+
+impl_contract_id!(TradeTick);
+impl_contract_id!(QuoteTick);
+impl_contract_id!(OhlcTick);
+impl_contract_id!(EodTick);
+impl_contract_id!(OpenInterestTick);
+impl_contract_id!(SnapshotTradeTick);
+impl_contract_id!(TradeQuoteTick);
+impl_contract_id!(MarketValueTick);
+impl_contract_id!(GreeksTick);
+impl_contract_id!(IvTick);
 
 // ─────────────────────────────────────────────────────────────────────────────
 //  Hand-written impl blocks

--- a/crates/thetadatadx/build.rs
+++ b/crates/thetadatadx/build.rs
@@ -39,6 +39,8 @@ struct TickTypeDef {
     price_typed_columns: Vec<String>,
     #[serde(default)]
     eod_style: bool,
+    #[serde(default)]
+    contract_id: bool,
     columns: Vec<ColumnDef>,
 }
 
@@ -204,6 +206,14 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
                 col.name
             ));
         }
+    }
+
+    // Contract identification columns (wildcard queries inject expiration/strike/right).
+    if def.contract_id {
+        out.push_str("    let _cid_exp_idx = h.iter().position(|c| *c == \"expiration\");\n");
+        out.push_str("    let _cid_strike_idx = h.iter().position(|c| *c == \"strike\");\n");
+        out.push_str("    let _cid_right_idx = h.iter().position(|c| *c == \"right\");\n");
+        out.push_str("    let _cid_strike_is_typed = _cid_strike_idx.is_some() && h.contains(&\"strike\");\n");
     }
 
     // Precompute price_is_typed flags for price_typed_columns.
@@ -426,6 +436,32 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
             }
             other => panic!("unknown column type '{other}' in parser for {type_name}"),
         }
+    }
+
+    // Contract identification fields (injected when contract_id = true).
+    if def.contract_id {
+        out.push_str(
+            "                expiration: _cid_exp_idx.map(|i| row_number(row, i)).unwrap_or(0),\n",
+        );
+        out.push_str("                strike: match _cid_strike_idx {\n");
+        out.push_str(
+            "                    Some(i) if _cid_strike_is_typed => row_price_value(row, i),\n",
+        );
+        out.push_str("                    Some(i) => row_number(row, i),\n");
+        out.push_str("                    None => 0,\n");
+        out.push_str("                },\n");
+        out.push_str("                right: _cid_right_idx.map(|i| {\n");
+        out.push_str("                    let s = row_text(row, i);\n");
+        out.push_str(
+            "                    if s.is_empty() { 0i32 } else { s.as_bytes()[0] as i32 }\n",
+        );
+        out.push_str("                }).unwrap_or(0),\n");
+        out.push_str("                strike_price_type: match _cid_strike_idx {\n");
+        out.push_str(
+            "                    Some(i) if _cid_strike_is_typed => row_price_type(row, i),\n",
+        );
+        out.push_str("                    _ => 0,\n");
+        out.push_str("                },\n");
     }
 
     out.push_str("            }\n");

--- a/crates/thetadatadx/endpoint_schema.toml
+++ b/crates/thetadatadx/endpoint_schema.toml
@@ -22,6 +22,8 @@
 #   copy = true/false   -- whether to derive Copy (false when String fields exist)
 #   align = 64          -- repr(C, align(N)); omit for no repr attribute
 #   doc = "..."         -- doc comment on the struct
+#   contract_id = true  -- inject expiration/strike/right/strike_price_type fields
+#                          (populated by server on wildcard queries, 0 otherwise)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Existing 4 tick types (hand-written before, now generated)
@@ -31,6 +33,7 @@
 doc = "Trade tick -- 16 fields. Core unit of trade data."
 copy = true
 align = 64
+contract_id = true
 parser = "parse_trade_ticks"
 required = ["ms_of_day", "price"]
 price_typed_columns = ["price"]
@@ -57,6 +60,7 @@ columns = [
 doc = "Quote tick -- 11 fields. NBBO quote data."
 copy = true
 align = 64
+contract_id = true
 parser = "parse_quote_ticks"
 required = ["ms_of_day", "bid", "ask"]
 price_typed_columns = ["bid", "ask"]
@@ -78,6 +82,7 @@ columns = [
 doc = "OHLC tick -- 9 fields. Aggregated bar data."
 copy = true
 align = 64
+contract_id = true
 parser = "parse_ohlc_ticks"
 required = ["ms_of_day", "open"]
 price_typed_columns = ["open", "high", "low", "close"]
@@ -97,6 +102,7 @@ columns = [
 doc = "End-of-day tick -- 18 fields. Full EOD snapshot with OHLC + quote."
 copy = true
 align = 64
+contract_id = true
 parser = "parse_eod_ticks"
 eod_style = true
 required = []
@@ -128,6 +134,7 @@ columns = [
 [types.OpenInterestTick]
 doc = "Open interest tick -- 3 fields."
 copy = true
+contract_id = true
 parser = "parse_open_interest_ticks"
 required = ["ms_of_day"]
 columns = [
@@ -139,6 +146,7 @@ columns = [
 [types.SnapshotTradeTick]
 doc = "Snapshot trade tick -- 7 fields. Abbreviated trade for snapshots."
 copy = true
+contract_id = true
 parser = "parse_snapshot_trade_ticks"
 required = ["ms_of_day", "price"]
 price_typed_columns = ["price"]
@@ -155,6 +163,7 @@ columns = [
 [types.TradeQuoteTick]
 doc = "Combined trade + quote tick -- 26 fields."
 copy = true
+contract_id = true
 parser = "parse_trade_quote_ticks"
 required = ["ms_of_day", "price"]
 price_typed_columns = ["price"]
@@ -192,6 +201,7 @@ columns = [
 doc = "Market value tick -- 7 fields. Market capitalization and related data."
 copy = true
 align = 64
+contract_id = true
 parser = "parse_market_value_ticks"
 required = ["ms_of_day"]
 columns = [
@@ -208,6 +218,7 @@ columns = [
 doc = "Greeks tick -- 24 fields. Full set of option greeks."
 copy = true
 align = 64
+contract_id = true
 parser = "parse_greeks_ticks"
 required = ["ms_of_day"]
 columns = [
@@ -241,6 +252,7 @@ columns = [
 doc = "Implied volatility tick -- 4 fields."
 copy = true
 align = 64
+contract_id = true
 parser = "parse_iv_ticks"
 required = ["ms_of_day"]
 columns = [

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -2321,6 +2321,21 @@ tdx.option_history_quote_stream("SPY", "20241220", "500000", "C", "20240315", "0
 
 ## Types and Enums
 
+### Contract Identification Fields
+
+10 tick types carry contract identification fields populated by the server on wildcard queries (pass `0` for expiration/strike/right). On single-contract queries these fields are `0`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `expiration` | i32 | Contract expiration (YYYYMMDD). 0 if absent. |
+| `strike` | i32 | Strike price (fixed-point). Use `strike_price()` for decoded float. |
+| `right` | i32 | Contract right: 67 = Call ('C'), 80 = Put ('P'). |
+| `strike_price_type` | i32 | Price type for decoding `strike`. |
+
+Helper methods (all 10 types): `strike_price()`, `is_call()`, `is_put()`, `has_contract_id()`.
+
+Types with contract ID: TradeTick, QuoteTick, OhlcTick, EodTick, OpenInterestTick, SnapshotTradeTick, TradeQuoteTick, MarketValueTick, GreeksTick, IvTick.
+
 ### TradeTick
 
 A single trade execution.
@@ -2340,8 +2355,12 @@ A single trade execution.
 | `records_back` | i32 | Records back count |
 | `price_type` | i32 | Decimal type for price decoding |
 | `date` | i32 | Date as YYYYMMDD integer |
+| `expiration` | i32 | Contract expiration (wildcard queries) |
+| `strike` | i32 | Contract strike (wildcard queries) |
+| `right` | i32 | Contract right C=67/P=80 (wildcard queries) |
+| `strike_price_type` | i32 | Strike price type (wildcard queries) |
 
-Helper methods: `get_price()`, `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`
+Helper methods: `get_price()`, `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`, `strike_price()`, `is_call()`, `is_put()`, `has_contract_id()`
 
 ### QuoteTick
 
@@ -2356,8 +2375,9 @@ An NBBO quote.
 | `bid_condition` / `ask_condition` | i32 | Condition codes |
 | `price_type` | i32 | Decimal type for price decoding |
 | `date` | i32 | Date as YYYYMMDD integer |
+| `expiration` / `strike` / `right` / `strike_price_type` | i32 | Contract ID (wildcard queries) |
 
-Helper methods: `bid_price()`, `ask_price()`, `midpoint_price()`, `midpoint_value()`
+Helper methods: `bid_price()`, `ask_price()`, `midpoint_price()`, `midpoint_value()`, plus contract ID helpers
 
 ### OhlcTick
 
@@ -2371,12 +2391,13 @@ An aggregated OHLC bar.
 | `count` | i32 | Number of trades in bar |
 | `price_type` | i32 | Decimal type for price decoding |
 | `date` | i32 | Date as YYYYMMDD integer |
+| `expiration` / `strike` / `right` / `strike_price_type` | i32 | Contract ID (wildcard queries) |
 
-Helper methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`
+Helper methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`, plus contract ID helpers
 
 ### EodTick
 
-Full end-of-day snapshot with OHLC + closing quote data (18 fields).
+Full end-of-day snapshot with OHLC + closing quote data.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -2390,14 +2411,15 @@ Full end-of-day snapshot with OHLC + closing quote data (18 fields).
 | `bid_condition` / `ask_condition` | i32 | Closing quote conditions |
 | `price_type` | i32 | Decimal type |
 | `date` | i32 | Date as YYYYMMDD |
+| `expiration` / `strike` / `right` / `strike_price_type` | i32 | Contract ID (wildcard queries) |
 
-Helper methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`, `bid_price()`, `ask_price()`, `midpoint_value()`
+Helper methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`, `bid_price()`, `ask_price()`, `midpoint_value()`, plus contract ID helpers
 
 ### TradeQuoteTick
 
-Combined trade + quote tick (25 fields). Contains the full trade data plus the prevailing NBBO quote at the time of the trade.
+Combined trade + quote tick. Contains the full trade data plus the prevailing NBBO quote at the time of the trade.
 
-Helper methods: `trade_price()`, `bid_price()`, `ask_price()`
+Helper methods: `trade_price()`, `bid_price()`, `ask_price()`, plus contract ID helpers
 
 ### OpenInterestTick
 
@@ -2406,6 +2428,7 @@ Helper methods: `trade_price()`, `bid_price()`, `ask_price()`
 | `ms_of_day` | i32 | Milliseconds since midnight ET |
 | `open_interest` | i32 | Open interest count |
 | `date` | i32 | Date as YYYYMMDD |
+| `expiration` / `strike` / `right` / `strike_price_type` | i32 | Contract ID (wildcard queries) |
 
 ### GreeksResult
 

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -175,6 +175,6 @@ Requires `pip install thetadatadx[pandas]`.
 
 - [Historical Data](../historical/) - all 61 endpoints with examples
 - [Real-Time Streaming](../streaming/) - FPSS subscribe/callback and polling
-- [Options & Greeks](../options) - option chain workflow and local Greeks
+- [Options & Greeks](../options) - option chain workflow, local Greeks, and wildcard queries with contract identification
 - [Configuration](../configuration) - timeouts, concurrency, server settings
 - [API Reference](../api-reference) - complete type and method listing

--- a/docs-site/docs/historical/option.md
+++ b/docs-site/docs/historical/option.md
@@ -5,6 +5,8 @@ description: 34 option data endpoints - list, snapshots, history, Greeks, trade 
 
 # Option Endpoints (34)
 
+All option tick types carry **contract identification fields** (`expiration`, `strike`, `right`, `strike_price_type`) populated on wildcard queries (pass `"0"` for expiration/strike/right). Use `has_contract_id()`, `strike_price()`, `is_call()`, `is_put()` to work with them.
+
 ## List
 
 ::: code-group

--- a/docs-site/docs/historical/option/index.md
+++ b/docs-site/docs/historical/option/index.md
@@ -18,6 +18,8 @@ Option contracts are identified by four parameters:
 | `strike` | Strike price in tenths of a cent | `"500000"` ($500.00) |
 | `right` | Call or put | `"C"` or `"P"` |
 
+**Wildcard queries:** Pass `"0"` for expiration, strike, and/or right to fetch data across multiple contracts. Each returned tick carries contract identification fields (`expiration`, `strike`, `right`, `strike_price_type`) so you can determine which contract it belongs to. See [Options & Greeks](/options#wildcard-queries-with-contract-identification) for usage examples.
+
 ## Endpoint Categories
 
 ### [List](./list/roots) (5 endpoints)

--- a/docs-site/docs/options.md
+++ b/docs-site/docs/options.md
@@ -137,6 +137,37 @@ print(df[["strike", "close", "volume"]].head(20))
 
 ---
 
+## Wildcard Queries with Contract Identification
+
+When you pass `"0"` for expiration, strike, or right, the server returns data across all matching contracts. Each tick includes contract identification fields (`expiration`, `strike`, `right`, `strike_price_type`) so you can distinguish which contract each tick belongs to.
+
+::: code-group
+```rust [Rust]
+// Wildcard: all SPY contracts on a given date
+let trades = client.option_history_trade("SPY", "0", "0", "0", "20240315").await?;
+for t in &trades {
+    if t.has_contract_id() {
+        println!("{} {} strike={:.2} price={:.4}",
+            t.expiration,
+            if t.is_call() { "C" } else { "P" },
+            t.strike_price(),
+            t.get_price().to_f64());
+    }
+}
+```
+```python [Python]
+# Wildcard: all SPY contracts on a given date
+trades = client.option_history_trade("SPY", "0", "0", "0", "20240315")
+for t in trades:
+    if "expiration" in t:
+        print(f"{t['expiration']} {t['right']} strike={t['strike']:.2f} price={t['price']:.4f}")
+```
+:::
+
+The 4 contract ID fields and helper methods (`strike_price()`, `is_call()`, `is_put()`, `has_contract_id()`) are available on all 10 option tick types.
+
+---
+
 ## Local Greeks Calculator
 
 Compute Greeks locally without any server call using the built-in Black-Scholes calculator. Works offline, no ThetaData subscription needed.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -884,6 +884,44 @@ let (contract, consumed) = Contract::from_bytes(&bytes)?;  // deserialize
 
 All 14 tick types are `Clone + Debug` structs generated from `endpoint_schema.toml`. Most are also `Copy` (except `OptionContract`, which contains a `String` field). Fields are typically `i32`, with `i64` for large values (e.g., `MarketValueTick.market_cap`), `f64` for Greeks/IV, and `String` for identifiers. Prices are stored in fixed-point encoding. Use the `*_price()` methods to get `Price` values with proper decimal handling.
 
+### Contract Identification Fields
+
+10 tick types carry **contract identification fields** that identify which option contract each tick belongs to. These fields are populated by the server on wildcard/bulk queries (where strike/expiration/right are `0`); on single-contract queries they are `0`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `expiration` | `i32` | Contract expiration date (YYYYMMDD). 0 on single-contract queries. |
+| `strike` | `i32` | Strike price (fixed-point encoded). Use `strike_price()` for `f64`. |
+| `right` | `i32` | Contract right: `67` = Call ('C'), `80` = Put ('P'). 0 if absent. |
+| `strike_price_type` | `i32` | Price type for decoding `strike`. |
+
+Helper methods on all 10 tick types:
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `strike_price()` | `f64` | Decode strike to float |
+| `is_call()` | `bool` | `right == 67` |
+| `is_put()` | `bool` | `right == 80` |
+| `has_contract_id()` | `bool` | `expiration != 0` |
+
+Tick types with contract ID: `TradeTick`, `QuoteTick`, `OhlcTick`, `EodTick`, `OpenInterestTick`, `SnapshotTradeTick`, `TradeQuoteTick`, `MarketValueTick`, `GreeksTick`, `IvTick`.
+
+**Not** on: `CalendarDay`, `InterestRateTick`, `PriceTick`.
+
+```rust
+// Wildcard query — ticks include contract identification
+let ticks = tdx.option_history_trade("AAPL", "0", "0", "0", "20250101").await?;
+for t in &ticks {
+    if t.has_contract_id() {
+        println!("{} {} strike={} price={}",
+            t.expiration,
+            if t.is_call() { "C" } else { "P" },
+            t.strike_price(),
+            t.get_price().to_f64());
+    }
+}
+```
+
 ### TradeTick
 
 16 fields representing a single trade.
@@ -906,6 +944,10 @@ pub struct TradeTick {
     pub records_back: i32,      // Records back count
     pub price_type: i32,        // Decimal type for price decoding
     pub date: i32,              // Date as YYYYMMDD integer
+    pub expiration: i32,        // Contract expiration (YYYYMMDD, 0 if absent)
+    pub strike: i32,            // Contract strike (fixed-point)
+    pub right: i32,             // C=67, P=80 (ASCII)
+    pub strike_price_type: i32, // Price type for strike decoding
 }
 ```
 
@@ -920,6 +962,9 @@ Methods:
 | `is_incremental_volume()` | `bool` | volume_type == 0 |
 | `regular_trading_hours()` | `bool` | 9:30 AM - 4:00 PM ET |
 | `is_seller()` | `bool` | ext_condition1 == 12 |
+| `strike_price()` | `f64` | Decoded strike price |
+| `is_call()` / `is_put()` | `bool` | Contract right check |
+| `has_contract_id()` | `bool` | Whether contract ID fields are populated |
 
 ### QuoteTick
 
@@ -938,21 +983,16 @@ pub struct QuoteTick {
     pub ask_condition: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 
-Methods:
-
-| Method | Return | Description |
-|--------|--------|-------------|
-| `bid_price()` | `Price` | Bid price with decimal handling |
-| `ask_price()` | `Price` | Ask price with decimal handling |
-| `midpoint_value()` | `i32` | Integer midpoint (bid + ask) / 2 |
-| `midpoint_price()` | `Price` | Midpoint as Price |
+Methods: `bid_price()`, `ask_price()`, `midpoint_value()`, `midpoint_price()`, plus contract ID helpers.
 
 ### OhlcTick
-
-9 fields representing an aggregated bar.
 
 ```rust
 pub struct OhlcTick {
@@ -965,10 +1005,14 @@ pub struct OhlcTick {
     pub count: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 
-Methods: `open_price()`, `high_price()`, `low_price()`, `close_price()` - all return `Price`.
+Methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`, plus contract ID helpers.
 
 ### EodTick
 
@@ -994,10 +1038,14 @@ pub struct EodTick {
     pub ask_condition: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 
-Methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`, `bid_price()`, `ask_price()`, `midpoint_value()` - all operate on the shared `price_type`.
+Methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`, `bid_price()`, `ask_price()`, `midpoint_value()`, plus contract ID helpers.
 
 ### OpenInterestTick
 
@@ -1006,12 +1054,14 @@ pub struct OpenInterestTick {
     pub ms_of_day: i32,
     pub open_interest: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 
 ### SnapshotTradeTick
-
-7-field abbreviated trade for snapshots.
 
 ```rust
 pub struct SnapshotTradeTick {
@@ -1022,10 +1072,14 @@ pub struct SnapshotTradeTick {
     pub price: i32,
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 
-Methods: `get_price() -> Price`.
+Methods: `get_price()`, plus contract ID helpers.
 
 ### TradeQuoteTick
 
@@ -1062,14 +1116,16 @@ pub struct TradeQuoteTick {
     // Shared
     pub price_type: i32,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 
-Methods: `trade_price()`, `bid_price()`, `ask_price()` - all return `Price`.
+Methods: `trade_price()`, `bid_price()`, `ask_price()`, plus contract ID helpers.
 
 ### MarketValueTick
-
-7 fields - market capitalization and related data.
 
 ```rust
 pub struct MarketValueTick {
@@ -1080,12 +1136,14 @@ pub struct MarketValueTick {
     pub book_value: i64,
     pub free_float: i64,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 
 ### GreeksTick
-
-24 fields - full set of option Greeks.
 
 ```rust
 pub struct GreeksTick {
@@ -1113,12 +1171,14 @@ pub struct GreeksTick {
     pub lambda: f64,
     pub vera: f64,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 
 ### IvTick
-
-4 fields - implied volatility.
 
 ```rust
 pub struct IvTick {
@@ -1126,6 +1186,10 @@ pub struct IvTick {
     pub implied_volatility: f64,
     pub iv_error: f64,
     pub date: i32,
+    pub expiration: i32,
+    pub strike: i32,
+    pub right: i32,
+    pub strike_price_type: i32,
 }
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,7 +172,7 @@ flowchart LR
     PARSERS --> DECODE
 ```
 
-The 14 generated tick types are: `TradeTick`, `QuoteTick`, `OhlcTick`, `EodTick`, `OpenInterestTick`, `SnapshotTradeTick`, `TradeQuoteTick`, `MarketValueTick`, `GreeksTick`, `IvTick`, `PriceTick`, `CalendarDay`, `InterestRateTick`, `OptionContract`.
+The 14 generated tick types are: `TradeTick`, `QuoteTick`, `OhlcTick`, `EodTick`, `OpenInterestTick`, `SnapshotTradeTick`, `TradeQuoteTick`, `MarketValueTick`, `GreeksTick`, `IvTick`, `PriceTick`, `CalendarDay`, `InterestRateTick`, `OptionContract`. 10 of these (all except `CalendarDay`, `InterestRateTick`, `PriceTick`, `OptionContract`) carry contract identification fields (`expiration`, `strike`, `right`, `strike_price_type`) populated by the server on wildcard queries.
 
 Adding a new tick type requires only adding a TOML table to `endpoint_schema.toml` - no hand-written struct or parser code needed. See `docs/endpoint-schema.md` for the full schema reference.
 

--- a/docs/endpoint-schema.md
+++ b/docs/endpoint-schema.md
@@ -41,6 +41,7 @@ These are included into the crate via `include!()`:
 | `required`             | `[string]` | Headers that must exist or the parser returns `vec![]` |
 | `price_typed_columns`  | `[string]` | Columns that may carry `Price`-typed cells (vs plain `Number`) |
 | `eod_style`            | `bool`     | Use `eod_num` helper that handles both Price and Number cells |
+| `contract_id`          | `bool`     | Inject `expiration`/`strike`/`right`/`strike_price_type` fields (populated on wildcard queries) |
 
 ### Per-column options
 

--- a/docs/macro-guide.md
+++ b/docs/macro-guide.md
@@ -118,7 +118,8 @@ The helper macros (`req_field_type!`, `req_param_type!`, `opt_field_type!`,
 Add a `[types.YourTick]` block in `crates/thetadatadx/endpoint_schema.toml`.
 `build.rs` generates the struct and `parse_your_ticks()` function automatically.
 See `docs/endpoint-schema.md` for the TOML format. The tick structs themselves
-live in `crates/tdbe/`.
+live in `crates/tdbe/`. Set `contract_id = true` if the tick type should carry
+contract identification fields (`expiration`/`strike`/`right`/`strike_price_type`).
 
 ### 2. Add the protobuf types (if new message)
 

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -237,20 +237,23 @@ All endpoints return fully typed C++ structs. No raw JSON.
 
 | Struct | Fields | Used by |
 |--------|--------|---------|
-| `EodTick` | ms_of_day, open, high, low, close, volume, count, bid, ask, date | EOD endpoints |
-| `OhlcTick` | ms_of_day, open, high, low, close, volume, count, date | OHLC endpoints |
-| `TradeTick` | ms_of_day, sequence, condition, size, exchange, price, price_raw, price_type, condition_flags, price_flags, volume_type, records_back, date | Trade endpoints |
-| `QuoteTick` | ms_of_day, bid_size, bid_exchange, bid, bid_condition, ask_size, ask_exchange, ask, ask_condition, date | Quote endpoints |
-| `TradeQuoteTick` | ms_of_day, sequence, ext_condition1-4, condition, size, exchange, price, condition_flags, price_flags, volume_type, records_back, quote_ms_of_day, bid_size, bid_exchange, bid, bid_condition, ask_size, ask_exchange, ask, ask_condition, date | Trade+quote endpoints |
-| `OpenInterestTick` | ms_of_day, open_interest, date | Open interest endpoints |
-| `GreeksTick` | ms_of_day, value, delta, gamma, theta, vega, rho, iv, iv_error, vanna, charm, vomma, veta, speed, zomma, color, ultima, d1, d2, dual_delta, dual_gamma, epsilon, lambda, date | Greeks snapshot/history |
-| `IvTick` | ms_of_day, iv, iv_error, date | IV-only endpoints |
+| `EodTick` | ms_of_day, open, high, low, close, volume, count, bid, ask, date, **expiration, strike, right, strike_price_type** | EOD endpoints |
+| `OhlcTick` | ms_of_day, open, high, low, close, volume, count, date, **expiration, strike, right, strike_price_type** | OHLC endpoints |
+| `TradeTick` | ms_of_day, sequence, condition, size, exchange, price, price_raw, price_type, condition_flags, price_flags, volume_type, records_back, date, **expiration, strike, right, strike_price_type** | Trade endpoints |
+| `QuoteTick` | ms_of_day, bid_size, bid_exchange, bid, bid_condition, ask_size, ask_exchange, ask, ask_condition, date, **expiration, strike, right, strike_price_type** | Quote endpoints |
+| `TradeQuoteTick` | ms_of_day, sequence, ext_condition1-4, condition, size, exchange, price, condition_flags, price_flags, volume_type, records_back, quote_ms_of_day, bid_size, bid_exchange, bid, bid_condition, ask_size, ask_exchange, ask, ask_condition, date, **expiration, strike, right, strike_price_type** | Trade+quote endpoints |
+| `OpenInterestTick` | ms_of_day, open_interest, date, **expiration, strike, right, strike_price_type** | Open interest endpoints |
+| `GreeksTick` | ms_of_day, value, delta, gamma, theta, vega, rho, iv, iv_error, vanna, charm, vomma, veta, speed, zomma, color, ultima, d1, d2, dual_delta, dual_gamma, epsilon, lambda, date, **expiration, strike, right, strike_price_type** | Greeks snapshot/history |
+| `IvTick` | ms_of_day, iv, iv_error, date, **expiration, strike, right, strike_price_type** | IV-only endpoints |
 | `PriceTick` | ms_of_day, price, date | Index price endpoints |
-| `MarketValueTick` | ms_of_day, market_cap, shares_outstanding, enterprise_value, book_value, free_float, date | Market value endpoints |
+| `MarketValueTick` | ms_of_day, market_cap, shares_outstanding, enterprise_value, book_value, free_float, date, **expiration, strike, right, strike_price_type** | Market value endpoints |
+| `SnapshotTradeTick` | ms_of_day, sequence, size, condition, price, price_type, date, **expiration, strike, right, strike_price_type** | Snapshot trade endpoints |
 | `OptionContract` | root, expiration, strike, right | option_list_contracts |
 | `CalendarDay` | date, is_open, open_time, close_time, status | Calendar endpoints |
 | `InterestRateTick` | ms_of_day, rate, date | Interest rate endpoints |
 | `Greeks` | value, delta, gamma, theta, vega, rho, iv, iv_error, vanna, charm, vomma, veta, speed, zomma, color, ultima, d1, d2, dual_delta, dual_gamma, epsilon, lambda | Standalone all_greeks() |
+
+**Contract identification fields** (bold above): `expiration`, `strike`, `right`, `strike_price_type` are populated by the server on wildcard queries (pass `"0"` for expiration/strike/right). On single-contract queries these fields are `0`.
 
 ## FPSS Streaming
 

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -63,6 +63,10 @@ typedef struct __attribute__((aligned(64))) {
     int32_t ask_condition;
     int32_t price_type;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxEodTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -91,6 +95,10 @@ typedef struct __attribute__((aligned(64))) {
     double lambda;
     double vera;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxGreeksTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -106,6 +114,10 @@ typedef struct __attribute__((aligned(64))) {
     double implied_volatility;
     double iv_error;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxIvTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -117,6 +129,10 @@ typedef struct __attribute__((aligned(64))) {
     int64_t book_value;
     int64_t free_float;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxMarketValueTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -129,12 +145,20 @@ typedef struct __attribute__((aligned(64))) {
     int32_t count;
     int32_t price_type;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxOhlcTick;
 
 typedef struct __attribute__((aligned(64))) {
     int32_t ms_of_day;
     int32_t open_interest;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxOpenInterestTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -156,6 +180,10 @@ typedef struct __attribute__((aligned(64))) {
     int32_t ask_condition;
     int32_t price_type;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxQuoteTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -166,6 +194,10 @@ typedef struct __attribute__((aligned(64))) {
     int32_t price;
     int32_t price_type;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxSnapshotTradeTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -195,6 +227,10 @@ typedef struct __attribute__((aligned(64))) {
     int32_t quote_price_type;
     int32_t price_type;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxTradeQuoteTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -214,6 +250,10 @@ typedef struct __attribute__((aligned(64))) {
     int32_t records_back;
     int32_t price_type;
     int32_t date;
+    int32_t expiration;
+    int32_t strike;
+    int32_t right;
+    int32_t strike_price_type;
 } TdxTradeTick;
 
 /* ═══════════════════════════════════════════════════════════════════════ */

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -234,24 +234,27 @@ defer client.Close()
 
 | Type | Fields | Description |
 |------|--------|-------------|
-| `EodTick` | MsOfDay, Open, High, Low, Close, Volume, Count, Bid, Ask, Date | End-of-day bar |
-| `OhlcTick` | MsOfDay, Open, High, Low, Close, Volume, Count, Date | OHLC bar |
-| `TradeTick` | MsOfDay, Sequence, Condition, Size, Exchange, Price, PriceRaw, PriceType, ConditionFlags, PriceFlags, VolumeType, RecordsBack, Date | Individual trade |
-| `QuoteTick` | MsOfDay, BidSize, BidExchange, Bid, BidCondition, AskSize, AskExchange, Ask, AskCondition, Date | NBBO quote |
-| `TradeQuoteTick` | All TradeTick fields + QuoteMsOfDay, BidSize, BidExchange, Bid, BidCondition, AskSize, AskExchange, Ask, AskCondition, Date | Combined trade+quote |
+| `EodTick` | MsOfDay, Open, High, Low, Close, Volume, Count, Bid, Ask, Date, **Expiration, Strike, Right, StrikePriceType** | End-of-day bar |
+| `OhlcTick` | MsOfDay, Open, High, Low, Close, Volume, Count, Date, **Expiration, Strike, Right, StrikePriceType** | OHLC bar |
+| `TradeTick` | MsOfDay, Sequence, Condition, Size, Exchange, Price, PriceRaw, PriceType, ConditionFlags, PriceFlags, VolumeType, RecordsBack, Date, **Expiration, Strike, Right, StrikePriceType** | Individual trade |
+| `QuoteTick` | MsOfDay, BidSize, BidExchange, Bid, BidCondition, AskSize, AskExchange, Ask, AskCondition, Date, **Expiration, Strike, Right, StrikePriceType** | NBBO quote |
+| `TradeQuoteTick` | All TradeTick fields + QuoteMsOfDay, BidSize, BidExchange, Bid, BidCondition, AskSize, AskExchange, Ask, AskCondition, Date, **Expiration, Strike, Right, StrikePriceType** | Combined trade+quote |
 
 #### Derived Types
 
 | Type | Fields | Description |
 |------|--------|-------------|
-| `OpenInterestTick` | MsOfDay, OpenInterest, Date | Open interest data point |
-| `MarketValueTick` | MsOfDay, MarketCap, SharesOut, EntValue, BookValue, FreeFloat, Date | Market value data |
-| `GreeksTick` | MsOfDay, Value, Delta, Gamma, Theta, Vega, Rho, IV, IVError, Vanna, Charm, Vomma, Veta, Speed, Zomma, Color, Ultima, D1, D2, DualDelta, DualGamma, Epsilon, Lambda, Date | Greeks time series |
-| `IVTick` | MsOfDay, IV, IVError, Date | Implied volatility data point |
+| `OpenInterestTick` | MsOfDay, OpenInterest, Date, **Expiration, Strike, Right, StrikePriceType** | Open interest data point |
+| `MarketValueTick` | MsOfDay, MarketCap, SharesOut, EntValue, BookValue, FreeFloat, Date, **Expiration, Strike, Right, StrikePriceType** | Market value data |
+| `GreeksTick` | MsOfDay, Value, Delta, Gamma, Theta, Vega, Rho, IV, IVError, Vanna, Charm, Vomma, Veta, Speed, Zomma, Color, Ultima, D1, D2, DualDelta, DualGamma, Epsilon, Lambda, Date, **Expiration, Strike, Right, StrikePriceType** | Greeks time series |
+| `IVTick` | MsOfDay, IV, IVError, Date, **Expiration, Strike, Right, StrikePriceType** | Implied volatility data point |
+| `SnapshotTradeTick` | MsOfDay, Sequence, Size, Condition, Price, PriceRaw, PriceType, Date, **Expiration, Strike, Right, StrikePriceType** | Snapshot trade |
 | `PriceTick` | MsOfDay, Price, Date | Price data point (indices) |
 | `CalendarDay` | Date, IsOpen, OpenTime, CloseTime, Status | Market calendar day |
 | `InterestRate` | Date, Rate | Interest rate data point |
 | `Contract` | Symbol, Expiration, Strike, Right | Option contract identifier |
+
+**Contract identification fields** (bold above): `Expiration`, `Strike`, `Right`, `StrikePriceType` are populated by the server on wildcard queries (pass `"0"` for expiration/strike/right). On single-contract queries these fields are `0`.
 
 ## FPSS Streaming
 

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -134,83 +134,104 @@ import (
 
 // cEodTick mirrors tdbe::EodTick #[repr(C, align(64))]
 type cEodTick struct {
-	MsOfDay      int32
-	MsOfDay2     int32
-	Open         int32
-	High         int32
-	Low          int32
-	Close        int32
-	Volume       int32
-	Count        int32
-	BidSize      int32
-	BidExchange  int32
-	Bid          int32
-	BidCondition int32
-	AskSize      int32
-	AskExchange  int32
-	Ask          int32
-	AskCondition int32
-	PriceType    int32
-	Date         int32
-	_pad         [64 - 18*4]byte // pad to 64 bytes
+	MsOfDay         int32
+	MsOfDay2        int32
+	Open            int32
+	High            int32
+	Low             int32
+	Close           int32
+	Volume          int32
+	Count           int32
+	BidSize         int32
+	BidExchange     int32
+	Bid             int32
+	BidCondition    int32
+	AskSize         int32
+	AskExchange     int32
+	Ask             int32
+	AskCondition    int32
+	PriceType       int32
+	Date            int32
+	Expiration      int32
+	Strike          int32
+	Right           int32
+	StrikePriceType int32
+	_pad            [128 - 22*4]byte
 }
 
 // cOhlcTick mirrors tdbe::OhlcTick #[repr(C, align(64))]
 type cOhlcTick struct {
-	MsOfDay   int32
-	Open      int32
-	High      int32
-	Low       int32
-	Close     int32
-	Volume    int32
-	Count     int32
-	PriceType int32
-	Date      int32
-	_pad      [64 - 9*4]byte
+	MsOfDay         int32
+	Open            int32
+	High            int32
+	Low             int32
+	Close           int32
+	Volume          int32
+	Count           int32
+	PriceType       int32
+	Date            int32
+	Expiration      int32
+	Strike          int32
+	Right           int32
+	StrikePriceType int32
+	_pad            [64 - 13*4]byte
 }
 
 // cTradeTick mirrors tdbe::TradeTick #[repr(C, align(64))]
 type cTradeTick struct {
-	MsOfDay        int32
-	Sequence       int32
-	ExtCondition1  int32
-	ExtCondition2  int32
-	ExtCondition3  int32
-	ExtCondition4  int32
-	Condition      int32
-	Size           int32
-	Exchange       int32
-	Price          int32
-	ConditionFlags int32
-	PriceFlags     int32
-	VolumeType     int32
-	RecordsBack    int32
-	PriceType      int32
-	Date           int32
+	MsOfDay         int32
+	Sequence        int32
+	ExtCondition1   int32
+	ExtCondition2   int32
+	ExtCondition3   int32
+	ExtCondition4   int32
+	Condition       int32
+	Size            int32
+	Exchange        int32
+	Price           int32
+	ConditionFlags  int32
+	PriceFlags      int32
+	VolumeType      int32
+	RecordsBack     int32
+	PriceType       int32
+	Date            int32
+	Expiration      int32
+	Strike          int32
+	Right           int32
+	StrikePriceType int32
+	_pad            [128 - 20*4]byte
 }
 
 // cQuoteTick mirrors tdbe::QuoteTick #[repr(C, align(64))]
 type cQuoteTick struct {
-	MsOfDay      int32
-	BidSize      int32
-	BidExchange  int32
-	Bid          int32
-	BidCondition int32
-	AskSize      int32
-	AskExchange  int32
-	Ask          int32
-	AskCondition int32
-	PriceType    int32
-	Date         int32
-	_pad         [64 - 11*4]byte
+	MsOfDay         int32
+	BidSize         int32
+	BidExchange     int32
+	Bid             int32
+	BidCondition    int32
+	AskSize         int32
+	AskExchange     int32
+	Ask             int32
+	AskCondition    int32
+	PriceType       int32
+	Date            int32
+	Expiration      int32
+	Strike          int32
+	Right           int32
+	StrikePriceType int32
+	_pad            [64 - 15*4]byte
 }
 
 // cOpenInterestTick mirrors tdbe::OpenInterestTick #[repr(C, align(64))]
 type cOpenInterestTick struct {
-	MsOfDay      int32
-	OpenInterest int32
-	Date         int32
-	_pad         [64 - 3*4]byte
+	MsOfDay         int32
+	OpenInterest    int32
+	Date            int32
+	Expiration      int32
+	Strike          int32
+	Right           int32
+	StrikePriceType int32
+	_pad            [64 - 7*4]byte
 }
 
 // cCalendarDay mirrors tdbe::CalendarDay #[repr(C, align(64))]
@@ -241,7 +262,11 @@ type cIvTick struct {
 	ImpliedVolatility  float64
 	IvError            float64
 	Date               int32
-	_pad2              [64 - 4 - 4 - 8 - 8 - 4]byte
+	Expiration         int32
+	Strike             int32
+	Right              int32
+	StrikePriceType    int32
+	_pad2              [64 - 4 - 4 - 8 - 8 - 4*5]byte
 }
 
 // cPriceTick mirrors tdbe::PriceTick #[repr(C, align(64))]
@@ -264,12 +289,16 @@ type cMarketValueTick struct {
 	BookValue         int64
 	FreeFloat         int64
 	Date              int32
-	_pad2             [64 - 4 - 4 - 5*8 - 4]byte
+	Expiration        int32
+	Strike            int32
+	Right             int32
+	StrikePriceType   int32
+	_pad2             [128 - 4 - 4 - 5*8 - 4*5]byte
 }
 
 // cGreeksTick mirrors tdbe::GreeksTick #[repr(C, align(64))]
 // This struct is > 64 bytes. align(64) means size is rounded up to multiple of 64.
-// Layout: i32(4) + pad(4) + 22*f64(176) + i32(4) = 188, rounded to 192
+// Layout: i32(4) + pad(4) + 22*f64(176) + 5*i32(20) = 204, rounded to 256
 type cGreeksTick struct {
 	MsOfDay            int32
 	_pad1              int32
@@ -296,51 +325,63 @@ type cGreeksTick struct {
 	Lambda             float64
 	Vera               float64
 	Date               int32
-	_pad2              [192 - 4 - 4 - 22*8 - 4]byte
+	Expiration         int32
+	Strike             int32
+	Right              int32
+	StrikePriceType    int32
+	_pad2              [256 - 4 - 4 - 22*8 - 4*5]byte
 }
 
 // cTradeQuoteTick mirrors tdbe::TradeQuoteTick #[repr(C, align(64))]
 // 26 i32 fields = 104 bytes, rounded to 128 (next multiple of 64)
 type cTradeQuoteTick struct {
-	MsOfDay        int32
-	Sequence       int32
-	ExtCondition1  int32
-	ExtCondition2  int32
-	ExtCondition3  int32
-	ExtCondition4  int32
-	Condition      int32
-	Size           int32
-	Exchange       int32
-	Price          int32
-	ConditionFlags int32
-	PriceFlags     int32
-	VolumeType     int32
-	RecordsBack    int32
-	QuoteMsOfDay   int32
-	BidSize        int32
-	BidExchange    int32
-	Bid            int32
-	BidCondition   int32
-	AskSize        int32
-	AskExchange    int32
-	Ask            int32
-	AskCondition   int32
-	QuotePriceType int32
-	PriceType      int32
-	Date           int32
-	_pad           [128 - 26*4]byte
+	MsOfDay         int32
+	Sequence        int32
+	ExtCondition1   int32
+	ExtCondition2   int32
+	ExtCondition3   int32
+	ExtCondition4   int32
+	Condition       int32
+	Size            int32
+	Exchange        int32
+	Price           int32
+	ConditionFlags  int32
+	PriceFlags      int32
+	VolumeType      int32
+	RecordsBack     int32
+	QuoteMsOfDay    int32
+	BidSize         int32
+	BidExchange     int32
+	Bid             int32
+	BidCondition    int32
+	AskSize         int32
+	AskExchange     int32
+	Ask             int32
+	AskCondition    int32
+	QuotePriceType  int32
+	PriceType       int32
+	Date            int32
+	Expiration      int32
+	Strike          int32
+	Right           int32
+	StrikePriceType int32
+	_pad            [128 - 30*4]byte
 }
 
 // cSnapshotTradeTick mirrors TdxSnapshotTradeTick #[repr(C, align(64))]
 type cSnapshotTradeTick struct {
-	MsOfDay   int32
-	Sequence  int32
-	Size      int32
-	Condition int32
-	Price     int32
-	PriceType int32
-	Date      int32
-	_pad      [64 - 7*4]byte
+	MsOfDay         int32
+	Sequence        int32
+	Size            int32
+	Condition       int32
+	Price           int32
+	PriceType       int32
+	Date            int32
+	Expiration      int32
+	Strike          int32
+	Right           int32
+	StrikePriceType int32
+	_pad            [64 - 11*4]byte
 }
 
 // cOptionContract mirrors TdxOptionContract from FFI
@@ -356,27 +397,35 @@ type cOptionContract struct {
 // These are pure Go structs with decoded float prices for user convenience.
 
 type EodTick struct {
-	MsOfDay int     `json:"ms_of_day"`
-	Open    float64 `json:"open"`
-	High    float64 `json:"high"`
-	Low     float64 `json:"low"`
-	Close   float64 `json:"close"`
-	Volume  int     `json:"volume"`
-	Count   int     `json:"count"`
-	Bid     float64 `json:"bid"`
-	Ask     float64 `json:"ask"`
-	Date    int     `json:"date"`
+	MsOfDay        int     `json:"ms_of_day"`
+	Open           float64 `json:"open"`
+	High           float64 `json:"high"`
+	Low            float64 `json:"low"`
+	Close          float64 `json:"close"`
+	Volume         int     `json:"volume"`
+	Count          int     `json:"count"`
+	Bid            float64 `json:"bid"`
+	Ask            float64 `json:"ask"`
+	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type OhlcTick struct {
-	MsOfDay int     `json:"ms_of_day"`
-	Open    float64 `json:"open"`
-	High    float64 `json:"high"`
-	Low     float64 `json:"low"`
-	Close   float64 `json:"close"`
-	Volume  int     `json:"volume"`
-	Count   int     `json:"count"`
-	Date    int     `json:"date"`
+	MsOfDay        int     `json:"ms_of_day"`
+	Open           float64 `json:"open"`
+	High           float64 `json:"high"`
+	Low            float64 `json:"low"`
+	Close          float64 `json:"close"`
+	Volume         int     `json:"volume"`
+	Count          int     `json:"count"`
+	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type TradeTick struct {
@@ -393,19 +442,27 @@ type TradeTick struct {
 	VolumeType     int     `json:"volume_type"`
 	RecordsBack    int     `json:"records_back"`
 	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type QuoteTick struct {
-	MsOfDay      int     `json:"ms_of_day"`
-	BidSize      int     `json:"bid_size"`
-	BidExchange  int     `json:"bid_exchange"`
-	Bid          float64 `json:"bid"`
-	BidCondition int     `json:"bid_condition"`
-	AskSize      int     `json:"ask_size"`
-	AskExchange  int     `json:"ask_exchange"`
-	Ask          float64 `json:"ask"`
-	AskCondition int     `json:"ask_condition"`
-	Date         int     `json:"date"`
+	MsOfDay        int     `json:"ms_of_day"`
+	BidSize        int     `json:"bid_size"`
+	BidExchange    int     `json:"bid_exchange"`
+	Bid            float64 `json:"bid"`
+	BidCondition   int     `json:"bid_condition"`
+	AskSize        int     `json:"ask_size"`
+	AskExchange    int     `json:"ask_exchange"`
+	Ask            float64 `json:"ask"`
+	AskCondition   int     `json:"ask_condition"`
+	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type TradeQuoteTick struct {
@@ -429,56 +486,76 @@ type TradeQuoteTick struct {
 	Ask            float64 `json:"ask"`
 	AskCondition   int     `json:"ask_condition"`
 	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type OpenInterestTick struct {
-	MsOfDay      int `json:"ms_of_day"`
-	OpenInterest int `json:"open_interest"`
-	Date         int `json:"date"`
+	MsOfDay        int   `json:"ms_of_day"`
+	OpenInterest   int   `json:"open_interest"`
+	Date           int   `json:"date"`
+	Expiration     int32 `json:"expiration,omitempty"`
+	Strike         int32 `json:"strike,omitempty"`
+	Right          int32 `json:"right,omitempty"`
+	StrikePriceType int32 `json:"strike_price_type,omitempty"`
 }
 
 type MarketValueTick struct {
-	MsOfDay   int     `json:"ms_of_day"`
-	MarketCap int64   `json:"market_cap"`
-	SharesOut int64   `json:"shares_outstanding"`
-	EntValue  int64   `json:"enterprise_value"`
-	BookValue int64   `json:"book_value"`
-	FreeFloat int64   `json:"free_float"`
-	Date      int     `json:"date"`
+	MsOfDay        int     `json:"ms_of_day"`
+	MarketCap      int64   `json:"market_cap"`
+	SharesOut      int64   `json:"shares_outstanding"`
+	EntValue       int64   `json:"enterprise_value"`
+	BookValue      int64   `json:"book_value"`
+	FreeFloat      int64   `json:"free_float"`
+	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type GreeksTick struct {
-	MsOfDay   int     `json:"ms_of_day"`
-	IV        float64 `json:"implied_volatility"`
-	Delta     float64 `json:"delta"`
-	Gamma     float64 `json:"gamma"`
-	Theta     float64 `json:"theta"`
-	Vega      float64 `json:"vega"`
-	Rho       float64 `json:"rho"`
-	IVError   float64 `json:"iv_error"`
-	Vanna     float64 `json:"vanna"`
-	Charm     float64 `json:"charm"`
-	Vomma     float64 `json:"vomma"`
-	Veta      float64 `json:"veta"`
-	Speed     float64 `json:"speed"`
-	Zomma     float64 `json:"zomma"`
-	Color     float64 `json:"color"`
-	Ultima    float64 `json:"ultima"`
-	D1        float64 `json:"d1"`
-	D2        float64 `json:"d2"`
-	DualDelta float64 `json:"dual_delta"`
-	DualGamma float64 `json:"dual_gamma"`
-	Epsilon   float64 `json:"epsilon"`
-	Lambda    float64 `json:"lambda"`
-	Vera      float64 `json:"vera"`
-	Date      int     `json:"date"`
+	MsOfDay        int     `json:"ms_of_day"`
+	IV             float64 `json:"implied_volatility"`
+	Delta          float64 `json:"delta"`
+	Gamma          float64 `json:"gamma"`
+	Theta          float64 `json:"theta"`
+	Vega           float64 `json:"vega"`
+	Rho            float64 `json:"rho"`
+	IVError        float64 `json:"iv_error"`
+	Vanna          float64 `json:"vanna"`
+	Charm          float64 `json:"charm"`
+	Vomma          float64 `json:"vomma"`
+	Veta           float64 `json:"veta"`
+	Speed          float64 `json:"speed"`
+	Zomma          float64 `json:"zomma"`
+	Color          float64 `json:"color"`
+	Ultima         float64 `json:"ultima"`
+	D1             float64 `json:"d1"`
+	D2             float64 `json:"d2"`
+	DualDelta      float64 `json:"dual_delta"`
+	DualGamma      float64 `json:"dual_gamma"`
+	Epsilon        float64 `json:"epsilon"`
+	Lambda         float64 `json:"lambda"`
+	Vera           float64 `json:"vera"`
+	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type IVTick struct {
-	MsOfDay int     `json:"ms_of_day"`
-	IV      float64 `json:"implied_volatility"`
-	IVError float64 `json:"iv_error"`
-	Date    int     `json:"date"`
+	MsOfDay        int     `json:"ms_of_day"`
+	IV             float64 `json:"implied_volatility"`
+	IVError        float64 `json:"iv_error"`
+	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type PriceTick struct {
@@ -504,14 +581,18 @@ type InterestRateTick struct {
 }
 
 type SnapshotTradeTick struct {
-	MsOfDay   int     `json:"ms_of_day"`
-	Sequence  int     `json:"sequence"`
-	Size      int     `json:"size"`
-	Condition int     `json:"condition"`
-	Price     float64 `json:"price"`
-	PriceRaw  int     `json:"price_raw"`
-	PriceType int     `json:"price_type"`
-	Date      int     `json:"date"`
+	MsOfDay        int     `json:"ms_of_day"`
+	Sequence       int     `json:"sequence"`
+	Size           int     `json:"size"`
+	Condition      int     `json:"condition"`
+	Price          float64 `json:"price"`
+	PriceRaw       int     `json:"price_raw"`
+	PriceType      int     `json:"price_type"`
+	Date           int     `json:"date"`
+	Expiration     int32   `json:"expiration,omitempty"`
+	Strike         int32   `json:"strike,omitempty"`
+	Right          int32   `json:"right,omitempty"`
+	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type OptionContract struct {
@@ -569,6 +650,7 @@ func convertEodTicks(arr C.TdxTickArray) []EodTick {
 			Open: priceToFloat(t.Open, t.PriceType), High: priceToFloat(t.High, t.PriceType),
 			Low: priceToFloat(t.Low, t.PriceType), Close: priceToFloat(t.Close, t.PriceType),
 			Bid: priceToFloat(t.Bid, t.PriceType), Ask: priceToFloat(t.Ask, t.PriceType),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -584,6 +666,7 @@ func convertOhlcTicks(arr C.TdxTickArray) []OhlcTick {
 			MsOfDay: int(t.MsOfDay), Volume: int(t.Volume), Count: int(t.Count), Date: int(t.Date),
 			Open: priceToFloat(t.Open, t.PriceType), High: priceToFloat(t.High, t.PriceType),
 			Low: priceToFloat(t.Low, t.PriceType), Close: priceToFloat(t.Close, t.PriceType),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -601,6 +684,7 @@ func convertTradeTicks(arr C.TdxTickArray) []TradeTick {
 			PriceRaw: int(t.Price), PriceType: int(t.PriceType), ConditionFlags: int(t.ConditionFlags),
 			PriceFlags: int(t.PriceFlags), VolumeType: int(t.VolumeType), RecordsBack: int(t.RecordsBack),
 			Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -618,6 +702,7 @@ func convertQuoteTicks(arr C.TdxTickArray) []QuoteTick {
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
 			Ask: priceToFloat(t.Ask, t.PriceType), AskCondition: int(t.AskCondition),
 			Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -639,6 +724,7 @@ func convertTradeQuoteTicks(arr C.TdxTickArray) []TradeQuoteTick {
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
 			Ask: priceToFloat(t.Ask, t.QuotePriceType), AskCondition: int(t.AskCondition),
 			Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -649,7 +735,12 @@ func convertOpenInterestTicks(arr C.TdxTickArray) []OpenInterestTick {
 	n := int(arr.len)
 	src := unsafe.Slice((*cOpenInterestTick)(arr.data), n)
 	result := make([]OpenInterestTick, n)
-	for i, t := range src { result[i] = OpenInterestTick{int(t.MsOfDay), int(t.OpenInterest), int(t.Date)} }
+	for i, t := range src {
+		result[i] = OpenInterestTick{
+			MsOfDay: int(t.MsOfDay), OpenInterest: int(t.OpenInterest), Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+		}
+	}
 	return result
 }
 
@@ -659,7 +750,11 @@ func convertMarketValueTicks(arr C.TdxTickArray) []MarketValueTick {
 	src := unsafe.Slice((*cMarketValueTick)(arr.data), n)
 	result := make([]MarketValueTick, n)
 	for i, t := range src {
-		result[i] = MarketValueTick{int(t.MsOfDay), t.MarketCap, t.SharesOutstanding, t.EnterpriseValue, t.BookValue, t.FreeFloat, int(t.Date)}
+		result[i] = MarketValueTick{
+			MsOfDay: int(t.MsOfDay), MarketCap: t.MarketCap, SharesOut: t.SharesOutstanding,
+			EntValue: t.EnterpriseValue, BookValue: t.BookValue, FreeFloat: t.FreeFloat, Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+		}
 	}
 	return result
 }
@@ -677,6 +772,7 @@ func convertGreeksTicks(arr C.TdxTickArray) []GreeksTick {
 			Speed: t.Speed, Zomma: t.Zomma, Color: t.Color, Ultima: t.Ultima,
 			D1: t.D1, D2: t.D2, DualDelta: t.DualDelta, DualGamma: t.DualGamma,
 			Epsilon: t.Epsilon, Lambda: t.Lambda, Vera: t.Vera, Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -687,7 +783,12 @@ func convertIvTicks(arr C.TdxTickArray) []IVTick {
 	n := int(arr.len)
 	src := unsafe.Slice((*cIvTick)(arr.data), n)
 	result := make([]IVTick, n)
-	for i, t := range src { result[i] = IVTick{int(t.MsOfDay), t.ImpliedVolatility, t.IvError, int(t.Date)} }
+	for i, t := range src {
+		result[i] = IVTick{
+			MsOfDay: int(t.MsOfDay), IV: t.ImpliedVolatility, IVError: t.IvError, Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+		}
+	}
 	return result
 }
 
@@ -730,6 +831,7 @@ func convertSnapshotTradeTicks(arr C.TdxTickArray) []SnapshotTradeTick {
 			MsOfDay: int(t.MsOfDay), Sequence: int(t.Sequence), Size: int(t.Size),
 			Condition: int(t.Condition), Price: priceToFloat(t.Price, t.PriceType),
 			PriceRaw: int(t.Price), PriceType: int(t.PriceType), Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -119,6 +119,31 @@ impl Config {
 
 // ── Tick types as Python dicts ──
 
+macro_rules! set_contract_id {
+    ($dict:expr, $tick:expr) => {
+        if $tick.expiration != 0 {
+            $dict.set_item("expiration", $tick.expiration).unwrap();
+            $dict
+                .set_item("strike", $tick.strike_price())
+                .unwrap();
+            $dict.set_item("strike_raw", $tick.strike).unwrap();
+            $dict.set_item("strike_price_type", $tick.strike_price_type).unwrap();
+            $dict
+                .set_item(
+                    "right",
+                    if $tick.is_call() {
+                        "C"
+                    } else if $tick.is_put() {
+                        "P"
+                    } else {
+                        ""
+                    },
+                )
+                .unwrap();
+        }
+    };
+}
+
 fn trade_tick_to_dict(py: Python<'_>, t: &tick::TradeTick) -> Py<PyAny> {
     let dict = PyDict::new(py);
     dict.set_item("ms_of_day", t.ms_of_day).unwrap();
@@ -134,6 +159,7 @@ fn trade_tick_to_dict(py: Python<'_>, t: &tick::TradeTick) -> Py<PyAny> {
     dict.set_item("volume_type", t.volume_type).unwrap();
     dict.set_item("records_back", t.records_back).unwrap();
     dict.set_item("date", t.date).unwrap();
+    set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
 
@@ -149,6 +175,7 @@ fn quote_tick_to_dict(py: Python<'_>, q: &tick::QuoteTick) -> Py<PyAny> {
     dict.set_item("ask", q.ask_price().to_f64()).unwrap();
     dict.set_item("ask_condition", q.ask_condition).unwrap();
     dict.set_item("date", q.date).unwrap();
+    set_contract_id!(dict, q);
     dict.into_any().unbind()
 }
 
@@ -162,6 +189,7 @@ fn ohlc_tick_to_dict(py: Python<'_>, o: &tick::OhlcTick) -> Py<PyAny> {
     dict.set_item("volume", o.volume).unwrap();
     dict.set_item("count", o.count).unwrap();
     dict.set_item("date", o.date).unwrap();
+    set_contract_id!(dict, o);
     dict.into_any().unbind()
 }
 
@@ -177,6 +205,7 @@ fn eod_tick_to_dict(py: Python<'_>, e: &tick::EodTick) -> Py<PyAny> {
     dict.set_item("bid", e.bid_price().to_f64()).unwrap();
     dict.set_item("ask", e.ask_price().to_f64()).unwrap();
     dict.set_item("date", e.date).unwrap();
+    set_contract_id!(dict, e);
     dict.into_any().unbind()
 }
 
@@ -193,6 +222,7 @@ fn trade_quote_tick_to_dict(py: Python<'_>, t: &tick::TradeQuoteTick) -> Py<PyAn
     dict.set_item("ask", t.ask_price().to_f64()).unwrap();
     dict.set_item("ask_size", t.ask_size).unwrap();
     dict.set_item("date", t.date).unwrap();
+    set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
 
@@ -201,6 +231,7 @@ fn open_interest_tick_to_dict(py: Python<'_>, t: &tick::OpenInterestTick) -> Py<
     dict.set_item("ms_of_day", t.ms_of_day).unwrap();
     dict.set_item("open_interest", t.open_interest).unwrap();
     dict.set_item("date", t.date).unwrap();
+    set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
 
@@ -215,6 +246,7 @@ fn market_value_tick_to_dict(py: Python<'_>, t: &tick::MarketValueTick) -> Py<Py
     dict.set_item("book_value", t.book_value).unwrap();
     dict.set_item("free_float", t.free_float).unwrap();
     dict.set_item("date", t.date).unwrap();
+    set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
 
@@ -230,6 +262,7 @@ fn greeks_tick_to_dict(py: Python<'_>, t: &tick::GreeksTick) -> Py<PyAny> {
     dict.set_item("rho", t.rho).unwrap();
     dict.set_item("iv_error", t.iv_error).unwrap();
     dict.set_item("date", t.date).unwrap();
+    set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
 
@@ -240,6 +273,7 @@ fn iv_tick_to_dict(py: Python<'_>, t: &tick::IvTick) -> Py<PyAny> {
         .unwrap();
     dict.set_item("iv_error", t.iv_error).unwrap();
     dict.set_item("date", t.date).unwrap();
+    set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
 


### PR DESCRIPTION
## Summary

- Add `expiration`, `strike`, `right`, `strike_price_type` fields to 10 option tick types (TradeTick, QuoteTick, OhlcTick, EodTick, OpenInterestTick, SnapshotTradeTick, TradeQuoteTick, MarketValueTick, GreeksTick, IvTick)
- Add `contract_id = true` schema flag in `endpoint_schema.toml`; `build.rs` injects column-index declarations and struct-field emissions for the 4 fields
- Add `impl_contract_id!` macro providing `strike_price()`, `is_call()`, `is_put()`, `has_contract_id()` on all 10 types
- Add `set_contract_id!` macro in Python SDK for conditional dict injection on wildcard queries
- Update C++ header (`thetadx.h`), Go SDK structs + conversion functions, with correct padding for `#[repr(C, align(64))]` compatibility
- Update 12 documentation files across `docs/`, `docs-site/`, and SDK READMEs

Fields are populated by the server on wildcard queries (pass `0` for expiration/strike/right); on single-contract queries they are `0`.

Closes #84