### PR TITLE
fix: harden SDK CI and preserve MCP wildcard fields

### DIFF
--- a/.github/actions/install-protoc/action.yml
+++ b/.github/actions/install-protoc/action.yml
@@ -18,7 +18,6 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        brew update
         brew install protobuf
         protoc --version
 

--- a/.github/actions/install-protoc/action.yml
+++ b/.github/actions/install-protoc/action.yml
@@ -1,0 +1,30 @@
+name: Install protoc
+description: Install the Protocol Buffers compiler on GitHub-hosted runners.
+
+runs:
+  using: composite
+  steps:
+    - name: Install protoc on Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
+        protoc --version
+
+    - name: Install protoc on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew update
+        brew install protobuf
+        protoc --version
+
+    - name: Install protoc on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        choco install protoc --yes
+        protoc --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -14,72 +21,102 @@ jobs:
   check:
     name: Format & Lint (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/install-protoc
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --workspace -- -D warnings
+      - run: cargo clippy --workspace --locked -- -D warnings
 
   test:
     name: Test
     runs-on: ubuntu-latest
     needs: check
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo test --workspace
+      - uses: ./.github/actions/install-protoc
+      - run: cargo test --workspace --locked
 
   surfaces:
     name: Extended Surfaces
     runs-on: ubuntu-latest
     needs: check
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
+      - uses: ./.github/actions/install-protoc
+      - run: cargo clippy --manifest-path tools/mcp/Cargo.toml --locked -- -D warnings
+      - run: cargo test --manifest-path tools/mcp/Cargo.toml --locked
+      - run: cargo clippy --manifest-path tools/server/Cargo.toml --locked -- -D warnings
+      - run: cargo test --manifest-path tools/server/Cargo.toml --locked
+      - run: cargo clippy --manifest-path tools/cli/Cargo.toml --locked -- -D warnings
+      - run: cargo test --manifest-path tools/cli/Cargo.toml --locked
+      - run: cargo check --manifest-path sdks/python/Cargo.toml --locked
+
+  sdk-bindings:
+    name: SDK Bindings (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: check
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            go_enabled: true
+          - os: macos-latest
+            go_enabled: true
+          - os: windows-latest
+            go_enabled: false
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - if: matrix.go_enabled
+        uses: actions/setup-go@v6
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo clippy --manifest-path tools/mcp/Cargo.toml -- -D warnings
-      - run: cargo test --manifest-path tools/mcp/Cargo.toml
-      - run: cargo clippy --manifest-path tools/server/Cargo.toml -- -D warnings
-      - run: cargo test --manifest-path tools/server/Cargo.toml
-      - run: cargo clippy --manifest-path tools/cli/Cargo.toml -- -D warnings
-      - run: cargo test --manifest-path tools/cli/Cargo.toml
-      - run: cargo check --manifest-path sdks/python/Cargo.toml
-      - run: cargo build --release -p thetadatadx-ffi
-      - run: go test ./...
-        working-directory: sdks/go
-        env:
-          LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
-      - run: c++ -std=c++17 -fsyntax-only -I sdks/cpp/include sdks/cpp/src/thetadx.cpp
+          go-version: "1.23"
+      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/install-protoc
+      - run: cargo build --release -p thetadatadx-ffi --locked
       - run: cmake -S sdks/cpp -B build/cpp
-      - run: cmake --build build/cpp --target thetadatadx_cpp
+      - run: cmake --build build/cpp --config Release --target thetadatadx_cpp
+      - if: matrix.go_enabled
+        shell: bash
+        working-directory: sdks/go
+        run: |
+          set -euo pipefail
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            export LD_LIBRARY_PATH="${{ github.workspace }}/target/release"
+          else
+            export DYLD_LIBRARY_PATH="${{ github.workspace }}/target/release"
+          fi
+          go test ./...
 
   build-ffi:
     name: Build FFI (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
@@ -100,15 +137,14 @@ jobs:
               target/release/thetadatadx_ffi.dll.lib
     runs-on: ${{ matrix.os }}
     needs: check
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo build --release -p thetadatadx-ffi
-      - uses: actions/upload-artifact@v4
+      - uses: ./.github/actions/install-protoc
+      - run: cargo build --release -p thetadatadx-ffi --locked
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-path }}
@@ -116,19 +152,28 @@ jobs:
   publish-crate:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    needs: [test, surfaces, build-ffi]
+    needs: [test, surfaces, sdk-bindings, build-ffi]
     if: startsWith(github.ref, 'refs/tags/v')
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: cargo publish -p tdbe --allow-dirty || true
+      - uses: ./.github/actions/install-protoc
+      - run: cargo publish -p tdbe --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - run: sleep 30
-      - run: cargo publish -p thetadatadx --allow-dirty || true
+      - shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in {1..10}; do
+            if cargo publish -p thetadatadx --locked; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 10 ]; then
+              exit 1
+            fi
+            sleep 30
+          done
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -140,16 +185,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: ffi-linux-x86_64
           path: artifacts/linux/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ffi-macos-arm64
           path: artifacts/macos/
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ffi-windows-x86_64
           path: artifacts/windows/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,16 +17,16 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: docs-site/package-lock.json
       - run: cd docs-site && npm ci
       - run: cd docs-site && npx vitepress build docs
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: docs-site/docs/.vitepress/dist
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
       - shell: bash
