### PR TITLE
refactor: move derive_ohlcvc to DirectConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,8 +344,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 ### Added
 
 - `ThetaDataDx::connect(creds, config)` — one auth, gRPC channel ready, no FPSS yet
-- `tdx.start_streaming(handler)` — lazy FPSS connection on demand
-- `tdx.start_streaming_no_ohlcvc(handler)` — same, without derived OHLCVC
+- `tdx.start_streaming(handler)` — lazy FPSS connection on demand (reads `derive_ohlcvc` from config)
 - `tdx.stop_streaming()` — clean shutdown of streaming, historical stays alive
 - `tdx.is_streaming()` — check if FPSS is active
 - All 61 historical methods via `Deref<Target = DirectClient>`
@@ -377,7 +376,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 - **FpssEvent split** — `FpssEvent::Quote { .. }` is now `FpssEvent::Data(FpssData::Quote { .. })`.
   Control events are `FpssEvent::Control(FpssControl::*)`. Migration: wrap your match arms.
 - **OHLCVC derivation opt-in/out** — `connect()` still derives OHLCVC (default).
-  New `connect_no_ohlcvc()` disables it for lower overhead on full trade streams.
+  Set `DirectConfig::derive_ohlcvc` to `false` to disable for lower overhead on full trade streams.
 - **FpssClient is fully sync** — no tokio in the streaming path. LMAX Disruptor
   ring buffer. Callback API: `FnMut(&FpssEvent)`.
 

