### PR TITLE
fix: calendar parser + remove EOD from request_type docs + wildcard right limitation

### DIFF
--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -744,6 +744,110 @@ mod tests {
             "mid-February 2006 should be EST under old DST rules"
         );
     }
+
+    /// Build a DataValue containing Text.
+    fn dv_text(s: &str) -> proto::DataValue {
+        proto::DataValue {
+            data_type: Some(proto::data_value::DataType::Text(s.to_string())),
+        }
+    }
+
+    #[test]
+    fn parse_calendar_v3_holiday() {
+        // Simulate calendar_year response for a holiday (full_close).
+        let table = proto::DataTable {
+            headers: vec!["date".into(), "type".into(), "open".into(), "close".into()],
+            data_table: vec![row_of(vec![
+                dv_text("2025-01-01"),
+                dv_text("full_close"),
+                dv_null(),
+                dv_null(),
+            ])],
+        };
+
+        let days = parse_calendar_days_v3(&table);
+        assert_eq!(days.len(), 1);
+        let d = &days[0];
+        assert_eq!(d.date, 20250101);
+        assert_eq!(d.is_open, 0);
+        assert_eq!(d.open_time, 0);
+        assert_eq!(d.close_time, 0);
+        assert_eq!(d.status, CALENDAR_STATUS_FULL_CLOSE);
+    }
+
+    #[test]
+    fn parse_calendar_v3_open_day() {
+        // Simulate calendar_on_date response for a regular trading day.
+        // Note: on_date and open_today omit the "date" column.
+        let table = proto::DataTable {
+            headers: vec!["type".into(), "open".into(), "close".into()],
+            data_table: vec![row_of(vec![
+                dv_text("open"),
+                dv_text("09:30:00"),
+                dv_text("16:00:00"),
+            ])],
+        };
+
+        let days = parse_calendar_days_v3(&table);
+        assert_eq!(days.len(), 1);
+        let d = &days[0];
+        assert_eq!(d.date, 0); // no date column
+        assert_eq!(d.is_open, 1);
+        assert_eq!(d.open_time, 34_200_000); // 9:30 AM = 9*3600+30*60 = 34200 seconds = 34200000 ms
+        assert_eq!(d.close_time, 57_600_000); // 4:00 PM = 16*3600 = 57600 seconds = 57600000 ms
+        assert_eq!(d.status, CALENDAR_STATUS_OPEN);
+    }
+
+    #[test]
+    fn parse_calendar_v3_early_close() {
+        // Simulate an early close day (day after Thanksgiving).
+        let table = proto::DataTable {
+            headers: vec!["date".into(), "type".into(), "open".into(), "close".into()],
+            data_table: vec![row_of(vec![
+                dv_text("2025-11-28"),
+                dv_text("early_close"),
+                dv_text("09:30:00"),
+                dv_text("13:00:00"),
+            ])],
+        };
+
+        let days = parse_calendar_days_v3(&table);
+        assert_eq!(days.len(), 1);
+        let d = &days[0];
+        assert_eq!(d.date, 20251128);
+        assert_eq!(d.is_open, 1);
+        assert_eq!(d.open_time, 34_200_000);
+        assert_eq!(d.close_time, 46_800_000); // 1:00 PM = 13*3600 = 46800 seconds = 46800000 ms
+        assert_eq!(d.status, CALENDAR_STATUS_EARLY_CLOSE);
+    }
+
+    #[test]
+    fn parse_calendar_v3_weekend() {
+        let table = proto::DataTable {
+            headers: vec!["type".into(), "open".into(), "close".into()],
+            data_table: vec![row_of(vec![dv_text("weekend"), dv_null(), dv_null()])],
+        };
+
+        let days = parse_calendar_days_v3(&table);
+        assert_eq!(days.len(), 1);
+        let d = &days[0];
+        assert_eq!(d.is_open, 0);
+        assert_eq!(d.status, CALENDAR_STATUS_WEEKEND);
+    }
+
+    #[test]
+    fn parse_time_text_valid() {
+        assert_eq!(super::parse_time_text("09:30:00"), 34_200_000);
+        assert_eq!(super::parse_time_text("16:00:00"), 57_600_000);
+        assert_eq!(super::parse_time_text("13:00:00"), 46_800_000);
+        assert_eq!(super::parse_time_text("00:00:00"), 0);
+    }
+
+    #[test]
+    fn parse_time_text_invalid_returns_zero() {
+        assert_eq!(super::parse_time_text("invalid"), 0);
+        assert_eq!(super::parse_time_text(""), 0);
+    }
 }
 
 /// Hand-written parser for OptionContract that handles the v3 server's