-        run: python -m pip install --upgrade pip maturin
+        run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"
       - name: Build wheel
         shell: bash
         run: python -m maturin build --release -m sdks/python/Cargo.toml -o dist/ --interpreter python
@@ -87,7 +87,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
       - shell: bash
-        run: python -m pip install --upgrade pip maturin
+        run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"
       - shell: bash
         run: python -m maturin build --release -m sdks/python/Cargo.toml -o dist/ --interpreter python
       - shell: bash
@@ -108,7 +108,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
       - shell: bash
-        run: python -m pip install --upgrade pip maturin
+        run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"
       - shell: bash
         run: python -m maturin sdist -m sdks/python/Cargo.toml -o dist/
       - shell: bash

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,64 +8,115 @@ on:
     branches: [main]
   workflow_dispatch:
 
-jobs:
-  smoke:
-    name: Smoke build (ubuntu py3.12)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: pip install maturin
-      - run: maturin build --release -m sdks/python/Cargo.toml -o dist/ -i python3.12
-        env:
-          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+permissions:
+  contents: read
 
+concurrency:
+  group: python-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
   build:
-    name: Build wheels (${{ matrix.os }} py${{ matrix.python }})
+    name: Build wheel (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - os: ubuntu-latest
+            python: "3.12"
+            label: ubuntu py3.12
+          - os: macos-latest
+            python: "3.12"
+            label: macos py3.12
+          - os: windows-latest
+            python: "3.12"
+            label: windows py3.12
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: pip install maturin
+      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/install-protoc
+      - shell: bash
+        run: python -m pip install --upgrade pip maturin
       - name: Build wheel
-        run: maturin build --release -m sdks/python/Cargo.toml -o dist/ -i python${{ matrix.python }}
-        env:
-          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
-      - uses: actions/upload-artifact@v4
+        shell: bash
+        run: python -m maturin build --release -m sdks/python/Cargo.toml -o dist/ --interpreter python
+      - name: Install wheel
+        shell: bash
+        run: python -m pip install --force-reinstall dist/*.whl
+      - name: Import smoke
+        shell: bash
+        run: |
+          python - <<'PY'
+          import thetadatadx
+          from thetadatadx import implied_volatility
+
+          iv, err = implied_volatility(450.0, 455.0, 0.05, 0.015, 30.0 / 365.0, 8.50, True)
+          print(thetadatadx.__file__)
+          print(round(iv, 6), round(err, 6))
+          PY
+      - if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.os }}-py${{ matrix.python }}
+          name: wheel-${{ runner.os }}
           path: dist/*.whl
+
+  compatibility:
+    name: ABI3 smoke (ubuntu py${{ matrix.python }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.9", "3.14"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/install-protoc
+      - shell: bash
+        run: python -m pip install --upgrade pip maturin
+      - shell: bash
+        run: python -m maturin build --release -m sdks/python/Cargo.toml -o dist/ --interpreter python
+      - shell: bash
+        run: python -m pip install --force-reinstall dist/*.whl
+      - shell: bash
+        run: python -c "import thetadatadx"
 
   sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install maturin
-      - run: maturin sdist -m sdks/python/Cargo.toml -o dist/
-      - uses: actions/upload-artifact@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: ./.github/actions/install-protoc
+      - shell: bash
+        run: python -m pip install --upgrade pip maturin
+      - shell: bash
+        run: python -m maturin sdist -m sdks/python/Cargo.toml -o dist/
+      - shell: bash
+        run: python -m pip install --force-reinstall dist/*.tar.gz
+      - shell: bash
+        run: python -c "import thetadatadx"
+      - if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -76,7 +127,7 @@ jobs:
     needs: [build, sdist]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist/
           merge-multiple: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ you need to get started.
 - **Rust stable** (see `rust-toolchain.toml` - includes rustfmt and clippy)
 - **protoc** (Protocol Buffers compiler) - only needed if modifying `.proto` files
 - **Python 3.9+** - for the Python SDK
-- **maturin** - for building the PyO3 Python bindings (`pip install maturin`)
+- **maturin** - for building the PyO3 Python bindings (`pip install "maturin>=1.9.4,<2.0"`)
 - **Go 1.21+** - for the Go SDK
 
 Note: `protoc` is required even if you're not modifying `.proto` files, because `build.rs` compiles protos during `cargo build`.

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -60,7 +60,7 @@ make
 For unsupported platforms where pre-built wheels are not available:
 
 ```bash
-pip install maturin
+pip install "maturin>=1.9.4,<2.0"
 git clone https://github.com/userFRM/ThetaDataDx.git
 cd ThetaDataDx/sdks/python
 maturin develop --release

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -60,7 +60,7 @@ make
 For unsupported platforms where pre-built wheels are not available:
 
 ```bash
-pip install maturin
+pip install "maturin>=1.9.4,<2.0"
 git clone https://github.com/userFRM/ThetaDataDx.git
 cd ThetaDataDx/sdks/python
 maturin develop --release

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -56,6 +56,12 @@ Multi-language SDKs for ThetaDataDx. All powered by the Rust core via FFI - thes
 
 The Python SDK uses [PyO3](https://pyo3.rs/) with [Maturin](https://www.maturin.rs/) for direct Rust-to-Python bindings, bypassing the C FFI layer. The Go and C++ SDKs go through the C FFI crate (`thetadatadx-ffi`), which exposes `extern "C"` functions compiled as both a shared library (`cdylib`) and a static archive (`staticlib`).
 
+## Validation Matrix
+
+- Python: wheel builds and import smoke are validated on Linux, macOS, and Windows. The package now targets the CPython stable ABI (`abi3`) with a minimum version of Python 3.9, so one wheel per platform covers Python 3.9+.
+- Go: validated on Linux and macOS. Windows support is not yet part of the official CI matrix because the Rust-to-CGo linking story still needs a dedicated import-library flow there.
+- C++: validated with CMake builds on Linux, macOS, and Windows against the generated FFI library.
+
 ## Python SDK
 
 **Binding technology:** PyO3 + Maturin (direct Rust-to-Python, no C FFI intermediate)
@@ -69,7 +75,7 @@ pip install thetadatadx[pandas]    # pandas
 pip install thetadatadx[polars]    # polars
 pip install thetadatadx[all]       # both
 
-# From source (requires Rust toolchain)
+# From source (requires Rust toolchain and maturin 1.9.4+)
 cd sdks/python
 pip install maturin
 maturin develop --release
@@ -89,7 +95,7 @@ g = all_greeks(spot=150.0, strike=155.0, rate=0.05,
                div_yield=0.015, tte=45/365, option_price=3.50, is_call=True)
 ```
 
-Requires Python 3.9+. See [sdks/python/README.md](python/README.md) for full documentation.
+Requires Python 3.9+. Binary wheels target the CPython stable ABI, so one wheel works across supported Python 3.9+ interpreters on the same platform. See [sdks/python/README.md](python/README.md) for full documentation.
 
 ## Go SDK
 
@@ -176,7 +182,8 @@ cargo build --release -p thetadatadx-ffi
 cd sdks/python && maturin develop --release && cd ../..
 
 # 3. Build the C++ SDK
-cd sdks/cpp && mkdir -p build && cd build && cmake .. && make && cd ../../..
+cmake -S sdks/cpp -B build/cpp
+cmake --build build/cpp --config Release --target thetadatadx_cpp
 
 # 4. Go SDK - no separate build step; CGo links at compile time
 cd sdks/go/examples && go build . && cd ../../..

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -77,7 +77,7 @@ pip install thetadatadx[all]       # both
 
 # From source (requires Rust toolchain and maturin 1.9.4+)
 cd sdks/python
-pip install maturin
+pip install "maturin>=1.9.4,<2.0"
 maturin develop --release
 ```
 

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.16)
-project(thetadatadx-cpp VERSION 0.1.0 LANGUAGES CXX)
+project(thetadatadx-cpp VERSION 6.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Path to the Rust FFI library (built with: cargo build --release -p thetadatadx-ffi)
 set(THETADX_FFI_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../target/release" CACHE PATH
-    "Directory containing libthetadatadx_ffi.so/.a")
+    "Directory containing the platform-specific thetadatadx FFI artifacts")
 
 # ── thetadatadx C++ library ──
 
@@ -18,20 +18,43 @@ target_include_directories(thetadatadx_cpp PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Link against the Rust FFI library
-find_library(THETADX_FFI_LIB
-    NAMES thetadatadx_ffi
-    PATHS ${THETADX_FFI_DIR}
-    NO_DEFAULT_PATH
-    REQUIRED
-)
+# Link against the Rust FFI library using an imported target so the correct
+# artifact is selected per platform.
+add_library(thetadatadx_ffi SHARED IMPORTED GLOBAL)
 
-target_link_libraries(thetadatadx_cpp PUBLIC
-    ${THETADX_FFI_LIB}
-    pthread
-    dl
-    m
-)
+if(WIN32)
+    set(THETADX_FFI_IMPLIB "${THETADX_FFI_DIR}/thetadatadx_ffi.dll.lib")
+    set(THETADX_FFI_RUNTIME "${THETADX_FFI_DIR}/thetadatadx_ffi.dll")
+    if(NOT EXISTS "${THETADX_FFI_IMPLIB}")
+        message(FATAL_ERROR "thetadatadx FFI import library not found: ${THETADX_FFI_IMPLIB}")
+    endif()
+    set_target_properties(thetadatadx_ffi PROPERTIES
+        IMPORTED_IMPLIB "${THETADX_FFI_IMPLIB}"
+        IMPORTED_LOCATION "${THETADX_FFI_RUNTIME}"
+    )
+elseif(APPLE)
+    set(THETADX_FFI_LIB "${THETADX_FFI_DIR}/libthetadatadx_ffi.dylib")
+    if(NOT EXISTS "${THETADX_FFI_LIB}")
+        message(FATAL_ERROR "thetadatadx FFI shared library not found: ${THETADX_FFI_LIB}")
+    endif()
+    set_target_properties(thetadatadx_ffi PROPERTIES
+        IMPORTED_LOCATION "${THETADX_FFI_LIB}"
+    )
+else()
+    set(THETADX_FFI_LIB "${THETADX_FFI_DIR}/libthetadatadx_ffi.so")
+    if(NOT EXISTS "${THETADX_FFI_LIB}")
+        message(FATAL_ERROR "thetadatadx FFI shared library not found: ${THETADX_FFI_LIB}")
+    endif()
+    set_target_properties(thetadatadx_ffi PROPERTIES
+        IMPORTED_LOCATION "${THETADX_FFI_LIB}"
+    )
+endif()
+
+target_link_libraries(thetadatadx_cpp PUBLIC thetadatadx_ffi)
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(thetadatadx_cpp PUBLIC pthread dl m)
+endif()
 
 # ── Example ──
 

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -10,6 +10,12 @@ C++ SDK for ThetaData market data, powered by the `thetadatadx` Rust crate via C
 - CMake 3.16+
 - Rust toolchain (for building the FFI library)
 
+## Platform Support
+
+- Linux: CI-validated
+- macOS: CI-validated
+- Windows: CI-validated
+
 ## Building
 
 First, build the Rust FFI library:
@@ -22,16 +28,14 @@ cargo build --release -p thetadatadx-ffi
 Then build the C++ SDK:
 
 ```bash
-cd sdks/cpp
-mkdir build && cd build
-cmake ..
-make
+cmake -S sdks/cpp -B build/cpp
+cmake --build build/cpp --config Release --target thetadatadx_cpp
 ```
 
 Run the example:
 
 ```bash
-./thetadatadx_example
+./build/cpp/thetadatadx_example
 ```
 
 ## Quick Start

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -20,6 +20,14 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#if defined(_MSC_VER)
+#define TDX_ALIGN64_BEGIN __declspec(align(64))
+#define TDX_ALIGN64_END
+#else
+#define TDX_ALIGN64_BEGIN
+#define TDX_ALIGN64_END __attribute__((aligned(64)))
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,15 +45,15 @@ typedef struct TdxFpssHandle TdxFpssHandle;
 /* All tick structs are 64-byte aligned to match Rust's #[repr(C, align(64))].
  * Price fields are f64 (double) -- decoded during parsing. No price_type. */
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t date;
     int32_t is_open;
     int32_t open_time;
     int32_t close_time;
     int32_t status;
-} TdxCalendarDay;
+} TdxCalendarDay TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t ms_of_day2;
     double open;
