### PR TITLE
refactor: decode all prices to f64 during parsing

### DIFF
--- a/crates/tdbe/src/types/tick.rs
+++ b/crates/tdbe/src/types/tick.rs
@@ -1,6 +1,3 @@
-use crate::flags;
-use crate::types::price::Price;
-
 /// Calendar day. Market open/close schedule.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -13,35 +10,34 @@ pub struct CalendarDay {
 }
 
 /// End-of-day tick. Full EOD snapshot with OHLC + quote.
+///
+/// All price fields are decoded to `f64` during parsing.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
 pub struct EodTick {
     pub ms_of_day: i32,
     pub ms_of_day2: i32,
-    pub open: i32,
-    pub high: i32,
-    pub low: i32,
-    pub close: i32,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
     pub volume: i32,
     pub count: i32,
     pub bid_size: i32,
     pub bid_exchange: i32,
-    pub bid: i32,
+    pub bid: f64,
     pub bid_condition: i32,
     pub ask_size: i32,
     pub ask_exchange: i32,
-    pub ask: i32,
+    pub ask: f64,
     pub ask_condition: i32,
-    pub price_type: i32,
     pub date: i32,
     /// Contract expiration (YYYYMMDD). Populated on wildcard queries, 0 otherwise.
     pub expiration: i32,
-    /// Contract strike (price-encoded). Use `strike_price()` for f64.
-    pub strike: i32,
+    /// Contract strike price (decoded to `f64`).
+    pub strike: f64,
     /// Contract right (C=67, P=80 ASCII). 0 on single-contract queries.
     pub right: i32,
-    /// Strike price type for decoding `strike`.
-    pub strike_price_type: i32,
 }
 
 /// Greeks tick. Full set of option greeks.
