### PR TITLE
docs: purge stale fixed-point/helper method refs from docs-site

### DIFF
--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -209,7 +209,7 @@ auto mv = client.stock_snapshot_market_value({"AAPL"});
 | `venue` | string | No | Data venue filter |
 | `min_time` | string | No | Minimum time of day (ms from midnight) |
 
-**Returns:** `Vec<MarketValueTick>` with market cap, shares outstanding, enterprise value, book value, free float.
+**Returns:** Array of MarketValueTick records with market cap, shares outstanding, enterprise value, book value, free float.
 
 ---
 
@@ -399,7 +399,7 @@ auto tq = client.stock_history_trade_quote("AAPL", "20240315");
 | `exclusive` | bool | No | Exclusive time bounds |
 | `venue` | string | No | Data venue filter |
 
-**Returns:** `Vec<TradeQuoteTick>` with combined trade + quote fields.
+**Returns:** Array of TradeQuoteTick records with combined trade + quote fields.
 
 **Tier:** Pro
 
@@ -613,7 +613,7 @@ auto contracts = client.option_list_contracts("TRADE", "SPY", "20240315");
 | `date` | string | Yes | Date (`YYYYMMDD`) |
 | `max_dte` | int | No | Maximum days to expiration filter |
 
-**Returns:** `Vec<OptionContract>` with root, expiration, strike, right.
+**Returns:** Array of OptionContract records with root, expiration, strike, right.
 
 ---
 
@@ -744,7 +744,7 @@ auto oi = client.option_snapshot_open_interest("SPY", "20241220", "500", "C");
 | `strike_range` | int | No | Strike range filter |
 | `min_time` | string | No | Minimum time of day (ms from midnight) |
 
-**Returns:** `Vec<OpenInterestTick>` with ms_of_day, open_interest, date.
+**Returns:** Array of OpenInterestTick records with ms_of_day, open_interest, date.
 
 ---
 
@@ -777,7 +777,7 @@ auto mv = client.option_snapshot_market_value("SPY", "20241220", "500", "C");
 | `strike_range` | int | No | Strike range filter |
 | `min_time` | string | No | Minimum time of day (ms from midnight) |
 
-**Returns:** `Vec<MarketValueTick>` with market cap, shares outstanding, enterprise value, book value, free float.
+**Returns:** Array of MarketValueTick records with market cap, shares outstanding, enterprise value, book value, free float.
 
 ---
 
