### PR TITLE
release: v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-04-05
+
+### Breaking Changes
+
+- **`start_streaming_no_ohlcvc()` removed** -- use `DirectConfig::derive_ohlcvc(false)` instead. (#129)
+- **Go SDK**: `SnapshotTradeTick` type removed (was dead code after FFI cleanup).
+
+### Added
+
+- **`DirectConfig::derive_ohlcvc(bool)`** -- config-driven OHLCVC opt-out, replaces duplicate method. (#129)
+- **REST server drop-in replacement** -- `--email`/`--password`, `--config`, `--fpss-region` CLI args. `/v3/system/status` endpoint. Startup banner. (#128)
+- **Error suppression 5s after STOP** -- matches Java terminal behavior. (#124)
+- **Auth retry on transient errors** -- 3 attempts, 2s delay, network errors only. (#125)
+- **Config validation** -- clamps queue_depth (16-1M), window_size (64-1024) with warnings. (#126)
+- **Password character warning** -- on INVALID_CREDENTIALS disconnect. (#127)
+- **Clippy pedantic zero warnings** -- `#[must_use]`, inlined format args, numeric separators, `try_from` casts, error docs. No blanket suppression. (#131)
+
+### Fixed
+
+- Zero `#[allow(dead_code)]` in entire project.
+- Go SDK dangling extern for removed `TdxSnapshotTradeTickArray`.
+- Doc comment typo `100_0000` -> `1_000_000`.
+- Test warning on unused `#[must_use]` return.
+- All `#[allow]` annotations have reason comments.
+
 ## [5.3.1] - 2026-04-04
 
 ### Added
@@ -664,7 +689,8 @@ See [TODO.md](TODO.md) for the production readiness checklist and performance ro
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v5.3.1...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v5.4.0...HEAD
+[5.4.0]: https://github.com/userFRM/ThetaDataDx/compare/v5.3.1...v5.4.0
 [5.3.1]: https://github.com/userFRM/ThetaDataDx/compare/v5.3.0...v5.3.1
 [5.3.0]: https://github.com/userFRM/ThetaDataDx/compare/v5.2.1...v5.3.0
 [5.2.1]: https://github.com/userFRM/ThetaDataDx/compare/v5.2.0...v5.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.3.1"
+version = "5.4.0"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "5.3.1"
+version = "5.4.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "5.3.1"
+version = "5.4.0"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ No-JVM ThetaData Terminal - native Rust SDK for direct market data access.
 
 ```toml
 [dependencies]
-thetadatadx = "5.3"
+thetadatadx = "5.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "5.3.1"
+version = "5.4.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -23,7 +23,7 @@ default = []
 config-file = ["dep:toml"]
 
 [dependencies]
-tdbe = { version = "0.5.0", path = "../tdbe" }
+tdbe = { version = "0.6.0", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -11,7 +11,7 @@ description: Install ThetaDataDx, configure credentials, and run your first quer
 ```toml [Rust]
 # Add to your Cargo.toml
 [dependencies]
-thetadatadx = "5.3"
+thetadatadx = "5.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 ```bash [Python]

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ description: Install ThetaDataDx for Rust, Python, Go, or C++.
 ```toml [Rust]
 # Add to your Cargo.toml
 [dependencies]
-thetadatadx = "5.3"
+thetadatadx = "5.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 ```bash [Python]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "5.3.1"
+version = "5.4.0"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"
@@ -10,5 +10,5 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.5.0", path = "../crates/tdbe" }
+tdbe = { version = "0.6.0", path = "../crates/tdbe" }
 tokio = { version = "1.50.0", features = ["rt-multi-thread"] }

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "5.3.1"
+version = "5.4.0"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.5.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.6.0", path = "../../crates/tdbe" }
 
 # PyO3 bindings
 pyo3 = { version = "=0.28.2", features = ["extension-module"] }

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "thetadatadx"
-version = "5.3.1"
+version = "5.4.0"
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "5.3.1"
+version = "5.4.0"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.5.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.6.0", path = "../../crates/tdbe" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.3"

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "5.3.1"
+version = "5.4.0"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.5.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.6.0", path = "../../crates/tdbe" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1", features = ["derive"] }
 sonic-rs = "0.3"

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "5.3.1"
+version = "5.4.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
-tdbe = { version = "0.5.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.6.0", path = "../../crates/tdbe" }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 sonic-rs = "0.3"


### PR DESCRIPTION
Codex approved. 233 tests, zero pedantic warnings, zero dead_code, full terminal parity.