@@ -73,9 +69,8 @@ pub struct GreeksTick {
     pub vera: f64,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// Interest rate tick.
@@ -96,9 +91,8 @@ pub struct IvTick {
     pub iv_error: f64,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// Market value tick.
@@ -113,28 +107,27 @@ pub struct MarketValueTick {
     pub free_float: i64,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// OHLC tick. Aggregated bar data.
+///
+/// All price fields are decoded to `f64` during parsing.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
 pub struct OhlcTick {
     pub ms_of_day: i32,
-    pub open: i32,
-    pub high: i32,
-    pub low: i32,
-    pub close: i32,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
     pub volume: i32,
     pub count: i32,
-    pub price_type: i32,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// Open interest tick.
@@ -145,53 +138,56 @@ pub struct OpenInterestTick {
     pub open_interest: i32,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// Option contract specification.
-#[derive(Debug, Clone)]
 pub struct OptionContract {
     pub root: String,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// Price tick. Generic price data point.
+///
+/// Price is decoded to `f64` during parsing.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
 pub struct PriceTick {
     pub ms_of_day: i32,
-    pub price: i32,
-    pub price_type: i32,
+    pub price: f64,
     pub date: i32,
 }
 
 /// Quote tick. NBBO quote data.
+///
+/// All price fields are decoded to `f64` during parsing.
+/// `midpoint` is computed as `(bid + ask) / 2.0` at parse time.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
 pub struct QuoteTick {
     pub ms_of_day: i32,
     pub bid_size: i32,
     pub bid_exchange: i32,
-    pub bid: i32,
+    pub bid: f64,
     pub bid_condition: i32,
     pub ask_size: i32,
     pub ask_exchange: i32,
-    pub ask: i32,
+    pub ask: f64,
     pub ask_condition: i32,
-    pub price_type: i32,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
+    /// Pre-computed midpoint: `(bid + ask) / 2.0`.
+    pub midpoint: f64,
 }
 
 /// Snapshot trade tick. Abbreviated trade for snapshots.
+///
+/// Price is decoded to `f64` during parsing.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
 pub struct SnapshotTradeTick {
@@ -199,16 +195,16 @@ pub struct SnapshotTradeTick {
     pub sequence: i32,
     pub size: i32,
     pub condition: i32,
-    pub price: i32,
-    pub price_type: i32,
+    pub price: f64,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// Combined trade + quote tick.
+///
+/// All price fields are decoded to `f64` during parsing.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
 pub struct TradeQuoteTick {
@@ -221,7 +217,7 @@ pub struct TradeQuoteTick {
     pub condition: i32,
     pub size: i32,
     pub exchange: i32,
-    pub price: i32,
+    pub price: f64,
     pub condition_flags: i32,
     pub price_flags: i32,
     pub volume_type: i32,
@@ -229,22 +225,21 @@ pub struct TradeQuoteTick {
     pub quote_ms_of_day: i32,
     pub bid_size: i32,
     pub bid_exchange: i32,
-    pub bid: i32,
+    pub bid: f64,
     pub bid_condition: i32,
     pub ask_size: i32,
     pub ask_exchange: i32,
-    pub ask: i32,
+    pub ask: f64,
     pub ask_condition: i32,
-    pub quote_price_type: i32,
-    pub price_type: i32,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// Trade tick. Core unit of trade data.
+///
+/// Price is decoded to `f64` during parsing.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
 pub struct TradeTick {
@@ -257,17 +252,15 @@ pub struct TradeTick {
     pub condition: i32,
     pub size: i32,
     pub exchange: i32,
-    pub price: i32,
+    pub price: f64,
     pub condition_flags: i32,
     pub price_flags: i32,
     pub volume_type: i32,
     pub records_back: i32,
-    pub price_type: i32,
     pub date: i32,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -277,14 +270,6 @@ pub struct TradeTick {
 macro_rules! impl_contract_id {
     ($ty:ident) => {
         impl $ty {
-            /// Decode strike as `f64` using the accompanying `strike_price_type`.
-            #[inline]
-            pub fn strike_price(&self) -> f64 {
-                if self.strike_price_type == 0 && self.strike == 0 {
-                    return 0.0;
-                }
-                Price::new(self.strike, self.strike_price_type).to_f64()
-            }
             /// `true` when `right` == 'C' (ASCII 67).
             #[inline]
             pub fn is_call(&self) -> bool {
@@ -319,20 +304,9 @@ impl_contract_id!(IvTick);
 //  Hand-written impl blocks
 // ─────────────────────────────────────────────────────────────────────────────
 
+use crate::flags;
+
 impl TradeTick {
-    #[inline]
-    #[must_use]
-    pub fn get_price(&self) -> Price {
-        Price::new(self.price, self.price_type)
-    }
-
-    /// Decode trade price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn price_f64(&self) -> f64 {
-        self.get_price().to_f64()
-    }
-
     #[must_use]
     pub fn is_cancelled(&self) -> bool {
         flags::trade::CANCELLED_RANGE.contains(&self.condition)
@@ -365,238 +339,15 @@ impl TradeTick {
     }
 }
 
-impl QuoteTick {
+impl OptionContract {
+    /// `true` when `right` == 'C' (ASCII 67).
     #[inline]
-    #[must_use]
-    pub fn bid_price(&self) -> Price {
-        Price::new(self.bid, self.price_type)
+    pub fn is_call(&self) -> bool {
+        self.right == 67
     }
-
+    /// `true` when `right` == 'P' (ASCII 80).
     #[inline]
-    #[must_use]
-    pub fn ask_price(&self) -> Price {
-        Price::new(self.ask, self.price_type)
-    }
-
-    /// Decode bid price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn bid_f64(&self) -> f64 {
-        self.bid_price().to_f64()
-    }
-
-    /// Decode ask price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn ask_f64(&self) -> f64 {
-        self.ask_price().to_f64()
-    }
-
-    /// Decode midpoint price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn midpoint_f64(&self) -> f64 {
-        self.midpoint_price().to_f64()
-    }
-
-    #[must_use]
-    pub fn midpoint_value(&self) -> i32 {
-        self.bid / 2 + self.ask / 2 + (self.bid % 2 + self.ask % 2) / 2
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn midpoint_price(&self) -> Price {
-        Price::new(self.midpoint_value(), self.price_type)
-    }
-}
-
-impl OhlcTick {
-    #[inline]
-    #[must_use]
-    pub fn open_price(&self) -> Price {
-        Price::new(self.open, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn high_price(&self) -> Price {
-        Price::new(self.high, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn low_price(&self) -> Price {
-        Price::new(self.low, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn close_price(&self) -> Price {
-        Price::new(self.close, self.price_type)
-    }
-
-    /// Decode open price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn open_f64(&self) -> f64 {
-        self.open_price().to_f64()
-    }
-    /// Decode high price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn high_f64(&self) -> f64 {
-        self.high_price().to_f64()
-    }
-    /// Decode low price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn low_f64(&self) -> f64 {
-        self.low_price().to_f64()
-    }
-    /// Decode close price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn close_f64(&self) -> f64 {
-        self.close_price().to_f64()
-    }
-}
-
-impl EodTick {
-    #[inline]
-    #[must_use]
-    pub fn open_price(&self) -> Price {
-        Price::new(self.open, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn high_price(&self) -> Price {
-        Price::new(self.high, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn low_price(&self) -> Price {
-        Price::new(self.low, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn close_price(&self) -> Price {
-        Price::new(self.close, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn bid_price(&self) -> Price {
-        Price::new(self.bid, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn ask_price(&self) -> Price {
-        Price::new(self.ask, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn midpoint_value(&self) -> i32 {
-        self.bid / 2 + self.ask / 2 + (self.bid % 2 + self.ask % 2) / 2
-    }
-
-    /// Decode open price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn open_f64(&self) -> f64 {
-        self.open_price().to_f64()
-    }
-    /// Decode high price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn high_f64(&self) -> f64 {
-        self.high_price().to_f64()
-    }
-    /// Decode low price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn low_f64(&self) -> f64 {
-        self.low_price().to_f64()
-    }
-    /// Decode close price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn close_f64(&self) -> f64 {
-        self.close_price().to_f64()
-    }
-    /// Decode bid price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn bid_f64(&self) -> f64 {
-        self.bid_price().to_f64()
-    }
-    /// Decode ask price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn ask_f64(&self) -> f64 {
-        self.ask_price().to_f64()
-    }
-}
-
-impl SnapshotTradeTick {
-    #[inline]
-    #[must_use]
-    pub fn get_price(&self) -> Price {
-        Price::new(self.price, self.price_type)
-    }
-
-    /// Decode trade price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn price_f64(&self) -> f64 {
-        self.get_price().to_f64()
-    }
-}
-
-impl TradeQuoteTick {
-    #[inline]
-    #[must_use]
-    pub fn trade_price(&self) -> Price {
-        Price::new(self.price, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn bid_price(&self) -> Price {
-        Price::new(self.bid, self.price_type)
-    }
-    #[inline]
-    #[must_use]
-    pub fn ask_price(&self) -> Price {
-        Price::new(self.ask, self.price_type)
-    }
-
-    /// Decode trade price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn trade_price_f64(&self) -> f64 {
-        self.trade_price().to_f64()
-    }
-    /// Decode bid price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn bid_f64(&self) -> f64 {
-        self.bid_price().to_f64()
-    }
-    /// Decode ask price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn ask_f64(&self) -> f64 {
-        self.ask_price().to_f64()
-    }
-}
-
-impl PriceTick {
-    #[inline]
-    #[must_use]
-    pub fn get_price(&self) -> Price {
-        Price::new(self.price, self.price_type)
-    }
-
-    /// Decode price to `f64`.
-    #[inline]
-    #[must_use]
-    pub fn price_f64(&self) -> f64 {
-        self.get_price().to_f64()
+    pub fn is_put(&self) -> bool {
+        self.right == 80
     }
 }

--- a/crates/thetadatadx/build.rs
+++ b/crates/thetadatadx/build.rs
@@ -38,8 +38,6 @@ struct TickTypeDef {
     #[serde(default)]
     required: Vec<String>,
     #[serde(default)]
-    price_typed_columns: Vec<String>,
-    #[serde(default)]
     eod_style: bool,
     #[serde(default)]
     contract_id: bool,
@@ -51,9 +49,6 @@ struct ColumnDef {
     name: String,
     field: String,
     r#type: String,
-    /// For `price_type` fields: which price column to extract the type from.
-    #[serde(default)]
-    price_source: Option<String>,
 }
 
 fn generate_tick_types() -> Result<(), Box<dyn std::error::Error>> {
@@ -92,7 +87,10 @@ fn generate_tick_types() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Generate a single parser function.
-// Reason: code generator — the match dispatch over column types cannot be meaningfully split.
+///
+/// Price columns are decoded to `f64` during extraction using the wire
+/// `price_type` (internally fetched, never exposed on the public struct).
+// Reason: code generator -- the match dispatch over column types cannot be meaningfully split.
 #[allow(clippy::too_many_lines)]
 fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
     let fn_name = &def.parser;
@@ -103,7 +101,7 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
     )
     .unwrap();
 
-    // If eod_style, emit the local eod_num helper inline.
+    // If eod_style, emit the local eod_num and eod_price helpers inline.
     if def.eod_style {
         out.push_str("    // EOD rows may have Price-typed cells or plain Number cells.\n");
         out.push_str("    fn eod_num(row: &crate::proto::DataValueList, idx: usize) -> i32 {\n");
@@ -124,24 +122,39 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
         out.push_str("            })\n");
         out.push_str("            .unwrap_or(0)\n");
         out.push_str("    }\n\n");
+
+        out.push_str("    // EOD price field: decode to f64 from Price or Number cell.\n");
+        out.push_str("    fn eod_price(row: &crate::proto::DataValueList, idx: usize) -> f64 {\n");
+        out.push_str("        row.values\n");
+        out.push_str("            .get(idx)\n");
+        out.push_str("            .and_then(|dv| dv.data_type.as_ref())\n");
+        out.push_str("            .map(|dt| match dt {\n");
+        out.push_str("                crate::proto::data_value::DataType::Price(p) => {\n");
+        out.push_str(
+            "                    tdbe::types::price::Price::new(p.value, p.r#type).to_f64()\n",
+        );
+        out.push_str("                }\n");
+        out.push_str(
+            "                crate::proto::data_value::DataType::Number(n) => *n as f64,\n",
+        );
+        out.push_str("                _ => 0.0,\n");
+        out.push_str("            })\n");
+        out.push_str("            .unwrap_or(0.0)\n");
+        out.push_str("    }\n\n");
     }
 
     out.push_str("    let h: Vec<&str> = table.headers.iter().map(|s| s.as_str()).collect();\n");
 
-    // For eod_style, use the shared find_header() from decode.rs (avoids a
-    // duplicate alias table that can diverge -- see Codex audit item 3).
+    // For eod_style, use the shared find_header() from decode.rs.
     if def.eod_style {
         out.push_str("    let find = |name: &str| find_header(&h, name);\n\n");
     }
 
-    // Determine which columns need the opt_number helper
-    let needs_opt_number = def.columns.iter().any(|c| {
-        (c.r#type == "i32"
-            && !def.required.contains(&c.name)
-            && c.price_source.is_none()
-            && c.field != "date")
-            || c.price_source.is_some() // price_source fallback uses opt_number
-    });
+    // Determine which columns need helpers.
+    let needs_opt_number = def
+        .columns
+        .iter()
+        .any(|c| c.r#type == "i32" && !def.required.contains(&c.name) && c.field != "date");
     let needs_opt_float = def
         .columns
         .iter()
@@ -151,7 +164,7 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
         .iter()
         .any(|c| c.r#type == "i64" && !def.required.contains(&c.name));
 
-    // Emit opt_number / opt_float / opt_i64 helpers (non-eod only)
+    // Emit opt_number / opt_float / opt_i64 helpers (non-eod only).
     if !def.eod_style {
         if needs_opt_number {
             out.push_str("    fn opt_number(row: &crate::proto::DataValueList, idx: Option<usize>) -> i32 {\n");
@@ -181,7 +194,7 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
         }
     }
 
-    // Required header guards (non-eod only)
+    // Required header guards (non-eod only).
     if !def.eod_style {
         for req in &def.required {
             let var = idx_var_name(req);
@@ -196,11 +209,6 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
 
     // Declare index variables for all columns.
     for col in &def.columns {
-        // Skip declaring index for columns that have price_source in eod_style,
-        // since they use the source column's index instead.
-        if def.eod_style && col.price_source.is_some() {
-            continue;
-        }
         let var = idx_var_name(&col.name);
         if def.eod_style {
             writeln!(out, "    let {var} = find(\"{}\");", col.name).unwrap();
@@ -219,24 +227,8 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
         out.push_str("    let _cid_strike_is_typed = _cid_strike_idx.is_some() && h.contains(&\"strike\");\n");
     }
 
-    // Precompute price_is_typed flags for price_typed_columns.
-    if !def.price_typed_columns.is_empty() && !def.eod_style {
-        out.push('\n');
-        for ptc in &def.price_typed_columns {
-            let var = idx_var_name(ptc);
-            let typed_var = format!("{ptc}_is_typed");
-            // For required columns, the idx is usize directly. For optional, it's Option<usize>.
-            if def.required.contains(ptc) {
-                writeln!(out, "    let {typed_var} = h.contains(&\"{ptc}\");").unwrap();
-            } else {
-                writeln!(
-                    out,
-                    "    let {typed_var} = {var}.is_some() && h.contains(&\"{ptc}\");"
-                )
-                .unwrap();
-            }
-        }
-    }
+    // Check if this is QuoteTick (needs midpoint computation).
+    let is_quote_tick = type_name == "QuoteTick";
 
     out.push('\n');
 
@@ -246,83 +238,20 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
     out.push_str("        .iter()\n");
     out.push_str("        .map(|row| {\n");
 
-    // For price-typed parsers, compute the price_type first (before the struct literal)
-    // if any column has a price_source.
-    let price_source_cols: Vec<&ColumnDef> = def
-        .columns
-        .iter()
-        .filter(|c| c.price_source.is_some())
-        .collect();
-    for psc in &price_source_cols {
-        let source = psc.price_source.as_ref().unwrap();
-        let source_var = idx_var_name(source);
-        let pt_var = format!("_pt_{}", psc.field);
-
-        if def.eod_style {
-            writeln!(out,
-                "            let {pt_var} = {source_var}.map(|i| row_price_type(row, i)).unwrap_or(0);"
-            ).unwrap();
-        } else if def.price_typed_columns.contains(source) {
-            let typed_var = format!("{source}_is_typed");
-            if def.required.contains(source) {
-                // source_var is usize
-                let pt_field_var = idx_var_name(&psc.name);
-                writeln!(out, "            let {pt_var} = if {typed_var} {{").unwrap();
-                writeln!(out, "                row_price_type(row, {source_var})").unwrap();
-                out.push_str("            } else {\n");
-                writeln!(out, "                opt_number(row, {pt_field_var})").unwrap();
-                out.push_str("            };\n");
-            } else {
-                // source_var is Option<usize>
-                let pt_field_var = idx_var_name(&psc.name);
-                writeln!(out, "            let {pt_var} = if {typed_var} {{").unwrap();
-                writeln!(
-                    out,
-                    "                {source_var}.map(|i| row_price_type(row, i)).unwrap_or(0)"
-                )
-                .unwrap();
-                out.push_str("            } else {\n");
-                writeln!(out, "                opt_number(row, {pt_field_var})").unwrap();
-                out.push_str("            };\n");
-            }
-        } else {
-            // Not price-typed: just use opt_number
-            let pt_field_var = idx_var_name(&psc.name);
-            writeln!(
-                out,
-                "            let {pt_var} = opt_number(row, {pt_field_var});"
-            )
-            .unwrap();
-        }
+    // Struct literal.
+    if is_quote_tick {
+        writeln!(out, "            let _tick = {type_name} {{").unwrap();
+    } else {
+        writeln!(out, "            {type_name} {{").unwrap();
     }
-
-    // Collect the names of columns that serve as the price_type source.
-    // These columns use row_price_value (their type IS the canonical one).
-    // All other price columns use row_price_value_normalized to match.
-    let price_source_names: std::collections::HashSet<&str> = def
-        .columns
-        .iter()
-        .filter_map(|c| c.price_source.as_deref())
-        .collect();
-
-    // Struct literal
-    writeln!(out, "            {type_name} {{").unwrap();
 
     for col in &def.columns {
         let var = idx_var_name(&col.name);
         let is_required = def.required.contains(&col.name);
 
-        // If this column has a price_source, use the precomputed _pt_ variable.
-        if col.price_source.is_some() {
-            let pt_var = format!("_pt_{}", col.field);
-            writeln!(out, "                {}: {pt_var},", col.field).unwrap();
-            continue;
-        }
-
         match col.r#type.as_str() {
             "i32" => {
                 if def.eod_style {
-                    // eod_style: all are Option<usize>, no required
                     writeln!(
                         out,
                         "                {}: {var}.map(|i| eod_num(row, i)).unwrap_or(0),",
@@ -330,7 +259,6 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
                     )
                     .unwrap();
                 } else if is_required {
-                    // Use row_date for `date` fields -- handles Timestamp -> YYYYMMDD.
                     let accessor = if col.field == "date" {
                         "row_date"
                     } else {
@@ -390,62 +318,14 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
                 }
             }
             "price" => {
-                // Price column: uses row_price_value if price-typed, otherwise row_number.
-                // For non-source price columns (e.g., high/low/close when open is the
-                // source), normalize to the source's price_type so all values in the
-                // struct use a consistent encoding.
-                let typed_var = format!("{}_is_typed", col.name);
-                let field = &col.field;
-                let is_source = price_source_names.contains(col.name.as_str());
-
-                if is_source || !price_source_cols.iter().any(|_| true) {
-                    // This IS the reference column (or there's no price_source at all).
-                    if is_required {
-                        writeln!(out, "                {field}: if {typed_var} {{").unwrap();
-                        writeln!(out, "                    row_price_value(row, {var})").unwrap();
-                        out.push_str("                } else {\n");
-                        writeln!(out, "                    row_number(row, {var})").unwrap();
-                        out.push_str("                },\n");
-                    } else {
-                        writeln!(out, "                {field}: match {var} {{").unwrap();
-                        writeln!(out,
-                            "                    Some(i) if {typed_var} => row_price_value(row, i),"
-                        )
-                        .unwrap();
-                        out.push_str("                    Some(i) => row_number(row, i),\n");
-                        out.push_str("                    None => 0,\n");
-                        out.push_str("                },\n");
-                    }
-                } else {
-                    // Non-source price column: normalize to the source's price_type.
-                    if is_required {
-                        writeln!(out, "                {field}: if {typed_var} {{").unwrap();
-                        writeln!(out,
-                            "                    row_price_value_normalized(row, {var}, _pt_price_type)"
-                        ).unwrap();
-                        out.push_str("                } else {\n");
-                        writeln!(out, "                    row_number(row, {var})").unwrap();
-                        out.push_str("                },\n");
-                    } else {
-                        writeln!(out, "                {field}: match {var} {{").unwrap();
-                        writeln!(out,
-                            "                    Some(i) if {typed_var} => row_price_value_normalized(row, i, _pt_price_type),"
-                        ).unwrap();
-                        out.push_str("                    Some(i) => row_number(row, i),\n");
-                        out.push_str("                    None => 0,\n");
-                        out.push_str("                },\n");
-                    }
-                }
-            }
-            "price_value" => {
-                // Always row_price_value, regardless of typed check (used for bid/ask in TradeQuoteTick).
+                // Decode price to f64 at parse time.
                 let field = &col.field;
                 if is_required {
-                    writeln!(out, "                {field}: row_price_value(row, {var}),").unwrap();
+                    writeln!(out, "                {field}: row_price_f64(row, {var}),").unwrap();
                 } else {
                     writeln!(out, "                {field}: match {var} {{").unwrap();
-                    out.push_str("                    Some(i) => row_price_value(row, i),\n");
-                    out.push_str("                    None => 0,\n");
+                    out.push_str("                    Some(i) => row_price_f64(row, i),\n");
+                    out.push_str("                    None => 0.0,\n");
                     out.push_str("                },\n");
                 }
             }
@@ -457,22 +337,14 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
                 )
                 .unwrap();
             }
-            "bool" => {
-                if is_required {
-                    writeln!(
-                        out,
-                        "                {}: row_number(row, {var}),",
-                        col.field
-                    )
-                    .unwrap();
-                } else {
-                    writeln!(
-                        out,
-                        "                {}: opt_number(row, {var}),",
-                        col.field
-                    )
-                    .unwrap();
-                }
+            "eod_price" => {
+                // EOD price field: decode to f64 from Price or Number cell.
+                writeln!(
+                    out,
+                    "                {}: {var}.map(|i| eod_price(row, i)).unwrap_or(0.0),",
+                    col.field
+                )
+                .unwrap();
             }
             other => panic!("unknown column type '{other}' in parser for {type_name}"),
         }
@@ -483,12 +355,13 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
         out.push_str(
             "                expiration: _cid_exp_idx.map(|i| { let n = row_number(row, i); if n != 0 { n } else { let s = row_text(row, i); parse_iso_date(&s) } }).unwrap_or(0),\n",
         );
+        // strike: decode to f64
         out.push_str("                strike: match _cid_strike_idx {\n");
         out.push_str(
-            "                    Some(i) if _cid_strike_is_typed => row_price_value(row, i),\n",
+            "                    Some(i) if _cid_strike_is_typed => row_price_f64(row, i),\n",
         );
-        out.push_str("                    Some(i) => row_number(row, i),\n");
-        out.push_str("                    None => 0,\n");
+        out.push_str("                    Some(i) => row_number(row, i) as f64,\n");
+        out.push_str("                    None => 0.0,\n");
         out.push_str("                },\n");
         out.push_str("                right: _cid_right_idx.map(|i| {\n");
         out.push_str("                    let s = row_text(row, i);\n");
@@ -496,15 +369,19 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
             "                    if s.is_empty() { 0i32 } else { s.as_bytes()[0] as i32 }\n",
         );
         out.push_str("                }).unwrap_or(0),\n");
-        out.push_str("                strike_price_type: match _cid_strike_idx {\n");
-        out.push_str(
-            "                    Some(i) if _cid_strike_is_typed => row_price_type(row, i),\n",
-        );
-        out.push_str("                    _ => 0,\n");
-        out.push_str("                },\n");
     }
 
-    out.push_str("            }\n");
+    if is_quote_tick {
+        // QuoteTick gets midpoint computed from bid + ask.
+        out.push_str("                midpoint: 0.0, // placeholder, set below\n");
+        out.push_str("            };\n");
+        out.push_str("            let mut _tick = _tick;\n");
+        out.push_str("            _tick.midpoint = (_tick.bid + _tick.ask) / 2.0;\n");
+        out.push_str("            _tick\n");
+    } else {
+        out.push_str("            }\n");
+    }
+
     out.push_str("        })\n");
     out.push_str("        .collect()\n");
     out.push_str("}\n\n");

--- a/crates/thetadatadx/endpoint_schema.toml
+++ b/crates/thetadatadx/endpoint_schema.toml
@@ -1,7 +1,6 @@
 # Tick Type Schema — single source of truth for all DataTable column schemas.
 #
 # build.rs reads this file and generates:
-#   - Rust tick structs  -> $OUT_DIR/tick_generated.rs
 #   - DataTable parsers  -> $OUT_DIR/decode_generated.rs
 #
 # Column types:
@@ -9,20 +8,19 @@
 #   i64     -> row_number_i64(row, i)                     default: 0
 #   f64     -> row_float(row, i)                          default: 0.0
 #   String  -> row_text(row, i)                           default: ""
-#   price   -> row_price_value(row, i) for .value,
-#              row_price_type(row, i) for price_type      default: 0
+#   price   -> decode to f64 via Price::new(raw, pt).to_f64()
 #   eod_num -> eod_num(row, i) handles both Price and Number cells  default: 0
+#   eod_price -> EOD price fields: decode to f64 at parse time
 #
 # Parser options:
 #   required = ["col1", "col2"]  -- headers that must exist or parser returns empty vec
-#   price_typed_columns = ["price", ...]  -- columns that may be Price-typed cells
 #   eod_style = true  -- use eod_num helper (handles both Price and Number cells)
 #
 # Struct options:
 #   copy = true/false   -- whether to derive Copy (false when String fields exist)
 #   align = 64          -- repr(C, align(N)); omit for no repr attribute
 #   doc = "..."         -- doc comment on the struct
-#   contract_id = true  -- inject expiration/strike/right/strike_price_type fields
+#   contract_id = true  -- inject expiration/strike/right fields
 #                          (populated by server on wildcard queries, 0 otherwise)
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -30,13 +28,12 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 [types.TradeTick]
-doc = "Trade tick -- 16 fields. Core unit of trade data."
+doc = "Trade tick -- 15 fields. Core unit of trade data."
 copy = true
 align = 64
 contract_id = true
 parser = "parse_trade_ticks"
 required = ["ms_of_day", "price"]
-price_typed_columns = ["price"]
 columns = [
     { name = "ms_of_day",       field = "ms_of_day",       type = "i32" },
     { name = "sequence",        field = "sequence",        type = "i32" },
@@ -52,18 +49,16 @@ columns = [
     { name = "price_flags",     field = "price_flags",     type = "i32" },
     { name = "volume_type",     field = "volume_type",     type = "i32" },
     { name = "records_back",    field = "records_back",    type = "i32" },
-    { name = "price_type",      field = "price_type",      type = "i32", price_source = "price" },
     { name = "date",            field = "date",            type = "i32" },
 ]
 
 [types.QuoteTick]
-doc = "Quote tick -- 11 fields. NBBO quote data."
+doc = "Quote tick -- 10 fields + midpoint. NBBO quote data."
 copy = true
 align = 64
 contract_id = true
 parser = "parse_quote_ticks"
 required = ["ms_of_day", "bid", "ask"]
-price_typed_columns = ["bid", "ask"]
 columns = [
     { name = "ms_of_day",     field = "ms_of_day",     type = "i32" },
     { name = "bid_size",      field = "bid_size",      type = "i32" },
@@ -74,18 +69,16 @@ columns = [
     { name = "ask_exchange",  field = "ask_exchange",  type = "i32" },
     { name = "ask",           field = "ask",           type = "price" },
     { name = "ask_condition", field = "ask_condition", type = "i32" },
-    { name = "price_type",    field = "price_type",    type = "i32", price_source = "bid" },
     { name = "date",          field = "date",          type = "i32" },
 ]
 
 [types.OhlcTick]
-doc = "OHLC tick -- 9 fields. Aggregated bar data."
+doc = "OHLC tick -- 8 fields. Aggregated bar data."
 copy = true
 align = 64
 contract_id = true
 parser = "parse_ohlc_ticks"
 required = ["ms_of_day", "open"]
-price_typed_columns = ["open", "high", "low", "close"]
 columns = [
     { name = "ms_of_day",  field = "ms_of_day",  type = "i32" },
     { name = "open",       field = "open",        type = "price" },
@@ -94,12 +87,11 @@ columns = [
     { name = "close",      field = "close",       type = "price" },
     { name = "volume",     field = "volume",      type = "i32" },
     { name = "count",      field = "count",       type = "i32" },
-    { name = "price_type", field = "price_type",  type = "i32", price_source = "open" },
     { name = "date",       field = "date",        type = "i32" },
 ]
 
 [types.EodTick]
-doc = "End-of-day tick -- 18 fields. Full EOD snapshot with OHLC + quote."
+doc = "End-of-day tick -- 17 fields. Full EOD snapshot with OHLC + quote."
 copy = true
 align = 64
 contract_id = true
@@ -109,21 +101,20 @@ required = []
 columns = [
     { name = "ms_of_day",     field = "ms_of_day",     type = "eod_num" },
     { name = "ms_of_day2",    field = "ms_of_day2",    type = "eod_num" },
-    { name = "open",          field = "open",          type = "eod_num" },
-    { name = "high",          field = "high",          type = "eod_num" },
-    { name = "low",           field = "low",           type = "eod_num" },
-    { name = "close",         field = "close",         type = "eod_num" },
+    { name = "open",          field = "open",          type = "eod_price" },
+    { name = "high",          field = "high",          type = "eod_price" },
+    { name = "low",           field = "low",           type = "eod_price" },
+    { name = "close",         field = "close",         type = "eod_price" },
     { name = "volume",        field = "volume",        type = "eod_num" },
     { name = "count",         field = "count",         type = "eod_num" },
     { name = "bid_size",      field = "bid_size",      type = "eod_num" },
     { name = "bid_exchange",  field = "bid_exchange",  type = "eod_num" },
-    { name = "bid",           field = "bid",           type = "eod_num" },
+    { name = "bid",           field = "bid",           type = "eod_price" },
     { name = "bid_condition", field = "bid_condition", type = "eod_num" },
     { name = "ask_size",      field = "ask_size",      type = "eod_num" },
     { name = "ask_exchange",  field = "ask_exchange",  type = "eod_num" },
-    { name = "ask",           field = "ask",           type = "eod_num" },
+    { name = "ask",           field = "ask",           type = "eod_price" },
     { name = "ask_condition", field = "ask_condition", type = "eod_num" },
-    { name = "price_type",    field = "price_type",    type = "i32", price_source = "open" },
     { name = "date",          field = "date",          type = "eod_num" },
 ]
 
@@ -144,30 +135,26 @@ columns = [
 ]
 
 [types.SnapshotTradeTick]
-doc = "Snapshot trade tick -- 7 fields. Abbreviated trade for snapshots."
+doc = "Snapshot trade tick -- 5 fields. Abbreviated trade for snapshots."
 copy = true
 contract_id = true
 parser = "parse_snapshot_trade_ticks"
 required = ["ms_of_day", "price"]
-price_typed_columns = ["price"]
 columns = [
     { name = "ms_of_day",  field = "ms_of_day",  type = "i32" },
     { name = "sequence",   field = "sequence",   type = "i32" },
     { name = "size",       field = "size",       type = "i32" },
     { name = "condition",  field = "condition",  type = "i32" },
     { name = "price",      field = "price",      type = "price" },
-    { name = "price_type", field = "price_type", type = "i32", price_source = "price" },
     { name = "date",       field = "date",       type = "i32" },
 ]
 
 [types.TradeQuoteTick]
-doc = "Combined trade + quote tick -- 26 fields."
+doc = "Combined trade + quote tick -- 24 fields."
 copy = true
 contract_id = true
 parser = "parse_trade_quote_ticks"
 required = ["ms_of_day", "price"]
-price_typed_columns = ["price"]
-# bid/ask always use row_price_value (not conditional on price_typed)
 columns = [
     { name = "ms_of_day",        field = "ms_of_day",        type = "i32" },
     { name = "sequence",         field = "sequence",         type = "i32" },
@@ -186,14 +173,12 @@ columns = [
     { name = "quote_ms_of_day",  field = "quote_ms_of_day",  type = "i32" },
     { name = "bid_size",         field = "bid_size",         type = "i32" },
     { name = "bid_exchange",     field = "bid_exchange",     type = "i32" },
-    { name = "bid",              field = "bid",              type = "price_value" },
+    { name = "bid",              field = "bid",              type = "price" },
     { name = "bid_condition",    field = "bid_condition",    type = "i32" },
     { name = "ask_size",         field = "ask_size",         type = "i32" },
     { name = "ask_exchange",     field = "ask_exchange",     type = "i32" },
-    { name = "ask",              field = "ask",              type = "price_value" },
+    { name = "ask",              field = "ask",              type = "price" },
     { name = "ask_condition",    field = "ask_condition",    type = "i32" },
-    { name = "quote_price_type", field = "quote_price_type", type = "i32" },
-    { name = "price_type",       field = "price_type",       type = "i32", price_source = "price" },
     { name = "date",             field = "date",             type = "i32" },
 ]
 
@@ -263,16 +248,14 @@ columns = [
 ]
 
 [types.PriceTick]
-doc = "Price tick -- 4 fields. Generic price data point."
+doc = "Price tick -- 3 fields. Generic price data point."
 copy = true
 align = 64
 parser = "parse_price_ticks"
 required = ["ms_of_day", "price"]
-price_typed_columns = ["price"]
 columns = [
     { name = "ms_of_day",  field = "ms_of_day",  type = "i32" },
     { name = "price",      field = "price",      type = "price" },
-    { name = "price_type", field = "price_type", type = "i32", price_source = "price" },
     { name = "date",       field = "date",       type = "i32" },
 ]
 
@@ -303,14 +286,13 @@ columns = [
 ]
 
 [types.OptionContract]
-doc = "Option contract -- 5 fields. Contract specification.\n\nCannot be `Copy` because of the `String` root field."
+doc = "Option contract -- 4 fields. Contract specification.\n\nCannot be `Copy` because of the `String` root field."
 copy = false
 parser = "parse_option_contracts"
 required = ["root"]
 columns = [
     { name = "root",              field = "root",              type = "String" },
     { name = "expiration",        field = "expiration",        type = "i32" },
-    { name = "strike",            field = "strike",            type = "i32" },
+    { name = "strike",            field = "strike",            type = "price" },
     { name = "right",             field = "right",             type = "i32" },
-    { name = "strike_price_type", field = "strike_price_type", type = "i32" },
 ]

--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -403,7 +403,8 @@ pub(crate) fn row_number(row: &proto::DataValueList, idx: usize) -> i32 {
 ///
 /// See [`row_number`] for null/missing cell handling rationale.
 // Reason: protocol-defined integer widths from Java FPSS specification.
-#[allow(clippy::cast_possible_truncation)]
+// Reason: retained for unit tests that verify raw price extraction.
+#[allow(clippy::cast_possible_truncation, dead_code)]
 pub(crate) fn row_price_value(row: &proto::DataValueList, idx: usize) -> i32 {
     row.values
         .get(idx)
@@ -435,7 +436,8 @@ pub(crate) fn row_price_value(row: &proto::DataValueList, idx: usize) -> i32 {
 ///
 /// See [`row_number`] for null/missing cell handling rationale.
 // Reason: protocol-defined integer widths from Java FPSS specification.
-#[allow(clippy::cast_possible_truncation)]
+// Reason: retained for unit tests that verify raw price type extraction.
+#[allow(clippy::cast_possible_truncation, dead_code)]
 pub(crate) fn row_price_type(row: &proto::DataValueList, idx: usize) -> i32 {
     row.values
         .get(idx)
@@ -454,6 +456,26 @@ pub(crate) fn row_price_type(row: &proto::DataValueList, idx: usize) -> i32 {
         .unwrap_or(0)
 }
 
+/// Decode a Price cell directly to `f64` using the cell's own `price_type`.
+///
+/// For Number cells, returns the number cast to `f64`.
+/// This is the primary accessor for the f64-native price API.
+// Reason: protocol-defined integer widths from Java FPSS specification.
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn row_price_f64(row: &proto::DataValueList, idx: usize) -> f64 {
+    row.values
+        .get(idx)
+        .and_then(|dv| dv.data_type.as_ref())
+        .map(|dt| match dt {
+            proto::data_value::DataType::Price(p) => {
+                tdbe::types::price::Price::new(p.value, p.r#type).to_f64()
+            }
+            proto::data_value::DataType::Number(n) => *n as f64,
+            _ => 0.0,
+        })
+        .unwrap_or(0.0)
+}
+
 /// Read a Price cell's value, normalized to `target_pt` (the row's canonical `price_type`).
 ///
 /// If the cell's `price_type` differs from `target_pt`, the value is rescaled
@@ -461,7 +483,8 @@ pub(crate) fn row_price_type(row: &proto::DataValueList, idx: usize) -> i32 {
 /// This handles OHLC bars where open/high/low/close can have different
 /// `price_types` per cell.
 // Reason: protocol-defined integer widths from Java FPSS specification.
-#[allow(clippy::cast_possible_truncation)]
+// Reason: retained for completeness; may be needed for future mixed-price-type handling.
+#[allow(clippy::cast_possible_truncation, dead_code)]
 pub(crate) fn row_price_value_normalized(
     row: &proto::DataValueList,
     idx: usize,
@@ -486,6 +509,7 @@ pub(crate) fn row_price_value_normalized(
 
 /// Rescale a price value from one `price_type` to another.
 /// Matches Java's `PriceCalcUtils.changePriceType`.
+#[allow(dead_code)]
 fn change_price_type(price: i32, from_type: i32, to_type: i32) -> i32 {
     const POW10: [i64; 10] = [
         1,
@@ -723,8 +747,7 @@ mod tests {
         // NullValue should default to 0, not corrupt subsequent fields.
         assert_eq!(tick.ext_condition1, 0);
         assert_eq!(tick.size, 100);
-        assert_eq!(tick.price, 15000);
-        assert_eq!(tick.price_type, 10);
+        assert!((tick.price - 15000.0).abs() < 1e-10);
         assert_eq!(tick.date, 20240301);
     }
 
@@ -953,15 +976,8 @@ pub fn parse_option_contracts_v3(table: &crate::proto::DataTable) -> Vec<OptionC
                 parse_iso_date(&s)
             });
 
-            // Strike: may be Price or Number
-            let (strike, strike_price_type) = strike_idx.map_or((0, 0), |i| {
-                let pv = row_price_value(row, i);
-                if pv != 0 {
-                    (pv, row_price_type(row, i))
-                } else {
-                    (row_number(row, i), 0)
-                }
-            });
+            // Strike: decode to f64 from Price or Number cell.
+            let strike = strike_idx.map_or(0.0, |i| row_price_f64(row, i));
 
             // Right: may be int or text "PUT"/"CALL"/"C"/"P"
             let right = right_idx.map_or(0, |i| {
@@ -982,7 +998,6 @@ pub fn parse_option_contracts_v3(table: &crate::proto::DataTable) -> Vec<OptionC
                 expiration,
                 strike,
                 right,
-                strike_price_type,
             }
         })
         .collect()

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -2181,8 +2181,8 @@ mod tests {
         let ticks = decode::parse_eod_ticks(&table);
         assert_eq!(ticks.len(), 1);
         assert_eq!(ticks[0].ms_of_day, 34200000);
-        assert_eq!(ticks[0].open, 15000);
-        assert_eq!(ticks[0].close, 15100);
+        assert!((ticks[0].open - 15000.0).abs() < 1e-10);
+        assert!((ticks[0].close - 15100.0).abs() < 1e-10);
         assert_eq!(ticks[0].date, 20240301);
     }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -919,9 +919,8 @@ pub struct TdxOptionContract {
     /// Heap-allocated NUL-terminated C string. Freed with the array.
     pub root: *const c_char,
     pub expiration: i32,
-    pub strike: i32,
+    pub strike: f64,
     pub right: i32,
-    pub strike_price_type: i32,
 }
 
 /// Array of FFI-safe option contracts.
@@ -949,7 +948,6 @@ impl TdxOptionContractArray {
                     expiration: c.expiration,
                     strike: c.strike,
                     right: c.right,
-                    strike_price_type: c.strike_price_type,
                 }
             })
             .collect();

--- a/sdks/cpp/examples/main.cpp
+++ b/sdks/cpp/examples/main.cpp
@@ -9,16 +9,16 @@ int main() {
         auto config = tdx::Config::production();
         auto client = tdx::Client::connect(creds, config);
 
-        // Fetch end-of-day data (raw #[repr(C)] structs — prices are raw integers)
+        // Fetch end-of-day data -- prices are already decoded to f64
         auto eod = client.stock_history_eod("AAPL", "20240101", "20240301");
         std::cout << "Got " << eod.size() << " EOD ticks for AAPL" << std::endl;
         for (auto& tick : eod) {
             std::cout << "  " << tick.date
                       << ": O=" << std::fixed << std::setprecision(2)
-                      << tdx::price_to_f64(tick.open, tick.price_type)
-                      << " H=" << tdx::price_to_f64(tick.high, tick.price_type)
-                      << " L=" << tdx::price_to_f64(tick.low, tick.price_type)
-                      << " C=" << tdx::price_to_f64(tick.close, tick.price_type)
+                      << tick.open
+                      << " H=" << tick.high
+                      << " L=" << tick.low
+                      << " C=" << tick.close
                       << " V=" << tick.volume
                       << std::endl;
         }

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -34,7 +34,8 @@ typedef struct TdxFpssHandle TdxFpssHandle;
 /*  #[repr(C)] tick types — layout-compatible with Rust tdbe structs      */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
-/* All tick structs are 64-byte aligned to match Rust's #[repr(C, align(64))]. */
+/* All tick structs are 64-byte aligned to match Rust's #[repr(C, align(64))].
+ * Price fields are f64 (double) -- decoded during parsing. No price_type. */
 
 typedef struct __attribute__((aligned(64))) {
     int32_t date;
@@ -47,26 +48,26 @@ typedef struct __attribute__((aligned(64))) {
 typedef struct __attribute__((aligned(64))) {
     int32_t ms_of_day;
     int32_t ms_of_day2;
-    int32_t open;
-    int32_t high;
-    int32_t low;
-    int32_t close;
+    double open;
+    double high;
+    double low;
+    double close;
     int32_t volume;
     int32_t count;
     int32_t bid_size;
     int32_t bid_exchange;
-    int32_t bid;
+    double bid;
     int32_t bid_condition;
+    /* 4 bytes padding */
     int32_t ask_size;
     int32_t ask_exchange;
-    int32_t ask;
+    double ask;
     int32_t ask_condition;
-    int32_t price_type;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    /* 4 bytes padding */
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxEodTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -96,9 +97,8 @@ typedef struct __attribute__((aligned(64))) {
     double vera;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxGreeksTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -115,9 +115,8 @@ typedef struct __attribute__((aligned(64))) {
     double iv_error;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxIvTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -130,25 +129,23 @@ typedef struct __attribute__((aligned(64))) {
     int64_t free_float;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxMarketValueTick;
 
 typedef struct __attribute__((aligned(64))) {
     int32_t ms_of_day;
-    int32_t open;
-    int32_t high;
-    int32_t low;
-    int32_t close;
+    /* 4 bytes padding before f64 */
+    double open;
+    double high;
+    double low;
+    double close;
     int32_t volume;
     int32_t count;
-    int32_t price_type;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxOhlcTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -156,15 +153,14 @@ typedef struct __attribute__((aligned(64))) {
     int32_t open_interest;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxOpenInterestTick;
 
 typedef struct __attribute__((aligned(64))) {
     int32_t ms_of_day;
-    int32_t price;
-    int32_t price_type;
+    /* 4 bytes padding before f64 */
+    double price;
     int32_t date;
 } TdxPriceTick;
 
@@ -172,19 +168,34 @@ typedef struct __attribute__((aligned(64))) {
     int32_t ms_of_day;
     int32_t bid_size;
     int32_t bid_exchange;
-    int32_t bid;
+    /* 4 bytes padding before f64 */
+    double bid;
     int32_t bid_condition;
     int32_t ask_size;
     int32_t ask_exchange;
-    int32_t ask;
+    /* 4 bytes padding before f64 */
+    double ask;
     int32_t ask_condition;
-    int32_t price_type;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    /* 4 bytes padding before f64 */
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
+    /* 4 bytes padding before f64 */
+    double midpoint;
 } TdxQuoteTick;
+
+typedef struct __attribute__((aligned(64))) {
+    int32_t ms_of_day;
+    int32_t sequence;
+    int32_t size;
+    int32_t condition;
+    double price;
+    int32_t date;
+    int32_t expiration;
+    double strike;
+    int32_t right;
+} TdxSnapshotTradeTick;
 
 typedef struct __attribute__((aligned(64))) {
     int32_t ms_of_day;
@@ -196,7 +207,8 @@ typedef struct __attribute__((aligned(64))) {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    int32_t price;
+    /* 4 bytes padding before f64 */
+    double price;
     int32_t condition_flags;
     int32_t price_flags;
     int32_t volume_type;
@@ -204,19 +216,19 @@ typedef struct __attribute__((aligned(64))) {
     int32_t quote_ms_of_day;
     int32_t bid_size;
     int32_t bid_exchange;
-    int32_t bid;
+    /* 4 bytes padding before f64 */
+    double bid;
     int32_t bid_condition;
     int32_t ask_size;
     int32_t ask_exchange;
-    int32_t ask;
+    /* 4 bytes padding before f64 */
+    double ask;
     int32_t ask_condition;
-    int32_t quote_price_type;
-    int32_t price_type;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    /* 4 bytes padding before f64 */
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxTradeQuoteTick;
 
 typedef struct __attribute__((aligned(64))) {
@@ -229,17 +241,16 @@ typedef struct __attribute__((aligned(64))) {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    int32_t price;
+    /* 4 bytes padding before f64 */
+    double price;
     int32_t condition_flags;
     int32_t price_flags;
     int32_t volume_type;
     int32_t records_back;
-    int32_t price_type;
     int32_t date;
     int32_t expiration;
-    int32_t strike;
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxTradeTick;
 
 /* ═══════════════════════════════════════════════════════════════════════ */
@@ -264,9 +275,9 @@ typedef struct { const TdxTradeQuoteTick* data; size_t len; } TdxTradeQuoteTickA
 typedef struct {
     const char* root;       /* heap-allocated, freed with tdx_option_contract_array_free */
     int32_t expiration;
-    int32_t strike;
+    /* 4 bytes padding before f64 */
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 } TdxOptionContract;
 
 typedef struct { const TdxOptionContract* data; size_t len; } TdxOptionContractArray;

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -46,65 +46,9 @@ using TradeQuoteTick = TdxTradeQuoteTick;
 struct OptionContract {
     std::string root;
     int32_t expiration;
-    int32_t strike;
+    double strike;
     int32_t right;
-    int32_t strike_price_type;
 };
-
-// ── Price decoding utility ──
-
-/** Decode a raw integer price + price_type to f64.
- *  ThetaData encoding: value * 10^(price_type - 10). */
-inline double price_to_f64(int32_t value, int32_t price_type) {
-    if (price_type == 0) return 0.0;
-    double v = static_cast<double>(value);
-    int exp = price_type - 10;
-    double factor = 1.0;
-    if (exp > 0) {
-        for (int i = 0; i < exp; ++i) factor *= 10.0;
-    } else if (exp < 0) {
-        for (int i = 0; i < -exp; ++i) factor *= 10.0;
-        factor = 1.0 / factor;
-    }
-    return v * factor;
-}
-
-// ── Convenience f64 price accessors ──
-// The tick types are C struct aliases, so we use free functions.
-
-/** Decode trade price to f64. Works with TradeTick and SnapshotTradeTick. */
-inline double trade_price_f64(const TradeTick& t) { return price_to_f64(t.price, t.price_type); }
-inline double trade_price_f64(const SnapshotTradeTick& t) { return price_to_f64(t.price, t.price_type); }
-
-/** Decode bid/ask/midpoint to f64 for QuoteTick. */
-inline double bid_f64(const QuoteTick& q) { return price_to_f64(q.bid, q.price_type); }
-inline double ask_f64(const QuoteTick& q) { return price_to_f64(q.ask, q.price_type); }
-inline double midpoint_f64(const QuoteTick& q) {
-    int32_t mid = q.bid / 2 + q.ask / 2 + (q.bid % 2 + q.ask % 2) / 2;
-    return price_to_f64(mid, q.price_type);
-}
-
-/** Decode OHLC prices to f64 for OhlcTick. */
-inline double open_f64(const OhlcTick& t) { return price_to_f64(t.open, t.price_type); }
-inline double high_f64(const OhlcTick& t) { return price_to_f64(t.high, t.price_type); }
-inline double low_f64(const OhlcTick& t) { return price_to_f64(t.low, t.price_type); }
-inline double close_f64(const OhlcTick& t) { return price_to_f64(t.close, t.price_type); }
-
-/** Decode OHLC + bid/ask prices to f64 for EodTick. */
-inline double open_f64(const EodTick& t) { return price_to_f64(t.open, t.price_type); }
-inline double high_f64(const EodTick& t) { return price_to_f64(t.high, t.price_type); }
-inline double low_f64(const EodTick& t) { return price_to_f64(t.low, t.price_type); }
-inline double close_f64(const EodTick& t) { return price_to_f64(t.close, t.price_type); }
-inline double bid_f64(const EodTick& t) { return price_to_f64(t.bid, t.price_type); }
-inline double ask_f64(const EodTick& t) { return price_to_f64(t.ask, t.price_type); }
-
-/** Decode trade/bid/ask prices to f64 for TradeQuoteTick. */
-inline double trade_price_f64(const TradeQuoteTick& t) { return price_to_f64(t.price, t.price_type); }
-inline double bid_f64(const TradeQuoteTick& t) { return price_to_f64(t.bid, t.price_type); }
-inline double ask_f64(const TradeQuoteTick& t) { return price_to_f64(t.ask, t.price_type); }
-
-/** Decode price to f64 for PriceTick. */
-inline double price_f64(const PriceTick& t) { return price_to_f64(t.price, t.price_type); }
 
 // ── Greeks result (from standalone tdx_all_greeks) ──
 

--- a/sdks/cpp/src/thetadx.cpp
+++ b/sdks/cpp/src/thetadx.cpp
@@ -193,7 +193,6 @@ std::vector<OptionContract> Client::option_list_contracts(const std::string& req
         c.expiration = arr.data[i].expiration;
         c.strike = arr.data[i].strike;
         c.right = arr.data[i].right;
-        c.strike_price_type = arr.data[i].strike_price_type;
         result.push_back(std::move(c));
     }
     tdx_option_contract_array_free(arr);

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -162,114 +162,130 @@ import "C"
 
 import (
 	"fmt"
-	"math"
 	"unsafe"
 )
 
 // ── C-compatible struct mirrors (matching Rust #[repr(C, align(64))]) ──
 // These are Go equivalents with matching field layout for unsafe.Slice conversion.
 // The align(64) means each struct occupies a multiple of 64 bytes.
+// Price fields are f64 (decoded during parsing). No price_type in public API.
 
 // cEodTick mirrors tdbe::EodTick #[repr(C, align(64))]
+// Layout: i32(4)+i32(4)+f64(8)*6+i32(4)*6+f64(8)*2+i32(4)+i32(4)+f64(8)+i32(4)
+// = 8 + 48 + 24 + 16 + 4 + 4 + 8 + 4 = 116, pad(4) to align f64, total needs care
+// Actually repr(C): ms_of_day(4), ms_of_day2(4), open(8), high(8), low(8), close(8),
+// volume(4), count(4), bid_size(4), bid_exchange(4), bid(8), bid_condition(4), pad(4),
+// ask_size(4), ask_exchange(4), ask(8), ask_condition(4), date(4), exp(4), pad(4),
+// strike(8), right(4), pad(4) -> 128 total, fits in 128 (2*64)
 type cEodTick struct {
-	MsOfDay         int32
-	MsOfDay2        int32
-	Open            int32
-	High            int32
-	Low             int32
-	Close           int32
-	Volume          int32
-	Count           int32
-	BidSize         int32
-	BidExchange     int32
-	Bid             int32
-	BidCondition    int32
-	AskSize         int32
-	AskExchange     int32
-	Ask             int32
-	AskCondition    int32
-	PriceType       int32
-	Date            int32
-	Expiration      int32
-	Strike          int32
-	Right           int32
-	StrikePriceType int32
-	_pad            [128 - 22*4]byte
+	MsOfDay      int32
+	MsOfDay2     int32
+	Open         float64
+	High         float64
+	Low          float64
+	Close        float64
+	Volume       int32
+	Count        int32
+	BidSize      int32
+	BidExchange  int32
+	Bid          float64
+	BidCondition int32
+	_pad1        int32
+	AskSize      int32
+	AskExchange  int32
+	Ask          float64
+	AskCondition int32
+	Date         int32
+	Expiration   int32
+	_pad2        int32
+	Strike       float64
+	Right        int32
+	_pad3        [128 - 124]byte
 }
 
 // cOhlcTick mirrors tdbe::OhlcTick #[repr(C, align(64))]
+// Layout: ms_of_day(4), pad(4), open(8), high(8), low(8), close(8),
+// volume(4), count(4), date(4), exp(4), strike(8), right(4), pad(4) = 72
+// rounded to 128
 type cOhlcTick struct {
-	MsOfDay         int32
-	Open            int32
-	High            int32
-	Low             int32
-	Close           int32
-	Volume          int32
-	Count           int32
-	PriceType       int32
-	Date            int32
-	Expiration      int32
-	Strike          int32
-	Right           int32
-	StrikePriceType int32
-	_pad            [64 - 13*4]byte
+	MsOfDay    int32
+	_pad1      int32
+	Open       float64
+	High       float64
+	Low        float64
+	Close      float64
+	Volume     int32
+	Count      int32
+	Date       int32
+	Expiration int32
+	Strike     float64
+	Right      int32
+	_pad2      [128 - 76]byte
 }
 
 // cTradeTick mirrors tdbe::TradeTick #[repr(C, align(64))]
+// Layout: 9*i32(36), pad(4), price(8), 4*i32(16), date(4), exp(4),
+// strike(8), right(4), pad(4) = 88, rounded to 128
 type cTradeTick struct {
-	MsOfDay         int32
-	Sequence        int32
-	ExtCondition1   int32
-	ExtCondition2   int32
-	ExtCondition3   int32
-	ExtCondition4   int32
-	Condition       int32
-	Size            int32
-	Exchange        int32
-	Price           int32
-	ConditionFlags  int32
-	PriceFlags      int32
-	VolumeType      int32
-	RecordsBack     int32
-	PriceType       int32
-	Date            int32
-	Expiration      int32
-	Strike          int32
-	Right           int32
-	StrikePriceType int32
-	_pad            [128 - 20*4]byte
+	MsOfDay        int32
+	Sequence       int32
+	ExtCondition1  int32
+	ExtCondition2  int32
+	ExtCondition3  int32
+	ExtCondition4  int32
+	Condition      int32
+	Size           int32
+	Exchange       int32
+	_pad1          int32
+	Price          float64
+	ConditionFlags int32
+	PriceFlags     int32
+	VolumeType     int32
+	RecordsBack    int32
+	Date           int32
+	Expiration     int32
+	Strike         float64
+	Right          int32
+	_pad2          [128 - 92]byte
 }
 
 // cQuoteTick mirrors tdbe::QuoteTick #[repr(C, align(64))]
+// Layout: ms_of_day(4), bid_size(4), bid_exchange(4), pad(4), bid(8),
+// bid_condition(4), ask_size(4), ask_exchange(4), pad(4), ask(8),
+// ask_condition(4), date(4), exp(4), pad(4), strike(8), right(4), pad(4),
+// midpoint(8) = 96, rounded to 128
 type cQuoteTick struct {
-	MsOfDay         int32
-	BidSize         int32
-	BidExchange     int32
-	Bid             int32
-	BidCondition    int32
-	AskSize         int32
-	AskExchange     int32
-	Ask             int32
-	AskCondition    int32
-	PriceType       int32
-	Date            int32
-	Expiration      int32
-	Strike          int32
-	Right           int32
-	StrikePriceType int32
-	_pad            [64 - 15*4]byte
+	MsOfDay      int32
+	BidSize      int32
+	BidExchange  int32
+	_pad1        int32
+	Bid          float64
+	BidCondition int32
+	AskSize      int32
+	AskExchange  int32
+	_pad2        int32
+	Ask          float64
+	AskCondition int32
+	Date         int32
+	Expiration   int32
+	_pad3        int32
+	Strike       float64
+	Right        int32
+	_pad4        int32
+	Midpoint     float64
+	_pad5        [128 - 96]byte
 }
 
 // cOpenInterestTick mirrors tdbe::OpenInterestTick #[repr(C, align(64))]
+// Layout: ms_of_day(4), oi(4), date(4), exp(4), strike(8), right(4), pad(4) = 32
 type cOpenInterestTick struct {
-	MsOfDay         int32
-	OpenInterest    int32
-	Date            int32
-	Expiration      int32
-	Strike          int32
-	Right           int32
-	StrikePriceType int32
-	_pad            [64 - 7*4]byte
+	MsOfDay      int32
+	OpenInterest int32
+	Date         int32
+	Expiration   int32
+	Strike       float64
+	Right        int32
+	_pad         [64 - 28]byte
 }
 
 // cCalendarDay mirrors tdbe::CalendarDay #[repr(C, align(64))]
@@ -283,7 +299,6 @@ type cCalendarDay struct {
 }
 
 // cInterestRateTick mirrors tdbe::InterestRateTick #[repr(C, align(64))]
-// Layout: i32, pad(4), f64, i32, pad to 64
 type cInterestRateTick struct {
 	MsOfDay int32
 	_pad1   int32
@@ -293,31 +308,31 @@ type cInterestRateTick struct {
 }
 
 // cIvTick mirrors tdbe::IvTick #[repr(C, align(64))]
-// Layout: i32, pad(4), f64, f64, i32, pad to 64
+// Layout: ms_of_day(4), pad(4), iv(8), iv_error(8), date(4), exp(4), strike(8), right(4), pad(4) = 48
 type cIvTick struct {
-	MsOfDay            int32
-	_pad1              int32
-	ImpliedVolatility  float64
-	IvError            float64
-	Date               int32
-	Expiration         int32
-	Strike             int32
-	Right              int32
-	StrikePriceType    int32
-	_pad2              [64 - 4 - 4 - 8 - 8 - 4*5]byte
+	MsOfDay           int32
+	_pad1             int32
+	ImpliedVolatility float64
+	IvError           float64
+	Date              int32
+	Expiration        int32
+	Strike            float64
+	Right             int32
+	_pad2             [64 - 48]byte
 }
 
 // cPriceTick mirrors tdbe::PriceTick #[repr(C, align(64))]
+// Layout: ms_of_day(4), pad(4), price(8), date(4), pad to 64
 type cPriceTick struct {
-	MsOfDay   int32
-	Price     int32
-	PriceType int32
-	Date      int32
-	_pad      [64 - 4*4]byte
+	MsOfDay int32
+	_pad1   int32
+	Price   float64
+	Date    int32
+	_pad2   [64 - 4 - 4 - 8 - 4]byte
 }
 
 // cMarketValueTick mirrors tdbe::MarketValueTick #[repr(C, align(64))]
-// Layout: i32, pad(4), i64, i64, i64, i64, i64, i32, pad to 64
+// Layout: ms_of_day(4), pad(4), 5*i64(40), date(4), exp(4), strike(8), right(4), pad(4) = 72
 type cMarketValueTick struct {
 	MsOfDay           int32
 	_pad1             int32
@@ -328,147 +343,135 @@ type cMarketValueTick struct {
 	FreeFloat         int64
 	Date              int32
 	Expiration        int32
-	Strike            int32
+	Strike            float64
 	Right             int32
-	StrikePriceType   int32
-	_pad2             [128 - 4 - 4 - 5*8 - 4*5]byte
+	_pad2             [128 - 76]byte
 }
 
 // cGreeksTick mirrors tdbe::GreeksTick #[repr(C, align(64))]
-// This struct is > 64 bytes. align(64) means size is rounded up to multiple of 64.
-// Layout: i32(4) + pad(4) + 22*f64(176) + 5*i32(20) = 204, rounded to 256
+// Layout: ms_of_day(4), pad(4), 22*f64(176), date(4), exp(4), strike(8), right(4), pad(4) = 208
+// rounded to 256
 type cGreeksTick struct {
-	MsOfDay            int32
-	_pad1              int32
-	ImpliedVolatility  float64
-	Delta              float64
-	Gamma              float64
-	Theta              float64
-	Vega               float64
-	Rho                float64
-	IvError            float64
-	Vanna              float64
-	Charm              float64
-	Vomma              float64
-	Veta               float64
-	Speed              float64
-	Zomma              float64
-	Color              float64
-	Ultima             float64
-	D1                 float64
-	D2                 float64
-	DualDelta          float64
-	DualGamma          float64
-	Epsilon            float64
-	Lambda             float64
-	Vera               float64
-	Date               int32
-	Expiration         int32
-	Strike             int32
-	Right              int32
-	StrikePriceType    int32
-	_pad2              [256 - 4 - 4 - 22*8 - 4*5]byte
+	MsOfDay           int32
+	_pad1             int32
+	ImpliedVolatility float64
+	Delta             float64
+	Gamma             float64
+	Theta             float64
+	Vega              float64
+	Rho               float64
+	IvError           float64
+	Vanna             float64
+	Charm             float64
+	Vomma             float64
+	Veta              float64
+	Speed             float64
+	Zomma             float64
+	Color             float64
+	Ultima            float64
+	D1                float64
+	D2                float64
+	DualDelta         float64
+	DualGamma         float64
+	Epsilon           float64
+	Lambda            float64
+	Vera              float64
+	Date              int32
+	Expiration        int32
+	Strike            float64
+	Right             int32
+	_pad2             [256 - 212]byte
 }
 
 // cTradeQuoteTick mirrors tdbe::TradeQuoteTick #[repr(C, align(64))]
-// 26 i32 fields = 104 bytes, rounded to 128 (next multiple of 64)
+// Layout: 9*i32(36), pad(4), price(8), 4*i32(16), quote_ms(4), bid_size(4),
+// bid_exchange(4), pad(4), bid(8), bid_condition(4), ask_size(4),
+// ask_exchange(4), pad(4), ask(8), ask_condition(4), date(4), exp(4), pad(4),
+// strike(8), right(4), pad(4) = 168, rounded to 192
 type cTradeQuoteTick struct {
-	MsOfDay         int32
-	Sequence        int32
-	ExtCondition1   int32
-	ExtCondition2   int32
-	ExtCondition3   int32
-	ExtCondition4   int32
-	Condition       int32
-	Size            int32
-	Exchange        int32
-	Price           int32
-	ConditionFlags  int32
-	PriceFlags      int32
-	VolumeType      int32
-	RecordsBack     int32
-	QuoteMsOfDay    int32
-	BidSize         int32
-	BidExchange     int32
-	Bid             int32
-	BidCondition    int32
-	AskSize         int32
-	AskExchange     int32
-	Ask             int32
-	AskCondition    int32
-	QuotePriceType  int32
-	PriceType       int32
-	Date            int32
-	Expiration      int32
-	Strike          int32
-	Right           int32
-	StrikePriceType int32
-	_pad            [128 - 30*4]byte
+	MsOfDay        int32
+	Sequence       int32
+	ExtCondition1  int32
+	ExtCondition2  int32
+	ExtCondition3  int32
+	ExtCondition4  int32
+	Condition      int32
+	Size           int32
+	Exchange       int32
+	_pad1          int32
+	Price          float64
+	ConditionFlags int32
+	PriceFlags     int32
+	VolumeType     int32
+	RecordsBack    int32
+	QuoteMsOfDay   int32
+	BidSize        int32
+	BidExchange    int32
+	_pad2          int32
+	Bid            float64
+	BidCondition   int32
+	AskSize        int32
+	AskExchange    int32
+	_pad3          int32
+	Ask            float64
+	AskCondition   int32
+	Date           int32
+	Expiration     int32
+	_pad4          int32
+	Strike         float64
+	Right          int32
+	_pad5          [192 - 164]byte
 }
 
 // cOptionContract mirrors TdxOptionContract from FFI
+// Layout: root(8 ptr), exp(4), pad(4), strike(8), right(4), pad(4) = 32
 type cOptionContract struct {
-	Root           uintptr // *const c_char
-	Expiration     int32
-	Strike         int32
-	Right          int32
-	StrikePriceType int32
+	Root       uintptr // *const c_char
+	Expiration int32
+	_pad1      int32
+	Strike     float64
+	Right      int32
+	_pad2      int32
 }
 
 // ── Go tick types (public API) ──
 // These are pure Go structs with decoded float prices for user convenience.
 
 type EodTick struct {
-	MsOfDay        int     `json:"ms_of_day"`
-	MsOfDay2       int     `json:"ms_of_day2"`
-	Open           float64 `json:"open"`
-	OpenRaw        int     `json:"open_raw,omitempty"`
-	High           float64 `json:"high"`
-	HighRaw        int     `json:"high_raw,omitempty"`
-	Low            float64 `json:"low"`
-	LowRaw         int     `json:"low_raw,omitempty"`
-	Close          float64 `json:"close"`
-	CloseRaw       int     `json:"close_raw,omitempty"`
-	Volume         int     `json:"volume"`
-	Count          int     `json:"count"`
-	BidSize        int     `json:"bid_size"`
-	BidExchange    int     `json:"bid_exchange"`
-	Bid            float64 `json:"bid"`
-	BidRaw         int     `json:"bid_raw,omitempty"`
-	BidCondition   int     `json:"bid_condition"`
-	AskSize        int     `json:"ask_size"`
-	AskExchange    int     `json:"ask_exchange"`
-	Ask            float64 `json:"ask"`
-	AskRaw         int     `json:"ask_raw,omitempty"`
-	AskCondition   int     `json:"ask_condition"`
-	PriceType      int     `json:"price_type"`
-	Date           int     `json:"date"`
-	Expiration     int32   `json:"expiration,omitempty"`
-	Strike         int32   `json:"strike,omitempty"`
-	Right          string  `json:"right,omitempty"`
-	RightRaw       int32   `json:"right_raw,omitempty"`
-	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	MsOfDay      int     `json:"ms_of_day"`
+	MsOfDay2     int     `json:"ms_of_day2"`
+	Open         float64 `json:"open"`
+	High         float64 `json:"high"`
+	Low          float64 `json:"low"`
+	Close        float64 `json:"close"`
+	Volume       int     `json:"volume"`
+	Count        int     `json:"count"`
+	BidSize      int     `json:"bid_size"`
+	BidExchange  int     `json:"bid_exchange"`
+	Bid          float64 `json:"bid"`
+	BidCondition int     `json:"bid_condition"`
+	AskSize      int     `json:"ask_size"`
+	AskExchange  int     `json:"ask_exchange"`
+	Ask          float64 `json:"ask"`
+	AskCondition int     `json:"ask_condition"`
+	Date         int     `json:"date"`
+	Expiration   int32   `json:"expiration,omitempty"`
+	Strike       float64 `json:"strike,omitempty"`
+	Right        string  `json:"right,omitempty"`
 }
 
 type OhlcTick struct {
-	MsOfDay        int     `json:"ms_of_day"`
-	Open           float64 `json:"open"`
-	OpenRaw        int     `json:"open_raw,omitempty"`
-	High           float64 `json:"high"`
-	HighRaw        int     `json:"high_raw,omitempty"`
-	Low            float64 `json:"low"`
-	LowRaw         int     `json:"low_raw,omitempty"`
-	Close          float64 `json:"close"`
-	CloseRaw       int     `json:"close_raw,omitempty"`
-	Volume         int     `json:"volume"`
-	Count          int     `json:"count"`
-	PriceType      int     `json:"price_type"`
-	Date           int     `json:"date"`
-	Expiration     int32   `json:"expiration,omitempty"`
-	Strike         int32   `json:"strike,omitempty"`
-	Right          string  `json:"right,omitempty"`
-	RightRaw       int32   `json:"right_raw,omitempty"`
-	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	MsOfDay    int     `json:"ms_of_day"`
+	Open       float64 `json:"open"`
+	High       float64 `json:"high"`
+	Low        float64 `json:"low"`
+	Close      float64 `json:"close"`
+	Volume     int     `json:"volume"`
+	Count      int     `json:"count"`
+	Date       int     `json:"date"`
+	Expiration int32   `json:"expiration,omitempty"`
+	Strike     float64 `json:"strike,omitempty"`
+	Right      string  `json:"right,omitempty"`
 }
 
 type TradeTick struct {
@@ -482,39 +485,31 @@ type TradeTick struct {
 	Size           int     `json:"size"`
 	Exchange       int     `json:"exchange"`
 	Price          float64 `json:"price"`
-	PriceRaw       int     `json:"price_raw,omitempty"`
-	PriceType      int     `json:"price_type"`
 	ConditionFlags int     `json:"condition_flags"`
 	PriceFlags     int     `json:"price_flags"`
 	VolumeType     int     `json:"volume_type"`
 	RecordsBack    int     `json:"records_back"`
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
-	Strike         int32   `json:"strike,omitempty"`
+	Strike         float64 `json:"strike,omitempty"`
 	Right          string  `json:"right,omitempty"`
-	RightRaw       int32   `json:"right_raw,omitempty"`
-	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type QuoteTick struct {
-	MsOfDay        int     `json:"ms_of_day"`
-	BidSize        int     `json:"bid_size"`
-	BidExchange    int     `json:"bid_exchange"`
-	Bid            float64 `json:"bid"`
-	BidRaw         int     `json:"bid_raw,omitempty"`
-	BidCondition   int     `json:"bid_condition"`
-	AskSize        int     `json:"ask_size"`
-	AskExchange    int     `json:"ask_exchange"`
-	Ask            float64 `json:"ask"`
-	AskRaw         int     `json:"ask_raw,omitempty"`
-	AskCondition   int     `json:"ask_condition"`
-	PriceType      int     `json:"price_type"`
-	Date           int     `json:"date"`
-	Expiration     int32   `json:"expiration,omitempty"`
-	Strike         int32   `json:"strike,omitempty"`
-	Right          string  `json:"right,omitempty"`
-	RightRaw       int32   `json:"right_raw,omitempty"`
-	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	MsOfDay      int     `json:"ms_of_day"`
+	BidSize      int     `json:"bid_size"`
+	BidExchange  int     `json:"bid_exchange"`
+	Bid          float64 `json:"bid"`
+	BidCondition int     `json:"bid_condition"`
+	AskSize      int     `json:"ask_size"`
+	AskExchange  int     `json:"ask_exchange"`
+	Ask          float64 `json:"ask"`
+	AskCondition int     `json:"ask_condition"`
+	Midpoint     float64 `json:"midpoint"`
+	Date         int     `json:"date"`
+	Expiration   int32   `json:"expiration,omitempty"`
+	Strike       float64 `json:"strike,omitempty"`
+	Right        string  `json:"right,omitempty"`
 }
 
 type TradeQuoteTick struct {
@@ -528,7 +523,6 @@ type TradeQuoteTick struct {
 	Size           int     `json:"size"`
 	Exchange       int     `json:"exchange"`
 	Price          float64 `json:"price"`
-	PriceRaw       int     `json:"price_raw,omitempty"`
 	ConditionFlags int     `json:"condition_flags"`
 	PriceFlags     int     `json:"price_flags"`
 	VolumeType     int     `json:"volume_type"`
@@ -537,47 +531,37 @@ type TradeQuoteTick struct {
 	BidSize        int     `json:"bid_size"`
 	BidExchange    int     `json:"bid_exchange"`
 	Bid            float64 `json:"bid"`
-	BidRaw         int     `json:"bid_raw,omitempty"`
 	BidCondition   int     `json:"bid_condition"`
 	AskSize        int     `json:"ask_size"`
 	AskExchange    int     `json:"ask_exchange"`
 	Ask            float64 `json:"ask"`
-	AskRaw         int     `json:"ask_raw,omitempty"`
 	AskCondition   int     `json:"ask_condition"`
-	QuotePriceType int     `json:"quote_price_type"`
-	PriceType      int     `json:"price_type"`
 	Date           int     `json:"date"`
 	Expiration     int32   `json:"expiration,omitempty"`
-	Strike         int32   `json:"strike,omitempty"`
+	Strike         float64 `json:"strike,omitempty"`
 	Right          string  `json:"right,omitempty"`
-	RightRaw       int32   `json:"right_raw,omitempty"`
-	StrikePriceType int32  `json:"strike_price_type,omitempty"`
 }
 
 type OpenInterestTick struct {
-	MsOfDay        int   `json:"ms_of_day"`
-	OpenInterest   int   `json:"open_interest"`
-	Date           int   `json:"date"`
-	Expiration     int32  `json:"expiration,omitempty"`
-	Strike         int32  `json:"strike,omitempty"`
-	Right          string `json:"right,omitempty"`
-	RightRaw       int32  `json:"right_raw,omitempty"`
-	StrikePriceType int32 `json:"strike_price_type,omitempty"`
+	MsOfDay      int     `json:"ms_of_day"`
+	OpenInterest int     `json:"open_interest"`
+	Date         int     `json:"date"`
+	Expiration   int32   `json:"expiration,omitempty"`
+	Strike       float64 `json:"strike,omitempty"`
+	Right        string  `json:"right,omitempty"`
 }
 
 type MarketValueTick struct {
-	MsOfDay        int     `json:"ms_of_day"`
-	MarketCap      int64   `json:"market_cap"`
-	SharesOut      int64   `json:"shares_outstanding"`
-	EntValue       int64   `json:"enterprise_value"`
-	BookValue      int64   `json:"book_value"`
-	FreeFloat      int64   `json:"free_float"`
-	Date           int     `json:"date"`
-	Expiration     int32   `json:"expiration,omitempty"`
-	Strike         int32   `json:"strike,omitempty"`
-	Right          string  `json:"right,omitempty"`
-	RightRaw       int32   `json:"right_raw,omitempty"`
-	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	MsOfDay   int     `json:"ms_of_day"`
+	MarketCap int64   `json:"market_cap"`
+	SharesOut int64   `json:"shares_outstanding"`
+	EntValue  int64   `json:"enterprise_value"`
+	BookValue int64   `json:"book_value"`
+	FreeFloat int64   `json:"free_float"`
+	Date      int     `json:"date"`
+	Expiration int32  `json:"expiration,omitempty"`
+	Strike    float64 `json:"strike,omitempty"`
+	Right     string  `json:"right,omitempty"`
 }
 
 type GreeksTick struct {
@@ -603,33 +587,27 @@ type GreeksTick struct {
 	DualGamma      float64 `json:"dual_gamma"`
 	Epsilon        float64 `json:"epsilon"`
 	Lambda         float64 `json:"lambda"`
-	Vera           float64 `json:"vera"`
-	Date           int     `json:"date"`
-	Expiration     int32   `json:"expiration,omitempty"`
-	Strike         int32   `json:"strike,omitempty"`
-	Right          string  `json:"right,omitempty"`
-	RightRaw       int32   `json:"right_raw,omitempty"`
-	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	Vera       float64 `json:"vera"`
+	Date       int     `json:"date"`
+	Expiration int32   `json:"expiration,omitempty"`
+	Strike     float64 `json:"strike,omitempty"`
+	Right      string  `json:"right,omitempty"`
 }
 
 type IVTick struct {
-	MsOfDay        int     `json:"ms_of_day"`
-	IV             float64 `json:"implied_volatility"`
-	IVError        float64 `json:"iv_error"`
-	Date           int     `json:"date"`
-	Expiration     int32   `json:"expiration,omitempty"`
-	Strike         int32   `json:"strike,omitempty"`
-	Right          string  `json:"right,omitempty"`
-	RightRaw       int32   `json:"right_raw,omitempty"`
-	StrikePriceType int32  `json:"strike_price_type,omitempty"`
+	MsOfDay    int     `json:"ms_of_day"`
+	IV         float64 `json:"implied_volatility"`
+	IVError    float64 `json:"iv_error"`
+	Date       int     `json:"date"`
+	Expiration int32   `json:"expiration,omitempty"`
+	Strike     float64 `json:"strike,omitempty"`
+	Right      string  `json:"right,omitempty"`
 }
 
 type PriceTick struct {
-	MsOfDay   int     `json:"ms_of_day"`
-	Price     float64 `json:"price"`
-	PriceRaw  int     `json:"price_raw,omitempty"`
-	PriceType int     `json:"price_type"`
-	Date      int     `json:"date"`
+	MsOfDay int     `json:"ms_of_day"`
+	Price   float64 `json:"price"`
+	Date    int     `json:"date"`
 }
 
 type CalendarDay struct {
@@ -647,12 +625,10 @@ type InterestRateTick struct {
 }
 
 type OptionContract struct {
-	Root           string `json:"root"`
-	Expiration     int    `json:"expiration"`
-	Strike         int    `json:"strike"`
-	Right          string `json:"right"`
-	RightRaw       int    `json:"right_raw,omitempty"`
-	StrikePriceType int   `json:"strike_price_type"`
+	Root       string  `json:"root"`
+	Expiration int     `json:"expiration"`
+	Strike     float64 `json:"strike"`
+	Right      string  `json:"right"`
 }
 
 type Greeks struct {
@@ -695,15 +671,6 @@ func RightStr(code int32) string {
 	}
 }
 
-// ── Price decoding ──
-
-func priceToFloat(value int32, priceType int32) float64 {
-	if priceType == 0 {
-		return 0.0
-	}
-	return float64(value) * math.Pow(10, float64(priceType-10))
-}
-
 // ── Generic array conversion helpers ──
 
 func convertEodTicks(arr C.TdxTickArray) []EodTick {
@@ -715,18 +682,12 @@ func convertEodTicks(arr C.TdxTickArray) []EodTick {
 		result[i] = EodTick{
 			MsOfDay: int(t.MsOfDay), MsOfDay2: int(t.MsOfDay2), Date: int(t.Date),
 			Volume: int(t.Volume), Count: int(t.Count),
-			Open: priceToFloat(t.Open, t.PriceType), OpenRaw: int(t.Open),
-			High: priceToFloat(t.High, t.PriceType), HighRaw: int(t.High),
-			Low: priceToFloat(t.Low, t.PriceType), LowRaw: int(t.Low),
-			Close: priceToFloat(t.Close, t.PriceType), CloseRaw: int(t.Close),
+			Open: t.Open, High: t.High, Low: t.Low, Close: t.Close,
 			BidSize: int(t.BidSize), BidExchange: int(t.BidExchange),
-			Bid: priceToFloat(t.Bid, t.PriceType), BidRaw: int(t.Bid),
-			BidCondition: int(t.BidCondition),
+			Bid: t.Bid, BidCondition: int(t.BidCondition),
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
-			Ask: priceToFloat(t.Ask, t.PriceType), AskRaw: int(t.Ask),
-			AskCondition: int(t.AskCondition),
-			PriceType: int(t.PriceType),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Ask: t.Ask, AskCondition: int(t.AskCondition),
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -740,12 +701,8 @@ func convertOhlcTicks(arr C.TdxTickArray) []OhlcTick {
 	for i, t := range src {
 		result[i] = OhlcTick{
 			MsOfDay: int(t.MsOfDay), Volume: int(t.Volume), Count: int(t.Count), Date: int(t.Date),
-			Open: priceToFloat(t.Open, t.PriceType), OpenRaw: int(t.Open),
-			High: priceToFloat(t.High, t.PriceType), HighRaw: int(t.High),
-			Low: priceToFloat(t.Low, t.PriceType), LowRaw: int(t.Low),
-			Close: priceToFloat(t.Close, t.PriceType), CloseRaw: int(t.Close),
-			PriceType: int(t.PriceType),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Open: t.Open, High: t.High, Low: t.Low, Close: t.Close,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -762,11 +719,11 @@ func convertTradeTicks(arr C.TdxTickArray) []TradeTick {
 			ExtCondition1: int(t.ExtCondition1), ExtCondition2: int(t.ExtCondition2),
 			ExtCondition3: int(t.ExtCondition3), ExtCondition4: int(t.ExtCondition4),
 			Condition: int(t.Condition),
-			Size: int(t.Size), Exchange: int(t.Exchange), Price: priceToFloat(t.Price, t.PriceType),
-			PriceRaw: int(t.Price), PriceType: int(t.PriceType), ConditionFlags: int(t.ConditionFlags),
+			Size: int(t.Size), Exchange: int(t.Exchange), Price: t.Price,
+			ConditionFlags: int(t.ConditionFlags),
 			PriceFlags: int(t.PriceFlags), VolumeType: int(t.VolumeType), RecordsBack: int(t.RecordsBack),
 			Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -780,11 +737,11 @@ func convertQuoteTicks(arr C.TdxTickArray) []QuoteTick {
 	for i, t := range src {
 		result[i] = QuoteTick{
 			MsOfDay: int(t.MsOfDay), BidSize: int(t.BidSize), BidExchange: int(t.BidExchange),
-			Bid: priceToFloat(t.Bid, t.PriceType), BidRaw: int(t.Bid), BidCondition: int(t.BidCondition),
+			Bid: t.Bid, BidCondition: int(t.BidCondition),
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
-			Ask: priceToFloat(t.Ask, t.PriceType), AskRaw: int(t.Ask), AskCondition: int(t.AskCondition),
-			PriceType: int(t.PriceType), Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Ask: t.Ask, AskCondition: int(t.AskCondition),
+			Midpoint: t.Midpoint, Date: int(t.Date),
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -801,17 +758,15 @@ func convertTradeQuoteTicks(arr C.TdxTickArray) []TradeQuoteTick {
 			ExtCondition1: int(t.ExtCondition1), ExtCondition2: int(t.ExtCondition2),
 			ExtCondition3: int(t.ExtCondition3), ExtCondition4: int(t.ExtCondition4),
 			Condition: int(t.Condition),
-			Size: int(t.Size), Exchange: int(t.Exchange), Price: priceToFloat(t.Price, t.PriceType),
-			PriceRaw: int(t.Price),
+			Size: int(t.Size), Exchange: int(t.Exchange), Price: t.Price,
 			ConditionFlags: int(t.ConditionFlags), PriceFlags: int(t.PriceFlags),
 			VolumeType: int(t.VolumeType), RecordsBack: int(t.RecordsBack),
 			QuoteMsOfDay: int(t.QuoteMsOfDay), BidSize: int(t.BidSize), BidExchange: int(t.BidExchange),
-			Bid: priceToFloat(t.Bid, t.QuotePriceType), BidRaw: int(t.Bid), BidCondition: int(t.BidCondition),
+			Bid: t.Bid, BidCondition: int(t.BidCondition),
 			AskSize: int(t.AskSize), AskExchange: int(t.AskExchange),
-			Ask: priceToFloat(t.Ask, t.QuotePriceType), AskRaw: int(t.Ask), AskCondition: int(t.AskCondition),
-			QuotePriceType: int(t.QuotePriceType), PriceType: int(t.PriceType),
+			Ask: t.Ask, AskCondition: int(t.AskCondition),
 			Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -825,7 +780,7 @@ func convertOpenInterestTicks(arr C.TdxTickArray) []OpenInterestTick {
 	for i, t := range src {
 		result[i] = OpenInterestTick{
 			MsOfDay: int(t.MsOfDay), OpenInterest: int(t.OpenInterest), Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -840,7 +795,7 @@ func convertMarketValueTicks(arr C.TdxTickArray) []MarketValueTick {
 		result[i] = MarketValueTick{
 			MsOfDay: int(t.MsOfDay), MarketCap: t.MarketCap, SharesOut: t.SharesOutstanding,
 			EntValue: t.EnterpriseValue, BookValue: t.BookValue, FreeFloat: t.FreeFloat, Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -859,7 +814,7 @@ func convertGreeksTicks(arr C.TdxTickArray) []GreeksTick {
 			Speed: t.Speed, Zomma: t.Zomma, Color: t.Color, Ultima: t.Ultima,
 			D1: t.D1, D2: t.D2, DualDelta: t.DualDelta, DualGamma: t.DualGamma,
 			Epsilon: t.Epsilon, Lambda: t.Lambda, Vera: t.Vera, Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -873,7 +828,7 @@ func convertIvTicks(arr C.TdxTickArray) []IVTick {
 	for i, t := range src {
 		result[i] = IVTick{
 			MsOfDay: int(t.MsOfDay), IV: t.ImpliedVolatility, IVError: t.IvError, Date: int(t.Date),
-			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(int32(t.Right)), RightRaw: t.Right, StrikePriceType: t.StrikePriceType,
+			Expiration: t.Expiration, Strike: t.Strike, Right: RightStr(t.Right),
 		}
 	}
 	return result
@@ -885,7 +840,7 @@ func convertPriceTicks(arr C.TdxTickArray) []PriceTick {
 	src := unsafe.Slice((*cPriceTick)(arr.data), n)
 	result := make([]PriceTick, n)
 	for i, t := range src {
-		result[i] = PriceTick{MsOfDay: int(t.MsOfDay), Price: priceToFloat(t.Price, t.PriceType), PriceRaw: int(t.Price), PriceType: int(t.PriceType), Date: int(t.Date)}
+		result[i] = PriceTick{MsOfDay: int(t.MsOfDay), Price: t.Price, Date: int(t.Date)}
 	}
 	return result
 }
@@ -918,7 +873,7 @@ func convertOptionContracts(arr C.TdxOptionContractArray) []OptionContract {
 		if t.Root != 0 {
 			root = C.GoString((*C.char)(unsafe.Pointer(t.Root)))
 		}
-		result[i] = OptionContract{root, int(t.Expiration), int(t.Strike), RightStr(t.Right), int(t.Right), int(t.StrikePriceType)}
+		result[i] = OptionContract{Root: root, Expiration: int(t.Expiration), Strike: t.Strike, Right: RightStr(t.Right)}
 	}
 	return result
 }

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -166,11 +166,7 @@ macro_rules! set_contract_id {
     ($dict:expr, $tick:expr) => {
         if $tick.expiration != 0 {
             $dict.set_item("expiration", $tick.expiration).unwrap();
-            $dict
-                .set_item("strike", $tick.strike_price())
-                .unwrap();
-            $dict.set_item("strike_raw", $tick.strike).unwrap();
-            $dict.set_item("strike_price_type", $tick.strike_price_type).unwrap();
+            $dict.set_item("strike", $tick.strike).unwrap();
             $dict
                 .set_item(
                     "right",
@@ -198,9 +194,7 @@ fn trade_tick_to_dict(py: Python<'_>, t: &tick::TradeTick) -> Py<PyAny> {
     dict.set_item("condition", t.condition).unwrap();
     dict.set_item("size", t.size).unwrap();
     dict.set_item("exchange", t.exchange).unwrap();
-    dict.set_item("price", t.get_price().to_f64()).unwrap();
-    dict.set_item("price_raw", t.price).unwrap();
-    dict.set_item("price_type", t.price_type).unwrap();
+    dict.set_item("price", t.price).unwrap();
     dict.set_item("condition_flags", t.condition_flags).unwrap();
     dict.set_item("price_flags", t.price_flags).unwrap();
     dict.set_item("volume_type", t.volume_type).unwrap();
@@ -215,15 +209,13 @@ fn quote_tick_to_dict(py: Python<'_>, q: &tick::QuoteTick) -> Py<PyAny> {
     dict.set_item("ms_of_day", q.ms_of_day).unwrap();
     dict.set_item("bid_size", q.bid_size).unwrap();
     dict.set_item("bid_exchange", q.bid_exchange).unwrap();
-    dict.set_item("bid", q.bid_price().to_f64()).unwrap();
-    dict.set_item("bid_raw", q.bid).unwrap();
+    dict.set_item("bid", q.bid).unwrap();
     dict.set_item("bid_condition", q.bid_condition).unwrap();
     dict.set_item("ask_size", q.ask_size).unwrap();
     dict.set_item("ask_exchange", q.ask_exchange).unwrap();
-    dict.set_item("ask", q.ask_price().to_f64()).unwrap();
-    dict.set_item("ask_raw", q.ask).unwrap();
+    dict.set_item("ask", q.ask).unwrap();
     dict.set_item("ask_condition", q.ask_condition).unwrap();
-    dict.set_item("price_type", q.price_type).unwrap();
+    dict.set_item("midpoint", q.midpoint).unwrap();
     dict.set_item("date", q.date).unwrap();
     set_contract_id!(dict, q);
     dict.into_any().unbind()
@@ -232,17 +224,12 @@ fn quote_tick_to_dict(py: Python<'_>, q: &tick::QuoteTick) -> Py<PyAny> {
 fn ohlc_tick_to_dict(py: Python<'_>, o: &tick::OhlcTick) -> Py<PyAny> {
     let dict = PyDict::new(py);
     dict.set_item("ms_of_day", o.ms_of_day).unwrap();
-    dict.set_item("open", o.open_price().to_f64()).unwrap();
-    dict.set_item("open_raw", o.open).unwrap();
-    dict.set_item("high", o.high_price().to_f64()).unwrap();
-    dict.set_item("high_raw", o.high).unwrap();
-    dict.set_item("low", o.low_price().to_f64()).unwrap();
-    dict.set_item("low_raw", o.low).unwrap();
-    dict.set_item("close", o.close_price().to_f64()).unwrap();
-    dict.set_item("close_raw", o.close).unwrap();
+    dict.set_item("open", o.open).unwrap();
+    dict.set_item("high", o.high).unwrap();
+    dict.set_item("low", o.low).unwrap();
+    dict.set_item("close", o.close).unwrap();
     dict.set_item("volume", o.volume).unwrap();
     dict.set_item("count", o.count).unwrap();
-    dict.set_item("price_type", o.price_type).unwrap();
     dict.set_item("date", o.date).unwrap();
     set_contract_id!(dict, o);
     dict.into_any().unbind()
@@ -252,27 +239,20 @@ fn eod_tick_to_dict(py: Python<'_>, e: &tick::EodTick) -> Py<PyAny> {
     let dict = PyDict::new(py);
     dict.set_item("ms_of_day", e.ms_of_day).unwrap();
     dict.set_item("ms_of_day2", e.ms_of_day2).unwrap();
-    dict.set_item("open", e.open_price().to_f64()).unwrap();
-    dict.set_item("open_raw", e.open).unwrap();
-    dict.set_item("high", e.high_price().to_f64()).unwrap();
-    dict.set_item("high_raw", e.high).unwrap();
-    dict.set_item("low", e.low_price().to_f64()).unwrap();
-    dict.set_item("low_raw", e.low).unwrap();
-    dict.set_item("close", e.close_price().to_f64()).unwrap();
-    dict.set_item("close_raw", e.close).unwrap();
+    dict.set_item("open", e.open).unwrap();
+    dict.set_item("high", e.high).unwrap();
+    dict.set_item("low", e.low).unwrap();
+    dict.set_item("close", e.close).unwrap();
     dict.set_item("volume", e.volume).unwrap();
     dict.set_item("count", e.count).unwrap();
     dict.set_item("bid_size", e.bid_size).unwrap();
     dict.set_item("bid_exchange", e.bid_exchange).unwrap();
-    dict.set_item("bid", e.bid_price().to_f64()).unwrap();
-    dict.set_item("bid_raw", e.bid).unwrap();
+    dict.set_item("bid", e.bid).unwrap();
     dict.set_item("bid_condition", e.bid_condition).unwrap();
     dict.set_item("ask_size", e.ask_size).unwrap();
     dict.set_item("ask_exchange", e.ask_exchange).unwrap();
-    dict.set_item("ask", e.ask_price().to_f64()).unwrap();
-    dict.set_item("ask_raw", e.ask).unwrap();
+    dict.set_item("ask", e.ask).unwrap();
     dict.set_item("ask_condition", e.ask_condition).unwrap();
-    dict.set_item("price_type", e.price_type).unwrap();
     dict.set_item("date", e.date).unwrap();
     set_contract_id!(dict, e);
     dict.into_any().unbind()
@@ -289,8 +269,7 @@ fn trade_quote_tick_to_dict(py: Python<'_>, t: &tick::TradeQuoteTick) -> Py<PyAn
     dict.set_item("condition", t.condition).unwrap();
     dict.set_item("size", t.size).unwrap();
     dict.set_item("exchange", t.exchange).unwrap();
-    dict.set_item("price", t.trade_price().to_f64()).unwrap();
-    dict.set_item("price_raw", t.price).unwrap();
+    dict.set_item("price", t.price).unwrap();
     dict.set_item("condition_flags", t.condition_flags).unwrap();
     dict.set_item("price_flags", t.price_flags).unwrap();
     dict.set_item("volume_type", t.volume_type).unwrap();
@@ -298,16 +277,12 @@ fn trade_quote_tick_to_dict(py: Python<'_>, t: &tick::TradeQuoteTick) -> Py<PyAn
     dict.set_item("quote_ms_of_day", t.quote_ms_of_day).unwrap();
     dict.set_item("bid_size", t.bid_size).unwrap();
     dict.set_item("bid_exchange", t.bid_exchange).unwrap();
-    dict.set_item("bid", t.bid_price().to_f64()).unwrap();
-    dict.set_item("bid_raw", t.bid).unwrap();
+    dict.set_item("bid", t.bid).unwrap();
     dict.set_item("bid_condition", t.bid_condition).unwrap();
     dict.set_item("ask_size", t.ask_size).unwrap();
     dict.set_item("ask_exchange", t.ask_exchange).unwrap();
-    dict.set_item("ask", t.ask_price().to_f64()).unwrap();
-    dict.set_item("ask_raw", t.ask).unwrap();
+    dict.set_item("ask", t.ask).unwrap();
     dict.set_item("ask_condition", t.ask_condition).unwrap();
-    dict.set_item("quote_price_type", t.quote_price_type).unwrap();
-    dict.set_item("price_type", t.price_type).unwrap();
     dict.set_item("date", t.date).unwrap();
     set_contract_id!(dict, t);
     dict.into_any().unbind()
@@ -382,9 +357,7 @@ fn iv_tick_to_dict(py: Python<'_>, t: &tick::IvTick) -> Py<PyAny> {
 fn price_tick_to_dict(py: Python<'_>, t: &tick::PriceTick) -> Py<PyAny> {
     let dict = PyDict::new(py);
     dict.set_item("ms_of_day", t.ms_of_day).unwrap();
-    dict.set_item("price", t.get_price().to_f64()).unwrap();
-    dict.set_item("price_raw", t.price).unwrap();
-    dict.set_item("price_type", t.price_type).unwrap();
+    dict.set_item("price", t.price).unwrap();
     dict.set_item("date", t.date).unwrap();
     dict.into_any().unbind()
 }
@@ -413,8 +386,6 @@ fn option_contract_to_dict(py: Python<'_>, c: &tick::OptionContract) -> Py<PyAny
     dict.set_item("expiration", c.expiration).unwrap();
     dict.set_item("strike", c.strike).unwrap();
     dict.set_item("right", c.right).unwrap();
-    dict.set_item("strike_price_type", c.strike_price_type)
-        .unwrap();
     dict.into_any().unbind()
 }
 
@@ -531,8 +502,6 @@ enum BufferedEvent {
         size: i32,
         exchange: i32,
         price: f64,
-        price_raw: i32,
-        price_type: i32,
         condition_flags: i32,
         price_flags: i32,
         volume_type: i32,
@@ -640,8 +609,6 @@ fn fpss_event_to_buffered(event: &fpss::FpssEvent) -> BufferedEvent {
                 size: *size,
                 exchange: *exchange,
                 price: price_to_f64(*price, *price_type),
-                price_raw: *price,
-                price_type: *price_type,
                 condition_flags: *condition_flags,
                 price_flags: *price_flags,
                 volume_type: *volume_type,
@@ -795,8 +762,6 @@ fn buffered_event_to_py(py: Python<'_>, event: &BufferedEvent) -> Py<PyAny> {
             size,
             exchange,
             price,
-            price_raw,
-            price_type,
             condition_flags,
             price_flags,
             volume_type,
@@ -816,8 +781,6 @@ fn buffered_event_to_py(py: Python<'_>, event: &BufferedEvent) -> Py<PyAny> {
             dict.set_item("size", size).unwrap();
             dict.set_item("exchange", exchange).unwrap();
             dict.set_item("price", price).unwrap();
-            dict.set_item("price_raw", price_raw).unwrap();
-            dict.set_item("price_type", price_type).unwrap();
             dict.set_item("condition_flags", condition_flags).unwrap();
             dict.set_item("price_flags", price_flags).unwrap();
             dict.set_item("volume_type", volume_type).unwrap();

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -2,7 +2,6 @@ use std::process;
 
 use clap::{Arg, ArgMatches, Command};
 use comfy_table::{presets::UTF8_FULL_CONDENSED, Cell, ContentArrangement, Table};
-use tdbe::types::price::Price;
 use thetadatadx::registry::{self, EndpointMeta};
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -709,13 +708,12 @@ fn format_ms(ms: i32) -> String {
     format!("{h:02}:{m:02}:{s:02}.{ms_frac:03}")
 }
 
-/// Format price from raw integer + `price_type` to a float string.
-fn format_price(value: i32, price_type: i32) -> String {
-    if price_type == 0 {
+/// Format a decoded f64 price for display.
+fn format_price_f64(value: f64) -> String {
+    if value == 0.0 {
         return "0.00".into();
     }
-    let p = Price::new(value, price_type);
-    format!("{p}")
+    format!("{value:.2}")
 }
 
 /// Format a YYYYMMDD integer date to a readable string.
@@ -889,28 +887,26 @@ fn render_eod(ticks: &[tdbe::types::tick::EodTick], fmt: &OutputFormat) {
         "ask_exchange",
         "ask",
         "ask_condition",
-        "price_type",
     ]);
     for t in ticks {
         td.push(vec![
             format_date(t.date),
             format_ms(t.ms_of_day),
             format_ms(t.ms_of_day2),
-            format_price(t.open, t.price_type),
-            format_price(t.high, t.price_type),
-            format_price(t.low, t.price_type),
-            format_price(t.close, t.price_type),
+            format_price_f64(t.open),
+            format_price_f64(t.high),
+            format_price_f64(t.low),
+            format_price_f64(t.close),
             format!("{}", t.volume),
             format!("{}", t.count),
             format!("{}", t.bid_size),
             format!("{}", t.bid_exchange),
-            format_price(t.bid, t.price_type),
+            format_price_f64(t.bid),
             format!("{}", t.bid_condition),
             format!("{}", t.ask_size),
             format!("{}", t.ask_exchange),
-            format_price(t.ask, t.price_type),
+            format_price_f64(t.ask),
             format!("{}", t.ask_condition),
-            format!("{}", t.price_type),
         ]);
     }
     td.render(fmt);
@@ -924,10 +920,10 @@ fn render_ohlc(ticks: &[tdbe::types::tick::OhlcTick], fmt: &OutputFormat) {
         td.push(vec![
             format_date(t.date),
             format_ms(t.ms_of_day),
-            format_price(t.open, t.price_type),
-            format_price(t.high, t.price_type),
-            format_price(t.low, t.price_type),
-            format_price(t.close, t.price_type),
+            format_price_f64(t.open),
+            format_price_f64(t.high),
+            format_price_f64(t.low),
+            format_price_f64(t.close),
             format!("{}", t.volume),
             format!("{}", t.count),
         ]);
@@ -949,7 +945,7 @@ fn render_trades(ticks: &[tdbe::types::tick::TradeTick], fmt: &OutputFormat) {
         td.push(vec![
             format_date(t.date),
             format_ms(t.ms_of_day),
-            format_price(t.price, t.price_type),
+            format_price_f64(t.price),
             format!("{}", t.size),
             format!("{}", t.exchange),
             format!("{}", t.condition),
@@ -971,7 +967,6 @@ fn render_quotes(ticks: &[tdbe::types::tick::QuoteTick], fmt: &OutputFormat) {
         "ask_exchange",
         "ask",
         "ask_condition",
-        "price_type",
     ]);
     for t in ticks {
         td.push(vec![
@@ -979,13 +974,12 @@ fn render_quotes(ticks: &[tdbe::types::tick::QuoteTick], fmt: &OutputFormat) {
             format_ms(t.ms_of_day),
             format!("{}", t.bid_size),
             format!("{}", t.bid_exchange),
-            format_price(t.bid, t.price_type),
+            format_price_f64(t.bid),
             format!("{}", t.bid_condition),
             format!("{}", t.ask_size),
             format!("{}", t.ask_exchange),
-            format_price(t.ask, t.price_type),
+            format_price_f64(t.ask),
             format!("{}", t.ask_condition),
-            format!("{}", t.price_type),
         ]);
     }
     td.render(fmt);
@@ -1018,15 +1012,15 @@ fn render_trade_quotes(ticks: &[tdbe::types::tick::TradeQuoteTick], fmt: &Output
         td.push(vec![
             format_date(t.date),
             format_ms(t.ms_of_day),
-            format_price(t.price, t.price_type),
+            format_price_f64(t.price),
             format!("{}", t.size),
             format!("{}", t.exchange),
             format!("{}", t.condition),
             format!("{}", t.sequence),
             format_ms(t.quote_ms_of_day),
-            format_price(t.bid, t.price_type),
+            format_price_f64(t.bid),
             format!("{}", t.bid_size),
-            format_price(t.ask, t.price_type),
+            format_price_f64(t.ask),
             format!("{}", t.ask_size),
         ]);
     }
@@ -1109,13 +1103,12 @@ fn render_iv(ticks: &[tdbe::types::tick::IvTick], fmt: &OutputFormat) {
 }
 
 fn render_price(ticks: &[tdbe::types::tick::PriceTick], fmt: &OutputFormat) {
-    let mut td = TabularData::new(vec!["date", "ms_of_day", "price", "price_type"]);
+    let mut td = TabularData::new(vec!["date", "ms_of_day", "price"]);
     for t in ticks {
         td.push(vec![
             format_date(t.date),
             format_ms(t.ms_of_day),
-            format_price(t.price, t.price_type),
-            format!("{}", t.price_type),
+            format_price_f64(t.price),
         ]);
     }
     td.render(fmt);
@@ -1148,20 +1141,13 @@ fn render_interest_rates(ticks: &[tdbe::types::tick::InterestRateTick], fmt: &Ou
 }
 
 fn render_option_contracts(contracts: &[tdbe::types::tick::OptionContract], fmt: &OutputFormat) {
-    let mut td = TabularData::new(vec![
-        "root",
-        "expiration",
-        "strike",
-        "right",
-        "strike_price_type",
-    ]);
+    let mut td = TabularData::new(vec!["root", "expiration", "strike", "right"]);
     for c in contracts {
         td.push(vec![
             c.root.clone(),
             format!("{}", c.expiration),
-            format!("{}", c.strike),
+            format_price_f64(c.strike),
             format!("{}", c.right),
-            format!("{}", c.strike_price_type),
         ]);
     }
     td.render(fmt);


### PR DESCRIPTION
## Summary

- All price fields on every tick struct are now `f64`, decoded at parse time using `Price::to_f64()`
- `price_type` removed from every public struct (still used internally by the parser)
- All `_f64()` / `_price()` / `get_price()` helper methods removed -- fields are already `f64`
- `strike` on contract ID fields decoded to `f64`, `strike_price_type` removed
- `QuoteTick` gains a pre-computed `midpoint` field (`(bid + ask) / 2.0`)
- `OptionContract.strike` is now `f64` instead of raw `i32`

**Files changed (13):** Rust core (tdbe tick structs + thetadatadx codegen/parser), FFI, Python SDK, Go SDK (C mirror structs + public types + converters), C/C++ headers, CLI

**Net: -519 lines** (577 added, 1096 removed)

## Before / After

```rust
// Before: manual decode on every access
let price = t.get_price().to_f64();
let open = e.open_price().to_f64();
let mid = q.midpoint_price().to_f64();

// After: just use the field
let price = t.price;
let open = e.open;
let mid = q.midpoint;
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings` (zero warnings)
- [x] `cargo test --workspace` (236 tests pass, 0 failures)
- [x] `grep -rn "price_type"` in public API: zero outside FPSS internals
- [x] `grep -rn "_f64()"` in tick.rs: zero

Closes #150