@@ -68,9 +76,9 @@ typedef struct __attribute__((aligned(64))) {
     /* 4 bytes padding */
     double strike;
     int32_t right;
-} TdxEodTick;
+} TdxEodTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
     double implied_volatility;
@@ -99,16 +107,16 @@ typedef struct __attribute__((aligned(64))) {
     int32_t expiration;
     double strike;
     int32_t right;
-} TdxGreeksTick;
+} TdxGreeksTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
     double rate;
     int32_t date;
-} TdxInterestRateTick;
+} TdxInterestRateTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
     double implied_volatility;
@@ -117,9 +125,9 @@ typedef struct __attribute__((aligned(64))) {
     int32_t expiration;
     double strike;
     int32_t right;
-} TdxIvTick;
+} TdxIvTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before i64 */
     int64_t market_cap;
@@ -131,9 +139,9 @@ typedef struct __attribute__((aligned(64))) {
     int32_t expiration;
     double strike;
     int32_t right;
-} TdxMarketValueTick;
+} TdxMarketValueTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
     double open;
@@ -146,25 +154,25 @@ typedef struct __attribute__((aligned(64))) {
     int32_t expiration;
     double strike;
     int32_t right;
-} TdxOhlcTick;
+} TdxOhlcTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t open_interest;
     int32_t date;
     int32_t expiration;
     double strike;
     int32_t right;
