### PR TITLE
fix: bump tdbe to 0.3.0 for crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -23,7 +23,7 @@ default = []
 config-file = ["dep:toml"]
 
 [dependencies]
-tdbe = { version = "0.2.0", path = "../tdbe" }
+tdbe = { version = "0.3.0", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"
@@ -10,5 +10,5 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.2.0", path = "../crates/tdbe" }
+tdbe = { version = "0.3.0", path = "../crates/tdbe" }
 tokio = { version = "1.50.0", features = ["rt-multi-thread"] }

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.2.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.3.0", path = "../../crates/tdbe" }
 
 # PyO3 bindings
 pyo3 = { version = "=0.28.2", features = ["extension-module"] }

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "thetadatadx"
-version = "5.2.0"
+version = "5.2.1"
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.2.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.3.0", path = "../../crates/tdbe" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.3"

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.2.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.3.0", path = "../../crates/tdbe" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1", features = ["derive"] }
 sonic-rs = "0.3"

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.2.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.3.0", path = "../../crates/tdbe" }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 sonic-rs = "0.3"


### PR DESCRIPTION
tdbe gained _f64() convenience methods and right_str() in v5.2.0 but wasn't bumped. Crates.io publish would fail.