### PR TITLE
fix: normalize right parameter for v3 server

### DIFF
--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -367,6 +367,19 @@ macro_rules! streaming_endpoint {
     };
 }
 
+/// Normalize the `right` parameter for the v3 MDDS server.
+///
+/// Accepts: `"C"`, `"P"`, `"call"`, `"put"`, `"both"`, `"*"`.
+/// Maps `"C"` -> `"call"`, `"P"` -> `"put"`, `"*"` -> `"both"`.
+fn normalize_right(right: &str) -> String {
+    match right {
+        "C" | "c" => "call".to_string(),
+        "P" | "p" => "put".to_string(),
+        "*" => "both".to_string(),
+        other => other.to_lowercase(),
+    }
+}
+
 /// Helper: build a `proto::ContractSpec` from the four standard option params.
 macro_rules! contract_spec {
     ($symbol:expr, $expiration:expr, $strike:expr, $right:expr) => {
@@ -374,7 +387,7 @@ macro_rules! contract_spec {
             symbol: $symbol.to_string(),
             expiration: $expiration.to_string(),
             strike: Some($strike.to_string()),
-            right: Some($right.to_string()),
+            right: Some(normalize_right(&$right.to_string())),
         })
     };
 }

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -2323,16 +2323,18 @@ tdx.option_history_quote_stream("SPY", "20241220", "500000", "C", "20240315", "0
 
 ### Contract Identification Fields
 
-10 tick types carry contract identification fields populated by the server on wildcard queries (pass `0` for expiration/strike/right). On single-contract queries these fields are `0`.
+10 tick types carry contract identification fields populated by the server on wildcard queries (pass `0` for expiration/strike). On single-contract queries these fields are `0`/empty.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `expiration` | i32 | Contract expiration (YYYYMMDD). 0 if absent. |
-| `strike` | i32 | Strike price (fixed-point). Use `strike_price()` for decoded float. |
-| `right` | i32 | Contract right: 67 = Call ('C'), 80 = Put ('P'). |
-| `strike_price_type` | i32 | Price type for decoding `strike`. |
+| Field | Type (Rust/FFI) | Type (Go) | Description |
+|-------|-----------------|-----------|-------------|
+| `expiration` | i32 | int32 | Contract expiration (YYYYMMDD). 0 if absent. |
+| `strike` | i32 | int32 | Strike price (fixed-point). Use `strike_price()` for decoded float. |
+| `right` | i32 | string | Contract right. Rust/FFI: 67=Call, 80=Put. Go: `"C"`, `"P"`, `""`. |
+| `right_raw` | — | int32 | Go only: raw integer value (67/80/0) for power users. |
+| `strike_price_type` | i32 | int32 | Price type for decoding `strike`. |
 
 Helper methods (all 10 types): `strike_price()`, `is_call()`, `is_put()`, `has_contract_id()`.
+Go helper: `RightStr(code int32) string` converts raw right codes to `"C"`/`"P"`/`""`.
 
 Types with contract ID: TradeTick, QuoteTick, OhlcTick, EodTick, OpenInterestTick, SnapshotTradeTick, TradeQuoteTick, MarketValueTick, GreeksTick, IvTick.
 
@@ -2357,7 +2359,7 @@ A single trade execution.
 | `date` | i32 | Date as YYYYMMDD integer |
 | `expiration` | i32 | Contract expiration (wildcard queries) |
 | `strike` | i32 | Contract strike (wildcard queries) |
-| `right` | i32 | Contract right C=67/P=80 (wildcard queries) |
+| `right` | i32 (Rust/FFI), string (Go) | Contract right. Rust: C=67/P=80. Go: `"C"`/`"P"`. |
 | `strike_price_type` | i32 | Strike price type (wildcard queries) |
 
 Helper methods: `get_price()`, `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`, `strike_price()`, `is_call()`, `is_put()`, `has_contract_id()`
@@ -2375,7 +2377,7 @@ An NBBO quote.
 | `bid_condition` / `ask_condition` | i32 | Condition codes |
 | `price_type` | i32 | Decimal type for price decoding |
 | `date` | i32 | Date as YYYYMMDD integer |
-| `expiration` / `strike` / `right` / `strike_price_type` | i32 | Contract ID (wildcard queries) |
+| `expiration` / `strike` / `right` / `strike_price_type` | i32 (Go: `right` is string) | Contract ID (wildcard queries) |
 
 Helper methods: `bid_price()`, `ask_price()`, `midpoint_price()`, `midpoint_value()`, plus contract ID helpers
 
@@ -2391,7 +2393,7 @@ An aggregated OHLC bar.
 | `count` | i32 | Number of trades in bar |
 | `price_type` | i32 | Decimal type for price decoding |
 | `date` | i32 | Date as YYYYMMDD integer |
-| `expiration` / `strike` / `right` / `strike_price_type` | i32 | Contract ID (wildcard queries) |
+| `expiration` / `strike` / `right` / `strike_price_type` | i32 (Go: `right` is string) | Contract ID (wildcard queries) |
 
 Helper methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`, plus contract ID helpers
 
@@ -2411,7 +2413,7 @@ Full end-of-day snapshot with OHLC + closing quote data.
 | `bid_condition` / `ask_condition` | i32 | Closing quote conditions |
 | `price_type` | i32 | Decimal type |
 | `date` | i32 | Date as YYYYMMDD |
-| `expiration` / `strike` / `right` / `strike_price_type` | i32 | Contract ID (wildcard queries) |
+| `expiration` / `strike` / `right` / `strike_price_type` | i32 (Go: `right` is string) | Contract ID (wildcard queries) |
 
 Helper methods: `open_price()`, `high_price()`, `low_price()`, `close_price()`, `bid_price()`, `ask_price()`, `midpoint_value()`, plus contract ID helpers
 
@@ -2428,7 +2430,7 @@ Helper methods: `trade_price()`, `bid_price()`, `ask_price()`, plus contract ID 
 | `ms_of_day` | i32 | Milliseconds since midnight ET |
 | `open_interest` | i32 | Open interest count |
 | `date` | i32 | Date as YYYYMMDD |
-| `expiration` / `strike` / `right` / `strike_price_type` | i32 | Contract ID (wildcard queries) |
+| `expiration` / `strike` / `right` / `strike_price_type` | i32 (Go: `right` is string) | Contract ID (wildcard queries) |
 
 ### GreeksResult
 
@@ -2495,6 +2497,8 @@ Option right: `Call`, `Put`
 
 - `from_char('C')` / `from_char('P')` - parse from character
 - `as_char()` - convert to `'C'` or `'P'`
+
+**Go SDK:** The `Right` field on all public tick structs is a `string` (`"C"`, `"P"`, or `""`) instead of `i32`. The raw integer value is available as `RightRaw`. Use `RightStr(code int32)` for manual conversion.
 
 ### StreamResponseType
 

--- a/docs-site/docs/options.md
+++ b/docs-site/docs/options.md
@@ -170,6 +170,10 @@ for t in trades:
 
 The 4 contract ID fields and helper methods (`strike_price()`, `is_call()`, `is_put()`, `has_contract_id()`) are available on all 10 option tick types.
 
+::: tip Right Field
+In Go and Python, the `right` field is a human-readable string: `"C"` (call), `"P"` (put), or `""` (not set). The raw integer value (67/80/0) is available as `right_raw` (Python) or `RightRaw` (Go) for power users. In Rust and C FFI, `right` remains an `i32` matching the wire format; use `right_str()` or `is_call()`/`is_put()` helpers.
+:::
+
 ---
 
 ## Local Greeks Calculator

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -919,12 +919,13 @@ All 14 tick types are `Clone + Debug` structs generated from `endpoint_schema.to
 
 > **Note:** Only `expiration` and `strike` support wildcards (`"0"`). The `right` parameter does **not** accept wildcards -- you must specify `"C"` or `"P"`.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `expiration` | `i32` | Contract expiration date (YYYYMMDD). 0 on single-contract queries. |
-| `strike` | `i32` | Strike price (fixed-point encoded). Use `strike_price()` for `f64`. |
-| `right` | `i32` | Contract right: `67` = Call ('C'), `80` = Put ('P'). 0 if absent. |
-| `strike_price_type` | `i32` | Price type for decoding `strike`. |
+| Field | Type (Rust/FFI) | Type (Go) | Description |
+|-------|-----------------|-----------|-------------|
+| `expiration` | `i32` | `int32` | Contract expiration date (YYYYMMDD). 0 on single-contract queries. |
+| `strike` | `i32` | `int32` | Strike price (fixed-point encoded). Use `strike_price()` for `f64`. |
+| `right` | `i32` | `string` | Contract right. Rust/FFI: `67` = Call, `80` = Put, `0` = absent. Go: `"C"`, `"P"`, `""`. |
+| `right_raw` | — | `int32` | Go only: raw integer value (67/80/0) for power users. |
+| `strike_price_type` | `i32` | `int32` | Price type for decoding `strike`. |
 
 Helper methods on all 10 tick types:
 

--- a/docs/jvm-deviations.md
+++ b/docs/jvm-deviations.md
@@ -275,6 +275,14 @@ As of v1.2.0:
 | **Source** | `TradeRef.java`, `FPSSClient` internal event handling | `fpss/mod.rs:decode_tick()` + `decode_frame()` Trade branch |
 | **Rationale** | The FPSS dev server sends 8-field trade ticks (simple format: `[ms_of_day, sequence, size, condition, price, exchange, price_type, date]`) while production sends 16-field trade ticks (extended format with ext_conditions, flags, volume_type, records_back). Java's `TradeRef.java` hard-codes 8-field indices and applies them to 16-field arrays, producing correct results only by accident when the server happens to send 16-field data with the 8-field subset at matching positions. ThetaDataDx records the actual FIT field count from the first absolute tick for each contract and dispatches to the correct field mapping. Fields absent in the 8-field format (`ext_condition1..4`, `condition_flags`, `price_flags`, `volume_type`, `records_back`) are set to 0. |
 
+### Right Field: String in Go/Python, Integer in Rust/FFI
+
+| | Java | Rust/FFI | Go/Python | Impact |
+|---|---|---|---|---|
+| **Behavior** | Internal `TradeTick` stores right as integer; WebSocket JSON returns string `"C"`/`"P"` | `i32` field on all tick structs (67=Call, 80=Put, 0=absent). `right_str()` helper available. | `string` field (`"C"`, `"P"`, `""`) on all public tick structs. `RightRaw int32` available for power users. | Go/Python consumers get human-readable strings by default |
+| **Source** | Decompiled `TradeRef.java`, `DataValue` protobuf cells | `tdbe` tick structs, `right_str()` in `contract.rs` | `sdks/go/client.go:RightStr()`, conversion functions |
+| **Rationale** | The Java terminal stores right as an integer internally (matching the wire format) but converts to `"C"`/`"P"` when serializing to WebSocket JSON for end-user consumption. ThetaDataDx follows the same principle at the SDK boundary: the Rust core and FFI layer preserve the raw `i32` for zero-overhead C interop, while higher-level SDKs (Go, Python) convert to human-readable strings in the conversion layer. The `RightRaw`/`right_raw` field preserves the original integer for users who need exact wire values. |
+
 ## What Is NOT Different
 
 These are identical to the Java terminal:

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -235,27 +235,29 @@ defer client.Close()
 
 | Type | Fields | Description |
 |------|--------|-------------|
-| `EodTick` | MsOfDay, Open, High, Low, Close, Volume, Count, Bid, Ask, Date, **Expiration, Strike, Right, StrikePriceType** | End-of-day bar |
-| `OhlcTick` | MsOfDay, Open, High, Low, Close, Volume, Count, Date, **Expiration, Strike, Right, StrikePriceType** | OHLC bar |
-| `TradeTick` | MsOfDay, Sequence, Condition, Size, Exchange, Price (float64), PriceRaw, ConditionFlags, PriceFlags, VolumeType, RecordsBack, Date, **Expiration, Strike, Right, StrikePriceType** | Individual trade |
-| `QuoteTick` | MsOfDay, BidSize, BidExchange, Bid, BidCondition, AskSize, AskExchange, Ask, AskCondition, Date, **Expiration, Strike, Right, StrikePriceType** | NBBO quote |
-| `TradeQuoteTick` | All TradeTick fields + QuoteMsOfDay, BidSize, BidExchange, Bid, BidCondition, AskSize, AskExchange, Ask, AskCondition, Date, **Expiration, Strike, Right, StrikePriceType** | Combined trade+quote |
+| `EodTick` | MsOfDay, Open, High, Low, Close, Volume, Count, Bid, Ask, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | End-of-day bar |
+| `OhlcTick` | MsOfDay, Open, High, Low, Close, Volume, Count, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | OHLC bar |
+| `TradeTick` | MsOfDay, Sequence, Condition, Size, Exchange, Price (float64), PriceRaw, ConditionFlags, PriceFlags, VolumeType, RecordsBack, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | Individual trade |
+| `QuoteTick` | MsOfDay, BidSize, BidExchange, Bid, BidCondition, AskSize, AskExchange, Ask, AskCondition, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | NBBO quote |
+| `TradeQuoteTick` | All TradeTick fields + QuoteMsOfDay, BidSize, BidExchange, Bid, BidCondition, AskSize, AskExchange, Ask, AskCondition, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | Combined trade+quote |
 
 #### Derived Types
 
 | Type | Fields | Description |
 |------|--------|-------------|
-| `OpenInterestTick` | MsOfDay, OpenInterest, Date, **Expiration, Strike, Right, StrikePriceType** | Open interest data point |
-| `MarketValueTick` | MsOfDay, MarketCap, SharesOut, EntValue, BookValue, FreeFloat, Date, **Expiration, Strike, Right, StrikePriceType** | Market value data |
-| `GreeksTick` | MsOfDay, Value, Delta, Gamma, Theta, Vega, Rho, IV, IVError, Vanna, Charm, Vomma, Veta, Speed, Zomma, Color, Ultima, D1, D2, DualDelta, DualGamma, Epsilon, Lambda, Date, **Expiration, Strike, Right, StrikePriceType** | Greeks time series |
-| `IVTick` | MsOfDay, IV, IVError, Date, **Expiration, Strike, Right, StrikePriceType** | Implied volatility data point |
-| `SnapshotTradeTick` | MsOfDay, Sequence, Size, Condition, Price (float64), PriceRaw, Date, **Expiration, Strike, Right, StrikePriceType** | Snapshot trade |
+| `OpenInterestTick` | MsOfDay, OpenInterest, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | Open interest data point |
+| `MarketValueTick` | MsOfDay, MarketCap, SharesOut, EntValue, BookValue, FreeFloat, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | Market value data |
+| `GreeksTick` | MsOfDay, Value, Delta, Gamma, Theta, Vega, Rho, IV, IVError, Vanna, Charm, Vomma, Veta, Speed, Zomma, Color, Ultima, D1, D2, DualDelta, DualGamma, Epsilon, Lambda, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | Greeks time series |
+| `IVTick` | MsOfDay, IV, IVError, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | Implied volatility data point |
+| `SnapshotTradeTick` | MsOfDay, Sequence, Size, Condition, Price (float64), PriceRaw, Date, **Expiration, Strike, Right (string), RightRaw (int32), StrikePriceType** | Snapshot trade |
 | `PriceTick` | MsOfDay, Price (float64), PriceRaw, Date | Price data point (indices) |
 | `CalendarDay` | Date, IsOpen, OpenTime, CloseTime, Status | Market calendar day |
 | `InterestRate` | Date, Rate | Interest rate data point |
-| `Contract` | Symbol, Expiration, Strike, Right | Option contract identifier |
+| `Contract` | Symbol, Expiration, Strike, Right (string), RightRaw | Option contract identifier |
 
-**Contract identification fields** (bold above): `Expiration`, `Strike`, `Right`, `StrikePriceType` are populated by the server on wildcard queries (pass `"0"` for expiration/strike/right). On single-contract queries these fields are `0`.
+**Contract identification fields** (bold above): `Expiration`, `Strike`, `Right`, `StrikePriceType` are populated by the server on wildcard queries (pass `"0"` for expiration/strike). On single-contract queries these fields are zero/empty.
+
+**Right field**: In the Go SDK, `Right` is a human-readable `string` (`"C"` for call, `"P"` for put, `""` if not set). The raw integer value (67/80/0) is available as `RightRaw` for power users who need it. The `RightStr()` helper function performs this conversion and is exported for use with custom data.
 
 ## FPSS Streaming
 

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -448,7 +448,8 @@ type EodTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -463,7 +464,8 @@ type OhlcTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -482,7 +484,8 @@ type TradeTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -499,7 +502,8 @@ type QuoteTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -526,7 +530,8 @@ type TradeQuoteTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -534,9 +539,10 @@ type OpenInterestTick struct {
 	MsOfDay        int   `json:"ms_of_day"`
 	OpenInterest   int   `json:"open_interest"`
 	Date           int   `json:"date"`
-	Expiration     int32 `json:"expiration,omitempty"`
-	Strike         int32 `json:"strike,omitempty"`
-	Right          int32 `json:"right,omitempty"`
+	Expiration     int32  `json:"expiration,omitempty"`
+	Strike         int32  `json:"strike,omitempty"`
+	Right          string `json:"right,omitempty"`
+	RightRaw       int32  `json:"right_raw,omitempty"`
 	StrikePriceType int32 `json:"strike_price_type,omitempty"`
 }
 
@@ -550,7 +556,8 @@ type MarketValueTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -581,7 +588,8 @@ type GreeksTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -592,7 +600,8 @@ type IVTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -627,7 +636,8 @@ type SnapshotTradeTick struct {
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
 	Strike         int32   `json:"strike,omitempty"`
-	Right          int32   `json:"right,omitempty"`
+	Right          string  `json:"right,omitempty"`
+	RightRaw       int32   `json:"right_raw,omitempty"`
 	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
@@ -635,7 +645,8 @@ type OptionContract struct {
 	Root           string `json:"root"`
 	Expiration     int    `json:"expiration"`
 	Strike         int    `json:"strike"`
-	Right          int    `json:"right"`
+	Right          string `json:"right"`
+	RightRaw       int    `json:"right_raw,omitempty"`
 	StrikePriceType int   `json:"strike_price_type"`
 }
 
@@ -664,6 +675,21 @@ type Greeks struct {
 	Lambda    float64 `json:"lambda"`
 }
 
+// ── Right decoding ──
+
+// RightStr converts the raw right code to a string.
+// 67='C' (Call), 80='P' (Put), 0="" (not set).
+func RightStr(code int32) string {
+	switch code {
+	case 67:
+		return "C"
+	case 80:
+		return "P"
+	default:
+		return ""
+	}
+}
+
 // ── Price decoding ──
 
 func priceToFloat(value int32, priceType int32) float64 {
@@ -686,7 +712,7 @@ func convertEodTicks(arr C.TdxTickArray) []EodTick {
 			Open: priceToFloat(t.Open, t.PriceType), High: priceToFloat(t.High, t.PriceType),
 			Low: priceToFloat(t.Low, t.PriceType), Close: priceToFloat(t.Close, t.PriceType),
 			Bid: priceToFloat(t.Bid, t.PriceType), Ask: priceToFloat(t.Ask, t.PriceType),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -702,7 +728,7 @@ func convertOhlcTicks(arr C.TdxTickArray) []OhlcTick {
 			MsOfDay: int(t.MsOfDay), Volume: int(t.Volume), Count: int(t.Count), Date: int(t.Date),
 			Open: priceToFloat(t.Open, t.PriceType), High: priceToFloat(t.High, t.PriceType),
 			Low: priceToFloat(t.Low, t.PriceType), Close: priceToFloat(t.Close, t.PriceType),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -720,7 +746,7 @@ func convertTradeTicks(arr C.TdxTickArray) []TradeTick {
 			PriceRaw: int(t.Price), ConditionFlags: int(t.ConditionFlags),
 			PriceFlags: int(t.PriceFlags), VolumeType: int(t.VolumeType), RecordsBack: int(t.RecordsBack),
 			Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -738,7 +764,7 @@ func convertQuoteTicks(arr C.TdxTickArray) []QuoteTick {
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
 			Ask: priceToFloat(t.Ask, t.PriceType), AskCondition: int(t.AskCondition),
 			Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -760,7 +786,7 @@ func convertTradeQuoteTicks(arr C.TdxTickArray) []TradeQuoteTick {
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
 			Ask: priceToFloat(t.Ask, t.QuotePriceType), AskCondition: int(t.AskCondition),
 			Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -774,7 +800,7 @@ func convertOpenInterestTicks(arr C.TdxTickArray) []OpenInterestTick {
 	for i, t := range src {
 		result[i] = OpenInterestTick{
 			MsOfDay: int(t.MsOfDay), OpenInterest: int(t.OpenInterest), Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -789,7 +815,7 @@ func convertMarketValueTicks(arr C.TdxTickArray) []MarketValueTick {
 		result[i] = MarketValueTick{
 			MsOfDay: int(t.MsOfDay), MarketCap: t.MarketCap, SharesOut: t.SharesOutstanding,
 			EntValue: t.EnterpriseValue, BookValue: t.BookValue, FreeFloat: t.FreeFloat, Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -808,7 +834,7 @@ func convertGreeksTicks(arr C.TdxTickArray) []GreeksTick {
 			Speed: t.Speed, Zomma: t.Zomma, Color: t.Color, Ultima: t.Ultima,
 			D1: t.D1, D2: t.D2, DualDelta: t.DualDelta, DualGamma: t.DualGamma,
 			Epsilon: t.Epsilon, Lambda: t.Lambda, Vera: t.Vera, Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -822,7 +848,7 @@ func convertIvTicks(arr C.TdxTickArray) []IVTick {
 	for i, t := range src {
 		result[i] = IVTick{
 			MsOfDay: int(t.MsOfDay), IV: t.ImpliedVolatility, IVError: t.IvError, Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -867,7 +893,7 @@ func convertSnapshotTradeTicks(arr C.TdxTickArray) []SnapshotTradeTick {
 			MsOfDay: int(t.MsOfDay), Sequence: int(t.Sequence), Size: int(t.Size),
 			Condition: int(t.Condition), Price: priceToFloat(t.Price, t.PriceType),
 			PriceRaw: int(t.Price), Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
 		}
 	}
 	return result
@@ -883,7 +909,7 @@ func convertOptionContracts(arr C.TdxOptionContractArray) []OptionContract {
 		if t.Root != 0 {
 			root = C.GoString((*C.char)(unsafe.Pointer(t.Root)))
 		}
-		result[i] = OptionContract{root, int(t.Expiration), int(t.Strike), int(t.Right), int(t.StrikePriceType)}
+		result[i] = OptionContract{root, int(t.Expiration), int(t.Strike), RightStr(t.Right), int(t.Right), int(t.StrikePriceType)}
 	}
 	return result
 }


### PR DESCRIPTION
Maps C->call, P->put, *->both. Users can use either convention.