-} TdxOpenInterestTick;
+} TdxOpenInterestTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
     double price;
     int32_t date;
-} TdxPriceTick;
+} TdxPriceTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t bid_size;
     int32_t bid_exchange;
@@ -183,9 +191,9 @@ typedef struct __attribute__((aligned(64))) {
     int32_t right;
     /* 4 bytes padding before f64 */
     double midpoint;
-} TdxQuoteTick;
+} TdxQuoteTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t sequence;
     int32_t size;
@@ -195,9 +203,9 @@ typedef struct __attribute__((aligned(64))) {
     int32_t expiration;
     double strike;
     int32_t right;
-} TdxSnapshotTradeTick;
+} TdxSnapshotTradeTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t sequence;
     int32_t ext_condition1;
@@ -229,9 +237,9 @@ typedef struct __attribute__((aligned(64))) {
     /* 4 bytes padding before f64 */
     double strike;
     int32_t right;
-} TdxTradeQuoteTick;
+} TdxTradeQuoteTick TDX_ALIGN64_END;
 
-typedef struct __attribute__((aligned(64))) {
+TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t sequence;
     int32_t ext_condition1;
@@ -251,7 +259,7 @@ typedef struct __attribute__((aligned(64))) {
     int32_t expiration;
     double strike;
     int32_t right;
-} TdxTradeTick;
+} TdxTradeTick TDX_ALIGN64_END;
 
 /* ═══════════════════════════════════════════════════════════════════════ */
 /*  Typed array return types                                              */

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -10,6 +10,12 @@ Go SDK for ThetaData market data, powered by the `thetadatadx` Rust crate via CG
 - Rust toolchain (for building the FFI library)
 - C compiler (for CGo)
 
