### PR TITLE
feat: REST server as drop-in terminal replacement

### DIFF
--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1026,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,9 +1043,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1117,6 +1139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1198,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1777,11 +1811,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1949,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1969,9 +2003,11 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "4.5.0"
+version = "5.3.1"
 dependencies = [
  "disruptor",
+ "metrics",
+ "paste",
  "prost",
  "prost-build",
  "prost-types",
@@ -1996,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "4.5.0"
+version = "5.3.1"
 dependencies = [
  "axum",
  "clap",
@@ -2087,9 +2123,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -2104,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2161,44 +2197,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -2922,12 +2956,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -12,12 +12,14 @@ license = "GPL-3.0-or-later"
 keywords = ["thetadata", "terminal", "market-data", "rest-api", "websocket"]
 categories = ["finance", "network-programming", "web-programming::http-server"]
 
+[workspace]
+
 [[bin]]
 name = "thetadatadx-server"
 path = "src/main.rs"
 
 [dependencies]
-thetadatadx = { path = "../../crates/thetadatadx" }
+thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 tdbe = { version = "0.5.0", path = "../../crates/tdbe" }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -7,12 +7,19 @@ Existing clients (Python SDK, Excel add-ins, curl scripts, browsers) work withou
 ## Quick start
 
 ```bash
-# Create credentials file (same format as the Java terminal)
+# With email/password directly (no creds file needed)
+thetadatadx-server --email you@example.com --password YOUR_PASSWORD
+
+# With credentials file (same format as the Java terminal)
 echo "your@email.com" > creds.txt
 echo "your_password" >> creds.txt
-
-# Run the server
 thetadatadx-server --creds creds.txt
+
+# With a TOML config file (same format as Java terminal's config.toml)
+thetadatadx-server --email you@example.com --password YOUR_PASSWORD --config config.toml
+
+# With a specific FPSS region
+thetadatadx-server --email you@example.com --password YOUR_PASSWORD --fpss-region dev
 ```
 
 The server starts:
@@ -23,15 +30,20 @@ The server starts:
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--email` | | ThetaData email (alternative to `--creds`) |
+| `--password` | | ThetaData password (alternative to `--creds`) |
 | `--creds` | `creds.txt` | Path to credentials file |
+| `--config` | | Path to TOML config file (same format as Java terminal) |
+| `--fpss-region` | `production` | FPSS region: `production`, `dev`, `stage` |
 | `--http-port` | `25503` | HTTP REST API port |
 | `--ws-port` | `25520` | WebSocket server port |
 | `--bind` | `127.0.0.1` | Bind address |
 | `--log-level` | `info` | Log level (`debug`, `trace`, `thetadatadx=trace`) |
+| `--no-fpss` | | Skip FPSS streaming connection at startup |
 
 ## REST API
 
-All 61 registry endpoints are auto-generated into REST routes at startup from `ENDPOINTS`. Plus 3 system routes = 64 total HTTP routes.
+All 61 registry endpoints are auto-generated into REST routes at startup from `ENDPOINTS`. Plus 4 system routes = 65 total HTTP routes.
 
 Routes follow the Java terminal's URL patterns:
 
@@ -132,11 +144,12 @@ GET /v3/calendar/year?year=...
 GET /v3/hist/rate/eod?root=...&start_date=...&end_date=...
 ```
 
-### System Routes (3)
+### System Routes (4)
 
 ```
+GET /v3/system/status          # {"status":"CONNECTED","version":"5.3.1"}
 GET /v3/system/mdds/status
-GET /v3/system/fpss/status
+GET /v3/system/fpss/status     # {"status":"CONNECTED","version":"5.3.1"}
 GET /v3/system/shutdown
 ```
 

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -13,7 +13,6 @@
 use sonic_rs::prelude::*;
 use tdbe::types::price::Price;
 use tdbe::types::tick::*;
-use thetadatadx::proto;
 
 // ---------------------------------------------------------------------------
 //  JSON envelope

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -202,33 +202,25 @@ async fn dispatch(
         "stock_snapshot_ohlc" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let ticks = client
-                .stock_snapshot_ohlc(&syms)
-                .await?;
+            let ticks = client.stock_snapshot_ohlc(&syms).await?;
             Ok(format::ok_envelope(format::ohlc_ticks_to_json(&ticks)))
         }
         "stock_snapshot_trade" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let ticks = client
-                .stock_snapshot_trade(&syms)
-                .await?;
+            let ticks = client.stock_snapshot_trade(&syms).await?;
             Ok(format::ok_envelope(format::trade_ticks_to_json(&ticks)))
         }
         "stock_snapshot_quote" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let ticks = client
-                .stock_snapshot_quote(&syms)
-                .await?;
+            let ticks = client.stock_snapshot_quote(&syms).await?;
             Ok(format::ok_envelope(format::quote_ticks_to_json(&ticks)))
         }
         "stock_snapshot_market_value" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let ticks = client
