### PR TITLE
fix: update server + MCP for f64 price migration (fixes #167, #168)

### DIFF
--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -435,14 +435,14 @@ fn serialize_eod_ticks(ticks: &[tdbe::types::tick::EodTick]) -> Value {
             json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
-                "open": t.open_price().to_f64(),
-                "high": t.high_price().to_f64(),
-                "low": t.low_price().to_f64(),
-                "close": t.close_price().to_f64(),
+                "open": t.open,
+                "high": t.high,
+                "low": t.low,
+                "close": t.close,
                 "volume": t.volume,
                 "count": t.count,
-                "bid": t.bid_price().to_f64(),
-                "ask": t.ask_price().to_f64(),
+                "bid": t.bid,
+                "ask": t.ask,
                 "bid_size": t.bid_size,
                 "ask_size": t.ask_size,
             })
@@ -458,10 +458,10 @@ fn serialize_ohlc_ticks(ticks: &[tdbe::types::tick::OhlcTick]) -> Value {
             json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
-                "open": t.open_price().to_f64(),
-                "high": t.high_price().to_f64(),
-                "low": t.low_price().to_f64(),
-                "close": t.close_price().to_f64(),
+                "open": t.open,
+                "high": t.high,
+                "low": t.low,
+                "close": t.close,
                 "volume": t.volume,
                 "count": t.count,
             })
@@ -477,7 +477,7 @@ fn serialize_trade_ticks(ticks: &[tdbe::types::tick::TradeTick]) -> Value {
             json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
-                "price": t.get_price().to_f64(),
+                "price": t.price,
                 "size": t.size,
                 "exchange": t.exchange,
                 "condition": t.condition,
@@ -495,10 +495,10 @@ fn serialize_quote_ticks(ticks: &[tdbe::types::tick::QuoteTick]) -> Value {
             json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
-                "bid": t.bid_price().to_f64(),
+                "bid": t.bid,
                 "bid_size": t.bid_size,
                 "bid_exchange": t.bid_exchange,
-                "ask": t.ask_price().to_f64(),
+                "ask": t.ask,
                 "ask_size": t.ask_size,
                 "ask_exchange": t.ask_exchange,
             })
@@ -514,14 +514,14 @@ fn serialize_trade_quote_ticks(ticks: &[tdbe::types::tick::TradeQuoteTick]) -> V
             json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
-                "price": t.trade_price().to_f64(),
+                "price": t.price,
                 "size": t.size,
                 "exchange": t.exchange,
                 "condition": t.condition,
                 "sequence": t.sequence,
-                "bid": t.bid_price().to_f64(),
+                "bid": t.bid,
                 "bid_size": t.bid_size,
-                "ask": t.ask_price().to_f64(),
+                "ask": t.ask,
                 "ask_size": t.ask_size,
             })
         })