+## Platform Support
+
+- Linux: CI-validated
+- macOS: CI-validated
+- Windows: not yet part of the official CI matrix for the Go binding
+
 ## Building
 
 First, build the Rust FFI library:
@@ -19,7 +25,7 @@ First, build the Rust FFI library:
 cargo build --release -p thetadatadx-ffi
 ```
 
-This produces `target/release/libthetadatadx_ffi.so` (Linux) or `libthetadatadx_ffi.dylib` (macOS).
+This produces `target/release/libthetadatadx_ffi.so` (Linux), `libthetadatadx_ffi.dylib` (macOS), or `thetadatadx_ffi.dll` plus import library artifacts on Windows.
 
 Then build or run your Go code:
 

--- a/sdks/go/thetadx.go
+++ b/sdks/go/thetadx.go
@@ -1,8 +1,9 @@
 package thetadatadx
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/../../target/release -lthetadatadx_ffi -lm -ldl -lpthread
-#cgo darwin LDFLAGS: -framework Security -framework SystemConfiguration
+#cgo linux LDFLAGS: -L${SRCDIR}/../../target/release -lthetadatadx_ffi -lm -ldl -lpthread
+#cgo darwin LDFLAGS: -L${SRCDIR}/../../target/release -lthetadatadx_ffi -framework Security -framework SystemConfiguration
+#cgo windows LDFLAGS: -L${SRCDIR}/../../target/release -lthetadatadx_ffi
 #include "ffi_bridge.h"
 */
 import "C"

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -3,6 +3,11 @@ name = "thetadatadx-py"
 version = "6.0.0"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
+license = "GPL-3.0-or-later"
+homepage = "https://github.com/userFRM/ThetaDataDx"
+repository = "https://github.com/userFRM/ThetaDataDx"
+documentation = "https://github.com/userFRM/ThetaDataDx/blob/main/docs/api-reference.md"
+readme = "README.md"
 
 [lib]
 name = "thetadatadx"
@@ -13,8 +18,9 @@ crate-type = ["cdylib"]
 thetadatadx = { path = "../../crates/thetadatadx" }
 tdbe = { version = "0.7.0", path = "../../crates/tdbe" }
 
-# PyO3 bindings
-pyo3 = { version = "=0.28.2", features = ["extension-module"] }
+# PyO3 bindings. We target the stable ABI so one wheel per platform supports
+# every Python version from 3.9 upward.
+pyo3 = { version = "=0.28.2", features = ["abi3-py39"] }
 
 # Async bridge: run tokio futures from sync Python
 tokio = { version = "1.50.0", features = ["rt-multi-thread"] }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -22,9 +22,11 @@ pip install thetadatadx[all]
 Or build from source (requires Rust toolchain):
 
 ```bash