@@ -816,7 +816,7 @@ auto iv = client.option_snapshot_greeks_implied_volatility("SPY", "20241220", "5
 | `min_time` | string | No | Minimum time of day (ms from midnight) |
 | `use_market_value` | bool | No | Use market value instead of last trade |
 
-**Returns:** `Vec<IvTick>` with implied_volatility, iv_error.
+**Returns:** Array of IvTick records with implied_volatility, iv_error.
 
 **Tier:** Pro
 
@@ -857,7 +857,7 @@ auto greeks = client.option_snapshot_greeks_all("SPY", "20241220", "500", "C");
 | `min_time` | string | No | Minimum time of day |
 | `use_market_value` | bool | No | Use market value instead of last trade |
 
-**Returns:** `Vec<GreeksTick>` with all 22 Greeks.
+**Returns:** Array of GreeksTick records with all 22 Greeks.
 
 **Tier:** Pro
 
@@ -884,7 +884,7 @@ auto g = client.option_snapshot_greeks_first_order("SPY", "20241220", "500", "C"
 
 Parameters are identical to [option_snapshot_greeks_all](#option_snapshot_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with first-order Greeks (delta, theta, vega, rho).
+**Returns:** Array of GreeksTick records with first-order Greeks (delta, theta, vega, rho).
 
 **Tier:** Pro
 
@@ -911,7 +911,7 @@ auto g = client.option_snapshot_greeks_second_order("SPY", "20241220", "500", "C
 
 Parameters are identical to [option_snapshot_greeks_all](#option_snapshot_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with second-order Greeks (gamma, vanna, charm, vomma).
+**Returns:** Array of GreeksTick records with second-order Greeks (gamma, vanna, charm, vomma).
 
 **Tier:** Pro
 
@@ -938,7 +938,7 @@ auto g = client.option_snapshot_greeks_third_order("SPY", "20241220", "500", "C"
 
 Parameters are identical to [option_snapshot_greeks_all](#option_snapshot_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with third-order Greeks (speed, zomma, color, ultima).
+**Returns:** Array of GreeksTick records with third-order Greeks (speed, zomma, color, ultima).
 
 **Tier:** Pro
 
@@ -1159,7 +1159,7 @@ auto oi = client.option_history_open_interest("SPY", "20241220", "500", "C", "20
 | `max_dte` | int | No | Maximum days to expiration |
 | `strike_range` | int | No | Strike range filter |
 
-**Returns:** `Vec<OpenInterestTick>` with ms_of_day, open_interest, date.
+**Returns:** Array of OpenInterestTick records with ms_of_day, open_interest, date.
 
 ---
 
@@ -1200,7 +1200,7 @@ auto g = client.option_history_greeks_eod("SPY", "20241220", "500", "C", "202401
 | `max_dte` | int | No | Maximum days to expiration |
 | `strike_range` | int | No | Strike range filter |
 
-**Returns:** `Vec<GreeksTick>` with EOD Greeks per date.
+**Returns:** Array of GreeksTick records with EOD Greeks per date.
 
 **Tier:** Pro
 
@@ -1241,7 +1241,7 @@ auto g = client.option_history_greeks_all("SPY", "20241220", "500", "C", "202403
 | `version` | string | No | Greeks calculation version |
 | `strike_range` | int | No | Strike range filter |
 
-**Returns:** `Vec<GreeksTick>` with all 22 Greeks at each sampled point.
+**Returns:** Array of GreeksTick records with all 22 Greeks at each sampled point.
 
 **Tier:** Pro
 
@@ -1282,7 +1282,7 @@ auto g = client.option_history_trade_greeks_all("SPY", "20241220", "500", "C", "
 | `max_dte` | int | No | Maximum days to expiration |
 | `strike_range` | int | No | Strike range filter |
 
-**Returns:** `Vec<GreeksTick>` with all 22 Greeks per trade.
+**Returns:** Array of GreeksTick records with all 22 Greeks per trade.
 
 **Tier:** Pro
 
@@ -1311,7 +1311,7 @@ auto g = client.option_history_greeks_first_order("SPY", "20241220", "500", "C",
 
 Parameters are identical to [option_history_greeks_all](#option_history_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with first-order Greeks at each sampled point.
+**Returns:** Array of GreeksTick records with first-order Greeks at each sampled point.
 
 **Tier:** Pro
 
@@ -1340,7 +1340,7 @@ auto g = client.option_history_trade_greeks_first_order("SPY", "20241220", "500"
 
 Parameters are identical to [option_history_trade_greeks_all](#option_history_trade_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with first-order Greeks per trade.
+**Returns:** Array of GreeksTick records with first-order Greeks per trade.
 
 **Tier:** Pro
 
@@ -1369,7 +1369,7 @@ auto g = client.option_history_greeks_second_order("SPY", "20241220", "500", "C"
 
 Parameters are identical to [option_history_greeks_all](#option_history_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with second-order Greeks at each sampled point.
+**Returns:** Array of GreeksTick records with second-order Greeks at each sampled point.
 
 **Tier:** Pro
 
@@ -1398,7 +1398,7 @@ auto g = client.option_history_trade_greeks_second_order("SPY", "20241220", "500
 
 Parameters are identical to [option_history_trade_greeks_all](#option_history_trade_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with second-order Greeks per trade.
+**Returns:** Array of GreeksTick records with second-order Greeks per trade.
 
 **Tier:** Pro
 
@@ -1427,7 +1427,7 @@ auto g = client.option_history_greeks_third_order("SPY", "20241220", "500", "C",
 
 Parameters are identical to [option_history_greeks_all](#option_history_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with third-order Greeks at each sampled point.
+**Returns:** Array of GreeksTick records with third-order Greeks at each sampled point.
 
 **Tier:** Pro
 
@@ -1456,7 +1456,7 @@ auto g = client.option_history_trade_greeks_third_order("SPY", "20241220", "500"
 
 Parameters are identical to [option_history_trade_greeks_all](#option_history_trade_greeks_all).
 
-**Returns:** `Vec<GreeksTick>` with third-order Greeks per trade.
+**Returns:** Array of GreeksTick records with third-order Greeks per trade.
 
 **Tier:** Pro
 
@@ -1485,7 +1485,7 @@ auto iv = client.option_history_greeks_implied_volatility("SPY", "20241220", "50
 
 Parameters are identical to [option_history_greeks_all](#option_history_greeks_all).
 
-**Returns:** `Vec<IvTick>` with implied volatility at each sampled point.
+**Returns:** Array of IvTick records with implied volatility at each sampled point.
 
 **Tier:** Pro
 
@@ -1514,7 +1514,7 @@ auto iv = client.option_history_trade_greeks_implied_volatility("SPY", "20241220
 
 Parameters are identical to [option_history_trade_greeks_all](#option_history_trade_greeks_all).
 
-**Returns:** `Vec<IvTick>` with IV per trade.
+**Returns:** Array of IvTick records with IV per trade.
 
 **Tier:** Pro
 
@@ -1700,7 +1700,7 @@ auto prices = client.index_snapshot_price({"SPX"});
 | `symbols` | string[] | Yes | One or more index symbols |
 | `min_time` | string | No | Minimum time of day (ms from midnight) |
 
-**Returns:** `Vec<PriceTick>` with ms_of_day, price, date.
+**Returns:** Array of PriceTick records with ms_of_day, price, date.
 
 ---
 
@@ -1728,7 +1728,7 @@ auto mv = client.index_snapshot_market_value({"SPX"});
 | `symbols` | string[] | Yes | One or more index symbols |
 | `min_time` | string | No | Minimum time of day (ms from midnight) |
 
-**Returns:** `Vec<MarketValueTick>` with market cap, shares outstanding, enterprise value, book value, free float.
+**Returns:** Array of MarketValueTick records with market cap, shares outstanding, enterprise value, book value, free float.
 
 ---
 
@@ -1820,7 +1820,7 @@ auto prices = client.index_history_price("SPX", "20240315", "60000");
 | `start_time` | string | No | Start time (ms from midnight) |
 | `end_time` | string | No | End time (ms from midnight) |
 
-**Returns:** `Vec<PriceTick>` with price at each sampled point.
+**Returns:** Array of PriceTick records with price at each sampled point.
 
 ---
 
@@ -1850,7 +1850,7 @@ auto prices = client.index_at_time_price("SPX", "20240101", "20240301", "3420000
 | `end_date` | string | Yes | End date (`YYYYMMDD`) |
 | `time_of_day` | string | Yes | Ms from midnight ET |
 
-**Returns:** `Vec<PriceTick>` with one price per date.
+**Returns:** Array of PriceTick records with one price per date.
 
 ---
 
@@ -1877,7 +1877,7 @@ auto info = client.calendar_open_today();
 
 **Parameters:** None
 
-**Returns:** `Vec<CalendarDay>` with is_open, open_time, close_time.
+**Returns:** Array of CalendarDay records with is_open, open_time, close_time.
 
 ---
 
@@ -1904,7 +1904,7 @@ auto info = client.calendar_on_date("20240315");
 |-----------|------|----------|-------------|
 | `date` | string | Yes | Date (`YYYYMMDD`) |
 
-**Returns:** `Vec<CalendarDay>` with calendar info for the date.
+**Returns:** Array of CalendarDay records with calendar info for the date.
 
 ---
 
@@ -1931,7 +1931,7 @@ auto cal = client.calendar_year("2024");
 |-----------|------|----------|-------------|
 | `year` | string | Yes | 4-digit year (e.g. `"2024"`) |
 
-**Returns:** `Vec<CalendarDay>` with calendar info for every trading day.
+**Returns:** Array of CalendarDay records with calendar info for every trading day.
 
 ---
 
@@ -1962,7 +1962,7 @@ auto rates = client.interest_rate_history_eod("SOFR", "20240101", "20240301");
 | `start_date` | string | Yes | Start date (`YYYYMMDD`) |
 | `end_date` | string | Yes | End date (`YYYYMMDD`) |
 
-**Returns:** `Vec<InterestRateTick>` with rate per date.
+**Returns:** Array of InterestRateTick records with rate per date.
 
 ---
 
@@ -2289,7 +2289,7 @@ For historical endpoints that can return millions of rows, `_stream` variants pr
 tdx.stock_history_trade_stream("AAPL", "20240315")
     .stream(|trades: &[TradeTick]| {
         for t in trades {
-            println!("{}: {}", t.date, t.get_price());
+            println!("{}: {}", t.date, t.price);
         }
     }).await?;
 ```
@@ -2461,7 +2461,7 @@ Result of `all_greeks()`. All fields are `f64`.
 
 ### Price
 
-Fixed-point price with variable decimal precision.
+Internal fixed-point price type used for wire-level decoding. All public tick fields are `f64`.
 
 ```
 real_price = value * 10^(price_type - 10)
@@ -2496,7 +2496,7 @@ Option right: `Call`, `Put`
 - `from_char('C')` / `from_char('P')` - parse from character
 - `as_char()` - convert to `'C'` or `'P'`
 
-**Go SDK:** The `Right` field on all public tick structs is a `string` (`"C"`, `"P"`, or `""`) instead of `i32`. The raw integer value is available as `RightRaw`. Use `RightStr(code int32)` for manual conversion.
+**Go SDK:** The `Right` field on all public tick structs is a `string` (`"C"`, `"P"`, or `""`) instead of `i32`. Use `RightStr(code int32)` for manual conversion.
 
 ### StreamResponseType
 

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -159,7 +159,7 @@ int main() {
 ]
 ```
 
-> SPY end-of-day data. Prices shown as f64 (decoded from fixed-point). All endpoints return structured data with the same JSON-like shape across SDKs.
+> SPY end-of-day data. All prices are `f64`. All endpoints return structured data with the same JSON-like shape across SDKs.
 
 ## With pandas DataFrames (Python)
 

--- a/docs-site/docs/historical/calendar/on-date.md
+++ b/docs-site/docs/historical/calendar/on-date.md
@@ -52,7 +52,7 @@ for (const auto& t : data) {
 
 ## Response
 
-Returns a `Vec<CalendarDay>` with calendar information:
+Returns an array of CalendarDay records with calendar information:
 
 <div class="param-list">
 <div class="param">

--- a/docs-site/docs/historical/calendar/open-today.md
+++ b/docs-site/docs/historical/calendar/open-today.md
@@ -47,7 +47,7 @@ None.
 
 ## Response
 
-Returns a `Vec<CalendarDay>` with market status fields:
+Returns an array of CalendarDay records with market status fields:
 
 <div class="param-list">
 <div class="param">

--- a/docs-site/docs/historical/calendar/year.md
+++ b/docs-site/docs/historical/calendar/year.md
@@ -52,7 +52,7 @@ for (const auto& t : data) {
 
 ## Response
 
-Returns a `Vec<CalendarDay>` with calendar info for non-standard days in the year (holidays, early closes):
+Returns an array of CalendarDay records with calendar info for non-standard days in the year (holidays, early closes):
 
 <div class="param-list">
 <div class="param">

--- a/docs-site/docs/historical/index-data/at-time/price.md
+++ b/docs-site/docs/historical/index-data/at-time/price.md
@@ -60,7 +60,7 @@ for (const auto& t : data) {
 
 ## Response
 
-Returns a `Vec<PriceTick>` with one entry per trading day:
+Returns an array of PriceTick records with one entry per trading day:
 
 <div class="param-list">
 <div class="param">

--- a/docs-site/docs/historical/index-data/history/price.md
+++ b/docs-site/docs/historical/index-data/history/price.md
@@ -7,7 +7,7 @@ description: Intraday price history for an index.
 
 <TierBadge tier="standard" />
 
-Retrieve intraday price history for an index on a single date at a specified interval. Returns price data as `Vec<PriceTick>`.
+Retrieve intraday price history for an index on a single date at a specified interval.
 
 ## Code Example
 
@@ -64,7 +64,7 @@ for (const auto& t : data) {
 
 ## Response
 
-Returns a `Vec<PriceTick>` with price and time fields:
+Returns an array of PriceTick records with price and time fields:
 
 <div class="param-list">
 <div class="param">
@@ -96,6 +96,6 @@ Returns a `Vec<PriceTick>` with price and time fields:
 
 ## Notes
 
-- Returns `Vec<PriceTick>` in Rust.
+- Returns an array of PriceTick records (typed per SDK).
 - For OHLC-structured data across a date range, use [index_history_ohlc](./ohlc) instead.
 - Operates on a single date only. For multi-day queries, use [index_history_eod](./eod) or [index_history_ohlc](./ohlc).

--- a/docs-site/docs/historical/index-data/snapshot/market-value.md
+++ b/docs-site/docs/historical/index-data/snapshot/market-value.md
@@ -56,7 +56,7 @@ for (const auto& t : data) {
 
 ## Response
 
-Returns a `Vec<MarketValueTick>` with market value fields:
+Returns an array of MarketValueTick records with market value fields:
 
 <div class="param-list">
 <div class="param">
@@ -86,5 +86,5 @@ Returns a `Vec<MarketValueTick>` with market value fields:
 
 ## Notes
 
-- Returns `Vec<MarketValueTick>` in Rust.
+- Returns an array of MarketValueTick records (typed per SDK).
 - Market value represents the total capitalization of the index constituents.

--- a/docs-site/docs/historical/index-data/snapshot/price.md
+++ b/docs-site/docs/historical/index-data/snapshot/price.md
@@ -7,7 +7,7 @@ description: Latest price snapshot for one or more indices.
 
 <TierBadge tier="value" />
 
-Get the latest price snapshot for one or more index symbols. Returns the most recent price data as `Vec<PriceTick>`.
+Get the latest price snapshot for one or more index symbols.
 
 ## Code Example
 
@@ -52,7 +52,7 @@ for (const auto& t : data) {
 
 ## Response
 
-Returns a `Vec<PriceTick>` with price fields:
+Returns an array of PriceTick records with price fields:
 
 <div class="param-list">
 <div class="param">
@@ -84,5 +84,5 @@ Returns a `Vec<PriceTick>` with price fields:
 
 ## Notes
 
-- Returns `Vec<PriceTick>` in Rust.
+- Returns an array of PriceTick records (typed per SDK).
 - For OHLC-structured data, use [index_snapshot_ohlc](./ohlc) instead.

--- a/docs-site/docs/historical/rate/eod.md
+++ b/docs-site/docs/historical/rate/eod.md
@@ -56,7 +56,7 @@ for (const auto& t : data) {
 
 ## Response
 
-Returns a `Vec<InterestRateTick>` with rate data per trading day:
+Returns an array of InterestRateTick records with rate data per trading day:
 
 <div class="param-list">
 <div class="param">

--- a/docs-site/docs/historical/stock.md
+++ b/docs-site/docs/historical/stock.md
@@ -51,7 +51,7 @@ let ticks: Vec<TradeTick> = tdx.stock_snapshot_trade(&["AAPL"]).await?;
 // Latest NBBO quote snapshot
 let ticks: Vec<QuoteTick> = tdx.stock_snapshot_quote(&["AAPL", "MSFT", "GOOGL"]).await?;
 for q in &ticks {
-    println!("bid={} ask={}", q.bid_price(), q.ask_price());
+    println!("bid={} ask={}", q.bid, q.ask);
 }
 
 // Latest market value snapshot
@@ -106,8 +106,8 @@ Snapshot endpoints accept multiple symbols in a single call. Batch your requests
 let eod: Vec<EodTick> = tdx.stock_history_eod("AAPL", "20240101", "20240301").await?;
 for t in &eod {
     println!("{}: O={} H={} L={} C={} V={}",
-        t.date, t.open_price(), t.high_price(),
-        t.low_price(), t.close_price(), t.volume);
+        t.date, t.open, t.high,
+        t.low, t.close, t.volume);
 }
 
 // Intraday OHLC bars (single date)

--- a/docs-site/docs/historical/stock/at-time/quote.md
+++ b/docs-site/docs/historical/stock/at-time/quote.md
@@ -85,7 +85,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>bid</code> / <code>ask</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point prices. Use <code>bid_price()</code>, <code>ask_price()</code>, <code>midpoint_price()</code> for decoded values.</div>
+<div class="param-desc">Bid/ask prices (<code>f64</code>, decoded at parse time). <code>midpoint</code> is pre-computed.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>bid_condition</code> / <code>ask_condition</code><span class="param-type">i32</span></div>
@@ -99,7 +99,6 @@ for (const auto& t : data) {
 </div>
 </div>
 
-Helper methods: `bid_price()`, `ask_price()`, `midpoint_price()`, `midpoint_value()`
 
 ## Common Time Values
 

--- a/docs-site/docs/historical/stock/at-time/trade.md
+++ b/docs-site/docs/historical/stock/at-time/trade.md
@@ -94,7 +94,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>price</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point price. Use <code>get_price()</code> for decoded <code>f64</code>.</div>
+<div class="param-desc">Trade price (<code>f64</code>, decoded at parse time).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>condition_flags</code><span class="param-type">i32</span></div>
@@ -120,7 +120,7 @@ for (const auto& t : data) {
 </div>
 </div>
 
-Helper methods: `get_price()`, `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`
+Helper methods: `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`
 
 ## Common Time Values
 

--- a/docs-site/docs/historical/stock/history/eod.md
+++ b/docs-site/docs/historical/stock/history/eod.md
@@ -67,7 +67,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>open</code> / <code>high</code> / <code>low</code> / <code>close</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point OHLC prices. Use <code>open_price()</code>, <code>high_price()</code>, <code>low_price()</code>, <code>close_price()</code> to get decoded <code>f64</code> values.</div>
+<div class="param-desc">OHLC prices (<code>f64</code>, decoded at parse time).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>volume</code><span class="param-type">i32</span></div>
@@ -87,7 +87,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>bid</code> / <code>ask</code><span class="param-type">i32</span></div>
-<div class="param-desc">Closing bid/ask prices (fixed-point). Use <code>bid_price()</code>, <code>ask_price()</code>, <code>midpoint_value()</code>.</div>
+<div class="param-desc">Closing bid/ask prices (<code>f64</code>, decoded at parse time).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>bid_condition</code> / <code>ask_condition</code><span class="param-type">i32</span></div>

--- a/docs-site/docs/historical/stock/history/ohlc.md
+++ b/docs-site/docs/historical/stock/history/ohlc.md
@@ -135,7 +135,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>open</code> / <code>high</code> / <code>low</code> / <code>close</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point OHLC prices. Use <code>open_price()</code>, <code>high_price()</code>, <code>low_price()</code>, <code>close_price()</code> for decoded <code>f64</code>.</div>
+<div class="param-desc">OHLC prices (<code>f64</code>, decoded at parse time).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>volume</code><span class="param-type">i32</span></div>

--- a/docs-site/docs/historical/stock/history/quote.md
+++ b/docs-site/docs/historical/stock/history/quote.md
@@ -87,7 +87,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>bid</code> / <code>ask</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point prices. Use <code>bid_price()</code>, <code>ask_price()</code>, <code>midpoint_price()</code> for decoded values.</div>
+<div class="param-desc">Bid/ask prices (<code>f64</code>, decoded at parse time). <code>midpoint</code> is pre-computed.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>bid_condition</code> / <code>ask_condition</code><span class="param-type">i32</span></div>
@@ -101,7 +101,6 @@ for (const auto& t : data) {
 </div>
 </div>
 
-Helper methods: `bid_price()`, `ask_price()`, `midpoint_price()`, `midpoint_value()`
 
 
 ### Sample Response

--- a/docs-site/docs/historical/stock/history/trade-quote.md
+++ b/docs-site/docs/historical/stock/history/trade-quote.md
@@ -74,7 +74,6 @@ for (const auto& t : data) {
 
 Combined trade + quote tick (25 fields). Contains the full trade data plus the prevailing NBBO quote at the time of the trade.
 
-Helper methods: `trade_price()`, `bid_price()`, `ask_price()`
 
 
 ### Sample Response
@@ -92,6 +91,6 @@ Helper methods: `trade_price()`, `bid_price()`, `ask_price()`
 ## Notes
 
 - This endpoint merges trade and quote streams so each trade row includes the best bid/ask at the time of execution. Useful for computing effective spread, price improvement, and trade classification.
-- Returns `Vec<TradeQuoteTick>` in Rust, list of dicts in Python, `[]TradeQuoteTick` in Go, `vector<TradeQuoteTick>` in C++.
+- Returns an array of TradeQuoteTick records (typed per SDK).
 - This is a Pro-tier endpoint. Value and Standard subscriptions do not have access.
 - The response can be very large for active symbols. Consider filtering with `start_time` / `end_time` or using date ranges that cover only the session you need.

--- a/docs-site/docs/historical/stock/history/trade.md
+++ b/docs-site/docs/historical/stock/history/trade.md
@@ -95,7 +95,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>price</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point price. Use <code>get_price()</code> for decoded <code>f64</code>.</div>
+<div class="param-desc">Trade price (<code>f64</code>, decoded at parse time).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>condition_flags</code><span class="param-type">i32</span></div>
@@ -121,7 +121,7 @@ for (const auto& t : data) {
 </div>
 </div>
 
-Helper methods: `get_price()`, `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`
+Helper methods: `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`
 
 
 ### Sample Response

--- a/docs-site/docs/historical/stock/snapshot/market-value.md
+++ b/docs-site/docs/historical/stock/snapshot/market-value.md
@@ -76,4 +76,4 @@ for (const auto& t : data) {
 ## Notes
 
 - Accepts multiple symbols in a single call.
-- Returns `Vec<MarketValueTick>` in Rust.
+- Returns an array of MarketValueTick records (typed per SDK).

--- a/docs-site/docs/historical/stock/snapshot/ohlc.md
+++ b/docs-site/docs/historical/stock/snapshot/ohlc.md
@@ -67,7 +67,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>open</code> / <code>high</code> / <code>low</code> / <code>close</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point OHLC prices. Use <code>open_price()</code>, <code>high_price()</code>, <code>low_price()</code>, <code>close_price()</code> for decoded values.</div>
+<div class="param-desc">OHLC prices (<code>f64</code>, decoded at parse time).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>volume</code><span class="param-type">i32</span></div>
@@ -99,4 +99,4 @@ for (const auto& t : data) {
 ## Notes
 
 - Accepts multiple symbols in a single call. Batch requests to reduce round-trips.
-- Prices are stored as fixed-point integers. Use the helper methods to get decoded float values.
+- All price fields are `f64` -- decoded during parsing.

--- a/docs-site/docs/historical/stock/snapshot/quote.md
+++ b/docs-site/docs/historical/stock/snapshot/quote.md
@@ -75,7 +75,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>bid</code> / <code>ask</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point prices. Use <code>bid_price()</code>, <code>ask_price()</code>, <code>midpoint_price()</code> for decoded values.</div>
+<div class="param-desc">Bid/ask prices (<code>f64</code>, decoded at parse time). <code>midpoint</code> is pre-computed.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>bid_condition</code> / <code>ask_condition</code><span class="param-type">i32</span></div>
@@ -89,7 +89,6 @@ for (const auto& t : data) {
 </div>
 </div>
 
-Helper methods: `bid_price()`, `ask_price()`, `midpoint_price()`, `midpoint_value()`
 
 
 ### Sample Response
@@ -105,4 +104,4 @@ Helper methods: `bid_price()`, `ask_price()`, `midpoint_price()`, `midpoint_valu
 
 - Accepts multiple symbols in a single call. Batch requests to reduce round-trips.
 - The NBBO represents the best bid and ask across all exchanges.
-- Use `midpoint_price()` to get the midpoint between bid and ask.
+- The `midpoint` field is pre-computed from bid and ask.

--- a/docs-site/docs/historical/stock/snapshot/trade.md
+++ b/docs-site/docs/historical/stock/snapshot/trade.md
@@ -87,7 +87,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>price</code><span class="param-type">i32</span></div>
-<div class="param-desc">Fixed-point price. Use <code>get_price()</code> for decoded <code>f64</code>.</div>
+<div class="param-desc">Trade price (<code>f64</code>, decoded at parse time).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>condition_flags</code><span class="param-type">i32</span></div>
@@ -113,7 +113,7 @@ for (const auto& t : data) {
 </div>
 </div>
 
-Helper methods: `get_price()`, `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`
+Helper methods: `is_cancelled()`, `regular_trading_hours()`, `is_seller()`, `is_incremental_volume()`
 
 
 ### Sample Response
@@ -128,4 +128,4 @@ Helper methods: `get_price()`, `is_cancelled()`, `regular_trading_hours()`, `is_
 ## Notes
 
 - Accepts multiple symbols in a single call.
-- Prices are stored as fixed-point integers. Use the `get_price()` helper to get the decoded float value.
+- All price fields are `f64` -- decoded during parsing.

--- a/docs-site/docs/options.md
+++ b/docs-site/docs/options.md
@@ -158,7 +158,7 @@ for t in trades:
 ```
 :::
 
-The 4 contract ID fields and helper methods (`strike_price()`, `is_call()`, `is_put()`, `has_contract_id()`) are available on all 10 option tick types.
+The 4 contract ID fields and helper methods (`is_call()`, `is_put()`, `has_contract_id()`) are available on all 10 option tick types.
 
 ::: tip Right Field
 In Go and Python, the `right` field is a human-readable string: `"C"` (call), `"P"` (put), or `""` (not set). In Rust and C FFI, `right` is an `i32` (67=Call, 80=Put); use `is_call()`/`is_put()` helpers.

--- a/docs-site/docs/streaming.md
+++ b/docs-site/docs/streaming.md
@@ -11,7 +11,7 @@ Each SDK exposes FPSS differently:
 
 - **Rust** -- Fully synchronous callback model. Events dispatched through an LMAX Disruptor ring buffer. No Tokio on the streaming hot path.
 - **Python** -- Polling model with `next_event()`. Events returned as Python dicts with all fields.
-- **Go** -- Polling model with `NextEvent()`. Events returned as typed `*FpssEvent` structs. Price fields are pre-decoded to `float64`; raw integers available as `*Raw` fields.
+- **Go** -- Polling model with `NextEvent()`. Events returned as typed `*FpssEvent` structs. All price fields are `float64` -- decoded during parsing.
 - **C++** -- Polling model with `next_event()`. Events returned as `FpssEventPtr` (`unique_ptr<TdxFpssEvent>`, RAII). `#[repr(C)]` layout-compatible structs.
 
 ::: warning No JSON in FFI


### PR DESCRIPTION
## Summary

- Removed all "fixed-point" language from response field `<div class="param-desc">` blocks across 24 docs-site pages, replacing with accurate `f64` descriptions
- Removed deleted helper methods (`get_price()`, `bid_price()`, `ask_price()`, `open_price()`, `high_price()`, `low_price()`, `close_price()`, `trade_price()`, `midpoint_price()`, `midpoint_value()`, `strike_price()`) from Helper methods lists
- Replaced "Prices are stored as fixed-point integers" notes with "All price fields are `f64` -- decoded during parsing"
- Made ~30 `Returns Vec<FooTick>` descriptions language-neutral ("Array of FooTick records")
- Removed `RightRaw` reference from api-reference.md Go SDK note
- Removed `*Raw` fields reference from streaming.md Go SDK description
- Added internal-type note to `Price` struct in api-reference.md
- Fixed stale code examples: `q.bid_price()` -> `q.bid`, `t.open_price()` -> `t.open`, `t.get_price()` -> `t.price`
- Updated quickstart.md "decoded from fixed-point" -> "All prices are `f64`"

## Test plan

- [ ] Verify docs-site builds without errors
- [ ] Spot-check 3-4 pages for correct wording
- [ ] Re-run the audit greps to confirm zero remaining matches outside changelog


🤖 Generated with [Claude Code](https://claude.com/claude-code)