--- a/crates/thetadatadx/src/config.rs
+++ b/crates/thetadatadx/src/config.rs
@@ -223,6 +223,16 @@ pub struct DirectConfig {
     /// Default: [`ReconnectPolicy::Auto`] — matches Java terminal behavior.
     pub reconnect_policy: ReconnectPolicy,
 
+    // -- OHLCVC derivation --
+    /// Whether to derive OHLCVC bars locally from trade events.
+    ///
+    /// When `true` (default), the FPSS client emits derived `FpssData::Ohlcvc`
+    /// events after each trade. When `false`, only server-sent OHLCVC frames
+    /// (wire code 24) are emitted, reducing per-trade throughput overhead.
+    ///
+    /// The Java terminal always derives OHLCVC with no way to disable it.
+    pub derive_ohlcvc: bool,
+
     // -- Threading --
     /// Number of tokio worker threads. `None` = tokio default (number of CPU cores).
     ///
@@ -282,6 +292,9 @@ impl DirectConfig {
             // Auto-reconnect matches Java terminal behavior by default
             reconnect_policy: ReconnectPolicy::Auto,
 
+            // Derive OHLCVC from trades by default (matches Java terminal)
+            derive_ohlcvc: true,
+
             // Default: use all CPU cores
             tokio_worker_threads: None,
         }
@@ -337,6 +350,15 @@ impl DirectConfig {
     pub fn mdds_uri(&self) -> String {
         let scheme = if self.mdds_tls { "https" } else { "http" };
         format!("{}://{}:{}", scheme, self.mdds_host, self.mdds_port)
+    }
+
+    /// Set whether to derive OHLCVC bars locally from trade events.
+    ///
+    /// When `false`, only server-sent OHLCVC frames are emitted,
+    /// reducing per-trade throughput overhead.
+    pub fn derive_ohlcvc(mut self, enabled: bool) -> Self {
+        self.derive_ohlcvc = enabled;
+        self
     }
 
     /// Parse FPSS hosts from a comma-separated `host:port,host:port,...` string.
@@ -612,6 +634,10 @@ mod config_file {
                 // TOML config cannot express custom closures; default to Auto.
                 // Use the builder API to set Manual or Custom programmatically.
                 reconnect_policy: super::ReconnectPolicy::Auto,
+
+                // Default: derive OHLCVC from trades (matches production default).
+                // Use the builder API to disable programmatically.
+                derive_ohlcvc: true,
 
                 tokio_worker_threads: None,
             })

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -29,7 +29,7 @@
 //! # fn example() -> Result<(), thetadatadx::error::Error> {
 //! let creds = Credentials::new("user@example.com", "pw");
 //! let hosts = thetadatadx::config::DirectConfig::production().fpss_hosts;
-//! let client = FpssClient::connect(&creds, &hosts, 4096, Default::default(), Default::default(), |event: &FpssEvent| {
+//! let client = FpssClient::connect(&creds, &hosts, 4096, Default::default(), Default::default(), true, |event: &FpssEvent| {
 //!     // Runs on the Disruptor consumer thread -- keep it fast.
 //!     // Push to your own queue for heavy processing.
 //!     match event {
@@ -335,18 +335,24 @@ impl FpssClient {
     /// 5. Start I/O thread (blocking TLS read -> Disruptor ring -> callback)
     ///
     /// Source: `FPSSClient.connect()` and `FPSSClient.sendCredentials()`.
-    /// Connect with default settings (OHLCVC derivation enabled).
+    /// Connect to FPSS streaming servers.
     ///
     /// `hosts` is the FPSS server list from [`DirectConfig::fpss_hosts`].
     /// Servers are tried in order until one connects.
     ///
     /// `policy` controls auto-reconnect behavior after involuntary disconnect.
+    ///
+    /// When `derive_ohlcvc` is `false`, the client will NOT emit derived
+    /// `FpssData::Ohlcvc` events after each trade. You still receive
+    /// server-sent OHLCVC frames (wire code 24). This reduces throughput
+    /// overhead by eliminating one extra event per trade.
     pub fn connect<F>(
         creds: &Credentials,
         hosts: &[(String, u16)],
         ring_size: usize,
         flush_mode: FpssFlushMode,
         policy: ReconnectPolicy,
+        derive_ohlcvc: bool,
         handler: F,
     ) -> Result<Self, Error>
     where
@@ -360,43 +366,7 @@ impl FpssClient {
             server_addr,
             hosts.to_vec(),
             ring_size,
-            true,
-            flush_mode,
-            policy,
-            handler,
-        )
-    }
-
-    /// Connect with OHLCVC derivation disabled.
-    ///
-    /// When `derive_ohlcvc` is false, the client will NOT emit derived
-    /// `FpssData::Ohlcvc` events after each trade. You still receive
-    /// server-sent OHLCVC frames. This reduces throughput overhead by
-    /// eliminating one extra event per trade.
-    ///
-    /// `hosts` is the FPSS server list from [`DirectConfig::fpss_hosts`].
-    ///
-    /// `policy` controls auto-reconnect behavior after involuntary disconnect.
-    pub fn connect_no_ohlcvc<F>(
-        creds: &Credentials,
-        hosts: &[(String, u16)],
-        ring_size: usize,
-        flush_mode: FpssFlushMode,
-        policy: ReconnectPolicy,
-        handler: F,
-    ) -> Result<Self, Error>
-    where
-        F: FnMut(&FpssEvent) + Send + 'static,
-    {
-        let borrowed: Vec<(&str, u16)> = hosts.iter().map(|(h, p)| (h.as_str(), *p)).collect();
-        let (stream, server_addr) = connection::connect_to_servers(&borrowed)?;
-        Self::connect_with_stream(
-            creds,
-            stream,
-            server_addr,
-            hosts.to_vec(),
-            ring_size,
-            false,
+            derive_ohlcvc,
             flush_mode,
             policy,
             handler,
@@ -567,9 +537,9 @@ impl FpssClient {
     /// [`FpssData::Ohlcvc`] events interleaved. This is normal behavior from
     /// the ThetaData FPSS server.
     ///
-    /// If OHLCVC derivation is enabled (default via [`connect`]), you will also
-    /// receive locally-derived [`FpssData::Ohlcvc`] after each trade. Use
-    /// [`connect_no_ohlcvc`] to disable this and reduce throughput overhead.
+    /// If OHLCVC derivation is enabled (default), you will also
+    /// receive locally-derived [`FpssData::Ohlcvc`] after each trade. Pass
+    /// `derive_ohlcvc: false` to [`connect`] to disable this and reduce throughput overhead.
     ///
     /// # Wire protocol (from `PacketStream.java`)
     ///
@@ -2042,6 +2012,7 @@ pub fn reconnect<F>(
     ring_size: usize,
     flush_mode: FpssFlushMode,
     policy: ReconnectPolicy,
+    derive_ohlcvc: bool,
     handler: F,
 ) -> Result<FpssClient, Error>
 where
@@ -2050,7 +2021,15 @@ where
     tracing::info!(delay_ms, "waiting before FPSS reconnection");
     thread::sleep(Duration::from_millis(delay_ms));
 
-    let client = FpssClient::connect(creds, hosts, ring_size, flush_mode, policy, handler)?;
+    let client = FpssClient::connect(
+        creds,
+        hosts,
+        ring_size,
+        flush_mode,
+        policy,
+        derive_ohlcvc,
+        handler,
+    )?;
 
     // Re-subscribe all previous per-contract subscriptions with req_id = -1
     // Source: FPSSClient.java -- reconnect logic uses req_id = -1 for re-subscriptions

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -93,28 +93,7 @@ impl ThetaDataDx {
             config.fpss_ring_size,
             config.fpss_flush_mode,
             config.reconnect_policy.clone(),
-            handler,
-        )?;
-        *guard = Some(client);
-        Ok(())
-    }
-
-    /// Start streaming with OHLCVC derivation disabled.
-    pub fn start_streaming_no_ohlcvc<F>(&self, handler: F) -> Result<(), Error>
-    where
-        F: FnMut(&FpssEvent) + Send + 'static,
-    {
-        let mut guard = self.streaming.lock().unwrap_or_else(|e| e.into_inner());
-        if guard.is_some() {
-            return Err(Error::Fpss("streaming already started".into()));
-        }
-        let config = self.historical.config();
-        let client = FpssClient::connect_no_ohlcvc(
-            &self.creds,
-            &config.fpss_hosts,
-            config.fpss_ring_size,
-            config.fpss_flush_mode,
-            config.reconnect_policy.clone(),
+            config.derive_ohlcvc,
             handler,
         )?;
         *guard = Some(client);

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -184,8 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `ThetaDataDx::connect(creds, config)` — one auth, gRPC channel ready, no FPSS yet
-- `tdx.start_streaming(handler)` — lazy FPSS connection on demand
-- `tdx.start_streaming_no_ohlcvc(handler)` — same, without derived OHLCVC
+- `tdx.start_streaming(handler)` — lazy FPSS connection on demand (reads `derive_ohlcvc` from config)
 - `tdx.stop_streaming()` — clean shutdown of streaming, historical stays alive
 - `tdx.is_streaming()` — check if FPSS is active
 - All 61 historical methods via `Deref<Target = DirectClient>`
@@ -217,7 +216,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **FpssEvent split** — `FpssEvent::Quote { .. }` is now `FpssEvent::Data(FpssData::Quote { .. })`.
   Control events are `FpssEvent::Control(FpssControl::*)`. Migration: wrap your match arms.
 - **OHLCVC derivation opt-in/out** — `connect()` still derives OHLCVC (default).
-  New `connect_no_ohlcvc()` disables it for lower overhead on full trade streams.
+  Set `DirectConfig::derive_ohlcvc` to `false` to disable for lower overhead on full trade streams.
 - **FpssClient is fully sync** — no tokio in the streaming path. LMAX Disruptor
   ring buffer. Callback API: `FnMut(&FpssEvent)`.
 

--- a/docs-site/docs/streaming.md
+++ b/docs-site/docs/streaming.md
@@ -492,8 +492,7 @@ Undecoded fallback for corrupt or unrecognized frames. Fields: `code` (u8), `pay
 
 | Method | Description |
 |--------|-------------|
-| `start_streaming(callback)` | Begin streaming with an event callback |
-| `start_streaming_no_ohlcvc(callback)` | Start without local OHLCVC derivation |
+| `start_streaming(callback)` | Begin streaming with an event callback (reads `derive_ohlcvc` from config) |
 | `subscribe_quotes(contract)` | Subscribe to quote data |
 | `subscribe_trades(contract)` | Subscribe to trade data |
 | `subscribe_open_interest(contract)` | Subscribe to open interest |
@@ -516,8 +515,7 @@ Undecoded fallback for corrupt or unrecognized frames. Fields: `code` (u8), `pay
 
 | Method | Description |
 |--------|-------------|
-| `start_streaming()` | Connect to FPSS streaming servers |
-| `start_streaming_no_ohlcvc()` | Connect without OHLCVC derivation |
+| `start_streaming()` | Connect to FPSS streaming servers (reads `derive_ohlcvc` from config) |
 | `subscribe_quotes(symbol)` | Subscribe to quote data |
 | `subscribe_trades(symbol)` | Subscribe to trade data |
 | `subscribe_open_interest(symbol)` | Subscribe to open interest |

--- a/docs-site/docs/streaming/events.md
+++ b/docs-site/docs/streaming/events.md
@@ -292,7 +292,7 @@ The dev server (port 20200) sends a simplified 8-field trade format: `ms_of_day`
 | `received_at_ns` | `u64` | Wall-clock nanoseconds since UNIX epoch |
 
 ::: tip
-OHLCVC bars can come from two sources: wire code 24 (server-sent bars) or trade-derived (computed locally from trade events when OHLCVC derivation is enabled). Use `start_streaming_no_ohlcvc()` to disable local derivation.
+OHLCVC bars can come from two sources: wire code 24 (server-sent bars) or trade-derived (computed locally from trade events when OHLCVC derivation is enabled). Set `config.derive_ohlcvc = false` (Rust: `DirectConfig::production().derive_ohlcvc(false)`) to disable local derivation.
 :::
 
 ## Control Event Reference
@@ -392,8 +392,7 @@ Price fields (`Bid`, `Ask`, `Price`, `Open`, `High`, `Low`, `Close`) are pre-dec
 
 | Method | Description |
 |--------|-------------|
-| `start_streaming(callback)` | Begin streaming with an event callback |
-| `start_streaming_no_ohlcvc(callback)` | Start without local OHLCVC derivation |
+| `start_streaming(callback)` | Begin streaming with an event callback (reads `derive_ohlcvc` from config) |
 | `subscribe_quotes(contract)` | Subscribe to quote data |
 | `subscribe_trades(contract)` | Subscribe to trade data |
 | `subscribe_open_interest(contract)` | Subscribe to open interest |
@@ -416,8 +415,7 @@ Price fields (`Bid`, `Ask`, `Price`, `Open`, `High`, `Low`, `Close`) are pre-dec
 
 | Method | Description |
 |--------|-------------|
-| `start_streaming()` | Connect to FPSS streaming servers |
-| `start_streaming_no_ohlcvc()` | Connect without OHLCVC derivation |
+| `start_streaming()` | Connect to FPSS streaming servers (reads `derive_ohlcvc` from config) |
 | `subscribe_quotes(symbol)` | Subscribe to quote data |
 | `subscribe_trades(symbol)` | Subscribe to trade data |
 | `subscribe_open_interest(symbol)` | Subscribe to open interest |

--- a/docs/jvm-deviations.md
+++ b/docs/jvm-deviations.md
@@ -15,7 +15,7 @@ Intentional differences between this Rust implementation and the decompiled Java
 As of v1.2.0:
 - **Contract wire format** — now matches Java exactly (fixed in PR #12; previous versions had a protocol-level bug in option contract serialization).
 - **Greeks formulas** — operator precedence now matches Java exactly (fixed in PR #12). Note: `vera` (DataType code 166) is returned by the server in Greeks responses, not computed locally by the SDK.
-- **OHLCVC-from-trade derivation** — matches Java behavior when enabled (default). Unlike Java, this is **opt-in/out**: use `ThetaDataDx::start_streaming_no_ohlcvc()` to disable derived OHLCVC events and reduce per-trade throughput overhead. The Java terminal always derives OHLCVC with no way to disable it.
+- **OHLCVC-from-trade derivation** — matches Java behavior when enabled (default). Unlike Java, this is **opt-in/out**: set `DirectConfig::derive_ohlcvc` to `false` to disable derived OHLCVC events and reduce per-trade throughput overhead. The Java terminal always derives OHLCVC with no way to disable it.
 
 ## Client-Side Behavior
 

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -38,7 +38,6 @@ All 61 endpoints are available as `tdx_stock_*`, `tdx_option_*`, `tdx_index_*`, 
 | Function | Description |
 |----------|-------------|
 | `tdx_unified_start_streaming` | Start FPSS on the unified handle |
-| `tdx_unified_start_streaming_no_ohlcvc` | Start FPSS without derived OHLCVC |
 | `tdx_unified_subscribe_quotes` | Subscribe to quote stream |
 | `tdx_unified_subscribe_trades` | Subscribe to trade stream |
 | `tdx_unified_subscribe_open_interest` | Subscribe to open interest stream |

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -753,6 +753,19 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_policy(config: *mut TdxConfig,
     };
 }
 
+/// Set FPSS OHLCVC derivation on a config handle.
+///
+/// - `enabled = 1` (default): derive OHLCVC bars locally from trade events
+/// - `enabled = 0`: only emit server-sent OHLCVC frames (lower overhead)
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_set_derive_ohlcvc(config: *mut TdxConfig, enabled: i32) {
+    if config.is_null() {
+        return;
+    }
+    let config = unsafe { &mut *config };
+    config.inner.derive_ohlcvc = enabled != 0;
+}
+
 // ── Client ──
 
 /// Connect to ThetaData servers (authenticates via Nexus API).
@@ -1987,38 +2000,6 @@ pub unsafe extern "C" fn tdx_unified_start_streaming(handle: *const TdxUnified) 
     }
 }
 
-/// Start FPSS streaming with OHLCVC derivation disabled.
-///
-/// Returns 0 on success, -1 on error (check `tdx_last_error()`).
-#[no_mangle]
-pub unsafe extern "C" fn tdx_unified_start_streaming_no_ohlcvc(handle: *const TdxUnified) -> i32 {
-    if handle.is_null() {
-        set_error("unified handle is null");
-        return -1;
-    }
-    let handle = unsafe { &*handle };
-
-    let (tx, rx) = std::sync::mpsc::channel::<FfiBufferedEvent>();
-
-    match handle
-        .inner
-        .start_streaming_no_ohlcvc(move |event: &thetadatadx::fpss::FpssEvent| {
-            let buffered = fpss_event_to_ffi(event);
-            let _ = tx.send(buffered);
-        }) {
-        Ok(()) => {
-            if let Ok(mut guard) = handle.rx.lock() {
-                *guard = Some(Arc::new(Mutex::new(rx)));
-            }
-            0
-        }
-        Err(e) => {
-            set_error(&e.to_string());
-            -1
-        }
-    }
-}
-
 /// Subscribe to quote data for a stock symbol via the unified client.
 ///
 /// Returns the request ID on success, or -1 on error (check `tdx_last_error()`).
@@ -2526,6 +2507,7 @@ pub unsafe extern "C" fn tdx_fpss_connect(
         config.inner.fpss_ring_size,
         config.inner.fpss_flush_mode,
         config.inner.reconnect_policy.clone(),
+        config.inner.derive_ohlcvc,
         move |event: &thetadatadx::fpss::FpssEvent| {
             let buffered = fpss_event_to_ffi(event);
             let _ = tx.send(buffered);

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -400,6 +400,13 @@ void tdx_config_set_reconnect_policy(TdxConfig* config, int policy);
  */
 void tdx_config_set_flush_mode(TdxConfig* config, int mode);
 
+/**
+ * Set FPSS OHLCVC derivation on a config handle.
+ *   enabled=1 (default): derive OHLCVC bars locally from trade events.
+ *   enabled=0: only emit server-sent OHLCVC frames (lower overhead).
+ */
+void tdx_config_set_derive_ohlcvc(TdxConfig* config, int enabled);
+
 /* ── Client ── */
 
 /** Connect to ThetaData servers. Returns NULL on connection/auth failure. */

--- a/sdks/go/thetadx.go
+++ b/sdks/go/thetadx.go
@@ -28,6 +28,7 @@ extern TdxConfig* tdx_config_stage();
 extern void tdx_config_free(TdxConfig* config);
 extern void tdx_config_set_reconnect_policy(TdxConfig* config, int policy);
 extern void tdx_config_set_flush_mode(TdxConfig* config, int mode);
+extern void tdx_config_set_derive_ohlcvc(TdxConfig* config, int enabled);
 
 // ── Client ──
 extern TdxClient* tdx_client_connect(const TdxCredentials* creds, const TdxConfig* config);
@@ -317,6 +318,17 @@ func (c *Config) SetReconnectPolicy(policy int) {
 //   - 1 = Immediate: flush after every frame write.
 func (c *Config) SetFlushMode(mode int) {
 	C.tdx_config_set_flush_mode(c.handle, C.int(mode))
+}
+
+// SetDeriveOhlcvc sets whether to derive OHLCVC bars locally from trade events.
+//   - true (default): derive OHLCVC bars from trades.
+//   - false: only emit server-sent OHLCVC frames (lower overhead).
+func (c *Config) SetDeriveOhlcvc(enabled bool) {
+	v := 0
+	if enabled {
+		v = 1
+	}
+	C.tdx_config_set_derive_ohlcvc(c.handle, C.int(v))
 }
 
 // Close frees the config handle.

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -135,6 +135,21 @@ impl Config {
         }
     }
 
+    /// Set whether to derive OHLCVC bars locally from trade events.
+    ///
+    /// When ``False``, only server-sent OHLCVC frames are emitted,
+    /// reducing per-trade throughput overhead.
+    #[setter]
+    fn set_derive_ohlcvc(&mut self, enabled: bool) {
+        self.inner.derive_ohlcvc = enabled;
+    }
+
+    /// Get the current OHLCVC derivation setting.
+    #[getter]
+    fn get_derive_ohlcvc(&self) -> bool {
+        self.inner.derive_ohlcvc
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Config(mdds={}:{}, fpss_hosts={})",
@@ -973,23 +988,6 @@ impl ThetaDataDx {
 
         self.tdx
             .start_streaming(move |event: &fpss::FpssEvent| {
-                let buffered = fpss_event_to_buffered(event);
-                let _ = tx.send(buffered);
-            })
-            .map_err(to_py_err)?;
-
-        if let Ok(mut guard) = self.rx.lock() {
-            *guard = Some(Arc::new(Mutex::new(rx)));
-        }
-        Ok(())
-    }
-
-    /// Start FPSS streaming with OHLCVC derivation disabled.
-    fn start_streaming_no_ohlcvc(&self) -> PyResult<()> {
-        let (tx, rx) = std::sync::mpsc::channel::<BufferedEvent>();
-
-        self.tdx
-            .start_streaming_no_ohlcvc(move |event: &fpss::FpssEvent| {
                 let buffered = fpss_event_to_buffered(event);
                 let _ = tx.send(buffered);
             })


### PR DESCRIPTION
## Summary

- Add `derive_ohlcvc: bool` field to `DirectConfig` (default `true`) with builder method
- Remove `FpssClient::connect_no_ohlcvc()` -- `connect()` now takes `derive_ohlcvc: bool` parameter
- Remove `ThetaDataDx::start_streaming_no_ohlcvc()` -- `start_streaming()` reads from config
- Remove `tdx_unified_start_streaming_no_ohlcvc` FFI function
- Add `tdx_config_set_derive_ohlcvc` FFI function
- Add Python `Config.derive_ohlcvc` getter/setter
- Add Go `Config.SetDeriveOhlcvc(bool)` method
- Add C header `tdx_config_set_derive_ohlcvc` declaration
- Update all docs (streaming.md, events.md, jvm-deviations.md, changelogs, ffi README)

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (230 tests, 3 doc-tests)
- [ ] Verify Python SDK builds with `maturin develop`
- [ ] Verify Go SDK compiles with `go build`

Closes #129

Generated with [Claude Code](https://claude.com/claude-code)