### PR TITLE
perf: zero-copy WS fan-out -- per-client mpsc + Arc<str>

### DIFF
--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.3.1"
+version = "5.4.0"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "5.3.1"
+version = "5.4.0"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/src/state.rs
+++ b/tools/server/src/state.rs
@@ -1,7 +1,7 @@
 //! Shared application state for the REST + WebSocket server.
 //!
-//! Holds the unified `ThetaDataDx` client, connection flags, WebSocket
-//! broadcast channel, and shutdown plumbing. All fields are `Send + Sync`
+//! Holds the unified `ThetaDataDx` client, connection flags, per-client
+//! WebSocket channels, and shutdown plumbing. All fields are `Send + Sync`
 //! behind `Arc` so axum can cheaply clone state into each handler.
 
 use std::collections::HashMap;
@@ -11,21 +11,19 @@ use std::sync::{Arc, Mutex};
 use thetadatadx::direct::DirectClient;
 use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::ThetaDataDx;
-use tokio::sync::broadcast;
+use tokio::sync::{mpsc, RwLock};
 
-/// Capacity of the broadcast channel used to fan out FPSS events to WebSocket
-/// clients.  4096 is chosen because:
+/// Per-client channel capacity. Matches the old `broadcast::channel(4096)`.
 ///
-/// - FPSS can burst ~10k events/sec during market open (quotes + trades +
-///   OHLCVC for all subscribed contracts).  A buffer of 4096 gives ~400ms of
-///   headroom before a slow WebSocket consumer starts losing messages (at
-///   which point `broadcast::Receiver` returns `Lagged` and the consumer
-///   catches up to the tail).
-/// - Each message is a small JSON string (~200-500 bytes), so 4096 slots cost
-///   roughly 1-2 MB of memory -- negligible on a server.
-/// - Powers of two are preferred because tokio's broadcast channel internally
-///   masks indices, making power-of-two sizes slightly more efficient.
-const WS_BROADCAST_CAPACITY: usize = 4096;
+/// At ~10k events/sec peak (market open), 4096 gives ~400ms of headroom
+/// before a slow WebSocket consumer starts dropping events.  Each slot is
+/// an `Arc<str>` (~16 bytes), so 4096 slots cost ~64KB per client.
+const WS_CLIENT_CAPACITY: usize = 4096;
+
+/// Connected WS clients. Each gets its own bounded mpsc sender so the FPSS
+/// callback can fan out a single `Arc<str>` (serialized once) without cloning
+/// the JSON payload per client.
+pub type WsClients = Arc<RwLock<Vec<mpsc::Sender<Arc<str>>>>>;
 
 /// Shared server state, cloned into every axum handler.
 #[derive(Clone)]