-pip install maturin
+pip install "maturin>=1.9.4,<2.0"
 maturin develop --release
 ```
+
+Binary wheels use CPython's stable ABI (`abi3`) with a minimum Python version of 3.9, so one wheel per platform supports Python 3.9+.
 
 ## Quick Start
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.9.4,<2.0"]
 build-backend = "maturin"
 
 [project]
 name = "thetadatadx"
-version = "5.4.0"
+dynamic = ["version"]
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -30,6 +30,3 @@ Discord = "https://discord.thetadata.us/"
 pandas = ["pandas>=1.5"]
 polars = ["polars>=0.20"]
 all = ["pandas>=1.5", "polars>=0.20"]
-
-[tool.maturin]
-features = ["pyo3/extension-module"]

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -25,7 +25,7 @@ use std::io::Write as _;
 use std::sync::Arc;
 
 use serde::Serialize;
-use sonic_rs::{json, JsonContainerTrait, JsonValueTrait, Value};
+use sonic_rs::{json, JsonContainerTrait, JsonValueMutTrait, JsonValueTrait, Value};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::RwLock;
 
@@ -405,11 +405,44 @@ fn negotiate_protocol_version(client_version: Option<&str>) -> &'static str {
 //  Serialization helpers
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Render ThetaData's option right code as a human-readable MCP field value.
+fn option_right_value(right: i32) -> Value {
+    match right {
+        67 => "C".into(),
+        80 => "P".into(),
+        _ => right.into(),
+    }
+}
+
+/// Attach wildcard option contract identifiers to a serialized tick row.
+///
+/// ThetaData only populates these fields on wildcard/bulk queries, where
+/// callers request `expiration = "0"` and/or `strike = "0"`. Single-contract
+/// queries leave them as zero, so MCP omits them to keep those payloads lean.
+fn insert_contract_id_fields(row: &mut Value, expiration: i32, strike: f64, right: i32) {
+    if expiration == 0 {
+        return;
+    }
+
+    let object = row
+        .as_object_mut()
+        .expect("serialized tick rows must always be JSON objects");
+    object.insert(
+        "expiration",
+        sonic_rs::to_value(&expiration).expect("i32 contract expiration should serialize"),
+    );
+    object.insert(
+        "strike",
+        sonic_rs::to_value(&strike).expect("f64 contract strike should serialize"),
+    );
+    object.insert("right", option_right_value(right));
+}
+
 fn serialize_eod_ticks(ticks: &[tdbe::types::tick::EodTick]) -> Value {
     let rows: Vec<Value> = ticks
         .iter()
         .map(|t| {
-            json!({
+            let mut row = json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
                 "open": t.open,
@@ -422,7 +455,9 @@ fn serialize_eod_ticks(ticks: &[tdbe::types::tick::EodTick]) -> Value {
                 "ask": t.ask,
                 "bid_size": t.bid_size,
                 "ask_size": t.ask_size,
-            })
+            });
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
@@ -432,7 +467,7 @@ fn serialize_ohlc_ticks(ticks: &[tdbe::types::tick::OhlcTick]) -> Value {
     let rows: Vec<Value> = ticks
         .iter()
         .map(|t| {
-            json!({
+            let mut row = json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
                 "open": t.open,
@@ -441,7 +476,9 @@ fn serialize_ohlc_ticks(ticks: &[tdbe::types::tick::OhlcTick]) -> Value {
                 "close": t.close,
                 "volume": t.volume,
                 "count": t.count,
-            })
+            });
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
@@ -451,7 +488,7 @@ fn serialize_trade_ticks(ticks: &[tdbe::types::tick::TradeTick]) -> Value {
     let rows: Vec<Value> = ticks
         .iter()
         .map(|t| {
-            json!({
+            let mut row = json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
                 "price": t.price,
@@ -459,7 +496,9 @@ fn serialize_trade_ticks(ticks: &[tdbe::types::tick::TradeTick]) -> Value {
                 "exchange": t.exchange,
                 "condition": t.condition,
                 "sequence": t.sequence,
-            })
+            });
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
@@ -469,7 +508,7 @@ fn serialize_quote_ticks(ticks: &[tdbe::types::tick::QuoteTick]) -> Value {
     let rows: Vec<Value> = ticks
         .iter()
         .map(|t| {
-            json!({
+            let mut row = json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
                 "bid": t.bid,
@@ -478,7 +517,9 @@ fn serialize_quote_ticks(ticks: &[tdbe::types::tick::QuoteTick]) -> Value {
                 "ask": t.ask,
                 "ask_size": t.ask_size,
                 "ask_exchange": t.ask_exchange,
-            })
+            });
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
@@ -488,7 +529,7 @@ fn serialize_trade_quote_ticks(ticks: &[tdbe::types::tick::TradeQuoteTick]) -> V
     let rows: Vec<Value> = ticks
         .iter()
         .map(|t| {
-            json!({
+            let mut row = json!({
                 "date": t.date,
                 "ms_of_day": t.ms_of_day,
                 "price": t.price,
@@ -500,7 +541,9 @@ fn serialize_trade_quote_ticks(ticks: &[tdbe::types::tick::TradeQuoteTick]) -> V
                 "bid_size": t.bid_size,
                 "ask": t.ask,
                 "ask_size": t.ask_size,
-            })
+            });
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
@@ -509,9 +552,12 @@ fn serialize_trade_quote_ticks(ticks: &[tdbe::types::tick::TradeQuoteTick]) -> V
 fn serialize_open_interest_ticks(ticks: &[tdbe::types::tick::OpenInterestTick]) -> Value {
     let rows: Vec<Value> = ticks
         .iter()
-        .map(
-            |t| json!({"date": t.date, "ms_of_day": t.ms_of_day, "open_interest": t.open_interest}),
-        )
+        .map(|t| {
+            let mut row =
+                json!({"date": t.date, "ms_of_day": t.ms_of_day, "open_interest": t.open_interest});
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
+        })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
 }
@@ -520,12 +566,14 @@ fn serialize_market_value_ticks(ticks: &[tdbe::types::tick::MarketValueTick]) ->
     let rows: Vec<Value> = ticks
         .iter()
         .map(|t| {
-            json!({
+            let mut row = json!({
                 "date": t.date, "ms_of_day": t.ms_of_day,
                 "market_cap": t.market_cap, "shares_outstanding": t.shares_outstanding,
                 "enterprise_value": t.enterprise_value, "book_value": t.book_value,
                 "free_float": t.free_float,
-            })
+            });
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
@@ -535,12 +583,14 @@ fn serialize_greeks_ticks(ticks: &[tdbe::types::tick::GreeksTick]) -> Value {
     let rows: Vec<Value> = ticks
         .iter()
         .map(|t| {
-            json!({
+            let mut row = json!({
                 "date": t.date, "ms_of_day": t.ms_of_day,
                 "implied_volatility": t.implied_volatility, "delta": t.delta,
                 "gamma": t.gamma, "theta": t.theta, "vega": t.vega, "rho": t.rho,
                 "iv_error": t.iv_error,
-            })
+            });
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
@@ -550,10 +600,12 @@ fn serialize_iv_ticks(ticks: &[tdbe::types::tick::IvTick]) -> Value {
     let rows: Vec<Value> = ticks
         .iter()
         .map(|t| {
-            json!({
+            let mut row = json!({
                 "date": t.date, "ms_of_day": t.ms_of_day,
                 "implied_volatility": t.implied_volatility, "iv_error": t.iv_error,
-            })
+            });
+            insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
+            row
         })
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
@@ -1039,6 +1091,64 @@ mod tests {
     use std::collections::HashSet;
 
     use super::*;
+    use tdbe::types::tick::{EodTick, GreeksTick};
+
+    fn sample_eod_tick(expiration: i32, strike: f64, right: i32) -> EodTick {
+        EodTick {
+            ms_of_day: 0,
+            ms_of_day2: 0,
+            open: 1.0,
+            high: 1.0,
+            low: 1.0,
+            close: 1.0,
+            volume: 10,
+            count: 1,
+            bid_size: 2,
+            bid_exchange: 0,
+            bid: 0.9,
+            bid_condition: 0,
+            ask_size: 3,
+            ask_exchange: 0,
+            ask: 1.1,
+            ask_condition: 0,
+            date: 20221219,
+            expiration,
+            strike,
+            right,
+        }
+    }
+
+    fn sample_greeks_tick(expiration: i32, strike: f64, right: i32) -> GreeksTick {
+        GreeksTick {
+            ms_of_day: 0,
+            implied_volatility: 0.25,
+            delta: 0.5,
+            gamma: 0.1,
+            theta: -0.01,
+            vega: 0.2,
+            rho: 0.05,
+            iv_error: 0.0,
+            vanna: 0.0,
+            charm: 0.0,
+            vomma: 0.0,
+            veta: 0.0,
+            speed: 0.0,
+            zomma: 0.0,
+            color: 0.0,
+            ultima: 0.0,
+            d1: 0.0,
+            d2: 0.0,
+            dual_delta: 0.0,
+            dual_gamma: 0.0,
+            epsilon: 0.0,
+            lambda: 0.0,
+            vera: 0.0,
+            date: 20221219,
+            expiration,
+            strike,
+            right,
+        }
+    }
 
     #[test]
     fn negotiate_protocol_version_uses_requested_supported_version() {
@@ -1160,6 +1270,52 @@ mod tests {
         assert_eq!(
             args.optional_date("end_date").expect("end_date should validate"),
             Some("20260409")
+        );
+    }
+
+    #[test]
+    fn serialize_option_history_eod_preserves_bulk_contract_identifiers() {
+        let payload = serialize_eod_ticks(&[sample_eod_tick(20230120, 385.0, 67)]);
+        let tick = payload
+            .get("ticks")
+            .and_then(|value: &Value| value.as_array())
+            .and_then(|rows| rows.get(0))
+            .expect("serialized tick row should exist");
+
+        assert_eq!(
+            tick.get("expiration").and_then(|value: &Value| value.as_i64()),
+            Some(20230120)
+        );
+        assert_eq!(
+            tick.get("strike").and_then(|value: &Value| value.as_f64()),
+            Some(385.0)
+        );
+        assert_eq!(
+            tick.get("right").and_then(|value: &Value| value.as_str()),
+            Some("C")
+        );
+    }
+
+    #[test]
+    fn serialize_option_history_greeks_eod_omits_contract_identifiers_for_single_contract_rows() {
+        let payload = serialize_greeks_ticks(&[sample_greeks_tick(0, 0.0, 0)]);
+        let tick = payload
+            .get("ticks")
+            .and_then(|value: &Value| value.as_array())
+            .and_then(|rows| rows.get(0))
+            .expect("serialized tick row should exist");
+
+        assert!(
+            tick.get("expiration").is_none(),
+            "single-contract rows should not emit wildcard-only expiration metadata"
+        );
+        assert!(
+            tick.get("strike").is_none(),
+            "single-contract rows should not emit wildcard-only strike metadata"
+        );
+        assert!(
+            tick.get("right").is_none(),
+            "single-contract rows should not emit wildcard-only right metadata"
         );
     }
 }


### PR DESCRIPTION
## Summary
- harden GitHub Actions coverage for Rust tools and supported SDK surfaces
- switch the Python SDK packaging flow to abi3 wheels with real PR-time wheel/sdist validation
- preserve wildcard option contract identifiers in MCP bulk responses so multi-strike option queries are usable

## Details
- replace the deprecated Node-based `arduino/setup-protoc` action with a local composite protoc installer
- upgrade core GitHub Actions versions and add concurrency, timeouts, and stricter release behavior
- validate Python wheel builds on Linux/macOS/Windows during PRs and run source-distribution install smoke checks
- fix Python package metadata drift by sourcing the version from Cargo and filling in missing Cargo package metadata
- tighten Go and C++ SDK build configuration and docs to match the supported CI matrix
- include `expiration`, `strike`, and human-readable `right` fields in MCP output for wildcard option tick rows while omitting them for single-contract rows

## Validation
- `cargo fmt --all`
- `cargo test -p thetadatadx --locked`
- `cargo clippy -p thetadatadx --locked -- -D warnings`
- `cargo test --manifest-path tools/mcp/Cargo.toml --locked`
- `cargo clippy --manifest-path tools/mcp/Cargo.toml --locked -- -D warnings`
- `cargo test --manifest-path tools/server/Cargo.toml --locked`
- `cargo clippy --manifest-path tools/server/Cargo.toml --locked -- -D warnings`
- `cargo test --manifest-path tools/cli/Cargo.toml --locked`
- `cargo clippy --manifest-path tools/cli/Cargo.toml --locked -- -D warnings`
- `cargo check --manifest-path sdks/python/Cargo.toml --locked`
- Python wheel build/install/import smoke via `maturin`
- Python sdist build/install/import smoke via `maturin`
- `cargo build --release -p thetadatadx-ffi --locked`
- `go test ./...` in `sdks/go`
- `cmake -S sdks/cpp -B build/cpp && cmake --build build/cpp --config Release --target thetadatadx_cpp`

## Notes
- Go on Windows is still not in the official CI matrix because the Rust-to-CGo import-library path there still needs a dedicated solution.
