### PR TITLE
feat: terminal parity — STOP suppression, auth retry, config validation, password warning

### DIFF
--- a/crates/thetadatadx/src/auth/nexus.rs
+++ b/crates/thetadatadx/src/auth/nexus.rs
@@ -138,6 +138,20 @@ impl AuthUser {
 
 // -- Public API --
 
+/// Maximum number of retry attempts for transient network errors during auth.
+const AUTH_MAX_RETRIES: u32 = 3;
+
+/// Delay between auth retry attempts.
+const AUTH_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+/// Check whether a `reqwest` error is a transient network error worth retrying.
+///
+/// Returns `true` for connection refused, timeouts, and DNS failures.
+/// Returns `false` for auth failures (wrong password) and server-side rejections.
+fn is_transient_network_error(err: &reqwest::Error) -> bool {
+    err.is_connect() || err.is_timeout()
+}
+
 /// Authenticate against the Nexus API and return the session info.
 ///
 /// This performs the same HTTP POST as the Java terminal's
@@ -145,6 +159,11 @@ impl AuthUser {
 ///
 /// The returned `AuthResponse.session_id` is a UUID string that must be
 /// embedded in every MDDS gRPC request as `QueryInfo.auth_token.session_uuid`.
+///
+/// Transient network errors (connection refused, timeout, DNS failure) are
+/// retried up to 3 times with 2-second delays. Auth failures (wrong password,
+/// invalid credentials) are NOT retried.
+///
 /// # Errors
 ///
 /// Returns an error on network, authentication, or parsing failure.
@@ -169,14 +188,42 @@ pub async fn authenticate(creds: &Credentials) -> Result<AuthResponse, Error> {
         "authenticating against Nexus API"
     );
 
-    let resp = client
-        .post(NEXUS_AUTH_URL)
-        .header(TERMINAL_KEY_HEADER, TERMINAL_KEY)
-        .header("Accept", "application/json")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| Error::Auth(format!("Nexus API request failed: {e}")))?;
+    // Retry loop for transient network errors (connection refused, timeout, DNS).
+    // Auth failures (wrong password, 401/404) are NOT retried.
+    let mut last_err: Option<reqwest::Error> = None;
+    let resp = 'retry: {
+        for attempt in 1..=AUTH_MAX_RETRIES {
+            match client
+                .post(NEXUS_AUTH_URL)
+                .header(TERMINAL_KEY_HEADER, TERMINAL_KEY)
+                .header("Accept", "application/json")
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(r) => break 'retry r,
+                Err(e) if is_transient_network_error(&e) && attempt < AUTH_MAX_RETRIES => {
+                    tracing::warn!(
+                        attempt,
+                        max = AUTH_MAX_RETRIES,
+                        error = %e,
+                        delay_secs = AUTH_RETRY_DELAY.as_secs(),
+                        "Nexus auth request failed (transient), retrying"
+                    );
+                    last_err = Some(e);
+                    tokio::time::sleep(AUTH_RETRY_DELAY).await;
+                }
+                Err(e) => {
+                    return Err(Error::Auth(format!("Nexus API request failed: {e}")));
+                }
+            }
+        }
+        // All retries exhausted (should not reach here, but handle defensively).
+        return Err(Error::Auth(format!(
+            "Nexus API request failed after {AUTH_MAX_RETRIES} retries: {}",
+            last_err.map_or_else(|| "unknown".to_string(), |e| e.to_string())
+        )));
+    };
 
     let status = resp.status();
     // Java special-cases 401 and 404 as "invalid credentials".

--- a/crates/thetadatadx/src/config.rs
+++ b/crates/thetadatadx/src/config.rs
@@ -39,6 +39,29 @@ use tdbe::types::enums::RemoveReason;
 
 use crate::error::Error;
 