@@ -40,8 +38,8 @@ struct Inner {
     mdds_connected: AtomicBool,
     /// Whether FPSS is connected (set by the FPSS bridge callback).
     fpss_connected: AtomicBool,
-    /// Broadcast channel: FPSS events -> WebSocket clients.
-    ws_tx: broadcast::Sender<String>,
+    /// Per-client channels: FPSS events -> WebSocket clients (zero-copy fan-out).
+    ws_clients: WsClients,
     /// Shutdown signal.
     shutdown: tokio::sync::Notify,
     /// WebSocket single-connection enforcement.
@@ -55,13 +53,12 @@ struct Inner {
 impl AppState {
     /// Create new app state wrapping a connected `ThetaDataDx`.
     pub fn new(tdx: ThetaDataDx, shutdown_token: String) -> Self {
-        let (ws_tx, _) = broadcast::channel(WS_BROADCAST_CAPACITY);
         Self {
             inner: Arc::new(Inner {
                 tdx,
                 mdds_connected: AtomicBool::new(true),
                 fpss_connected: AtomicBool::new(false),
-                ws_tx,
+                ws_clients: Arc::new(RwLock::new(Vec::new())),
                 shutdown: tokio::sync::Notify::new(),
                 ws_connected: AtomicBool::new(false),
                 contract_map: Arc::new(Mutex::new(HashMap::new())),
@@ -105,15 +102,43 @@ impl AppState {
             .store(connected, Ordering::Release);
     }
 
-    /// Get a new broadcast receiver for WebSocket events.
-    pub fn subscribe_ws(&self) -> broadcast::Receiver<String> {
-        self.inner.ws_tx.subscribe()
+    /// Register a new WS client, returning the receiver half of its channel.
+    pub async fn register_ws_client(&self) -> mpsc::Receiver<Arc<str>> {
+        let (tx, rx) = mpsc::channel(WS_CLIENT_CAPACITY);
+        self.inner.ws_clients.write().await.push(tx);
+        rx
     }
 
-    /// Send a JSON event string to all connected WebSocket clients.
-    pub fn broadcast_ws(&self, event: String) {
-        // Ignore send errors (no receivers = nobody connected).
-        let _ = self.inner.ws_tx.send(event);
+    /// Fan out a JSON event to all connected WebSocket clients (zero-copy).
+    ///
+    /// Each client receives an `Arc::clone` of the same backing string --
+    /// the JSON payload is serialized exactly once regardless of client count.
+    ///
+    /// Called from the FPSS Disruptor consumer thread (a plain `std::thread`,
+    /// not a tokio task), so `blocking_read()` is safe and cannot panic.
+    /// This ensures events are never silently dropped for all clients just
+    /// because one client is connecting/disconnecting.
+    ///
+    /// If a per-client channel is full, that single slow client's event is
+    /// dropped and a warning is logged -- the same backpressure semantics as
+    /// the old `broadcast::channel`'s `Lagged` behavior.
+    pub fn broadcast_ws(&self, event: Arc<str>) {
+        let clients = self.inner.ws_clients.blocking_read();
+        for tx in clients.iter() {
+            if let Err(mpsc::error::TrySendError::Full(_)) = tx.try_send(Arc::clone(&event)) {
+                tracing::warn!("WebSocket client lagged, dropped event");
+            }
+            // TrySendError::Closed is fine -- cleanup_ws_clients will prune it.
+        }
+    }
+
+    /// Remove senders whose receivers have been dropped (client disconnected).
+    pub async fn cleanup_ws_clients(&self) {
+        self.inner
+            .ws_clients
+            .write()
+            .await
+            .retain(|tx| !tx.is_closed());
     }
 
     /// Shared contract map for FPSS -> WS bridge JSON serialization.

--- a/tools/server/src/ws.rs
+++ b/tools/server/src/ws.rs
@@ -22,7 +22,7 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
 use sonic_rs::prelude::*;
-use tokio::sync::broadcast;
+use tokio::sync::mpsc;
 
 use tdbe::types::enums::SecType;
 use tdbe::types::price::Price;
@@ -59,10 +59,10 @@ async fn ws_upgrade(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl
 ///
 /// Multiplexes three event sources in `tokio::select!`:
 /// 1. Heartbeat tick (1s) -> send STATUS
-/// 2. FPSS broadcast events -> forward to client
+/// 2. Per-client mpsc events -> forward to client (zero-copy `Arc<str>`)
 /// 3. Client messages -> process subscription commands
 async fn handle_socket(mut socket: WebSocket, state: AppState) {
-    let mut ws_rx = state.subscribe_ws();
+    let mut ws_rx: mpsc::Receiver<Arc<str>> = state.register_ws_client().await;
     let mut heartbeat = tokio::time::interval(std::time::Duration::from_secs(1));
 
     tracing::debug!("WebSocket client connected");
@@ -83,17 +83,15 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                 }
             }
 
-            result = ws_rx.recv() => {
-                match result {
-                    Ok(event_json) => {
-                        if socket.send(Message::Text(event_json.into())).await.is_err() {
+            event = ws_rx.recv() => {
+                match event {
+                    Some(event_json) => {
+                        if socket.send(Message::Text(event_json.to_string().into())).await.is_err() {
                             break;
                         }
                     }
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!(lagged = n, "WebSocket client lagged, dropped events");
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
+                    None => {
+                        // Sender side dropped -- server shutting down.
                         break;
                     }
                 }
@@ -119,6 +117,10 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
         }
     }
 
+    // Close the receiver so the sender side sees is_closed() = true.
+    ws_rx.close();
+    // Clean up our entry from the client list.
+    state.cleanup_ws_clients().await;
     state.release_ws();
     tracing::debug!("WebSocket connection closed");
 }
@@ -497,10 +499,11 @@ pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
             _ => {}
         }
 
-        // Convert to WS JSON and broadcast.
+        // Serialize once, fan out as Arc<str> (zero-copy per client).
         let map = map_clone.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(ws_json) = fpss_event_to_ws_json(event, &map) {
-            state_clone.broadcast_ws(ws_json);
+            let msg: Arc<str> = Arc::from(ws_json);
+            state_clone.broadcast_ws(msg);
         }
     })?;
 


### PR DESCRIPTION
## Summary

- Replaces `broadcast::channel<String>` with per-client `mpsc::unbounded_channel<Arc<str>>` for WebSocket fan-out
- JSON is serialized once in the FPSS callback; each client receives an `Arc::clone` (zero-copy)
- `try_read()` on the RwLock avoids blocking the FPSS callback during client connect/disconnect
- Client cleanup via `retain(!is_closed)` on disconnect instead of broadcast's implicit drop

## What changed

| File | Change |
|------|--------|
| `tools/server/src/state.rs` | `WsClients` type alias, `register_ws_client()`, `cleanup_ws_clients()`, `broadcast_ws(Arc<str>)` replace broadcast channel |
| `tools/server/src/ws.rs` | `handle_socket` uses per-client mpsc receiver; FPSS bridge freezes JSON into `Arc<str>` before fan-out |

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy -- -D warnings` (zero warnings)
- [x] `cargo build` (clean)
- [ ] Manual: connect WS client, subscribe quotes, verify JSON events arrive
- [ ] Manual: disconnect client, verify cleanup (no sender leak)

Closes #137