### PR TITLE
v5.1.0: contract IDs, 8-field trades, repr(C) FPSS, zero-JSON FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [5.1.0] - 2026-04-03
+
+### Breaking Changes
 
 - **FPSS FFI events now use `#[repr(C)]` typed structs** instead of JSON serialization. `tdx_fpss_next_event` and `tdx_unified_next_event` return `*mut TdxFpssEvent` (a flat tagged struct with quote, trade, open interest, OHLCVC, control, and raw_data variants). Free with `tdx_fpss_event_free`. (#82)
 - C++ SDK: `FpssClient::next_event()` returns `FpssEventPtr` (RAII unique_ptr to `TdxFpssEvent`).
 - Go SDK: `FpssClient.NextEvent()` returns `*FpssEvent` with typed Go structs.
 - Streaming event prices are now raw integers with `price_type` (matching the wire format). Callers decode with `Price::new(value, price_type).to_f64()` or `tdx::price_to_f64(value, price_type)`.
+- `serde_json` removed from FFI crate dependencies -- zero JSON crosses the FFI boundary.
+
+### Added
+
+- **Contract identification on all 10 option tick types** -- `expiration`, `strike`, `right`, `strike_price_type` fields populated by the server on wildcard queries. Helper methods `strike_price()`, `is_call()`, `is_put()`, `has_contract_id()` on all 10 tick types via `impl_contract_id!` macro. (#84)
+- **8-field trade tick support** -- FPSS dev server sends abbreviated 8-field trade ticks; production sends 16-field. `decode_tick()` now auto-detects the field count from the first absolute tick per contract and dispatches to the correct index mapping. (#86)
+- **`#[repr(C)]` FPSS event structs** in all SDKs -- `TdxFpssQuote`, `TdxFpssTrade`, `TdxFpssOpenInterest`, `TdxFpssOhlcvc`, `TdxFpssControl`, `TdxFpssRawData` with tagged `TdxFpssEvent` wrapper. (#82)
+- `FfiBufferedEvent` with owned backing storage for safe cross-thread `Send` of pointer-containing structs.
+- Go SDK: `FpssQuote`, `FpssTrade`, `FpssOpenInterestData`, `FpssOhlcvc`, `FpssControlData` Go structs mirroring Rust `#[repr(C)]` layout.
+- C++ SDK: `FpssClient` class with RAII `FpssEventPtr` for streaming.
+- Python SDK: `greeks_tick_to_dict` now emits all 24 fields (was 8). (#92)
+- `tdbe`: contract ID fields and `impl_contract_id!` macro on all 10 tick types.
+
+### Fixed
+
+- **9 stale JSON references** in FFI doc comments, FFI README, Go README, docs-site API reference, and macro guide -- all now correctly describe typed structs. (#92)
+- Python SDK `greeks_tick_to_dict` missing 16 fields (vanna, charm, vomma, veta, speed, zomma, color, ultima, d1, d2, dual_delta, dual_gamma, epsilon, lambda, vera, date). (#92)
+- Go SDK README documented `ActiveSubscriptions()` return type as `json.RawMessage` -- actually returns `[]Subscription`. (#92)
+- docs-site Go streaming example said "returns json.RawMessage or nil" -- now says "*FpssEvent or nil".
 
 ## [5.0.2] - 2026-04-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.0.2"
+version = "5.1.0"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "5.0.2"
+version = "5.1.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "5.0.2"
+version = "5.1.0"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "5.0.2"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -2217,7 +2217,7 @@ if event:
     print(event)
 ```
 ```go [Go]
-event, err := fpss.NextEvent(5000)  // returns json.RawMessage or nil
+event, err := fpss.NextEvent(5000)  // returns *FpssEvent or nil
 ```
 ```cpp [C++]
 std::string event = fpss.next_event(5000);  // empty string on timeout
@@ -2247,7 +2247,7 @@ fpss.shutdown();
 |--------|---------|-------------|
 | `is_streaming` | bool | Check if the streaming connection is live |
 | `contract_map` / `contract_lookup` | map/string | Look up server-assigned contract IDs |
-| `active_subscriptions` | list/JSON | Get list of active subscriptions |
+| `active_subscriptions` | list/typed structs | Get list of active subscriptions |
 
 ### FpssEvent Types
 

--- a/docs/macro-guide.md
+++ b/docs/macro-guide.md
@@ -224,7 +224,7 @@ The FFI layer uses its own macro set to wrap the Rust builders into
 | `tick_array_free!`             | Generates the `extern "C"` free function for a tick array |
 | `ffi_typed_endpoint!`          | Wraps a typed endpoint with C string params            |
 | `ffi_typed_endpoint_no_params!`| Wraps a typed endpoint with no params                  |
-| `ffi_typed_snapshot_endpoint!` | Wraps a snapshot endpoint (takes JSON array of symbols)|
+| `ffi_typed_snapshot_endpoint!` | Wraps a snapshot endpoint (takes C string array of symbols)|
 | `ffi_list_endpoint!`           | Wraps a list endpoint with C string params             |
 | `ffi_list_endpoint_no_params!` | Wraps a list endpoint with no params                   |
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "5.0.2"
+version = "5.1.0"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -51,8 +51,8 @@ All 61 endpoints are available as `tdx_stock_*`, `tdx_option_*`, `tdx_index_*`, 
 | `tdx_unified_unsubscribe_full_open_interest` | Unsubscribe from firehose open interest stream |
 | `tdx_unified_is_streaming` | Check if FPSS connection is live |
 | `tdx_unified_contract_lookup` | Look up contract by ID |
-| `tdx_unified_active_subscriptions` | List active subscriptions (JSON) |
-| `tdx_unified_next_event` | Poll for next event (JSON, blocks with timeout) |
+| `tdx_unified_active_subscriptions` | List active subscriptions (typed `TdxSubscriptionArray`) |
+| `tdx_unified_next_event` | Poll for next event (`*mut TdxFpssEvent`, blocks with timeout) |
 | `tdx_unified_stop_streaming` | Stop streaming, historical stays alive |
 | `tdx_unified_free` | Free the unified handle |
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -106,7 +106,7 @@ pub struct TdxUnified {
 ///
 /// Uses the same pattern as the Python SDK: an internal mpsc channel buffering
 /// events from the Disruptor callback, and `tdx_fpss_next_event` polls it with
-/// a timeout, returning JSON.
+/// a timeout, returning a `*mut TdxFpssEvent` typed struct.
 pub struct TdxFpssHandle {
     inner: Arc<Mutex<Option<thetadatadx::fpss::FpssClient>>>,
     rx: Arc<Mutex<std::sync::mpsc::Receiver<FfiBufferedEvent>>>,
@@ -2296,7 +2296,7 @@ pub unsafe extern "C" fn tdx_unified_is_streaming(handle: *const TdxUnified) -> 
     }
 }
 
-/// Look up a contract by ID. Returns JSON string or null.
+/// Look up a contract by ID. Returns a Display-formatted C string or null.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_unified_contract_lookup(
     handle: *const TdxUnified,
@@ -2934,7 +2934,7 @@ pub unsafe extern "C" fn tdx_fpss_is_authenticated(handle: *const TdxFpssHandle)
 
 /// Look up a single contract by its server-assigned ID.
 ///
-/// Returns a JSON string representation of the contract, or NULL if not found.
+/// Returns a Display-formatted C string representation of the contract, or NULL if not found.
 /// Caller must free the returned string with `tdx_string_free`.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_fpss_contract_lookup(

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -340,7 +340,7 @@ Prices in streaming events are raw integers with a `PriceType` field. Decode usi
 | `UnsubscribeFullOpenInterest(secType)` | `(int, error)` | Unsubscribe from all OI for a security type |
 | `IsAuthenticated()` | `bool` | Check if FPSS client is authenticated |
 | `ContractLookup(id)` | `(string, error)` | Look up contract by server-assigned ID |
-| `ActiveSubscriptions()` | `(json.RawMessage, error)` | List currently active subscriptions |
+| `ActiveSubscriptions()` | `([]Subscription, error)` | List currently active subscriptions |
 | `NextEvent(timeoutMs)` | `(*FpssEvent, error)` | Poll next event as typed struct (nil on timeout) |
 | `Shutdown()` | | Graceful shutdown of streaming |
 | `Close()` | | Free the FPSS handle (call after Shutdown) |

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "5.0.2"
+version = "5.1.0"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "thetadatadx"
-version = "5.0.2"
+version = "5.1.0"
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "5.0.2"
+version = "5.1.0"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "5.0.2"
+version = "5.1.0"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "5.0.2"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

- **Zero JSON in FFI**: `serde_json` removed from FFI crate. All FPSS streaming events now use `#[repr(C)]` typed structs (`TdxFpssQuote`, `TdxFpssTrade`, `TdxFpssOpenInterest`, `TdxFpssOhlcvc`, `TdxFpssControl`, `TdxFpssRawData`) across all SDKs.
- **Contract identification on all 10 option tick types**: `expiration`, `strike`, `right`, `strike_price_type` fields with helper methods (`strike_price()`, `is_call()`, `is_put()`, `has_contract_id()`).
- **8-field trade tick support**: auto-detects abbreviated dev server trade format vs production 16-field format.
- **9 stale JSON doc references fixed**: FFI doc comments, FFI README, Go README, docs-site API reference, macro guide all corrected to describe typed structs.
- **Python SDK greeks_tick_to_dict**: now emits all 24 fields (was missing 16).
- **Version bump**: all crates to 5.1.0.

Closes #82 Closes #84 Closes #86 Closes #92

## Verification

- `cargo fmt --all -- --check` -- clean
- `cargo clippy --workspace -- -D warnings` -- clean
- `cargo test --workspace` -- 176 tests pass
- `grep -c serde_json ffi/src/lib.rs` -- 0
- `grep serde_json ffi/Cargo.toml` -- no matches