### PR TITLE
feat: human-readable display helpers for all tick fields

### DIFF
--- a/crates/tdbe/src/display.rs
+++ b/crates/tdbe/src/display.rs
@@ -1,0 +1,1979 @@
+//! Human-readable display helpers for tick fields.
+//!
+//! All lookups are `const`-compatible: static arrays with index or match-based
+//! access. No `HashMap`, no `LazyLock`, no allocations on the lookup path.
+//!
+//! # Time / Date formatting
+//!
+//! ```
+//! # use tdbe::display;
+//! assert_eq!(display::time_str(34_200_000), "09:30:00.000");
+//! assert_eq!(display::date_str(20_240_315), "2024-03-15");
+//! ```
+//!
+//! # Exchange lookup (78 exchanges, code 0..=77)
+//!
+//! ```
+//! # use tdbe::display;
+//! assert_eq!(display::exchange_name(1), "NasdaqExchange");
+//! assert_eq!(display::exchange_symbol(3), "NYSE");
+//! ```
+//!
+//! # Trade / quote condition names
+//!
+//! ```
+//! # use tdbe::display;
+//! assert_eq!(display::condition_name(0), "REGULAR");
+//! assert_eq!(display::quote_condition_name(17), "HALTED");
+//! ```
+
+use core::fmt::Write;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Time helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Decompose milliseconds-of-day into `(hour, minute, second, millis)`.
+#[inline]
+pub fn time_hms(ms_of_day: i32) -> (u8, u8, u8, u16) {
+    let ms = ms_of_day as u32;
+    let total_secs = ms / 1000;
+    let millis = (ms % 1000) as u16;
+    let h = (total_secs / 3600) as u8;
+    let m = ((total_secs % 3600) / 60) as u8;
+    let s = (total_secs % 60) as u8;
+    (h, m, s, millis)
+}
+
+/// Format milliseconds-of-day as `"HH:MM:SS.mmm"`.
+pub fn time_str(ms_of_day: i32) -> String {
+    let (h, m, s, ms) = time_hms(ms_of_day);
+    let mut buf = String::with_capacity(12);
+    let _ = write!(buf, "{h:02}:{m:02}:{s:02}.{ms:03}");
+    buf
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Date helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Decompose a `YYYYMMDD` integer date into `(year, month, day)`.
+#[inline]
+pub fn date_ymd(date: i32) -> (i32, u8, u8) {
+    let y = date / 10_000;
+    let m = ((date % 10_000) / 100) as u8;
+    let d = (date % 100) as u8;
+    (y, m, d)
+}
+
+/// Format a `YYYYMMDD` integer date as `"YYYY-MM-DD"`.
+pub fn date_str(date: i32) -> String {
+    let (y, m, d) = date_ymd(date);
+    let mut buf = String::with_capacity(10);
+    let _ = write!(buf, "{y:04}-{m:02}-{d:02}");
+    buf
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Exchange codes  (0..=77, direct index)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// `(name, symbol)` for each exchange code, indexed by code.
+const EXCHANGES: [(&str, &str); 78] = [
+    ("NanexComp", "COMP"),                              // 0
+    ("NasdaqExchange", "NQEX"),                         // 1
+    ("NasdaqAlternativeDisplayFacility", "NQAD"),       // 2
+    ("NewYorkStockExchange", "NYSE"),                   // 3
+    ("AmericanStockExchange", "AMEX"),                  // 4
+    ("ChicagoBoardOptionsExchange", "CBOE"),            // 5
+    ("InternationalSecuritiesExchange", "ISEX"),        // 6
+    ("NYSEARCA(Pacific)", "PACF"),                      // 7
+    ("NationalStockExchange(Cincinnati)", "CINC"),      // 8
+    ("PhiladelphiaStockExchange", "PHIL"),              // 9
+    ("OptionsPricingReportingAuthority", "OPRA"),       // 10
+    ("BostonStock/OptionsExchange", "BOST"),            // 11
+    ("NasdaqGlobal+SelectMarket(NMS)", "NQNM"),         // 12
+    ("NasdaqCapitalMarket(SmallCap)", "NQSC"),          // 13
+    ("NasdaqBulletinBoard", "NQBB"),                    // 14
+    ("NasdaqOTC", "NQPK"),                              // 15
+    ("NasdaqIndexes(GIDS)", "NQIX"),                    // 16
+    ("ChicagoStockExchange", "CHIC"),                   // 17
+    ("TorontoStockExchange", "TSE"),                    // 18
+    ("CanadianVentureExchange", "CDNX"),                // 19
+    ("ChicagoMercantileExchange", "CME"),               // 20
+    ("NewYorkBoardofTrade", "NYBT"),                    // 21
+    ("ISEMercury", "MRCY"),                             // 22
+    ("COMEX(divisionofNYMEX)", "COMX"),                 // 23
+    ("ChicagoBoardofTrade", "CBOT"),                    // 24
+    ("NewYorkMercantileExchange", "NYMX"),              // 25
+    ("KansasCityBoardofTrade", "KCBT"),                 // 26
+    ("MinneapolisGrainExchange", "MGEX"),               // 27
+    ("NYSE/ARCABonds", "NYBO"),                         // 28
+    ("NasdaqBasic", "NQBS"),                            // 29
+    ("DowJonesIndices", "DOWJ"),                        // 30
+    ("ISEGemini", "GEMI"),                              // 31
+    ("SingaporeInternationalMonetaryExchange", "SIMX"), // 32
+    ("LondonStockExchange", "FTSE"),                    // 33
+    ("Eurex", "EURX"),                                  // 34
+    ("ImpliedPrice", "IMPL"),                           // 35
+    ("DataTransmissionNetwork", "DTN"),                 // 36
+    ("LondonMetalsExchangeMatchedTrades", "LMT"),       // 37
+    ("LondonMetalsExchange", "LME"),                    // 38
+    ("IntercontinentalExchange(IPE)", "IPEX"),          // 39
+    ("NasdaqMutualFunds(MFDS)", "NQMF"),                // 40
+    ("COMEXClearport", "fcec"),                         // 41
+    ("CBOEC2OptionExchange", "C2"),                     // 42
+    ("MiamiExchange", "MIAX"),                          // 43
+    ("NYMEXClearport", "CLRP"),                         // 44
+    ("Barclays", "BARK"),                               // 45
+    ("MiamiEmeraldOptionsExchange", "EMLD"),            // 46
+    ("NASDAQBoston", "NQBX"),                           // 47
+    ("HotSpotEurexUS", "HOTS"),                         // 48
+    ("EurexUS", "EUUS"),                                // 49
+    ("EurexEU", "EUEU"),                                // 50
+    ("EuronextCommodities", "ENCM"),                    // 51
+    ("EuronextIndexDerivatives", "ENID"),               // 52
+    ("EuronextInterestRates", "ENIR"),                  // 53
+    ("CBOEFuturesExchange", "CFE"),                     // 54
+    ("PhiladelphiaBoardofTrade", "PBOT"),               // 55
+    ("FCME", "CMEFloor"),                               // 56
+    ("FINRA/NASDAQTradeReportingFacility", "NQNX"),     // 57
+    ("BSETradeReportingFacility", "BTRF"),              // 58
+    ("NYSETradeReportingFacility", "NTRF"),             // 59
+    ("BATSTrading", "BATS"),                            // 60
+    ("CBOTFloor", "FCBT"),                              // 61
+    ("PinkSheets", "PINK"),                             // 62
+    ("BATSYExchange", "BATY"),                          // 63
+    ("DirectEdgeA", "EDGE"),                            // 64
+    ("DirectEdgeX", "EDGX"),                            // 65
+    ("RussellIndexes", "RUSL"),                         // 66
+    ("CMEIndexes", "CMEX"),                             // 67
+    ("InvestorsExchange", "IEX"),                       // 68
+    ("MiamiPearlOptionsExchange", "PERL"),              // 69
+    ("LondonStockExchange", "LSE"),                     // 70
+    ("NYSEGlobalIndexFeed", "GIF"),                     // 71
+    ("TSXIndexes", "TSIX"),                             // 72
+    ("MembersExchange", "MEMX"),                        // 73
+    ("CBOECGI", "CGI"),                                 // 74
+    ("LongTermStockExchange", "LTSE"),                  // 75
+    ("MIAXSapphire", "SPHR"),                           // 76
+    ("24XNationalExchange", "24X"),                     // 77
+];
+
+/// Exchange full name by code. Returns `"UNKNOWN"` for out-of-range codes.
+#[inline]
+pub fn exchange_name(code: i32) -> &'static str {
+    match EXCHANGES.get(code as usize) {
+        Some((name, _)) => name,
+        None => "UNKNOWN",
+    }
+}
+
+/// Exchange symbol by code. Returns `"UNKNOWN"` for out-of-range codes.
+#[inline]
+pub fn exchange_symbol(code: i32) -> &'static str {
+    match EXCHANGES.get(code as usize) {
+        Some((_, sym)) => sym,
+        None => "UNKNOWN",
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Trade condition codes  (0..=148, match-based)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Semantic flags for a trade condition.
+pub struct TradeConditionInfo {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub cancel: bool,
+    pub late_report: bool,
+    pub volume: bool,
+    pub high: bool,
+    pub low: bool,
+    pub last: bool,
+}
+
+/// Trade condition name by code. Returns `"UNKNOWN"` for unmapped codes.
+pub fn condition_name(code: i32) -> &'static str {
+    match condition_info(code) {
+        Some(info) => info.name,
+        None => "UNKNOWN",
+    }
+}
+
+/// Full trade condition info by code.
+pub fn condition_info(code: i32) -> Option<&'static TradeConditionInfo> {
+    // Using a const array indexed by code for O(1) lookup.
+    // All 149 conditions (0..=148) are contiguous.
+    const TABLE: [TradeConditionInfo; 149] = [
+        TradeConditionInfo {
+            name: "REGULAR",
+            description: "Regular Trade",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "FORMT",
+            description: "Form T. Before and After Regular Hours.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "OUTOFSEQ",
+            description: "Report was sent Out Of Sequence.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "AVGPRC",
+            description: "Average Price for a trade. NYSE/AMEX stocks.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "AVGPRC_NASDAQ",
+            description: "Average Price. Nasdaq stocks.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "OPENREPORTLATE",
+            description: "NYSE/AMEX. Market opened Late.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "OPENREPORTOUTOFSEQ",
+            description: "Report IS out of sequence. Market was open.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "OPENREPORTINSEQ",
+            description: "Opening report. This is the first price.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "PRIORREFERENCEPRICE",
+            description: "Trade references price established earlier.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "NEXTDAYSALE",
+            description: "NYSE/AMEX: Next Day Clearing.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BUNCHED",
+            description: "Aggregate of 2 or more Regular trades.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CASHSALE",
+            description: "Delivery of securities and payment on the same day.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "SELLER",
+            description: "Stock can be delivered up to 60 days later.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "SOLDLAST",
+            description: "Late Reporting.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "RULE127",
+            description: "NYSE only. Rule 127 block trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "BUNCHEDSOLD",
+            description: "Several trades bunched, report is late.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "NONBOARDLOT",
+            description: "Size of trade is less than a board lot (oddlot).",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "POSIT",
+            description: "POSIT Canada mid-point matching.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "AUTOEXECUTION",
+            description: "Transaction executed electronically.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "HALT",
+            description: "Temporary halt in trading.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "DELAYED",
+            description: "Indicates a delayed opening.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "REOPEN",
+            description: "Reopening of a previously halted contract.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "ACQUISITION",
+            description: "Exchange Acquisition.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CASHMARKET",
+            description: "Cash only Market.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "NEXTDAYMARKET",
+            description: "Next Day Only Market.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "BURSTBASKET",
+            description: "Specialist basket execution.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "OPENDETAIL",
+            description: "Opening/Reopening Trade Detail.",
+            cancel: false,
+            late_report: true,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "INTRADETAIL",
+            description: "Detail trade of a previous trade.",
+            cancel: false,
+            late_report: true,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BASKETONCLOSE",
+            description: "Paired basket order on close.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RULE155",
+            description: "AMEX only rule 155.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "DISTRIBUTION",
+            description: "Sale of a large block of stock.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "SPLIT",
+            description: "Execution in 2 markets.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "REGULARSETTLE",
+            description: "Regular settlement.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CUSTOMBASKETCROSS",
+            description: "Custom basket cross.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "ADJTERMS",
+            description: "Terms adjusted for stock split/dividend.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "SPREAD",
+            description: "Spread between 2 options.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STRADDLE",
+            description: "Straddle between 2 options.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "BUYWRITE",
+            description: "Option part of a covered call.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "COMBO",
+            description: "A buy and a sell in 2+ options.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STPD",
+            description: "Traded at agreed price following non-stopped trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CANC",
+            description: "Cancel a previously reported trade.",
+            cancel: true,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CANCLAST",
+            description: "Cancel the most recent qualifying last trade.",
+            cancel: true,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CANCOPEN",
+            description: "Cancel the opening trade report.",
+            cancel: true,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CANCONLY",
+            description: "Cancel the only trade report.",
+            cancel: true,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CANCSTPD",
+            description: "Cancel the STPD trade report.",
+            cancel: true,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "MATCHCROSS",
+            description: "Cross Trade from crossing session.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "FASTMARKET",
+            description: "Unusually hectic market conditions.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "NOMINAL",
+            description: "Nominal price for margin/risk evaluation.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CABINET",
+            description: "Deep out-of-the-money option trade.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BLANKPRICE",
+            description: "Sent by exchange to blank out a price.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "NOTSPECIFIED",
+            description: "Unspecified condition.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "MCOFFICIALCLOSE",
+            description: "Market Center official closing value.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "SPECIALTERMS",
+            description: "All trades settled in non-regular manner.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CONTINGENTORDER",
+            description: "Contingent order on offsetting security.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "INTERNALCROSS",
+            description: "Cross between two client accounts.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOPPEDREGULAR",
+            description: "Stopped Stock Regular Trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOPPEDSOLDLAST",
+            description: "Stopped Stock SoldLast Trade.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOPPEDOUTOFSEQ",
+            description: "Stopped Stock Out of Sequence.",
+            cancel: false,
+            late_report: true,
+            volume: false,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BASIS",
+            description: "Basket/index participation unit transaction.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "VWAP",
+            description: "Volume Weighted Average Price.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "SPECIALSESSION",
+            description: "Special Trading Session at last sale price.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "NANEXADMIN",
+            description: "Volume and price corrections.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "OPENREPORT",
+            description: "Opening trade report.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "MARKETONCLOSE",
+            description: "Market Center closing value.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "SETTLEPRICE",
+            description: "Settlement Price.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "OUTOFSEQPREMKT",
+            description: "Out of sequence pre/post market trade.",
+            cancel: false,
+            late_report: true,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "MCOFFICIALOPEN",
+            description: "Market Center official opening value.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "FUTURESSPREAD",
+            description: "Futures spread execution.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "OPENRANGE",
+            description: "Opening range high/low.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CLOSERANGE",
+            description: "Closing range high/low.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "NOMINALCABINET",
+            description: "Nominal Cabinet.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CHANGINGTRANS",
+            description: "Changing Transaction.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CHANGINGTRANSCAB",
+            description: "Changing Cabinet Transaction.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "NOMINALUPDATE",
+            description: "Nominal price update.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "PITSETTLEMENT",
+            description: "Pit session settlement price.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BLOCKTRADE",
+            description: "Large block trade (typically 10,000+ shares).",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "EXGFORPHYSICAL",
+            description: "Exchange Future for Physical.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "VOLUMEADJUSTMENT",
+            description: "Cumulative volume adjustment.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "VOLATILITYTRADE",
+            description: "Volatility trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "YELLOWFLAG",
+            description: "Exchange may be experiencing technical difficulties.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "FLOORPRICE",
+            description: "Floor Bid/Ask on LME.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "OFFICIALPRICE",
+            description: "Official bid/ask price on LME.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "UNOFFICIALPRICE",
+            description: "Unofficial bid/ask price on LME.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MIDBIDASKPRICE",
+            description: "Mid bid-ask price on LME.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "ENDSESSIONHIGH",
+            description: "End of Session High Price.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: true,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "ENDSESSIONLOW",
+            description: "End of Session Low Price.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BACKWARDATION",
+            description: "Immediate delivery price > future delivery.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CONTANGO",
+            description: "Future delivery price > immediate delivery.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "HOLIDAY",
+            description: "Holiday.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "PREOPENING",
+            description: "Pre-opening period (7:00-9:30 AM).",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "POSTFULL",
+            description: "Post Full.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "POSTRESTRICTED",
+            description: "Post Restricted.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CLOSINGAUCTION",
+            description: "Closing Auction.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BATCH",
+            description: "Batch.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "TRADING",
+            description: "Trading.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "INTERMARKETSWEEP",
+            description: "Intermarket Sweep Order Execution.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "DERIVATIVE",
+            description: "Derivatively priced.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "REOPENING",
+            description: "Market center re-opening prints.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CLOSING",
+            description: "Market center closing prints.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "CAPELECTION",
+            description: "Odd Lot Trade (formerly Cap Election).",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "SPOTSETTLEMENT",
+            description: "Spot Settlement.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "BASISHIGH",
+            description: "Basis High.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BASISLOW",
+            description: "Basis Low.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "YIELD",
+            description: "Yield (Cantor Treasuries).",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "PRICEVARIATION",
+            description: "Price Variation.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CONTINGENTTRADEFORMERLYSTOCKOPTION",
+            description: "Contingent trade execution.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "STOPPEDIM",
+            description: "Stopped at non-trade-through price.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "BENCHMARK",
+            description: "Benchmark.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "TRADETHRUEXEMPT",
+            description: "Trade Through Exempt.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "IMPLIED",
+            description: "Spread trade leg price.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "OTC",
+            description: "Over The Counter.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "MKTSUPERVISION",
+            description: "Market Supervision.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RESERVED_77",
+            description: "",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RESERVED_91",
+            description: "",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CONTINGENTUTP",
+            description: "Contingent UTP.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "ODDLOT",
+            description: "Trade with size between 1-99.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RESERVED_89",
+            description: "",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "CORRECTEDCSLAST",
+            description: "Corrected consolidated last.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "OPRAEXTHOURS",
+            description: "OPRA extended trading hours session.",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RESERVED_78",
+            description: "",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RESERVED_81",
+            description: "",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RESERVED_84",
+            description: "",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RESERVED_878",
+            description: "",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "RESERVED_90",
+            description: "",
+            cancel: false,
+            late_report: false,
+            volume: false,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "QUALIFIEDCONTINGENTTRADE",
+            description: "Qualified Contingent Trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "SINGLELEGAUCTIONNONISO",
+            description: "Single leg auction (non-ISO).",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "SINGLELEGAUCTIONISO",
+            description: "Single leg auction (ISO).",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "SINGLELEGCROSSNONISO",
+            description: "Single leg cross (non-ISO).",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "SINGLELEGCROSSISO",
+            description: "Single leg cross (ISO).",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "SINGLELEGFLOORTRADE",
+            description: "Single leg floor trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILEGAUTOELECTRONICTRADE",
+            description: "Multi-leg auto electronic trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILEGAUCTION",
+            description: "Multi-leg auction.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILEGCROSS",
+            description: "Multi-leg cross.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILEGFLOORTRADE",
+            description: "Multi-leg floor trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILEGAUTOELECTRADEAGAINSTSINGLELEG",
+            description: "Multi-leg auto trade vs single leg.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOCKOPTIONSAUCTION",
+            description: "Stock/options auction.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILEGAUCTIONAGAINSTSINGLELEG",
+            description: "Multi-leg auction vs single leg.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILEGFLOORTRADEAGAINSTSINGLELEG",
+            description: "Multi-leg floor trade vs single leg.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOCKOPTIONSAUTOELECTRADE",
+            description: "Stock/options auto electronic trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOCKOPTIONSCROSS",
+            description: "Stock/options cross.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOCKOPTIONSFLOORTRADE",
+            description: "Stock/options floor trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOCKOPTIONSAUTOELECTRADEAGAINSTSINGLELEG",
+            description: "Stock/options auto trade vs single leg.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOCKOPTIONSAUCTIONAGAINSTSINGLELEG",
+            description: "Stock/options auction vs single leg.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "STOCKOPTIONSFLOORTRADEAGAINSTSINGLELEG",
+            description: "Stock/options floor trade vs single leg.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILEGFLOORTRADEOFPROPRIETARYPRODUCTS",
+            description: "Multi-leg proprietary products floor trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "BIDAGGRESSOR",
+            description: "Aggressor on the buy side.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "ASKAGGRESSOR",
+            description: "Aggressor on the sell side.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: true,
+            low: true,
+            last: true,
+        },
+        TradeConditionInfo {
+            name: "MULTILATERALCOMPRESSIONTRADEOFPROPRIETARYDATAPRODUCTS",
+            description: "Multilateral compression trade.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+        TradeConditionInfo {
+            name: "EXTENDEDHOURSTRADE",
+            description: "Trade executed outside regular market hours.",
+            cancel: false,
+            late_report: false,
+            volume: true,
+            high: false,
+            low: false,
+            last: false,
+        },
+    ];
+
+    if code >= 0 && (code as usize) < TABLE.len() {
+        Some(&TABLE[code as usize])
+    } else {
+        None
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Quote condition codes  (0..=74, direct index)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Quote condition names, indexed by code.
+const QUOTE_CONDITIONS: [&str; 75] = [
+    "REGULAR",              // 0
+    "BID_ASK_AUTO_EXEC",    // 1
+    "ROTATION",             // 2
+    "SPECIALIST_ASK",       // 3
+    "SPECIALIST_BID",       // 4
+    "LOCKED",               // 5
+    "FAST_MARKET",          // 6
+    "SPECIALIST_BID_ASK",   // 7
+    "ONE_SIDE",             // 8
+    "OPENING_QUOTE",        // 9
+    "CLOSING_QUOTE",        // 10
+    "MARKET_MAKER_CLOSED",  // 11
+    "DEPTH_ON_ASK",         // 12
+    "DEPTH_ON_BID",         // 13
+    "DEPTH_ON_BID_ASK",     // 14
+    "TIER_3",               // 15
+    "CROSSED",              // 16
+    "HALTED",               // 17
+    "OPERATIONAL_HALT",     // 18
+    "NEWS_OUT",             // 19
+    "NEWS_PENDING",         // 20
+    "NON_FIRM",             // 21
+    "DUE_TO_RELATED",       // 22
+    "RESUME",               // 23
+    "NO_MARKET_MAKERS",     // 24
+    "ORDER_IMBALANCE",      // 25
+    "ORDER_INFLUX",         // 26
+    "INDICATED",            // 27
+    "PRE_OPEN",             // 28
+    "IN_VIEW_OF_COMMON",    // 29
+    "RELATED_NEWS_PENDING", // 30
+    "RELATED_NEWS_OUT",     // 31
+    "ADDITIONAL_INFO",      // 32
+    "RELATED_ADD_INFO",     // 33
+    "NO_OPEN_RESUME",       // 34
+    "DELETED",              // 35
+    "REGULATORY_HALT",      // 36
+    "SEC_SUSPENSION",       // 37
+    "NON_COMLIANCE",        // 38
+    "FILINGS_NOT_CURRENT",  // 39
+    "CATS_HALTED",          // 40
+    "CATS",                 // 41
+    "EX_DIV_OR_SPLIT",      // 42
+    "UNASSIGNED",           // 43
+    "INSIDE_OPEN",          // 44
+    "INSIDE_CLOSED",        // 45
+    "OFFER_WANTED",         // 46
+    "BID_WANTED",           // 47
+    "CASH",                 // 48
+    "INACTIVE",             // 49
+    "NATIONAL_BBO",         // 50
+    "NOMINAL",              // 51
+    "CABINET",              // 52
+    "NOMINAL_CABINET",      // 53
+    "BLANK_PRICE",          // 54
+    "SLOW_BID_ASK",         // 55
+    "SLOW_LIST",            // 56
+    "SLOW_BID",             // 57
+    "SLOW_ASK",             // 58
+    "BID_OFFER_WANTED",     // 59
+    "SUBPENNY",             // 60
+    "NON_BBO",              // 61
+    "SPECIAL_OPEN",         // 62
+    "BENCHMARK",            // 63
+    "IMPLIED",              // 64
+    "EXCHANGE_BEST",        // 65
+    "MKT_WIDE_HALT_1",      // 66
+    "MKT_WIDE_HALT_2",      // 67
+    "MKT_WIDE_HALT_3",      // 68
+    "ON_DEMAND_AUCTION",    // 69
+    "NON_FIRM_BID",         // 70
+    "NON_FIRM_ASK",         // 71
+    "RETAIL_BID",           // 72
+    "RETAIL_ASK",           // 73
+    "RETAIL_QTE",           // 74
+];
+
+/// Quote condition name by code. Returns `"UNKNOWN"` for unmapped codes.
+#[inline]
+pub fn quote_condition_name(code: i32) -> &'static str {
+    match QUOTE_CONDITIONS.get(code as usize) {
+        Some(name) => name,
+        None => "UNKNOWN",
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Option right helper
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Decode the `right` field: ASCII 67 = `"C"`, 80 = `"P"`, else `""`.
+#[inline]
+pub fn right_str(code: i32) -> &'static str {
+    match code {
+        67 => "C",
+        80 => "P",
+        _ => "",
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Request type constants
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub const REQUEST_TYPE_TRADE: &str = "trade";
+pub const REQUEST_TYPE_QUOTE: &str = "quote";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Time helpers ──
+
+    #[test]
+    fn test_time_hms_market_open() {
+        assert_eq!(time_hms(34_200_000), (9, 30, 0, 0));
+    }
+
+    #[test]
+    fn test_time_str_market_open() {
+        assert_eq!(time_str(34_200_000), "09:30:00.000");
+    }
+
+    #[test]
+    fn test_time_str_with_millis() {
+        assert_eq!(time_str(34_200_123), "09:30:00.123");
+    }
+
+    #[test]
+    fn test_time_str_midnight() {
+        assert_eq!(time_str(0), "00:00:00.000");
+    }
+
+    #[test]
+    fn test_time_str_end_of_day() {
+        // 23:59:59.999
+        assert_eq!(time_str(86_399_999), "23:59:59.999");
+    }
+
+    // ── Date helpers ──
+
+    #[test]
+    fn test_date_ymd() {
+        assert_eq!(date_ymd(20_240_315), (2024, 3, 15));
+    }
+
+    #[test]
+    fn test_date_str() {
+        assert_eq!(date_str(20_240_315), "2024-03-15");
+    }
+
+    #[test]
+    fn test_date_str_jan_first() {
+        assert_eq!(date_str(20_250_101), "2025-01-01");
+    }
+
+    // ── Exchange lookups ──
+
+    #[test]
+    fn test_exchange_name_nasdaq() {
+        assert_eq!(exchange_name(1), "NasdaqExchange");
+    }
+
+    #[test]
+    fn test_exchange_symbol_nyse() {
+        assert_eq!(exchange_symbol(3), "NYSE");
+    }
+
+    #[test]
+    fn test_exchange_iex() {
+        assert_eq!(exchange_name(68), "InvestorsExchange");
+        assert_eq!(exchange_symbol(68), "IEX");
+    }
+
+    #[test]
+    fn test_exchange_out_of_range() {
+        assert_eq!(exchange_name(999), "UNKNOWN");
+        assert_eq!(exchange_symbol(-1), "UNKNOWN");
+    }
+
+    #[test]
+    fn test_exchange_last_entry() {
+        assert_eq!(exchange_name(77), "24XNationalExchange");
+        assert_eq!(exchange_symbol(77), "24X");
+    }
+
+    // ── Trade condition lookups ──
+
+    #[test]
+    fn test_condition_regular() {
+        assert_eq!(condition_name(0), "REGULAR");
+        let info = condition_info(0).unwrap();
+        assert!(!info.cancel);
+        assert!(info.volume);
+        assert!(info.last);
+    }
+
+    #[test]
+    fn test_condition_canc() {
+        assert_eq!(condition_name(40), "CANC");
+        let info = condition_info(40).unwrap();
+        assert!(info.cancel);
+        assert!(!info.volume);
+    }
+
+    #[test]
+    fn test_condition_intermarket_sweep() {
+        assert_eq!(condition_name(95), "INTERMARKETSWEEP");
+    }
+
+    #[test]
+    fn test_condition_last_entry() {
+        assert_eq!(condition_name(148), "EXTENDEDHOURSTRADE");
+    }
+
+    #[test]
+    fn test_condition_out_of_range() {
+        assert_eq!(condition_name(999), "UNKNOWN");
+        assert!(condition_info(999).is_none());
+        assert_eq!(condition_name(-1), "UNKNOWN");
+    }
+
+    // ── Quote condition lookups ──
+
+    #[test]
+    fn test_quote_condition_regular() {
+        assert_eq!(quote_condition_name(0), "REGULAR");
+    }
+
+    #[test]
+    fn test_quote_condition_halted() {
+        assert_eq!(quote_condition_name(17), "HALTED");
+    }
+
+    #[test]
+    fn test_quote_condition_last_entry() {
+        assert_eq!(quote_condition_name(74), "RETAIL_QTE");
+    }
+
+    #[test]
+    fn test_quote_condition_out_of_range() {
+        assert_eq!(quote_condition_name(999), "UNKNOWN");
+    }
+
+    // ── Right helper ──
+
+    #[test]
+    fn test_right_str_call() {
+        assert_eq!(right_str(67), "C");
+    }
+
+    #[test]
+    fn test_right_str_put() {
+        assert_eq!(right_str(80), "P");
+    }
+
+    #[test]
+    fn test_right_str_neither() {
+        assert_eq!(right_str(0), "");
+    }
+}

--- a/crates/tdbe/src/lib.rs
+++ b/crates/tdbe/src/lib.rs
@@ -14,6 +14,7 @@
 //! For network access, use the `thetadatadx` crate which depends on `tdbe`.
 
 pub mod codec;
+pub mod display;
 pub mod error;
 pub mod flags;
 pub mod greeks;

--- a/crates/tdbe/src/types/tick.rs
+++ b/crates/tdbe/src/types/tick.rs
@@ -1,3 +1,4 @@
+use crate::display;
 use crate::flags;
 use crate::types::price::Price;
 
@@ -300,9 +301,111 @@ macro_rules! impl_contract_id {
             pub fn has_contract_id(&self) -> bool {
                 self.expiration != 0
             }
+            /// Human-readable right: `"C"`, `"P"`, or `""`.
+            #[inline]
+            pub fn right_str(&self) -> &'static str {
+                display::right_str(self.right)
+            }
         }
     };
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Display helpers: time_str / date_str on all tick types with those fields
+// ─────────────────────────────────────────────────────────────────────────────
+
+macro_rules! impl_time_date_display {
+    ($ty:ident) => {
+        impl $ty {
+            /// Format `ms_of_day` as `"HH:MM:SS.mmm"`.
+            #[inline]
+            pub fn time_str(&self) -> String {
+                display::time_str(self.ms_of_day)
+            }
+            /// Format `date` as `"YYYY-MM-DD"`.
+            #[inline]
+            pub fn date_str(&self) -> String {
+                display::date_str(self.date)
+            }
+        }
+    };
+}
+
+impl_time_date_display!(TradeTick);
+impl_time_date_display!(QuoteTick);
+impl_time_date_display!(OhlcTick);
+impl_time_date_display!(EodTick);
+impl_time_date_display!(OpenInterestTick);
+impl_time_date_display!(SnapshotTradeTick);
+impl_time_date_display!(TradeQuoteTick);
+impl_time_date_display!(MarketValueTick);
+impl_time_date_display!(GreeksTick);
+impl_time_date_display!(IvTick);
+impl_time_date_display!(PriceTick);
+impl_time_date_display!(InterestRateTick);
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Display helpers: condition + exchange on trade-type ticks
+// ─────────────────────────────────────────────────────────────────────────────
+
+macro_rules! impl_trade_display {
+    ($ty:ident) => {
+        impl $ty {
+            /// Human-readable trade condition name.
+            #[inline]
+            pub fn condition_name(&self) -> &'static str {
+                display::condition_name(self.condition)
+            }
+            /// Human-readable exchange name.
+            #[inline]
+            pub fn exchange_name(&self) -> &'static str {
+                display::exchange_name(self.exchange)
+            }
+            /// Exchange ticker symbol.
+            #[inline]
+            pub fn exchange_symbol(&self) -> &'static str {
+                display::exchange_symbol(self.exchange)
+            }
+        }
+    };
+}
+
+impl_trade_display!(TradeTick);
+impl_trade_display!(TradeQuoteTick);
+
+// SnapshotTradeTick has condition but no exchange field.
+impl SnapshotTradeTick {
+    /// Human-readable trade condition name.
+    #[inline]
+    pub fn condition_name(&self) -> &'static str {
+        display::condition_name(self.condition)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Display helpers: bid/ask exchange on quote-type ticks
+// ─────────────────────────────────────────────────────────────────────────────
+
+macro_rules! impl_quote_exchange_display {
+    ($ty:ident) => {
+        impl $ty {
+            /// Human-readable bid exchange name.
+            #[inline]
+            pub fn bid_exchange_name(&self) -> &'static str {
+                display::exchange_name(self.bid_exchange)
+            }
+            /// Human-readable ask exchange name.
+            #[inline]
+            pub fn ask_exchange_name(&self) -> &'static str {
+                display::exchange_name(self.ask_exchange)
+            }
+        }
+    };
+}
+
+impl_quote_exchange_display!(QuoteTick);
+impl_quote_exchange_display!(EodTick);
+impl_quote_exchange_display!(TradeQuoteTick);
 
 impl_contract_id!(TradeTick);
 impl_contract_id!(QuoteTick);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1733,3 +1733,96 @@ pub fn fie_line_to_string(data: &[u8]) -> Option<String>;
 pub const fn char_to_nibble(c: u8) -> Option<u8>;
 pub const fn nibble_to_char(n: u8) -> Option<u8>;
 ```
+
+## Display Helpers (`tdbe::display`)
+
+Human-readable formatting for tick fields. All lookups use const arrays -- zero allocations on the lookup path, no `HashMap`, no `LazyLock`.
+
+### Time / Date
+
+```rust
+pub fn time_str(ms_of_day: i32) -> String       // "09:30:00.000"
+pub fn time_hms(ms_of_day: i32) -> (u8, u8, u8, u16)  // (h, m, s, ms)
+pub fn date_str(date: i32) -> String             // "2024-03-15"
+pub fn date_ymd(date: i32) -> (i32, u8, u8)     // (year, month, day)
+```
+
+### Exchange Lookup (78 exchanges, code 0..=77)
+
+```rust
+pub fn exchange_name(code: i32) -> &'static str   // "NasdaqExchange"
+pub fn exchange_symbol(code: i32) -> &'static str  // "NQEX"
+```
+
+### Trade Condition Lookup (149 conditions, code 0..=148)
+
+```rust
+pub fn condition_name(code: i32) -> &'static str
+pub fn condition_info(code: i32) -> Option<&'static TradeConditionInfo>
+
+pub struct TradeConditionInfo {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub cancel: bool,
+    pub late_report: bool,
+    pub volume: bool,
+    pub high: bool,
+    pub low: bool,
+    pub last: bool,
+}
+```
+
+### Quote Condition Lookup (75 conditions, code 0..=74)
+
+```rust
+pub fn quote_condition_name(code: i32) -> &'static str
+```
+
+### Option Right
+
+```rust
+pub fn right_str(code: i32) -> &'static str  // "C", "P", or ""
+```
+
+### Request Type Constants
+
+```rust
+pub const REQUEST_TYPE_TRADE: &str = "trade";
+pub const REQUEST_TYPE_QUOTE: &str = "quote";
+```
+
+### Tick Type Convenience Methods
+
+All tick types with `ms_of_day` and `date` fields gain:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `time_str()` | `String` | `ms_of_day` formatted as `"HH:MM:SS.mmm"` |
+| `date_str()` | `String` | `date` formatted as `"YYYY-MM-DD"` |
+
+Tick types with `condition` and `exchange` (TradeTick, TradeQuoteTick) gain:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `condition_name()` | `&'static str` | Human-readable trade condition |
+| `exchange_name()` | `&'static str` | Exchange full name |
+| `exchange_symbol()` | `&'static str` | Exchange ticker symbol |
+
+SnapshotTradeTick gains `condition_name()` (no exchange field).
+
+Tick types with `bid_exchange` / `ask_exchange` (QuoteTick, EodTick, TradeQuoteTick) gain:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `bid_exchange_name()` | `&'static str` | Bid exchange full name |
+| `ask_exchange_name()` | `&'static str` | Ask exchange full name |
+
+All contract-ID tick types gain `right_str()` returning `"C"`, `"P"`, or `""`.
+
+### SDK Integration
+
+**Python**: Every tick dict includes `time_str`, `date_str`. Trade ticks add `condition_name`, `exchange_name`. Quote/EOD ticks add `bid_exchange_name`, `ask_exchange_name`. Contract-ID ticks use `right_str()` for the `right` field.
+
+**Go**: All public tick structs include `TimeStr`, `DateStr` string fields. Trade ticks add `ConditionName`, `ExchangeName`. Quote ticks add `BidExchangeName`, `AskExchangeName`. Standalone functions `TimeStr()`, `DateStr()`, `ExchangeName()`, `ConditionName()`, `QuoteConditionName()`, `RightStr()` are available in the `thetadatadx` package.
+
+**C++**: Free functions `time_str()`, `date_str()`, `exchange_name()`, `condition_name()`, `quote_condition_name()` in the `tdx` namespace.

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -106,6 +106,145 @@ inline double ask_f64(const TradeQuoteTick& t) { return price_to_f64(t.ask, t.pr
 /** Decode price to f64 for PriceTick. */
 inline double price_f64(const PriceTick& t) { return price_to_f64(t.price, t.price_type); }
 
+// ── Display helpers ──
+
+/** Format milliseconds-of-day as "HH:MM:SS.mmm". */
+inline std::string time_str(int32_t ms_of_day) {
+    uint32_t ms = static_cast<uint32_t>(ms_of_day);
+    uint32_t total_secs = ms / 1000;
+    uint32_t millis = ms % 1000;
+    uint32_t h = total_secs / 3600;
+    uint32_t m = (total_secs % 3600) / 60;
+    uint32_t s = total_secs % 60;
+    char buf[13];
+    snprintf(buf, sizeof(buf), "%02u:%02u:%02u.%03u", h, m, s, millis);
+    return std::string(buf);
+}
+
+/** Format YYYYMMDD integer as "YYYY-MM-DD". */
+inline std::string date_str(int32_t date) {
+    int y = date / 10000;
+    int m = (date % 10000) / 100;
+    int d = date % 100;
+    char buf[11];
+    snprintf(buf, sizeof(buf), "%04d-%02d-%02d", y, m, d);
+    return std::string(buf);
+}
+
+/** Exchange name by code. Returns "UNKNOWN" for out-of-range codes. */
+inline const char* exchange_name(int32_t code) {
+    static const char* names[] = {
+        "NanexComp", "NasdaqExchange", "NasdaqAlternativeDisplayFacility",
+        "NewYorkStockExchange", "AmericanStockExchange", "ChicagoBoardOptionsExchange",
+        "InternationalSecuritiesExchange", "NYSEARCA(Pacific)",
+        "NationalStockExchange(Cincinnati)", "PhiladelphiaStockExchange",
+        "OptionsPricingReportingAuthority", "BostonStock/OptionsExchange",
+        "NasdaqGlobal+SelectMarket(NMS)", "NasdaqCapitalMarket(SmallCap)",
+        "NasdaqBulletinBoard", "NasdaqOTC", "NasdaqIndexes(GIDS)",
+        "ChicagoStockExchange", "TorontoStockExchange", "CanadianVentureExchange",
+        "ChicagoMercantileExchange", "NewYorkBoardofTrade", "ISEMercury",
+        "COMEX(divisionofNYMEX)", "ChicagoBoardofTrade", "NewYorkMercantileExchange",
+        "KansasCityBoardofTrade", "MinneapolisGrainExchange", "NYSE/ARCABonds",
+        "NasdaqBasic", "DowJonesIndices", "ISEGemini",
+        "SingaporeInternationalMonetaryExchange", "LondonStockExchange", "Eurex",
+        "ImpliedPrice", "DataTransmissionNetwork", "LondonMetalsExchangeMatchedTrades",
+        "LondonMetalsExchange", "IntercontinentalExchange(IPE)",
+        "NasdaqMutualFunds(MFDS)", "COMEXClearport", "CBOEC2OptionExchange",
+        "MiamiExchange", "NYMEXClearport", "Barclays",
+        "MiamiEmeraldOptionsExchange", "NASDAQBoston", "HotSpotEurexUS",
+        "EurexUS", "EurexEU", "EuronextCommodities", "EuronextIndexDerivatives",
+        "EuronextInterestRates", "CBOEFuturesExchange", "PhiladelphiaBoardofTrade",
+        "FCME", "FINRA/NASDAQTradeReportingFacility", "BSETradeReportingFacility",
+        "NYSETradeReportingFacility", "BATSTrading", "CBOTFloor", "PinkSheets",
+        "BATSYExchange", "DirectEdgeA", "DirectEdgeX", "RussellIndexes",
+        "CMEIndexes", "InvestorsExchange", "MiamiPearlOptionsExchange",
+        "LondonStockExchange", "NYSEGlobalIndexFeed", "TSXIndexes",
+        "MembersExchange", "CBOECGI", "LongTermStockExchange", "MIAXSapphire",
+        "24XNationalExchange",
+    };
+    if (code >= 0 && code < 78) return names[code];
+    return "UNKNOWN";
+}
+
+/** Trade condition name by code. Returns "UNKNOWN" for out-of-range codes. */
+inline const char* condition_name(int32_t code) {
+    static const char* names[] = {
+        "REGULAR", "FORMT", "OUTOFSEQ", "AVGPRC", "AVGPRC_NASDAQ",
+        "OPENREPORTLATE", "OPENREPORTOUTOFSEQ", "OPENREPORTINSEQ",
+        "PRIORREFERENCEPRICE", "NEXTDAYSALE", "BUNCHED", "CASHSALE",
+        "SELLER", "SOLDLAST", "RULE127", "BUNCHEDSOLD", "NONBOARDLOT",
+        "POSIT", "AUTOEXECUTION", "HALT", "DELAYED", "REOPEN",
+        "ACQUISITION", "CASHMARKET", "NEXTDAYMARKET", "BURSTBASKET",
+        "OPENDETAIL", "INTRADETAIL", "BASKETONCLOSE", "RULE155",
+        "DISTRIBUTION", "SPLIT", "REGULARSETTLE", "CUSTOMBASKETCROSS",
+        "ADJTERMS", "SPREAD", "STRADDLE", "BUYWRITE", "COMBO", "STPD",
+        "CANC", "CANCLAST", "CANCOPEN", "CANCONLY", "CANCSTPD",
+        "MATCHCROSS", "FASTMARKET", "NOMINAL", "CABINET", "BLANKPRICE",
+        "NOTSPECIFIED", "MCOFFICIALCLOSE", "SPECIALTERMS", "CONTINGENTORDER",
+        "INTERNALCROSS", "STOPPEDREGULAR", "STOPPEDSOLDLAST", "STOPPEDOUTOFSEQ",
+        "BASIS", "VWAP", "SPECIALSESSION", "NANEXADMIN", "OPENREPORT",
+        "MARKETONCLOSE", "SETTLEPRICE", "OUTOFSEQPREMKT", "MCOFFICIALOPEN",
+        "FUTURESSPREAD", "OPENRANGE", "CLOSERANGE", "NOMINALCABINET",
+        "CHANGINGTRANS", "CHANGINGTRANSCAB", "NOMINALUPDATE", "PITSETTLEMENT",
+        "BLOCKTRADE", "EXGFORPHYSICAL", "VOLUMEADJUSTMENT", "VOLATILITYTRADE",
+        "YELLOWFLAG", "FLOORPRICE", "OFFICIALPRICE", "UNOFFICIALPRICE",
+        "MIDBIDASKPRICE", "ENDSESSIONHIGH", "ENDSESSIONLOW", "BACKWARDATION",
+        "CONTANGO", "HOLIDAY", "PREOPENING", "POSTFULL", "POSTRESTRICTED",
+        "CLOSINGAUCTION", "BATCH", "TRADING", "INTERMARKETSWEEP",
+        "DERIVATIVE", "REOPENING", "CLOSING", "CAPELECTION", "SPOTSETTLEMENT",
+        "BASISHIGH", "BASISLOW", "YIELD", "PRICEVARIATION",
+        "CONTINGENTTRADEFORMERLYSTOCKOPTION", "STOPPEDIM", "BENCHMARK",
+        "TRADETHRUEXEMPT", "IMPLIED", "OTC", "MKTSUPERVISION",
+        "RESERVED_77", "RESERVED_91", "CONTINGENTUTP", "ODDLOT",
+        "RESERVED_89", "CORRECTEDCSLAST", "OPRAEXTHOURS", "RESERVED_78",
+        "RESERVED_81", "RESERVED_84", "RESERVED_878", "RESERVED_90",
+        "QUALIFIEDCONTINGENTTRADE", "SINGLELEGAUCTIONNONISO",
+        "SINGLELEGAUCTIONISO", "SINGLELEGCROSSNONISO", "SINGLELEGCROSSISO",
+        "SINGLELEGFLOORTRADE", "MULTILEGAUTOELECTRONICTRADE",
+        "MULTILEGAUCTION", "MULTILEGCROSS", "MULTILEGFLOORTRADE",
+        "MULTILEGAUTOELECTRADEAGAINSTSINGLELEG", "STOCKOPTIONSAUCTION",
+        "MULTILEGAUCTIONAGAINSTSINGLELEG",
+        "MULTILEGFLOORTRADEAGAINSTSINGLELEG", "STOCKOPTIONSAUTOELECTRADE",
+        "STOCKOPTIONSCROSS", "STOCKOPTIONSFLOORTRADE",
+        "STOCKOPTIONSAUTOELECTRADEAGAINSTSINGLELEG",
+        "STOCKOPTIONSAUCTIONAGAINSTSINGLELEG",
+        "STOCKOPTIONSFLOORTRADEAGAINSTSINGLELEG",
+        "MULTILEGFLOORTRADEOFPROPRIETARYPRODUCTS", "BIDAGGRESSOR",
+        "ASKAGGRESSOR",
+        "MULTILATERALCOMPRESSIONTRADEOFPROPRIETARYDATAPRODUCTS",
+        "EXTENDEDHOURSTRADE",
+    };
+    if (code >= 0 && code < 149) return names[code];
+    return "UNKNOWN";
+}
+
+/** Quote condition name by code. Returns "UNKNOWN" for out-of-range codes. */
+inline const char* quote_condition_name(int32_t code) {
+    static const char* names[] = {
+        "REGULAR", "BID_ASK_AUTO_EXEC", "ROTATION", "SPECIALIST_ASK",
+        "SPECIALIST_BID", "LOCKED", "FAST_MARKET", "SPECIALIST_BID_ASK",
+        "ONE_SIDE", "OPENING_QUOTE", "CLOSING_QUOTE", "MARKET_MAKER_CLOSED",
+        "DEPTH_ON_ASK", "DEPTH_ON_BID", "DEPTH_ON_BID_ASK", "TIER_3",
+        "CROSSED", "HALTED", "OPERATIONAL_HALT", "NEWS_OUT", "NEWS_PENDING",
+        "NON_FIRM", "DUE_TO_RELATED", "RESUME", "NO_MARKET_MAKERS",
+        "ORDER_IMBALANCE", "ORDER_INFLUX", "INDICATED", "PRE_OPEN",
+        "IN_VIEW_OF_COMMON", "RELATED_NEWS_PENDING", "RELATED_NEWS_OUT",
+        "ADDITIONAL_INFO", "RELATED_ADD_INFO", "NO_OPEN_RESUME", "DELETED",
+        "REGULATORY_HALT", "SEC_SUSPENSION", "NON_COMLIANCE",
+        "FILINGS_NOT_CURRENT", "CATS_HALTED", "CATS", "EX_DIV_OR_SPLIT",
+        "UNASSIGNED", "INSIDE_OPEN", "INSIDE_CLOSED", "OFFER_WANTED",
+        "BID_WANTED", "CASH", "INACTIVE", "NATIONAL_BBO", "NOMINAL",
+        "CABINET", "NOMINAL_CABINET", "BLANK_PRICE", "SLOW_BID_ASK",
+        "SLOW_LIST", "SLOW_BID", "SLOW_ASK", "BID_OFFER_WANTED",
+        "SUBPENNY", "NON_BBO", "SPECIAL_OPEN", "BENCHMARK", "IMPLIED",
+        "EXCHANGE_BEST", "MKT_WIDE_HALT_1", "MKT_WIDE_HALT_2",
+        "MKT_WIDE_HALT_3", "ON_DEMAND_AUCTION", "NON_FIRM_BID",
+        "NON_FIRM_ASK", "RETAIL_BID", "RETAIL_ASK", "RETAIL_QTE",
+    };
+    if (code >= 0 && code < 75) return names[code];
+    return "UNKNOWN";
+}
+
 // ── Greeks result (from standalone tdx_all_greeks) ──
 
 struct Greeks {

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -450,6 +450,11 @@ type EodTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr         string `json:"time_str"`
+	DateStr         string `json:"date_str"`
+	BidExchangeName string `json:"bid_exchange_name,omitempty"`
+	AskExchangeName string `json:"ask_exchange_name,omitempty"`
 }
 
 type OhlcTick struct {
@@ -465,6 +470,9 @@ type OhlcTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr string `json:"time_str"`
+	DateStr string `json:"date_str"`
 }
 
 type TradeTick struct {
@@ -484,6 +492,11 @@ type TradeTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr        string `json:"time_str"`
+	DateStr        string `json:"date_str"`
+	ConditionName  string `json:"condition_name"`
+	ExchangeName   string `json:"exchange_name"`
 }
 
 type QuoteTick struct {
@@ -501,6 +514,11 @@ type QuoteTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr         string `json:"time_str"`
+	DateStr         string `json:"date_str"`
+	BidExchangeName string `json:"bid_exchange_name"`
+	AskExchangeName string `json:"ask_exchange_name"`
 }
 
 type TradeQuoteTick struct {
@@ -528,6 +546,13 @@ type TradeQuoteTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr         string `json:"time_str"`
+	DateStr         string `json:"date_str"`
+	ConditionName   string `json:"condition_name"`
+	ExchangeName    string `json:"exchange_name"`
+	BidExchangeName string `json:"bid_exchange_name"`
+	AskExchangeName string `json:"ask_exchange_name"`
 }
 
 type OpenInterestTick struct {
@@ -538,6 +563,9 @@ type OpenInterestTick struct {
 	Strike         int32 `json:"strike,omitempty"`
 	Right          int32 `json:"right,omitempty"`
 	StrikePriceType int32 `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr string `json:"time_str"`
+	DateStr string `json:"date_str"`
 }
 
 type MarketValueTick struct {
@@ -552,6 +580,9 @@ type MarketValueTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr string `json:"time_str"`
+	DateStr string `json:"date_str"`
 }
 
 type GreeksTick struct {
@@ -583,6 +614,9 @@ type GreeksTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr string `json:"time_str"`
+	DateStr string `json:"date_str"`
 }
 
 type IVTick struct {
@@ -594,6 +628,9 @@ type IVTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr string `json:"time_str"`
+	DateStr string `json:"date_str"`
 }
 
 type PriceTick struct {
@@ -601,6 +638,9 @@ type PriceTick struct {
 	Price    float64 `json:"price"`
 	PriceRaw int     `json:"price_raw,omitempty"`
 	Date     int     `json:"date"`
+	// Display helpers
+	TimeStr string `json:"time_str"`
+	DateStr string `json:"date_str"`
 }
 
 type CalendarDay struct {
@@ -615,6 +655,9 @@ type InterestRateTick struct {
 	MsOfDay int     `json:"ms_of_day"`
 	Rate    float64 `json:"rate"`
 	Date    int     `json:"date"`
+	// Display helpers
+	TimeStr string `json:"time_str"`
+	DateStr string `json:"date_str"`
 }
 
 type SnapshotTradeTick struct {
@@ -629,6 +672,10 @@ type SnapshotTradeTick struct {
 	Strike         int32   `json:"strike,omitempty"`
 	Right          int32   `json:"right,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	// Display helpers
+	TimeStr       string `json:"time_str"`
+	DateStr       string `json:"date_str"`
+	ConditionName string `json:"condition_name"`
 }
 
 type OptionContract struct {
@@ -681,12 +728,15 @@ func convertEodTicks(arr C.TdxTickArray) []EodTick {
 	src := unsafe.Slice((*cEodTick)(arr.data), n)
 	result := make([]EodTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = EodTick{
-			MsOfDay: int(t.MsOfDay), Date: int(t.Date), Volume: int(t.Volume), Count: int(t.Count),
+			MsOfDay: msOfDay, Date: date, Volume: int(t.Volume), Count: int(t.Count),
 			Open: priceToFloat(t.Open, t.PriceType), High: priceToFloat(t.High, t.PriceType),
 			Low: priceToFloat(t.Low, t.PriceType), Close: priceToFloat(t.Close, t.PriceType),
 			Bid: priceToFloat(t.Bid, t.PriceType), Ask: priceToFloat(t.Ask, t.PriceType),
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
+			BidExchangeName: ExchangeName(int(t.BidExchange)), AskExchangeName: ExchangeName(int(t.AskExchange)),
 		}
 	}
 	return result
@@ -698,11 +748,13 @@ func convertOhlcTicks(arr C.TdxTickArray) []OhlcTick {
 	src := unsafe.Slice((*cOhlcTick)(arr.data), n)
 	result := make([]OhlcTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = OhlcTick{
-			MsOfDay: int(t.MsOfDay), Volume: int(t.Volume), Count: int(t.Count), Date: int(t.Date),
+			MsOfDay: msOfDay, Volume: int(t.Volume), Count: int(t.Count), Date: date,
 			Open: priceToFloat(t.Open, t.PriceType), High: priceToFloat(t.High, t.PriceType),
 			Low: priceToFloat(t.Low, t.PriceType), Close: priceToFloat(t.Close, t.PriceType),
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
 		}
 	}
 	return result
@@ -714,13 +766,16 @@ func convertTradeTicks(arr C.TdxTickArray) []TradeTick {
 	src := unsafe.Slice((*cTradeTick)(arr.data), n)
 	result := make([]TradeTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = TradeTick{
-			MsOfDay: int(t.MsOfDay), Sequence: int(t.Sequence), Condition: int(t.Condition),
+			MsOfDay: msOfDay, Sequence: int(t.Sequence), Condition: int(t.Condition),
 			Size: int(t.Size), Exchange: int(t.Exchange), Price: priceToFloat(t.Price, t.PriceType),
 			PriceRaw: int(t.Price), ConditionFlags: int(t.ConditionFlags),
 			PriceFlags: int(t.PriceFlags), VolumeType: int(t.VolumeType), RecordsBack: int(t.RecordsBack),
-			Date: int(t.Date),
+			Date: date,
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
+			ConditionName: ConditionName(int(t.Condition)), ExchangeName: ExchangeName(int(t.Exchange)),
 		}
 	}
 	return result
@@ -732,13 +787,16 @@ func convertQuoteTicks(arr C.TdxTickArray) []QuoteTick {
 	src := unsafe.Slice((*cQuoteTick)(arr.data), n)
 	result := make([]QuoteTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = QuoteTick{
-			MsOfDay: int(t.MsOfDay), BidSize: int(t.BidSize), BidExchange: int(t.BidExchange),
+			MsOfDay: msOfDay, BidSize: int(t.BidSize), BidExchange: int(t.BidExchange),
 			Bid: priceToFloat(t.Bid, t.PriceType), BidCondition: int(t.BidCondition),
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
 			Ask: priceToFloat(t.Ask, t.PriceType), AskCondition: int(t.AskCondition),
-			Date: int(t.Date),
+			Date: date,
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
+			BidExchangeName: ExchangeName(int(t.BidExchange)), AskExchangeName: ExchangeName(int(t.AskExchange)),
 		}
 	}
 	return result
@@ -750,8 +808,9 @@ func convertTradeQuoteTicks(arr C.TdxTickArray) []TradeQuoteTick {
 	src := unsafe.Slice((*cTradeQuoteTick)(arr.data), n)
 	result := make([]TradeQuoteTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = TradeQuoteTick{
-			MsOfDay: int(t.MsOfDay), Sequence: int(t.Sequence), Condition: int(t.Condition),
+			MsOfDay: msOfDay, Sequence: int(t.Sequence), Condition: int(t.Condition),
 			Size: int(t.Size), Exchange: int(t.Exchange), Price: priceToFloat(t.Price, t.PriceType),
 			ConditionFlags: int(t.ConditionFlags), PriceFlags: int(t.PriceFlags),
 			VolumeType: int(t.VolumeType), RecordsBack: int(t.RecordsBack),
@@ -759,8 +818,11 @@ func convertTradeQuoteTicks(arr C.TdxTickArray) []TradeQuoteTick {
 			Bid: priceToFloat(t.Bid, t.QuotePriceType), BidCondition: int(t.BidCondition),
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
 			Ask: priceToFloat(t.Ask, t.QuotePriceType), AskCondition: int(t.AskCondition),
-			Date: int(t.Date),
+			Date: date,
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
+			ConditionName: ConditionName(int(t.Condition)), ExchangeName: ExchangeName(int(t.Exchange)),
+			BidExchangeName: ExchangeName(int(t.BidExchange)), AskExchangeName: ExchangeName(int(t.AskExchange)),
 		}
 	}
 	return result
@@ -772,9 +834,11 @@ func convertOpenInterestTicks(arr C.TdxTickArray) []OpenInterestTick {
 	src := unsafe.Slice((*cOpenInterestTick)(arr.data), n)
 	result := make([]OpenInterestTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = OpenInterestTick{
-			MsOfDay: int(t.MsOfDay), OpenInterest: int(t.OpenInterest), Date: int(t.Date),
+			MsOfDay: msOfDay, OpenInterest: int(t.OpenInterest), Date: date,
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
 		}
 	}
 	return result
@@ -786,10 +850,12 @@ func convertMarketValueTicks(arr C.TdxTickArray) []MarketValueTick {
 	src := unsafe.Slice((*cMarketValueTick)(arr.data), n)
 	result := make([]MarketValueTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = MarketValueTick{
-			MsOfDay: int(t.MsOfDay), MarketCap: t.MarketCap, SharesOut: t.SharesOutstanding,
-			EntValue: t.EnterpriseValue, BookValue: t.BookValue, FreeFloat: t.FreeFloat, Date: int(t.Date),
+			MsOfDay: msOfDay, MarketCap: t.MarketCap, SharesOut: t.SharesOutstanding,
+			EntValue: t.EnterpriseValue, BookValue: t.BookValue, FreeFloat: t.FreeFloat, Date: date,
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
 		}
 	}
 	return result
@@ -801,14 +867,16 @@ func convertGreeksTicks(arr C.TdxTickArray) []GreeksTick {
 	src := unsafe.Slice((*cGreeksTick)(arr.data), n)
 	result := make([]GreeksTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = GreeksTick{
-			MsOfDay: int(t.MsOfDay), IV: t.ImpliedVolatility, Delta: t.Delta, Gamma: t.Gamma,
+			MsOfDay: msOfDay, IV: t.ImpliedVolatility, Delta: t.Delta, Gamma: t.Gamma,
 			Theta: t.Theta, Vega: t.Vega, Rho: t.Rho, IVError: t.IvError,
 			Vanna: t.Vanna, Charm: t.Charm, Vomma: t.Vomma, Veta: t.Veta,
 			Speed: t.Speed, Zomma: t.Zomma, Color: t.Color, Ultima: t.Ultima,
 			D1: t.D1, D2: t.D2, DualDelta: t.DualDelta, DualGamma: t.DualGamma,
-			Epsilon: t.Epsilon, Lambda: t.Lambda, Vera: t.Vera, Date: int(t.Date),
+			Epsilon: t.Epsilon, Lambda: t.Lambda, Vera: t.Vera, Date: date,
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
 		}
 	}
 	return result
@@ -820,9 +888,11 @@ func convertIvTicks(arr C.TdxTickArray) []IVTick {
 	src := unsafe.Slice((*cIvTick)(arr.data), n)
 	result := make([]IVTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = IVTick{
-			MsOfDay: int(t.MsOfDay), IV: t.ImpliedVolatility, IVError: t.IvError, Date: int(t.Date),
+			MsOfDay: msOfDay, IV: t.ImpliedVolatility, IVError: t.IvError, Date: date,
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
 		}
 	}
 	return result
@@ -834,7 +904,8 @@ func convertPriceTicks(arr C.TdxTickArray) []PriceTick {
 	src := unsafe.Slice((*cPriceTick)(arr.data), n)
 	result := make([]PriceTick, n)
 	for i, t := range src {
-		result[i] = PriceTick{MsOfDay: int(t.MsOfDay), Price: priceToFloat(t.Price, t.PriceType), PriceRaw: int(t.Price), Date: int(t.Date)}
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
+		result[i] = PriceTick{MsOfDay: msOfDay, Price: priceToFloat(t.Price, t.PriceType), PriceRaw: int(t.Price), Date: date, TimeStr: TimeStr(msOfDay), DateStr: DateStr(date)}
 	}
 	return result
 }
@@ -853,7 +924,10 @@ func convertInterestRateTicks(arr C.TdxTickArray) []InterestRateTick {
 	n := int(arr.len)
 	src := unsafe.Slice((*cInterestRateTick)(arr.data), n)
 	result := make([]InterestRateTick, n)
-	for i, t := range src { result[i] = InterestRateTick{int(t.MsOfDay), t.Rate, int(t.Date)} }
+	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
+		result[i] = InterestRateTick{MsOfDay: msOfDay, Rate: t.Rate, Date: date, TimeStr: TimeStr(msOfDay), DateStr: DateStr(date)}
+	}
 	return result
 }
 
@@ -863,11 +937,14 @@ func convertSnapshotTradeTicks(arr C.TdxTickArray) []SnapshotTradeTick {
 	src := unsafe.Slice((*cSnapshotTradeTick)(arr.data), n)
 	result := make([]SnapshotTradeTick, n)
 	for i, t := range src {
+		msOfDay := int(t.MsOfDay); date := int(t.Date)
 		result[i] = SnapshotTradeTick{
-			MsOfDay: int(t.MsOfDay), Sequence: int(t.Sequence), Size: int(t.Size),
+			MsOfDay: msOfDay, Sequence: int(t.Sequence), Size: int(t.Size),
 			Condition: int(t.Condition), Price: priceToFloat(t.Price, t.PriceType),
-			PriceRaw: int(t.Price), Date: int(t.Date),
+			PriceRaw: int(t.Price), Date: date,
 			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			TimeStr: TimeStr(msOfDay), DateStr: DateStr(date),
+			ConditionName: ConditionName(int(t.Condition)),
 		}
 	}
 	return result

--- a/sdks/go/display.go
+++ b/sdks/go/display.go
@@ -1,0 +1,229 @@
+package thetadatadx
+
+import "fmt"
+
+// ── Time / Date helpers ──
+
+// TimeStr formats milliseconds-of-day as "HH:MM:SS.mmm".
+func TimeStr(msOfDay int) string {
+	ms := uint32(msOfDay)
+	totalSecs := ms / 1000
+	millis := ms % 1000
+	h := totalSecs / 3600
+	m := (totalSecs % 3600) / 60
+	s := totalSecs % 60
+	return fmt.Sprintf("%02d:%02d:%02d.%03d", h, m, s, millis)
+}
+
+// DateStr formats a YYYYMMDD integer as "YYYY-MM-DD".
+func DateStr(date int) string {
+	y := date / 10000
+	m := (date % 10000) / 100
+	d := date % 100
+	return fmt.Sprintf("%04d-%02d-%02d", y, m, d)
+}
+
+// RightStr returns "C" for calls (ASCII 67), "P" for puts (ASCII 80), else "".
+func RightStr(code int32) string {
+	switch code {
+	case 67:
+		return "C"
+	case 80:
+		return "P"
+	default:
+		return ""
+	}
+}
+
+// ── Exchange lookup ──
+
+type exchangeEntry struct {
+	Name   string
+	Symbol string
+}
+
+var exchanges = [78]exchangeEntry{
+	{Name: "NanexComp", Symbol: "COMP"},
+	{Name: "NasdaqExchange", Symbol: "NQEX"},
+	{Name: "NasdaqAlternativeDisplayFacility", Symbol: "NQAD"},
+	{Name: "NewYorkStockExchange", Symbol: "NYSE"},
+	{Name: "AmericanStockExchange", Symbol: "AMEX"},
+	{Name: "ChicagoBoardOptionsExchange", Symbol: "CBOE"},
+	{Name: "InternationalSecuritiesExchange", Symbol: "ISEX"},
+	{Name: "NYSEARCA(Pacific)", Symbol: "PACF"},
+	{Name: "NationalStockExchange(Cincinnati)", Symbol: "CINC"},
+	{Name: "PhiladelphiaStockExchange", Symbol: "PHIL"},
+	{Name: "OptionsPricingReportingAuthority", Symbol: "OPRA"},
+	{Name: "BostonStock/OptionsExchange", Symbol: "BOST"},
+	{Name: "NasdaqGlobal+SelectMarket(NMS)", Symbol: "NQNM"},
+	{Name: "NasdaqCapitalMarket(SmallCap)", Symbol: "NQSC"},
+	{Name: "NasdaqBulletinBoard", Symbol: "NQBB"},
+	{Name: "NasdaqOTC", Symbol: "NQPK"},
+	{Name: "NasdaqIndexes(GIDS)", Symbol: "NQIX"},
+	{Name: "ChicagoStockExchange", Symbol: "CHIC"},
+	{Name: "TorontoStockExchange", Symbol: "TSE"},
+	{Name: "CanadianVentureExchange", Symbol: "CDNX"},
+	{Name: "ChicagoMercantileExchange", Symbol: "CME"},
+	{Name: "NewYorkBoardofTrade", Symbol: "NYBT"},
+	{Name: "ISEMercury", Symbol: "MRCY"},
+	{Name: "COMEX(divisionofNYMEX)", Symbol: "COMX"},
+	{Name: "ChicagoBoardofTrade", Symbol: "CBOT"},
+	{Name: "NewYorkMercantileExchange", Symbol: "NYMX"},
+	{Name: "KansasCityBoardofTrade", Symbol: "KCBT"},
+	{Name: "MinneapolisGrainExchange", Symbol: "MGEX"},
+	{Name: "NYSE/ARCABonds", Symbol: "NYBO"},
+	{Name: "NasdaqBasic", Symbol: "NQBS"},
+	{Name: "DowJonesIndices", Symbol: "DOWJ"},
+	{Name: "ISEGemini", Symbol: "GEMI"},
+	{Name: "SingaporeInternationalMonetaryExchange", Symbol: "SIMX"},
+	{Name: "LondonStockExchange", Symbol: "FTSE"},
+	{Name: "Eurex", Symbol: "EURX"},
+	{Name: "ImpliedPrice", Symbol: "IMPL"},
+	{Name: "DataTransmissionNetwork", Symbol: "DTN"},
+	{Name: "LondonMetalsExchangeMatchedTrades", Symbol: "LMT"},
+	{Name: "LondonMetalsExchange", Symbol: "LME"},
+	{Name: "IntercontinentalExchange(IPE)", Symbol: "IPEX"},
+	{Name: "NasdaqMutualFunds(MFDS)", Symbol: "NQMF"},
+	{Name: "COMEXClearport", Symbol: "fcec"},
+	{Name: "CBOEC2OptionExchange", Symbol: "C2"},
+	{Name: "MiamiExchange", Symbol: "MIAX"},
+	{Name: "NYMEXClearport", Symbol: "CLRP"},
+	{Name: "Barclays", Symbol: "BARK"},
+	{Name: "MiamiEmeraldOptionsExchange", Symbol: "EMLD"},
+	{Name: "NASDAQBoston", Symbol: "NQBX"},
+	{Name: "HotSpotEurexUS", Symbol: "HOTS"},
+	{Name: "EurexUS", Symbol: "EUUS"},
+	{Name: "EurexEU", Symbol: "EUEU"},
+	{Name: "EuronextCommodities", Symbol: "ENCM"},
+	{Name: "EuronextIndexDerivatives", Symbol: "ENID"},
+	{Name: "EuronextInterestRates", Symbol: "ENIR"},
+	{Name: "CBOEFuturesExchange", Symbol: "CFE"},
+	{Name: "PhiladelphiaBoardofTrade", Symbol: "PBOT"},
+	{Name: "FCME", Symbol: "CMEFloor"},
+	{Name: "FINRA/NASDAQTradeReportingFacility", Symbol: "NQNX"},
+	{Name: "BSETradeReportingFacility", Symbol: "BTRF"},
+	{Name: "NYSETradeReportingFacility", Symbol: "NTRF"},
+	{Name: "BATSTrading", Symbol: "BATS"},
+	{Name: "CBOTFloor", Symbol: "FCBT"},
+	{Name: "PinkSheets", Symbol: "PINK"},
+	{Name: "BATSYExchange", Symbol: "BATY"},
+	{Name: "DirectEdgeA", Symbol: "EDGE"},
+	{Name: "DirectEdgeX", Symbol: "EDGX"},
+	{Name: "RussellIndexes", Symbol: "RUSL"},
+	{Name: "CMEIndexes", Symbol: "CMEX"},
+	{Name: "InvestorsExchange", Symbol: "IEX"},
+	{Name: "MiamiPearlOptionsExchange", Symbol: "PERL"},
+	{Name: "LondonStockExchange", Symbol: "LSE"},
+	{Name: "NYSEGlobalIndexFeed", Symbol: "GIF"},
+	{Name: "TSXIndexes", Symbol: "TSIX"},
+	{Name: "MembersExchange", Symbol: "MEMX"},
+	{Name: "CBOECGI", Symbol: "CGI"},
+	{Name: "LongTermStockExchange", Symbol: "LTSE"},
+	{Name: "MIAXSapphire", Symbol: "SPHR"},
+	{Name: "24XNationalExchange", Symbol: "24X"},
+}
+
+// ExchangeName returns the exchange name for the given code, or "UNKNOWN".
+func ExchangeName(code int) string {
+	if code >= 0 && code < len(exchanges) {
+		return exchanges[code].Name
+	}
+	return "UNKNOWN"
+}
+
+// ExchangeSymbol returns the exchange symbol for the given code, or "UNKNOWN".
+func ExchangeSymbol(code int) string {
+	if code >= 0 && code < len(exchanges) {
+		return exchanges[code].Symbol
+	}
+	return "UNKNOWN"
+}
+
+// ── Trade condition lookup ──
+
+var conditionNames = [149]string{
+	"REGULAR", "FORMT", "OUTOFSEQ", "AVGPRC", "AVGPRC_NASDAQ",
+	"OPENREPORTLATE", "OPENREPORTOUTOFSEQ", "OPENREPORTINSEQ",
+	"PRIORREFERENCEPRICE", "NEXTDAYSALE", "BUNCHED", "CASHSALE",
+	"SELLER", "SOLDLAST", "RULE127", "BUNCHEDSOLD", "NONBOARDLOT",
+	"POSIT", "AUTOEXECUTION", "HALT", "DELAYED", "REOPEN",
+	"ACQUISITION", "CASHMARKET", "NEXTDAYMARKET", "BURSTBASKET",
+	"OPENDETAIL", "INTRADETAIL", "BASKETONCLOSE", "RULE155",
+	"DISTRIBUTION", "SPLIT", "REGULARSETTLE", "CUSTOMBASKETCROSS",
+	"ADJTERMS", "SPREAD", "STRADDLE", "BUYWRITE", "COMBO", "STPD",
+	"CANC", "CANCLAST", "CANCOPEN", "CANCONLY", "CANCSTPD",
+	"MATCHCROSS", "FASTMARKET", "NOMINAL", "CABINET", "BLANKPRICE",
+	"NOTSPECIFIED", "MCOFFICIALCLOSE", "SPECIALTERMS", "CONTINGENTORDER",
+	"INTERNALCROSS", "STOPPEDREGULAR", "STOPPEDSOLDLAST", "STOPPEDOUTOFSEQ",
+	"BASIS", "VWAP", "SPECIALSESSION", "NANEXADMIN", "OPENREPORT",
+	"MARKETONCLOSE", "SETTLEPRICE", "OUTOFSEQPREMKT", "MCOFFICIALOPEN",
+	"FUTURESSPREAD", "OPENRANGE", "CLOSERANGE", "NOMINALCABINET",
+	"CHANGINGTRANS", "CHANGINGTRANSCAB", "NOMINALUPDATE", "PITSETTLEMENT",
+	"BLOCKTRADE", "EXGFORPHYSICAL", "VOLUMEADJUSTMENT", "VOLATILITYTRADE",
+	"YELLOWFLAG", "FLOORPRICE", "OFFICIALPRICE", "UNOFFICIALPRICE",
+	"MIDBIDASKPRICE", "ENDSESSIONHIGH", "ENDSESSIONLOW", "BACKWARDATION",
+	"CONTANGO", "HOLIDAY", "PREOPENING", "POSTFULL", "POSTRESTRICTED",
+	"CLOSINGAUCTION", "BATCH", "TRADING", "INTERMARKETSWEEP",
+	"DERIVATIVE", "REOPENING", "CLOSING", "CAPELECTION", "SPOTSETTLEMENT",
+	"BASISHIGH", "BASISLOW", "YIELD", "PRICEVARIATION",
+	"CONTINGENTTRADEFORMERLYSTOCKOPTION", "STOPPEDIM", "BENCHMARK",
+	"TRADETHRUEXEMPT", "IMPLIED", "OTC", "MKTSUPERVISION",
+	"RESERVED_77", "RESERVED_91", "CONTINGENTUTP", "ODDLOT",
+	"RESERVED_89", "CORRECTEDCSLAST", "OPRAEXTHOURS", "RESERVED_78",
+	"RESERVED_81", "RESERVED_84", "RESERVED_878", "RESERVED_90",
+	"QUALIFIEDCONTINGENTTRADE", "SINGLELEGAUCTIONNONISO",
+	"SINGLELEGAUCTIONISO", "SINGLELEGCROSSNONISO", "SINGLELEGCROSSISO",
+	"SINGLELEGFLOORTRADE", "MULTILEGAUTOELECTRONICTRADE",
+	"MULTILEGAUCTION", "MULTILEGCROSS", "MULTILEGFLOORTRADE",
+	"MULTILEGAUTOELECTRADEAGAINSTSINGLELEG", "STOCKOPTIONSAUCTION",
+	"MULTILEGAUCTIONAGAINSTSINGLELEG",
+	"MULTILEGFLOORTRADEAGAINSTSINGLELEG", "STOCKOPTIONSAUTOELECTRADE",
+	"STOCKOPTIONSCROSS", "STOCKOPTIONSFLOORTRADE",
+	"STOCKOPTIONSAUTOELECTRADEAGAINSTSINGLELEG",
+	"STOCKOPTIONSAUCTIONAGAINSTSINGLELEG",
+	"STOCKOPTIONSFLOORTRADEAGAINSTSINGLELEG",
+	"MULTILEGFLOORTRADEOFPROPRIETARYPRODUCTS", "BIDAGGRESSOR",
+	"ASKAGGRESSOR",
+	"MULTILATERALCOMPRESSIONTRADEOFPROPRIETARYDATAPRODUCTS",
+	"EXTENDEDHOURSTRADE",
+}
+
+// ConditionName returns the trade condition name for the given code, or "UNKNOWN".
+func ConditionName(code int) string {
+	if code >= 0 && code < len(conditionNames) {
+		return conditionNames[code]
+	}
+	return "UNKNOWN"
+}
+
+// ── Quote condition lookup ──
+
+var quoteConditionNames = [75]string{
+	"REGULAR", "BID_ASK_AUTO_EXEC", "ROTATION", "SPECIALIST_ASK",
+	"SPECIALIST_BID", "LOCKED", "FAST_MARKET", "SPECIALIST_BID_ASK",
+	"ONE_SIDE", "OPENING_QUOTE", "CLOSING_QUOTE", "MARKET_MAKER_CLOSED",
+	"DEPTH_ON_ASK", "DEPTH_ON_BID", "DEPTH_ON_BID_ASK", "TIER_3",
+	"CROSSED", "HALTED", "OPERATIONAL_HALT", "NEWS_OUT", "NEWS_PENDING",
+	"NON_FIRM", "DUE_TO_RELATED", "RESUME", "NO_MARKET_MAKERS",
+	"ORDER_IMBALANCE", "ORDER_INFLUX", "INDICATED", "PRE_OPEN",
+	"IN_VIEW_OF_COMMON", "RELATED_NEWS_PENDING", "RELATED_NEWS_OUT",
+	"ADDITIONAL_INFO", "RELATED_ADD_INFO", "NO_OPEN_RESUME", "DELETED",
+	"REGULATORY_HALT", "SEC_SUSPENSION", "NON_COMLIANCE",
+	"FILINGS_NOT_CURRENT", "CATS_HALTED", "CATS", "EX_DIV_OR_SPLIT",
+	"UNASSIGNED", "INSIDE_OPEN", "INSIDE_CLOSED", "OFFER_WANTED",
+	"BID_WANTED", "CASH", "INACTIVE", "NATIONAL_BBO", "NOMINAL",
+	"CABINET", "NOMINAL_CABINET", "BLANK_PRICE", "SLOW_BID_ASK",
+	"SLOW_LIST", "SLOW_BID", "SLOW_ASK", "BID_OFFER_WANTED",
+	"SUBPENNY", "NON_BBO", "SPECIAL_OPEN", "BENCHMARK", "IMPLIED",
+	"EXCHANGE_BEST", "MKT_WIDE_HALT_1", "MKT_WIDE_HALT_2",
+	"MKT_WIDE_HALT_3", "ON_DEMAND_AUCTION", "NON_FIRM_BID",
+	"NON_FIRM_ASK", "RETAIL_BID", "RETAIL_ASK", "RETAIL_QTE",
+}
+
+// QuoteConditionName returns the quote condition name for the given code, or "UNKNOWN".
+func QuoteConditionName(code int) string {
+	if code >= 0 && code < len(quoteConditionNames) {
+		return quoteConditionNames[code]
+	}
+	return "UNKNOWN"
+}

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -8,6 +8,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::sync::OnceLock;
 use std::sync::{Arc, Mutex};
+use tdbe::display;
 use tdbe::types::tick;
 use thetadatadx::auth;
 use thetadatadx::config;
@@ -127,19 +128,10 @@ macro_rules! set_contract_id {
                 .set_item("strike", $tick.strike_price())
                 .unwrap();
             $dict.set_item("strike_raw", $tick.strike).unwrap();
-            $dict.set_item("strike_price_type", $tick.strike_price_type).unwrap();
             $dict
-                .set_item(
-                    "right",
-                    if $tick.is_call() {
-                        "C"
-                    } else if $tick.is_put() {
-                        "P"
-                    } else {
-                        ""
-                    },
-                )
+                .set_item("strike_price_type", $tick.strike_price_type)
                 .unwrap();
+            $dict.set_item("right", $tick.right_str()).unwrap();
         }
     };
 }
@@ -159,6 +151,10 @@ fn trade_tick_to_dict(py: Python<'_>, t: &tick::TradeTick) -> Py<PyAny> {
     dict.set_item("volume_type", t.volume_type).unwrap();
     dict.set_item("records_back", t.records_back).unwrap();
     dict.set_item("date", t.date).unwrap();
+    dict.set_item("time_str", display::time_str(t.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(t.date)).unwrap();
+    dict.set_item("condition_name", display::condition_name(t.condition)).unwrap();
+    dict.set_item("exchange_name", display::exchange_name(t.exchange)).unwrap();
     set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
@@ -175,6 +171,10 @@ fn quote_tick_to_dict(py: Python<'_>, q: &tick::QuoteTick) -> Py<PyAny> {
     dict.set_item("ask", q.ask_price().to_f64()).unwrap();
     dict.set_item("ask_condition", q.ask_condition).unwrap();
     dict.set_item("date", q.date).unwrap();
+    dict.set_item("time_str", display::time_str(q.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(q.date)).unwrap();
+    dict.set_item("bid_exchange_name", display::exchange_name(q.bid_exchange)).unwrap();
+    dict.set_item("ask_exchange_name", display::exchange_name(q.ask_exchange)).unwrap();
     set_contract_id!(dict, q);
     dict.into_any().unbind()
 }
@@ -189,6 +189,8 @@ fn ohlc_tick_to_dict(py: Python<'_>, o: &tick::OhlcTick) -> Py<PyAny> {
     dict.set_item("volume", o.volume).unwrap();
     dict.set_item("count", o.count).unwrap();
     dict.set_item("date", o.date).unwrap();
+    dict.set_item("time_str", display::time_str(o.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(o.date)).unwrap();
     set_contract_id!(dict, o);
     dict.into_any().unbind()
 }
@@ -205,6 +207,10 @@ fn eod_tick_to_dict(py: Python<'_>, e: &tick::EodTick) -> Py<PyAny> {
     dict.set_item("bid", e.bid_price().to_f64()).unwrap();
     dict.set_item("ask", e.ask_price().to_f64()).unwrap();
     dict.set_item("date", e.date).unwrap();
+    dict.set_item("time_str", display::time_str(e.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(e.date)).unwrap();
+    dict.set_item("bid_exchange_name", display::exchange_name(e.bid_exchange)).unwrap();
+    dict.set_item("ask_exchange_name", display::exchange_name(e.ask_exchange)).unwrap();
     set_contract_id!(dict, e);
     dict.into_any().unbind()
 }
@@ -222,6 +228,12 @@ fn trade_quote_tick_to_dict(py: Python<'_>, t: &tick::TradeQuoteTick) -> Py<PyAn
     dict.set_item("ask", t.ask_price().to_f64()).unwrap();
     dict.set_item("ask_size", t.ask_size).unwrap();
     dict.set_item("date", t.date).unwrap();
+    dict.set_item("time_str", display::time_str(t.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(t.date)).unwrap();
+    dict.set_item("condition_name", display::condition_name(t.condition)).unwrap();
+    dict.set_item("exchange_name", display::exchange_name(t.exchange)).unwrap();
+    dict.set_item("bid_exchange_name", display::exchange_name(t.bid_exchange)).unwrap();
+    dict.set_item("ask_exchange_name", display::exchange_name(t.ask_exchange)).unwrap();
     set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
@@ -231,6 +243,8 @@ fn open_interest_tick_to_dict(py: Python<'_>, t: &tick::OpenInterestTick) -> Py<
     dict.set_item("ms_of_day", t.ms_of_day).unwrap();
     dict.set_item("open_interest", t.open_interest).unwrap();
     dict.set_item("date", t.date).unwrap();
+    dict.set_item("time_str", display::time_str(t.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(t.date)).unwrap();
     set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
@@ -246,6 +260,8 @@ fn market_value_tick_to_dict(py: Python<'_>, t: &tick::MarketValueTick) -> Py<Py
     dict.set_item("book_value", t.book_value).unwrap();
     dict.set_item("free_float", t.free_float).unwrap();
     dict.set_item("date", t.date).unwrap();
+    dict.set_item("time_str", display::time_str(t.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(t.date)).unwrap();
     set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
@@ -277,6 +293,8 @@ fn greeks_tick_to_dict(py: Python<'_>, t: &tick::GreeksTick) -> Py<PyAny> {
     dict.set_item("lambda", t.lambda).unwrap();
     dict.set_item("vera", t.vera).unwrap();
     dict.set_item("date", t.date).unwrap();
+    dict.set_item("time_str", display::time_str(t.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(t.date)).unwrap();
     set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
@@ -288,6 +306,8 @@ fn iv_tick_to_dict(py: Python<'_>, t: &tick::IvTick) -> Py<PyAny> {
         .unwrap();
     dict.set_item("iv_error", t.iv_error).unwrap();
     dict.set_item("date", t.date).unwrap();
+    dict.set_item("time_str", display::time_str(t.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(t.date)).unwrap();
     set_contract_id!(dict, t);
     dict.into_any().unbind()
 }
@@ -298,6 +318,8 @@ fn price_tick_to_dict(py: Python<'_>, t: &tick::PriceTick) -> Py<PyAny> {
     dict.set_item("price", t.get_price().to_f64()).unwrap();
     dict.set_item("price_type", t.price_type).unwrap();
     dict.set_item("date", t.date).unwrap();
+    dict.set_item("time_str", display::time_str(t.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(t.date)).unwrap();
     dict.into_any().unbind()
 }
 
@@ -316,6 +338,8 @@ fn interest_rate_tick_to_dict(py: Python<'_>, t: &tick::InterestRateTick) -> Py<
     dict.set_item("ms_of_day", t.ms_of_day).unwrap();
     dict.set_item("rate", t.rate).unwrap();
     dict.set_item("date", t.date).unwrap();
+    dict.set_item("time_str", display::time_str(t.ms_of_day)).unwrap();
+    dict.set_item("date_str", display::date_str(t.date)).unwrap();
     dict.into_any().unbind()
 }
 


### PR DESCRIPTION
## Summary

- Add `tdbe::display` module with zero-cost const lookup tables for time/date formatting, exchange codes (78), trade conditions (149 with semantic flags), quote conditions (75), and option right decoding
- Add convenience methods on all tick types via macros: `time_str()`, `date_str()`, `condition_name()`, `exchange_name()`, `bid_exchange_name()`, `ask_exchange_name()`, `right_str()`
- Update Go, Python, and C++ SDKs to include decoded display fields automatically during conversion

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [x] `cargo test --workspace` passes (201 tests, including 24 new display module tests + 3 doc-tests)
- [ ] Verify Go SDK compiles with CGo (requires linked Rust FFI lib)
- [ ] Verify Python SDK builds with maturin
- [ ] Verify C++ SDK compiles with the updated header

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)