### PR TITLE
release: v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-04-04
+
+### Breaking Changes
+
+- **Go SDK**: price fields on public structs are now `float64` (decoded). Raw `int32` values available as `*Raw` fields. `PriceType` removed from public structs.
+- **Go FPSS events**: `FpssQuote.Bid`/`Ask`, `FpssTrade.Price`, `FpssOhlcvc.Open`/`High`/`Low`/`Close` are now `float64`. Raw values as `*Raw` fields.
+- **Rust FPSS events**: `FpssData::Quote`, `Trade`, `Ohlcvc` gain pre-decoded `*_f64` fields (`bid_f64`, `price_f64`, etc.).
+
+### Added
+
+- **Rust `_f64()` convenience methods** on all tick types: `price_f64()`, `bid_f64()`, `ask_f64()`, `open_f64()`, `high_f64()`, `low_f64()`, `close_f64()`, `midpoint_f64()`. (#95)
+- **Go pre-decoded f64 prices** on all public structs and FPSS events. Users get `tick.Price` as `float64` ready to use. (#95)
+- **C++ `tdx::` price helpers** -- 17 inline functions for f64 price decoding on all tick types.
+- **FFI FPSS events** gain `*_f64` fields (`bid_f64`, `ask_f64`, `price_f64`, `open_f64`, `high_f64`, `low_f64`, `close_f64`) pre-computed during event construction.
+
+### Fixed
+
+- **Go `PriceToF64` formula** was `value / 10^pt` instead of `value * 10^(pt-10)`. All FPSS streaming prices would have been wrong. (#95)
+
 ## [5.1.0] - 2026-04-03
 
 ### Breaking Changes
@@ -578,7 +597,10 @@ See [TODO.md](TODO.md) for the production readiness checklist and performance ro
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.2...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v5.2.0...HEAD
+[5.2.0]: https://github.com/userFRM/ThetaDataDx/compare/v5.1.1...v5.2.0
+[5.1.1]: https://github.com/userFRM/ThetaDataDx/compare/v5.1.0...v5.1.1
+[5.1.0]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.2...v5.1.0
 [5.0.2]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/userFRM/ThetaDataDx/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v4.5.0...v5.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.1.1"
+version = "5.2.0"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "5.1.1"
+version = "5.2.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "5.1.1"
+version = "5.2.0"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ No-JVM ThetaData Terminal - native Rust SDK for direct market data access.
 
 ```toml
 [dependencies]
-thetadatadx = "5.1"
+thetadatadx = "5.2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "5.1.1"
+version = "5.2.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -11,7 +11,7 @@ description: Install ThetaDataDx, configure credentials, and run your first quer
 ```toml [Rust]
 # Add to your Cargo.toml
 [dependencies]
-thetadatadx = "5.1"
+thetadatadx = "5.2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 ```bash [Python]

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ description: Install ThetaDataDx for Rust, Python, Go, or C++.
 ```toml [Rust]
 # Add to your Cargo.toml
 [dependencies]
-thetadatadx = "5.1"
+thetadatadx = "5.2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 ```bash [Python]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "5.1.1"
+version = "5.2.0"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "5.1.1"
+version = "5.2.0"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "thetadatadx"
-version = "5.1.1"
+version = "5.2.0"
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "5.1.1"
+version = "5.2.0"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "5.1.1"
+version = "5.2.0"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "5.1.1"
+version = "5.2.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

- Bump all crate versions to 5.2.0
- CHANGELOG with v5.2.0 entry
- Version pins updated to 5.2

### Breaking Changes
- Go SDK price fields now `float64` (decoded), `PriceType` removed from public structs
- Rust FPSS events gain `*_f64` fields

### Added
- Rust `_f64()` convenience methods on all tick types
- Go pre-decoded f64 prices on all structs + FPSS events
- C++ `tdx::` price helper functions
- FFI FPSS events `*_f64` fields

### Fixed
- Go `PriceToF64` formula was wrong (would corrupt all FPSS streaming prices)

Closes #99

## Test plan
- [ ] CI green on all 3 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)