+/// Clamp a `usize` value to `[min, max]`, logging a warning if it was out of range.
+fn clamp_with_warning(value: usize, min: usize, max: usize, name: &str) -> usize {
+    if value < min {
+        tracing::warn!(
+            field = name,
+            value,
+            min,
+            "config value below minimum, clamped"
+        );
+        min
+    } else if value > max {
+        tracing::warn!(
+            field = name,
+            value,
+            max,
+            "config value above maximum, clamped"
+        );
+        max
+    } else {
+        value
+    }
+}
+
 /// Controls FPSS reconnection behavior after a disconnect.
 ///
 /// # Default
@@ -299,6 +322,7 @@ impl DirectConfig {
             // Default: use all CPU cores
             tokio_worker_threads: None,
         }
+        .validate()
     }
 
     /// Dev FPSS configuration.
@@ -324,7 +348,7 @@ impl DirectConfig {
             ("test-server.thetadata.us".to_string(), 20200),
             ("test-server.thetadata.us".to_string(), 20201),
         ];
-        config
+        config.validate()
     }
 
     /// Stage FPSS configuration.
@@ -344,7 +368,28 @@ impl DirectConfig {
             ("test-server.thetadata.us".to_string(), 20100),
             ("test-server.thetadata.us".to_string(), 20101),
         ];
-        config
+        config.validate()
+    }
+
+    /// Validate configuration values and clamp out-of-range fields, logging
+    /// a warning for each clamped value.
+    ///
+    /// Called automatically by [`production()`](Self::production),
+    /// [`dev()`](Self::dev), and [`stage()`](Self::stage). Also useful after
+    /// loading from a TOML file or modifying fields programmatically.
+    #[must_use]
+    pub fn validate(mut self) -> Self {
+        self.fpss_queue_depth =
+            clamp_with_warning(self.fpss_queue_depth, 16, 1_000_000, "fpss_queue_depth");
+        self.mdds_window_size_kb =
+            clamp_with_warning(self.mdds_window_size_kb, 64, 1_024, "mdds_window_size_kb");
+        self.mdds_connection_window_size_kb = clamp_with_warning(
+            self.mdds_connection_window_size_kb,
+            64,
+            1_024,
+            "mdds_connection_window_size_kb",
+        );
+        self
     }
 
     /// Build the MDDS gRPC endpoint URI.
@@ -654,7 +699,8 @@ mod config_file {
                 derive_ohlcvc: true,
 
                 tokio_worker_threads: None,
-            })
+            }
+            .validate())
         }
     }
 }
@@ -903,6 +949,58 @@ mod tests {
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("TOML"));
         }
+    }
+
+    // -- Validation tests --
+
+    #[test]
+    fn validate_clamps_fpss_queue_depth_below_min() {
+        let mut config = DirectConfig::production();
+        config.fpss_queue_depth = 5;
+        let config = config.validate();
+        assert_eq!(config.fpss_queue_depth, 16);
+    }
+
+    #[test]
+    fn validate_clamps_fpss_queue_depth_above_max() {
+        let mut config = DirectConfig::production();
+        config.fpss_queue_depth = 2_000_000;
+        let config = config.validate();
+        assert_eq!(config.fpss_queue_depth, 1_000_000);
+    }
+
+    #[test]
+    fn validate_clamps_window_size_below_min() {
+        let mut config = DirectConfig::production();
+        config.mdds_window_size_kb = 10;
+        let config = config.validate();
+        assert_eq!(config.mdds_window_size_kb, 64);
+    }
+
+    #[test]
+    fn validate_clamps_window_size_above_max() {
+        let mut config = DirectConfig::production();
+        config.mdds_window_size_kb = 2_048;
+        let config = config.validate();
+        assert_eq!(config.mdds_window_size_kb, 1_024);
+    }
+
+    #[test]
+    fn validate_clamps_connection_window_size() {
+        let mut config = DirectConfig::production();
+        config.mdds_connection_window_size_kb = 2_048;
+        let config = config.validate();
+        assert_eq!(config.mdds_connection_window_size_kb, 1_024);
+    }
+
+    #[test]
+    fn validate_preserves_in_range_values() {
+        let config = DirectConfig::production();
+        let validated = config.validate();
+        // Production defaults are all within range.
+        assert_eq!(validated.fpss_queue_depth, 1_000_000);
+        assert_eq!(validated.mdds_window_size_kb, 64);
+        assert_eq!(validated.mdds_connection_window_size_kb, 64);
     }
 
     // -- Metrics tests --

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -91,7 +91,7 @@ use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use disruptor::{build_single_producer, Producer, Sequence};
 