@@ -835,4 +939,146 @@ fn parse_iso_date(s: &str) -> i32 {
         }
     }
     0
+}
+
+/// Parse a time string "HH:MM:SS" to milliseconds from midnight.
+fn parse_time_text(s: &str) -> i32 {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() == 3 {
+        if let (Ok(h), Ok(m), Ok(sec)) = (
+            parts[0].parse::<i32>(),
+            parts[1].parse::<i32>(),
+            parts[2].parse::<i32>(),
+        ) {
+            return (h * 3600 + m * 60 + sec) * 1000;
+        }
+    }
+    0
+}
+
+/// Calendar day status constants.
+///
+/// The v3 MDDS server sends a `type` column with text values. We map them to
+/// integer constants for the `CalendarDay.status` field:
+///
+/// | Server text    | Constant | Meaning                           |
+/// |----------------|----------|-----------------------------------|
+/// | `"open"`       | `0`      | Normal trading day                |
+/// | `"early_close"`| `1`      | Early close (e.g. day after Thanksgiving) |
+/// | `"full_close"` | `2`      | Market closed (holiday)           |
+/// | `"weekend"`    | `3`      | Weekend                           |
+/// | (unknown)      | `-1`     | Unrecognized status text          |
+pub const CALENDAR_STATUS_OPEN: i32 = 0;
+pub const CALENDAR_STATUS_EARLY_CLOSE: i32 = 1;
+pub const CALENDAR_STATUS_FULL_CLOSE: i32 = 2;
+pub const CALENDAR_STATUS_WEEKEND: i32 = 3;
+pub const CALENDAR_STATUS_UNKNOWN: i32 = -1;
+
+/// Map a v3 calendar `type` text to `(is_open, status)`.
+fn calendar_type_text(s: &str) -> (i32, i32) {
+    match s {
+        "open" => (1, CALENDAR_STATUS_OPEN),
+        "early_close" => (1, CALENDAR_STATUS_EARLY_CLOSE),
+        "full_close" => (0, CALENDAR_STATUS_FULL_CLOSE),
+        "weekend" => (0, CALENDAR_STATUS_WEEKEND),
+        _ => (0, CALENDAR_STATUS_UNKNOWN),
+    }
+}
+
+/// Hand-written parser for CalendarDay that handles the v3 server's
+/// text-formatted fields.
+///
+/// The v3 MDDS server sends calendar data with different column names and types
+/// than the generated parser expects:
+///
+/// | Schema field | Server header | Server type | Mapping                               |
+/// |--------------|---------------|-------------|---------------------------------------|
+/// | `date`       | `date`        | Text        | "2025-01-01" -> 20250101              |
+/// | `is_open`    | `type`        | Text        | "open"/"early_close" -> 1, else -> 0  |
+/// | `open_time`  | `open`        | Text / Null | "09:30:00" -> 34200000 ms             |
+/// | `close_time` | `close`       | Text / Null | "16:00:00" -> 57600000 ms             |
+/// | `status`     | `type`        | Text        | See [`CALENDAR_STATUS_OPEN`] etc.     |
+///
+/// Note: `calendar_on_date` and `calendar_open_today` omit the `date` column.
+pub fn parse_calendar_days_v3(table: &crate::proto::DataTable) -> Vec<CalendarDay> {
+    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();
+
+    let date_idx = h.iter().position(|&s| s == "date");
+    let type_idx = h.iter().position(|&s| s == "type");
+    let open_idx = h.iter().position(|&s| s == "open");
+    let close_idx = h.iter().position(|&s| s == "close");
+
+    table
+        .data_table
+        .iter()
+        .map(|row| {
+            // date: Text "2025-01-01" -> YYYYMMDD, or Number, or Timestamp
+            let date = date_idx
+                .map(|i| {
+                    // Try Number/Timestamp first (generated parser path)
+                    let n = row_number(row, i);
+                    if n != 0 {
+                        return n;
+                    }
+                    // v3: Text "2025-01-01"
+                    let s = row_text(row, i);
+                    if !s.is_empty() {
+                        return parse_iso_date(&s);
+                    }
+                    0
+                })
+                .unwrap_or(0);
+
+            // type: Text "open"/"full_close"/"early_close"/"weekend"
+            let (is_open, status) = type_idx
+                .map(|i| {
+                    let s = row_text(row, i);
+                    if !s.is_empty() {
+                        return calendar_type_text(&s);
+                    }
+                    // Fallback: try as Number (future-proofing)
+                    let n = row_number(row, i);
+                    (if n != 0 { 1 } else { 0 }, n)
+                })
+                .unwrap_or((0, 0));
+
+            // open: Text "09:30:00" -> ms_of_day, or Null/Number
+            let open_time = open_idx
+                .map(|i| {
+                    let n = row_number(row, i);
+                    if n != 0 {
+                        return n;
+                    }
+                    let s = row_text(row, i);
+                    if !s.is_empty() {
+                        return parse_time_text(&s);
+                    }
+                    0
+                })
+                .unwrap_or(0);
+
+            // close: Text "16:00:00" -> ms_of_day, or Null/Number
+            let close_time = close_idx
+                .map(|i| {
+                    let n = row_number(row, i);
+                    if n != 0 {
+                        return n;
+                    }
+                    let s = row_text(row, i);
+                    if !s.is_empty() {
+                        return parse_time_text(&s);
+                    }
+                    0
+                })
+                .unwrap_or(0);
+
+            CalendarDay {
+                date,
+                is_open,
+                open_time,
+                close_time,
+                status,
+            }
+        })
+        .collect()
 }

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -647,7 +647,7 @@ impl DirectClient {
     list_endpoint! {
         /// List available dates for a stock by request type.
         ///
-        /// `request_type` is e.g. `"EOD"`, `"TRADE"`, `"QUOTE"`, etc.
+        /// `request_type` is e.g. `"TRADE"`, `"QUOTE"`, etc.
         ///
         /// gRPC: `BetaThetaTerminal/GetStockListDates`
         fn stock_list_dates(request_type: &str, symbol: &str) -> "date";
@@ -1963,7 +1963,7 @@ parsed_endpoint! {
     grpc: get_calendar_open_today;
     request: CalendarOpenTodayRequest;
     query: CalendarOpenTodayRequestQuery {};
-    parse: decode::parse_calendar_days;
+    parse: decode::parse_calendar_days_v3;
     optional {}
 }
 
@@ -1977,7 +1977,7 @@ parsed_endpoint! {
     query: CalendarOnDateRequestQuery {
         date: date.to_string(),
     };
-    parse: decode::parse_calendar_days;
+    parse: decode::parse_calendar_days_v3;
     dates: date;
     optional {}
 }
@@ -1992,7 +1992,7 @@ parsed_endpoint! {
     query: CalendarYearRequestQuery {
         year: year.to_string(),
     };
-    parse: decode::parse_calendar_days;
+    parse: decode::parse_calendar_days_v3;
     optional {}
 }
 

--- a/docs-site/docs/historical/calendar/year.md
+++ b/docs-site/docs/historical/calendar/year.md
@@ -40,34 +40,34 @@ auto year_info = client.calendar_year("2024");
 
 ## Response
 
-Returns a `Vec<CalendarDay>` with calendar info for every trading day in the year:
+Returns a `Vec<CalendarDay>` with calendar info for non-standard days in the year (holidays, early closes):
 
 <div class="param-list">
 <div class="param">
-<div class="param-header"><code>is_open</code><span class="param-type">bool</span></div>
-<div class="param-desc">Whether the market is open on this date</div>
-</div>
-<div class="param">
-<div class="param-header"><code>open_time</code><span class="param-type">u32</span></div>
-<div class="param-desc">Market open time (milliseconds from midnight ET)</div>
-</div>
-<div class="param">
-<div class="param-header"><code>close_time</code><span class="param-type">u32</span></div>
-<div class="param-desc">Market close time (milliseconds from midnight ET)</div>
-</div>
-<div class="param">
-<div class="param-header"><code>early_close</code><span class="param-type">bool</span></div>
-<div class="param-desc">Whether this is an early close day</div>
-</div>
-<div class="param">
-<div class="param-header"><code>date</code><span class="param-type">u32</span></div>
+<div class="param-header"><code>date</code><span class="param-type">i32</span></div>
 <div class="param-desc">Date as <code>YYYYMMDD</code> integer</div>
+</div>
+<div class="param">
+<div class="param-header"><code>is_open</code><span class="param-type">i32</span></div>
+<div class="param-desc"><code>1</code> if the market is open, <code>0</code> if closed</div>
+</div>
+<div class="param">
+<div class="param-header"><code>open_time</code><span class="param-type">i32</span></div>
+<div class="param-desc">Market open time (milliseconds from midnight ET). <code>0</code> if closed.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>close_time</code><span class="param-type">i32</span></div>
+<div class="param-desc">Market close time (milliseconds from midnight ET). <code>0</code> if closed.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>status</code><span class="param-type">i32</span></div>
+<div class="param-desc">Day type: <code>0</code> = open, <code>1</code> = early close, <code>2</code> = full close (holiday), <code>3</code> = weekend</div>
 </div>
 </div>
 
 ## Notes
 
-- Returns entries for all calendar days in the year, not just trading days. Non-trading days have `is_open: false`.
+- The server returns only non-standard days (holidays and early closes), not every calendar day.
 - Useful for building local trading calendars and scheduling data collection.
 - Future years may have incomplete data if the exchange has not yet published the full calendar.
 - Reflects NYSE trading hours only.

--- a/docs-site/docs/historical/option/list/contracts.md
+++ b/docs-site/docs/historical/option/list/contracts.md
@@ -13,16 +13,16 @@ List all option contracts available for a given underlying symbol on a specific 
 
 ::: code-group
 ```rust [Rust]
-let contracts: Vec<OptionContract> = tdx.option_list_contracts("EOD", "SPY", "20240315").await?;
+let contracts: Vec<OptionContract> = tdx.option_list_contracts("TRADE", "SPY", "20240315").await?;
 ```
 ```python [Python]
-contracts = tdx.option_list_contracts("EOD", "SPY", "20240315")
+contracts = tdx.option_list_contracts("TRADE", "SPY", "20240315")
 ```
 ```go [Go]
-contracts, err := client.OptionListContracts("EOD", "SPY", "20240315")
+contracts, err := client.OptionListContracts("TRADE", "SPY", "20240315")
 ```
 ```cpp [C++]
-auto contracts = client.option_list_contracts("EOD", "SPY", "20240315");
+auto contracts = client.option_list_contracts("TRADE", "SPY", "20240315");
 ```
 :::
 
@@ -31,7 +31,7 @@ auto contracts = client.option_list_contracts("EOD", "SPY", "20240315");
 <div class="param-list">
 <div class="param">
 <div class="param-header"><code>request_type</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Data type (e.g. <code>"EOD"</code>, <code>"TRADE"</code>)</div>
+<div class="param-desc">Data type (e.g. <code>"TRADE"</code>, <code>"QUOTE"</code>)</div>
 </div>
 <div class="param">
 <div class="param-header"><code>symbol</code><span class="param-type">string</span><span class="param-badge required">required</span></div>

--- a/docs-site/docs/historical/option/list/dates.md
+++ b/docs-site/docs/historical/option/list/dates.md
@@ -14,17 +14,17 @@ List available dates for a specific option contract, filtered by data request ty
 ::: code-group
 ```rust [Rust]
 let dates: Vec<String> = tdx.option_list_dates(
-    "EOD", "SPY", "20241220", "500000", "C"
+    "TRADE", "SPY", "20241220", "500000", "C"
 ).await?;
 ```
 ```python [Python]
-dates = tdx.option_list_dates("EOD", "SPY", "20241220", "500000", "C")
+dates = tdx.option_list_dates("TRADE", "SPY", "20241220", "500000", "C")
 ```
 ```go [Go]
-dates, err := client.OptionListDates("EOD", "SPY", "20241220", "500000", "C")
+dates, err := client.OptionListDates("TRADE", "SPY", "20241220", "500000", "C")
 ```
 ```cpp [C++]
-auto dates = client.option_list_dates("EOD", "SPY", "20241220", "500000", "C");
+auto dates = client.option_list_dates("TRADE", "SPY", "20241220", "500000", "C");
 ```
 :::
 
@@ -33,7 +33,7 @@ auto dates = client.option_list_dates("EOD", "SPY", "20241220", "500000", "C");
 <div class="param-list">
 <div class="param">
 <div class="param-header"><code>request_type</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Data type: <code>"EOD"</code>, <code>"TRADE"</code>, <code>"QUOTE"</code>, or <code>"OHLC"</code></div>
+<div class="param-desc">Data type: <code>"TRADE"</code>, <code>"QUOTE"</code>, or <code>"OHLC"</code></div>
 </div>
 <div class="param">
 <div class="param-header"><code>symbol</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
@@ -64,5 +64,5 @@ auto dates = client.option_list_dates("EOD", "SPY", "20241220", "500000", "C");
 
 ## Notes
 
-- Different request types may have different date availability. EOD data typically goes back further than tick-level trade or quote data.
+- Different request types may have different date availability.
 - Strike prices are expressed in tenths of a cent: `"500000"` = $500.00.

--- a/docs-site/docs/historical/stock/list/dates.md
+++ b/docs-site/docs/historical/stock/list/dates.md
@@ -1,6 +1,6 @@
 ---
 title: List Dates
-description: Retrieve available dates for a stock by request type (EOD, Trade, Quote, OHLC).
+description: Retrieve available dates for a stock by request type (Trade, Quote, OHLC).
 ---
 
 # stock_list_dates
@@ -13,22 +13,22 @@ List available dates for a stock filtered by request type. Use this to discover 
 
 ::: code-group
 ```rust [Rust]
-let dates: Vec<String> = tdx.stock_list_dates("EOD", "AAPL").await?;
+let dates: Vec<String> = tdx.stock_list_dates("TRADE", "AAPL").await?;
 println!("First: {} Last: {}", dates.first().unwrap(), dates.last().unwrap());
 ```
 ```python [Python]
-dates = tdx.stock_list_dates("EOD", "AAPL")
+dates = tdx.stock_list_dates("TRADE", "AAPL")
 print(f"First: {dates[0]} Last: {dates[-1]}")
 ```
 ```go [Go]
-dates, err := client.StockListDates("EOD", "AAPL")
+dates, err := client.StockListDates("TRADE", "AAPL")
 if err != nil {
     log.Fatal(err)
 }
 fmt.Printf("First: %s Last: %s\n", dates[0], dates[len(dates)-1])
 ```
 ```cpp [C++]
-auto dates = client.stock_list_dates("EOD", "AAPL");
+auto dates = client.stock_list_dates("TRADE", "AAPL");
 std::cout << "First: " << dates.front()
           << " Last: " << dates.back() << std::endl;
 ```
@@ -39,7 +39,7 @@ std::cout << "First: " << dates.front()
 <div class="param-list">
 <div class="param">
 <div class="param-header"><code>request_type</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Data type: <code>"EOD"</code>, <code>"TRADE"</code>, <code>"QUOTE"</code>, or <code>"OHLC"</code></div>
+<div class="param-desc">Data type: <code>"TRADE"</code>, <code>"QUOTE"</code>, or <code>"OHLC"</code></div>
 </div>
 <div class="param">
 <div class="param-header"><code>symbol</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
@@ -53,5 +53,5 @@ List of date strings in `YYYYMMDD` format, sorted chronologically.
 
 ## Notes
 
-- The available date range varies by request type. Trade/quote tick data typically covers fewer years than EOD data.
+- The available date range varies by request type.
 - Use this endpoint to validate date ranges before making history requests.

--- a/docs-site/docs/options.md
+++ b/docs-site/docs/options.md
@@ -139,12 +139,16 @@ print(df[["strike", "close", "volume"]].head(20))
 
 ## Wildcard Queries with Contract Identification
 
-When you pass `"0"` for expiration, strike, or right, the server returns data across all matching contracts. Each tick includes contract identification fields (`expiration`, `strike`, `right`, `strike_price_type`) so you can distinguish which contract each tick belongs to.
+When you pass `"0"` for `expiration` or `strike`, the server returns data across all matching contracts. Each tick includes contract identification fields (`expiration`, `strike`, `right`, `strike_price_type`) so you can distinguish which contract each tick belongs to.
+
+::: warning
+The `right` parameter does **not** support wildcards. You must specify `"C"` (call) or `"P"` (put). Only `expiration` and `strike` accept `"0"` as a wildcard.
+:::
 
 ::: code-group
 ```rust [Rust]
-// Wildcard: all SPY contracts on a given date
-let trades = client.option_history_trade("SPY", "0", "0", "0", "20240315").await?;
+// Wildcard: all SPY call contracts on a given date
+let trades = client.option_history_trade("SPY", "0", "0", "C", "20240315").await?;
 for t in &trades {
     if t.has_contract_id() {
         println!("{} {} strike={:.2} price={:.4}",
@@ -156,8 +160,8 @@ for t in &trades {
 }
 ```
 ```python [Python]
-# Wildcard: all SPY contracts on a given date
-trades = client.option_history_trade("SPY", "0", "0", "0", "20240315")
+# Wildcard: all SPY call contracts on a given date
+trades = client.option_history_trade("SPY", "0", "0", "C", "20240315")
 for t in trades:
     if "expiration" in t:
         print(f"{t['expiration']} {t['right']} strike={t['strike']:.2f} price={t['price']:.4f}")

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -71,7 +71,7 @@ All available stock symbols. gRPC: `GetStockListSymbols`
 pub async fn stock_list_dates(&self, request_type: &str, symbol: &str) -> Result<Vec<String>, Error>
 ```
 
-Available dates for a stock by request type (e.g. `"EOD"`, `"TRADE"`, `"QUOTE"`). gRPC: `GetStockListDates`
+Available dates for a stock by request type (e.g. `"TRADE"`, `"QUOTE"`). gRPC: `GetStockListDates`
 
 ### Stock - Snapshot (4)
 
@@ -915,7 +915,9 @@ All 14 tick types are `Clone + Debug` structs generated from `endpoint_schema.to
 
 ### Contract Identification Fields
 
-10 tick types carry **contract identification fields** that identify which option contract each tick belongs to. These fields are populated by the server on wildcard/bulk queries (where strike/expiration/right are `0`); on single-contract queries they are `0`.
+10 tick types carry **contract identification fields** that identify which option contract each tick belongs to. These fields are populated by the server on wildcard/bulk queries (where `expiration` and/or `strike` are `"0"`); on single-contract queries they are `0`.
+
+> **Note:** Only `expiration` and `strike` support wildcards (`"0"`). The `right` parameter does **not** accept wildcards -- you must specify `"C"` or `"P"`.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -939,7 +941,8 @@ Tick types with contract ID: `TradeTick`, `QuoteTick`, `OhlcTick`, `EodTick`, `O
 
 ```rust
 // Wildcard query — ticks include contract identification
-let ticks = tdx.option_history_trade("AAPL", "0", "0", "0", "20250101").await?;
+// Note: right must be "C" or "P", only expiration and strike accept "0"
+let ticks = tdx.option_history_trade("AAPL", "0", "0", "C", "20250101").await?;
 for t in &ticks {
     if t.has_contract_id() {
         println!("{} {} strike={} price={}",


### PR DESCRIPTION
## Summary

- **Calendar parser**: wrote `parse_calendar_days_v3` to handle v3 MDDS server's text-formatted calendar data. The server sends `[date, type, open, close]` as Text/Null cells (e.g. `"2025-01-01"`, `"full_close"`, `"09:30:00"`), but the generated parser expected integer columns `[date, is_open, open_time, close_time, status]`, producing all zeros. The v3 parser maps ISO dates to YYYYMMDD, time strings to ms_of_day, and type strings to status constants. Includes 6 unit tests.
- **Remove EOD from request_type docs**: `stock_list_dates` and `option_list_contracts` doc comments and docs-site pages listed `"EOD"` as a valid `request_type` value. Corrected to `"TRADE"`, `"QUOTE"`.
- **Document wildcard right limitation**: `right` does not accept `"0"` as a wildcard. Only `expiration` and `strike` support wildcards. Added warning callouts to `docs-site/docs/options.md` and `docs/api-reference.md`, and updated all wildcard code examples.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (182 tests, including 6 new calendar parser tests)
- [x] Verified parser against live v3 server using debug example (holiday, open day, early close, weekend)

Closes #109

Generated with [Claude Code](https://claude.com/claude-code)