@@ -588,7 +588,7 @@ fn serialize_price_ticks(ticks: &[tdbe::types::tick::PriceTick]) -> Value {
         .map(|t| {
             json!({
                 "date": t.date, "ms_of_day": t.ms_of_day,
-                "price": t.get_price().to_f64(),
+                "price": t.price,
             })
         })
         .collect();

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -11,7 +11,6 @@
 //! ```
 
 use sonic_rs::prelude::*;
-use tdbe::types::price::Price;
 use tdbe::types::tick::*;
 
 // ---------------------------------------------------------------------------
@@ -52,15 +51,6 @@ pub fn list_envelope(items: &[String]) -> sonic_rs::Value {
 }
 
 // ---------------------------------------------------------------------------
-//  Price formatting -- matches Java PriceCalcUtils exactly
-// ---------------------------------------------------------------------------
-
-/// Format a price value to f64.
-fn fmt_price(value: i32, price_type: i32) -> f64 {
-    Price::new(value, price_type).to_f64()
-}
-
-// ---------------------------------------------------------------------------
 //  Tick -> sonic_rs::Value conversions
 // ---------------------------------------------------------------------------
 
@@ -72,19 +62,19 @@ pub fn eod_ticks_to_json(ticks: &[EodTick]) -> Vec<sonic_rs::Value> {
             sonic_rs::json!({
                 "ms_of_day": t.ms_of_day,
                 "ms_of_day2": t.ms_of_day2,
-                "open": fmt_price(t.open, t.price_type),
-                "high": fmt_price(t.high, t.price_type),
-                "low": fmt_price(t.low, t.price_type),
-                "close": fmt_price(t.close, t.price_type),
+                "open": t.open,
+                "high": t.high,
+                "low": t.low,
+                "close": t.close,
                 "volume": t.volume,
                 "count": t.count,
                 "bid_size": t.bid_size,
                 "bid_exchange": t.bid_exchange,
-                "bid": fmt_price(t.bid, t.price_type),
+                "bid": t.bid,
                 "bid_condition": t.bid_condition,
                 "ask_size": t.ask_size,
                 "ask_exchange": t.ask_exchange,
-                "ask": fmt_price(t.ask, t.price_type),
+                "ask": t.ask,
                 "ask_condition": t.ask_condition,
                 "date": t.date
             })
@@ -99,10 +89,10 @@ pub fn ohlc_ticks_to_json(ticks: &[OhlcTick]) -> Vec<sonic_rs::Value> {
         .map(|t| {
             sonic_rs::json!({
                 "ms_of_day": t.ms_of_day,
-                "open": fmt_price(t.open, t.price_type),
-                "high": fmt_price(t.high, t.price_type),
-                "low": fmt_price(t.low, t.price_type),
-                "close": fmt_price(t.close, t.price_type),
+                "open": t.open,
+                "high": t.high,
+                "low": t.low,
+                "close": t.close,
                 "volume": t.volume,
                 "count": t.count,
                 "date": t.date
@@ -121,7 +111,7 @@ pub fn trade_ticks_to_json(ticks: &[TradeTick]) -> Vec<sonic_rs::Value> {
                 "sequence": t.sequence,
                 "size": t.size,
                 "condition": t.condition,
-                "price": fmt_price(t.price, t.price_type),
+                "price": t.price,
                 "exchange": t.exchange,
                 "date": t.date
             })
@@ -138,11 +128,11 @@ pub fn quote_ticks_to_json(ticks: &[QuoteTick]) -> Vec<sonic_rs::Value> {
                 "ms_of_day": t.ms_of_day,
                 "bid_size": t.bid_size,
                 "bid_exchange": t.bid_exchange,
-                "bid": fmt_price(t.bid, t.price_type),
+                "bid": t.bid,
                 "bid_condition": t.bid_condition,
                 "ask_size": t.ask_size,
                 "ask_exchange": t.ask_exchange,
-                "ask": fmt_price(t.ask, t.price_type),
+                "ask": t.ask,
                 "ask_condition": t.ask_condition,
                 "date": t.date
             })
@@ -160,16 +150,16 @@ pub fn trade_quote_ticks_to_json(ticks: &[TradeQuoteTick]) -> Vec<sonic_rs::Valu
                 "sequence": t.sequence,
                 "size": t.size,
                 "condition": t.condition,
-                "price": fmt_price(t.price, t.price_type),
+                "price": t.price,
                 "exchange": t.exchange,
                 "quote_ms_of_day": t.quote_ms_of_day,
                 "bid_size": t.bid_size,
                 "bid_exchange": t.bid_exchange,
-                "bid": fmt_price(t.bid, t.price_type),
+                "bid": t.bid,
                 "bid_condition": t.bid_condition,
                 "ask_size": t.ask_size,
                 "ask_exchange": t.ask_exchange,
-                "ask": fmt_price(t.ask, t.price_type),
+                "ask": t.ask,
                 "ask_condition": t.ask_condition,
                 "date": t.date
             })
@@ -266,7 +256,7 @@ pub fn price_ticks_to_json(ticks: &[PriceTick]) -> Vec<sonic_rs::Value> {
         .map(|t| {
             sonic_rs::json!({
                 "ms_of_day": t.ms_of_day,
-                "price": fmt_price(t.price, t.price_type),
+                "price": t.price,
                 "date": t.date
             })
         })
@@ -311,8 +301,7 @@ pub fn option_contracts_to_json(contracts: &[OptionContract]) -> Vec<sonic_rs::V
                 "root": c.root,
                 "expiration": c.expiration,
                 "strike": c.strike,
-                "right": c.right,
-                "strike_price_type": c.strike_price_type
+                "right": c.right
             })
         })
         .collect()

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -83,19 +83,14 @@ pub async fn generic(
     // Validate required params.
     for p in ep.params {
         if p.required && !params.contains_key(p.name) {
-            let alt = match p.name {
-                _ => "",
-            };
-            if alt.is_empty() || !params.contains_key(alt) {
-                return error_response(
-                    StatusCode::BAD_REQUEST,
-                    "bad_request",
-                    &format!(
-                        "missing required parameter: '{}' ({})",
-                        p.name, p.description
-                    ),
-                );
-            }
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "bad_request",
+                &format!(
+                    "missing required parameter: '{}' ({})",
+                    p.name, p.description
+                ),
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- **server/format.rs**: Remove `fmt_price()`/`Price` import, use f64 tick fields directly. Remove `strike_price_type` from `OptionContract` JSON output.
- **server/handler.rs**: Simplify dead v2 param fallback match arm (clippy `match_single_binding` + `const_is_empty`).
- **mcp/main.rs**: Replace all `_price().to_f64()` / `get_price().to_f64()` with direct f64 field access.

Both tools were excluded from workspace and broke silently after the f64 migration (PR #153).

Fixes #167, #168

## Test plan

- [x] `cargo check --manifest-path tools/server/Cargo.toml` -- pass
- [x] `cargo check --manifest-path tools/mcp/Cargo.toml` -- pass
- [x] `cargo clippy` on both -- zero warnings
- [x] `cargo fmt --all -- --check` -- pass
- [x] `cargo test --workspace` -- pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)