@@ -417,6 +417,17 @@ impl FpssClient {
                 permissions
             }
             LoginResult::Disconnected(reason) => {
+                if matches!(
+                    reason,
+                    RemoveReason::InvalidCredentials
+                        | RemoveReason::InvalidLoginValues
+                        | RemoveReason::InvalidCredentialsNullUser
+                ) {
+                    tracing::warn!(
+                        "FPSS login failed. If your password contains special characters, \
+                         try URL-encoding them."
+                    );
+                }
                 return Err(Error::FpssDisconnected(format!(
                     "server rejected login: {reason:?}"
                 )));
@@ -1244,6 +1255,17 @@ fn io_loop<F>(
                 p
             }
             LoginResult::Disconnected(reason) => {
+                if matches!(
+                    reason,
+                    RemoveReason::InvalidCredentials
+                        | RemoveReason::InvalidLoginValues
+                        | RemoveReason::InvalidCredentialsNullUser
+                ) {
+                    tracing::warn!(
+                        "FPSS login failed. If your password contains special characters, \
+                         try URL-encoding them."
+                    );
+                }
                 tracing::warn!(reason = ?reason, "server rejected login on reconnect");
                 continue 'session;
             }
@@ -1488,7 +1510,15 @@ struct DeltaState {
     /// `(msg_type, contract_id)`. The dev server sends 8-field trades (simple
     /// format) while production sends 16-field trades (extended format).
     field_counts: HashMap<(u8, i32), usize>,
+    /// Timestamp of last STOP (market close) signal. Used to suppress
+    /// "unknown `contract_id`" warnings for 5 seconds after STOP, matching
+    /// Java terminal behavior where stale ticks are expected during teardown.
+    last_stop: Option<Instant>,
 }
+
+/// Duration after a STOP signal during which "unknown `contract_id`" warnings
+/// are suppressed. The Java terminal silences these for 5 seconds.
+const STOP_SUPPRESS_DURATION: Duration = Duration::from_secs(5);
 
 impl DeltaState {
     fn new() -> Self {
@@ -1499,6 +1529,7 @@ impl DeltaState {
             alloc_buf: vec![0i32; TRADE_FIELDS + 1],
             last_was_date: false,
             field_counts: HashMap::new(),
+            last_stop: None,
         }
     }
 
@@ -1507,11 +1538,21 @@ impl DeltaState {
     /// Called on START/STOP (market open/close) signals to reset delta
     /// decompression, matching Java's behavior where `Tick.readID()` starts
     /// fresh after a session boundary.
+    ///
+    /// Note: `last_stop` is intentionally NOT cleared here because STOP
+    /// itself calls `clear()`, and the timestamp must survive to suppress
+    /// stale-tick warnings for 5 seconds after the STOP signal.
     fn clear(&mut self) {
         self.prev.clear();
         self.ohlcvc.clear();
         self.last_was_date = false;
         self.field_counts.clear();
+    }
+
+    /// Whether we are within the post-STOP suppression window.
+    fn is_in_stop_suppression_window(&self) -> bool {
+        self.last_stop
+            .is_some_and(|t| t.elapsed() < STOP_SUPPRESS_DURATION)
     }
 
     /// Decode FIT payload and apply delta decompression.
@@ -1627,6 +1668,19 @@ fn decode_frame(
         .unwrap_or_default()
         .as_nanos() as u64;
 
+    // Log a warning when ticks arrive for contract IDs not in the map,
+    // but suppress for 5 seconds after STOP (market close) since stale
+    // ticks are expected during teardown. Matches Java terminal behavior.
+    let warn_unknown_contract = |contract_id: i32, kind: &str, delta_state: &DeltaState| {
+        let known = contract_map
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains_key(&contract_id);
+        if !known && !delta_state.is_in_stop_suppression_window() {
+            tracing::warn!(contract_id, kind, "no contract for ID");
+        }
+    };
+
     match code {
         StreamMsgType::Metadata => {
             // Can arrive again after reconnection
@@ -1671,6 +1725,7 @@ fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, QUOTE_FIELDS) {
                 Some((contract_id, f, _n)) => {
+                    warn_unknown_contract(contract_id, "quote", delta_state);
                     metrics::counter!("thetadatadx.fpss.events", "kind" => "quote").increment(1);
                     let pt = f[9];
                     (
@@ -1711,6 +1766,7 @@ fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, TRADE_FIELDS) {
                 Some((contract_id, f, n_data)) => {
+                    warn_unknown_contract(contract_id, "trade", delta_state);
                     metrics::counter!("thetadatadx.fpss.events", "kind" => "trade").increment(1);
 
                     if n_data != 8 && n_data != TRADE_FIELDS {
@@ -1830,6 +1886,7 @@ fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, OI_FIELDS) {
                 Some((contract_id, f, _n)) => {
+                    warn_unknown_contract(contract_id, "open_interest", delta_state);
                     metrics::counter!("thetadatadx.fpss.events", "kind" => "open_interest")
                         .increment(1);
                     (
@@ -1858,6 +1915,7 @@ fn decode_frame(
             let msg_code = code as u8;
             match delta_state.decode_tick(msg_code, payload, OHLCVC_FIELDS) {
                 Some((contract_id, f, _n)) => {
+                    warn_unknown_contract(contract_id, "ohlcvc", delta_state);
                     metrics::counter!("thetadatadx.fpss.events", "kind" => "ohlcvc").increment(1);
                     let acc = delta_state
                         .ohlcvc
@@ -1931,6 +1989,7 @@ fn decode_frame(
 
         StreamMsgType::Stop => {
             tracing::info!("market close signal received");
+            delta_state.last_stop = Some(Instant::now());
             delta_state.clear();
             contract_map
                 .lock()


### PR DESCRIPTION
## Summary

- **#124 — Error suppression after STOP**: Added `last_stop: Option<Instant>` to `DeltaState`. After a STOP (market close) signal, "no contract for ID" warnings are suppressed for 5 seconds, matching Java terminal behavior where stale ticks are expected during teardown.
- **#125 — Auth retry on transient errors**: The Nexus auth HTTP request now retries up to 3 times with 2-second delays on transient network errors (connection refused, timeout). Auth failures (wrong password, 401/404) are NOT retried.
- **#126 — Config validation**: Added `DirectConfig::validate()` that clamps `fpss_queue_depth` (16..=1,000,000), `mdds_window_size_kb` (64..=1,024), and `mdds_connection_window_size_kb` (64..=1,024) with tracing warnings. Called automatically from `production()`, `dev()`, `stage()`, and `from_toml_str()`.
- **#127 — Password character warning**: On FPSS login failure with `InvalidCredentials`/`InvalidLoginValues`/`InvalidCredentialsNullUser`, logs "FPSS login failed. If your password contains special characters, try URL-encoding them." — matching Java terminal's password hint.

Closes #124 Closes #125 Closes #126 Closes #127

## Test plan

- [x] `cargo clippy --workspace -- -D warnings -W clippy::pedantic` — zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] 6 new validation tests in `config::tests`
- [x] Config-file feature tests verified (`cargo test --features config-file`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)