-                .stock_snapshot_market_value(&syms)
-                .await?;
+            let ticks = client.stock_snapshot_market_value(&syms).await?;
             Ok(format::ok_envelope(format::market_value_ticks_to_json(
                 &ticks,
             )))
@@ -241,45 +233,28 @@ async fn dispatch(
         }
         "stock_history_ohlc" => {
             let ticks = client
-                .stock_history_ohlc(
-                    &sym(),
-                    &date(),
-                    &interval(),
-                )
+                .stock_history_ohlc(&sym(), &date(), &interval())
                 .await?;
             Ok(format::ok_envelope(format::ohlc_ticks_to_json(&ticks)))
         }
         "stock_history_ohlc_range" => {
             let ticks = client
-                .stock_history_ohlc_range(
-                    &sym(),
-                    &start(),
-                    &end(),
-                    &interval(),
-                )
+                .stock_history_ohlc_range(&sym(), &start(), &end(), &interval())
                 .await?;
             Ok(format::ok_envelope(format::ohlc_ticks_to_json(&ticks)))
         }
         "stock_history_trade" => {
-            let ticks = client
-                .stock_history_trade(&sym(), &date())
-                .await?;
+            let ticks = client.stock_history_trade(&sym(), &date()).await?;
             Ok(format::ok_envelope(format::trade_ticks_to_json(&ticks)))
         }
         "stock_history_quote" => {
             let ticks = client
-                .stock_history_quote(
-                    &sym(),
-                    &date(),
-                    &interval_quote(),
-                )
+                .stock_history_quote(&sym(), &date(), &interval_quote())
                 .await?;
             Ok(format::ok_envelope(format::quote_ticks_to_json(&ticks)))
         }
         "stock_history_trade_quote" => {
-            let ticks = client
-                .stock_history_trade_quote(&sym(), &date())
-                .await?;
+            let ticks = client.stock_history_trade_quote(&sym(), &date()).await?;
             Ok(format::ok_envelope(format::trade_quote_ticks_to_json(
                 &ticks,
             )))
@@ -288,23 +263,13 @@ async fn dispatch(
         // ── Stock At-Time (2) ───────────────────────────────────────
         "stock_at_time_trade" => {
             let ticks = client
-                .stock_at_time_trade(
-                    &sym(),
-                    &start(),
-                    &end(),
-                    &time_of_day(),
-                )
+                .stock_at_time_trade(&sym(), &start(), &end(), &time_of_day())
                 .await?;
             Ok(format::ok_envelope(format::trade_ticks_to_json(&ticks)))
         }
         "stock_at_time_quote" => {
             let ticks = client
-                .stock_at_time_quote(
-                    &sym(),
-                    &start(),
-                    &end(),
-                    &time_of_day(),
-                )
+                .stock_at_time_quote(&sym(), &start(), &end(), &time_of_day())
                 .await?;
             Ok(format::ok_envelope(format::quote_ticks_to_json(&ticks)))
         }
@@ -358,12 +323,7 @@ async fn dispatch(
         }
         "option_snapshot_open_interest" => {
             let ticks = client
-                .option_snapshot_open_interest(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                )
+                .option_snapshot_open_interest(&sym(), &exp(), &strike(), &right())
                 .await?;
             Ok(format::ok_envelope(format::open_interest_ticks_to_json(
                 &ticks,
@@ -371,12 +331,7 @@ async fn dispatch(
         }
         "option_snapshot_market_value" => {
             let ticks = client
-                .option_snapshot_market_value(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                )
+                .option_snapshot_market_value(&sym(), &exp(), &strike(), &right())
                 .await?;
             Ok(format::ok_envelope(format::market_value_ticks_to_json(
                 &ticks,
@@ -384,56 +339,31 @@ async fn dispatch(
         }
         "option_snapshot_greeks_implied_volatility" => {
             let ticks = client
-                .option_snapshot_greeks_implied_volatility(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                )
+                .option_snapshot_greeks_implied_volatility(&sym(), &exp(), &strike(), &right())
                 .await?;
             Ok(format::ok_envelope(format::iv_ticks_to_json(&ticks)))
         }
         "option_snapshot_greeks_all" => {
             let ticks = client
-                .option_snapshot_greeks_all(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                )
+                .option_snapshot_greeks_all(&sym(), &exp(), &strike(), &right())
                 .await?;
             Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_snapshot_greeks_first_order" => {
             let ticks = client
-                .option_snapshot_greeks_first_order(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                )
+                .option_snapshot_greeks_first_order(&sym(), &exp(), &strike(), &right())
                 .await?;
             Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_snapshot_greeks_second_order" => {
             let ticks = client
-                .option_snapshot_greeks_second_order(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                )
+                .option_snapshot_greeks_second_order(&sym(), &exp(), &strike(), &right())
                 .await?;
             Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
         "option_snapshot_greeks_third_order" => {
             let ticks = client
-                .option_snapshot_greeks_third_order(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                )
+                .option_snapshot_greeks_third_order(&sym(), &exp(), &strike(), &right())
                 .await?;
             Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
@@ -447,26 +377,13 @@ async fn dispatch(
         }
         "option_history_ohlc" => {
             let ticks = client
-                .option_history_ohlc(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                    &date(),
-                    &interval(),
-                )
+                .option_history_ohlc(&sym(), &exp(), &strike(), &right(), &date(), &interval())
                 .await?;
             Ok(format::ok_envelope(format::ohlc_ticks_to_json(&ticks)))
         }
         "option_history_trade" => {
             let ticks = client
-                .option_history_trade(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                    &date(),
-                )
+                .option_history_trade(&sym(), &exp(), &strike(), &right(), &date())
                 .await?;
             Ok(format::ok_envelope(format::trade_ticks_to_json(&ticks)))
         }
@@ -485,13 +402,7 @@ async fn dispatch(
         }
         "option_history_trade_quote" => {
             let ticks = client
-                .option_history_trade_quote(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                    &date(),
-                )
+                .option_history_trade_quote(&sym(), &exp(), &strike(), &right(), &date())
                 .await?;
             Ok(format::ok_envelope(format::trade_quote_ticks_to_json(
                 &ticks,
@@ -499,13 +410,7 @@ async fn dispatch(
         }
         "option_history_open_interest" => {
             let ticks = client
-                .option_history_open_interest(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                    &date(),
-                )
+                .option_history_open_interest(&sym(), &exp(), &strike(), &right(), &date())
                 .await?;
             Ok(format::ok_envelope(format::open_interest_ticks_to_json(
                 &ticks,
@@ -515,14 +420,7 @@ async fn dispatch(
         // ── Option History Greeks (12) ──────────────────────────────
         "option_history_greeks_eod" => {
             let ticks = client
-                .option_history_greeks_eod(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                    &start(),
-                    &end(),
-                )
+                .option_history_greeks_eod(&sym(), &exp(), &strike(), &right(), &start(), &end())
                 .await?;
             Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
@@ -541,13 +439,7 @@ async fn dispatch(
         }
         "option_history_trade_greeks_all" => {
             let ticks = client
-                .option_history_trade_greeks_all(
-                    &sym(),
-                    &exp(),
-                    &strike(),
-                    &right(),
-                    &date(),
-                )
+                .option_history_trade_greeks_all(&sym(), &exp(), &strike(), &right(), &date())
                 .await?;
             Ok(format::ok_envelope(format::greeks_ticks_to_json(&ticks)))
         }
@@ -696,25 +588,19 @@ async fn dispatch(
         "index_snapshot_ohlc" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let ticks = client
-                .index_snapshot_ohlc(&syms)
-                .await?;
+            let ticks = client.index_snapshot_ohlc(&syms).await?;
             Ok(format::ok_envelope(format::ohlc_ticks_to_json(&ticks)))
         }
         "index_snapshot_price" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let ticks = client
-                .index_snapshot_price(&syms)
-                .await?;
+            let ticks = client.index_snapshot_price(&syms).await?;
             Ok(format::ok_envelope(format::price_ticks_to_json(&ticks)))
         }
         "index_snapshot_market_value" => {
             let s = syms_str();
             let syms = parse_symbols(&s);
-            let ticks = client
-                .index_snapshot_market_value(&syms)
-                .await?;
+            let ticks = client.index_snapshot_market_value(&syms).await?;
             Ok(format::ok_envelope(format::market_value_ticks_to_json(
                 &ticks,
             )))
@@ -733,11 +619,7 @@ async fn dispatch(
         }
         "index_history_price" => {
             let ticks = client
-                .index_history_price(
-                    &sym(),
-                    &date(),
-                    &interval(),
-                )
+                .index_history_price(&sym(), &date(), &interval())
                 .await?;
             Ok(format::ok_envelope(format::price_ticks_to_json(&ticks)))
         }
@@ -785,19 +667,31 @@ async fn dispatch(
 //  System endpoints
 // ---------------------------------------------------------------------------
 
-/// GET /v2/system/mdds/status
+/// GET /v3/system/status -- matches Java terminal system status.
+pub async fn system_status(State(state): State<AppState>) -> Response {
+    let body = sonic_rs::json!({
+        "status": state.mdds_status(),
+        "version": env!("CARGO_PKG_VERSION")
+    });
+    json_response(&body)
+}
+
+/// GET /v3/system/mdds/status
 pub async fn system_mdds_status(State(state): State<AppState>) -> Response {
     let body = format::ok_envelope(vec![sonic_rs::Value::from(state.mdds_status())]);
     json_response(&body)
 }
 
-/// GET /v2/system/fpss/status
+/// GET /v3/system/fpss/status
 pub async fn system_fpss_status(State(state): State<AppState>) -> Response {
-    let body = format::ok_envelope(vec![sonic_rs::Value::from(state.fpss_status())]);
+    let body = sonic_rs::json!({
+        "status": state.fpss_status(),
+        "version": env!("CARGO_PKG_VERSION")
+    });
     json_response(&body)
 }
 
-/// GET /v2/system/shutdown -- requires `X-Shutdown-Token` header.
+/// GET /v3/system/shutdown -- requires `X-Shutdown-Token` header.
 pub async fn system_shutdown(State(state): State<AppState>, headers: HeaderMap) -> Response {
     let token = headers
         .get("X-Shutdown-Token")

--- a/tools/server/src/main.rs
+++ b/tools/server/src/main.rs
@@ -48,6 +48,22 @@ struct Args {
     #[arg(long, default_value = "creds.txt")]
     creds: String,
 
+    /// Email for ThetaData authentication (alternative to --creds file).
+    #[arg(long)]
+    email: Option<String>,
+
+    /// Password for ThetaData authentication (alternative to --creds file).
+    #[arg(long)]
+    password: Option<String>,
+
+    /// Path to TOML config file (same format as Java terminal's config.toml).
+    #[arg(long)]
+    config: Option<String>,
+
+    /// FPSS region: "production" (default), "dev", "stage".
+    #[arg(long, default_value = "production")]
+    fpss_region: String,
+
     /// HTTP REST API port (default matches Java terminal: 25503).
     #[arg(long, default_value_t = 25503)]
     http_port: u16,
@@ -86,8 +102,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate a random shutdown token and print it.
     let shutdown_token = uuid::Uuid::new_v4().to_string();
 
+    // Startup banner matching the Java terminal style.
+    let version = env!("CARGO_PKG_VERSION");
+    eprintln!();
+    eprintln!("ThetaDataDx Server v{version}");
+    eprintln!("Configuration: {}", args.fpss_region);
+    eprintln!("REST API: http://{}:{}/", args.bind, args.http_port);
+    eprintln!("WebSocket: ws://{}:{}/v1/events", args.bind, args.ws_port);
+    eprintln!();
+    eprintln!("Shutdown token: {shutdown_token}");
+    eprintln!(
+        "  curl http://{}:{}/v3/system/shutdown -H 'X-Shutdown-Token: {}'",
+        args.bind, args.http_port, shutdown_token
+    );
+
     tracing::info!(
-        version = env!("CARGO_PKG_VERSION"),
+        version,
         http_port = args.http_port,
         ws_port = args.ws_port,
         bind = %args.bind,
@@ -95,25 +125,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "starting thetadatadx-server"
     );
 
-    eprintln!("Shutdown token: {shutdown_token}");
-    eprintln!(
-        "  curl http://{}:{}/v3/system/shutdown -H 'X-Shutdown-Token: {}'",
-        args.bind, args.http_port, shutdown_token
-    );
+    // Step 1: Load credentials -- prefer --email/--password over --creds file.
+    let creds = if let (Some(email), Some(password)) = (&args.email, &args.password) {
+        tracing::info!("loaded credentials from --email/--password flags");
+        Credentials::new(email, password)
+    } else {
+        let c = Credentials::from_file(&args.creds)?;
+        tracing::info!(creds_file = %args.creds, "loaded credentials from file");
+        c
+    };
 
-    // Step 1: Load credentials and authenticate.
-    let creds = Credentials::from_file(&args.creds)?;
-    tracing::info!(creds_file = %args.creds, "loaded credentials");
+    // Step 2: Load config -- prefer --config file, then --fpss-region.
+    let config = if let Some(config_path) = &args.config {
+        tracing::info!(config_file = %config_path, "loaded config from file");
+        DirectConfig::from_file(config_path)?
+    } else {
+        match args.fpss_region.as_str() {
+            "dev" => DirectConfig::dev(),
+            "stage" => DirectConfig::stage(),
+            _ => DirectConfig::production(),
+        }
+    };
 
-    // Step 2: Connect unified client (gRPC historical).
-    let config = DirectConfig::production();
+    // Step 3: Connect unified client (gRPC historical).
     let tdx = ThetaDataDx::connect(&creds, config).await?;
     tracing::info!("MDDS connected");
 
-    // Step 3: Build shared state.
+    // Step 4: Build shared state.
     let state = AppState::new(tdx, shutdown_token);
 
-    // Step 4: Start FPSS streaming bridge.
+    // Step 5: Start FPSS streaming bridge.
     if !args.no_fpss {
         match ws::start_fpss_bridge(state.clone()) {
             Ok(()) => {
@@ -127,7 +168,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("FPSS bridge skipped (--no-fpss)");
     }
 
-    // Step 5: Build HTTP REST server with CORS.
+    // Step 6: Build HTTP REST server with CORS.
     let allowed_origin = format!("http://{}:{}", args.bind, args.http_port);
     let cors = CorsLayer::new()
         .allow_origin(
@@ -141,11 +182,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let http_app = router::build(state.clone()).layer(cors);
     let http_addr: SocketAddr = format!("{}:{}", args.bind, args.http_port).parse()?;
 
-    // Step 6: Build WebSocket server.
+    // Step 7: Build WebSocket server.
     let ws_app = ws::router(state.clone());
     let ws_addr: SocketAddr = format!("{}:{}", args.bind, args.ws_port).parse()?;
 
-    // Step 7: Start both servers concurrently.
+    // Step 8: Start both servers concurrently.
     tracing::info!(%http_addr, "HTTP REST server starting");
     tracing::info!(%ws_addr, "WebSocket server starting");
 

--- a/tools/server/src/router.rs
+++ b/tools/server/src/router.rs
@@ -125,6 +125,7 @@ pub fn build(state: AppState) -> Router {
 
     // System routes
     app = app
+        .route("/v3/system/status", get(handler::system_status))
         .route("/v3/system/mdds/status", get(handler::system_mdds_status))
         .route("/v3/system/fpss/status", get(handler::system_fpss_status))
         .route("/v3/system/shutdown", get(handler::system_shutdown));


### PR DESCRIPTION
## Summary

- Add `--email`/`--password` CLI flags as alternative to `--creds` file for ThetaData authentication
- Add `--config` flag for TOML config file loading (enables `config-file` feature on thetadatadx)
- Add `--fpss-region` flag for `production`/`dev`/`stage` FPSS server selection
- Add `GET /v3/system/status` endpoint returning `{"status":"CONNECTED","version":"5.3.1"}`
- Update `GET /v3/system/fpss/status` to return status + version JSON (matching Java terminal)
- Add Java-terminal-style startup banner with version, config, REST/WS URLs
- Add `[workspace]` to server `Cargo.toml` for independent builds (fixes worktree build)
- Fix pre-existing `cargo fmt` issues in handler.rs and unused import in format.rs
- Update README.md with new CLI options and system endpoints

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo build` succeeds
- [ ] Start server with `--email`/`--password` flags and verify connection
- [ ] Verify `GET /v3/system/status` returns expected JSON
- [ ] Verify `GET /v3/system/fpss/status` returns expected JSON
- [ ] Verify startup banner prints correctly

Closes #128

Generated with [Claude Code](https://claude.com/claude-code)