### PR TITLE
release: v6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.4.0"
+version = "6.0.0"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "5.4.0"
+version = "6.0.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "5.4.0"
+version = "6.0.0"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ No-JVM ThetaData Terminal - native Rust SDK for direct market data access.
 
 ```toml
 [dependencies]
-thetadatadx = "5.4"
+thetadatadx = "6.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "5.4.0"
+version = "6.0.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -23,7 +23,7 @@ default = []
 config-file = ["dep:toml"]
 
 [dependencies]
-tdbe = { version = "0.6.0", path = "../tdbe" }
+tdbe = { version = "0.7.0", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "5.4.0"
+version = "6.0.0"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"
@@ -10,5 +10,5 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.6.0", path = "../crates/tdbe" }
+tdbe = { version = "0.7.0", path = "../crates/tdbe" }
 tokio = { version = "1.50.0", features = ["rt-multi-thread"] }

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "5.4.0"
+version = "6.0.0"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.6.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.7.0", path = "../../crates/tdbe" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.3"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.4.0"
+version = "6.0.0"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "5.4.0"
+version = "6.0.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "5.4.0"
+version = "6.0.0"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.6.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.7.0", path = "../../crates/tdbe" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1", features = ["derive"] }
 sonic-rs = "0.3"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "5.4.0"
+version = "6.0.0"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "5.4.0"
+version = "6.0.0"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "5.4.0"
+version = "6.0.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23", features = ["ring"] }
-tdbe = { version = "0.6.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.7.0", path = "../../crates/tdbe" }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 sonic-rs = "0.3"


### PR DESCRIPTION
## v6.0.0 -- f64 Prices, Zero Boilerplate

**21 commits, 124 files, +5331/-2875 lines since v5.4.0**

### Breaking Changes

| Before (v5.x) | After (v6.0) |
|---|---|
| `tick.bid_f64()` | `tick.bid` |
| `tick.get_price().to_f64()` | `tick.price` |
| `tick.price_type` | removed |
| `tick.strike_price_type` | removed |
| `Price::new(bid, price_type).to_f64()` | `event.bid` |
| `Contract::option("SPY", 20260417, true, 550000)` | `Contract::option("SPY", "20260417", "550", "C")` |
| Python: `tick["price_raw"]`, `tick["bid_raw"]` | removed |
| Go: `RightRaw`, `StrikePriceType`, `PriceToF64` | removed |
| C++: `tdx::bid_f64(q)`, `tdx::price_to_f64()` | `q.bid`, `q.price` |

### What's New

- All prices decoded to f64 during parsing -- zero boilerplate
- FPSS streaming events: f64 prices, no price_type
- QuoteTick: `midpoint` field (pre-computed)
- Contract::option: 4 strings matching MDDS experience
- Go FFI compile-time struct size assertions
- WebSocket zero-copy fan-out
- Server `--no-ohlcvc` flag
- 233 tests, zero warnings, zero dead_code

### Verified by

- Full CI (fmt + clippy + test + server + MCP) on all 3 platforms
- Three independent code reviews (zero blockers)
- Full-repo audit (not just diff) -- zero stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)