### PR TITLE
Revert: restore TdxSnapshotTradeTick in C++ SDK

### DIFF
--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -254,6 +254,7 @@ All endpoints return fully typed C++ structs. No raw JSON.
 | `IvTick` | ms_of_day, implied_volatility, iv_error, date, **expiration, strike, right** | IV-only endpoints |
 | `PriceTick` | ms_of_day, price, date | Index price endpoints |
 | `MarketValueTick` | ms_of_day, market_cap, shares_outstanding, enterprise_value, book_value, free_float, date, **expiration, strike, right** | Market value endpoints |
+| `SnapshotTradeTick` | ms_of_day, sequence, size, condition, price, date, **expiration, strike, right** | Snapshot trade endpoints |
 | `OptionContract` | root, expiration, strike, right | option_list_contracts |
 | `CalendarDay` | date, is_open, open_time, close_time, status | Calendar endpoints |
 | `InterestRateTick` | ms_of_day, rate, date | Interest rate endpoints |

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -196,6 +196,18 @@ TDX_ALIGN64_BEGIN typedef struct {
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t sequence;
+    int32_t size;
+    int32_t condition;
+    double price;
+    int32_t date;
+    int32_t expiration;
+    double strike;
+    int32_t right;
+} TdxSnapshotTradeTick TDX_ALIGN64_END;
+
+TDX_ALIGN64_BEGIN typedef struct {
+    int32_t ms_of_day;
+    int32_t sequence;
     int32_t ext_condition1;
     int32_t ext_condition2;
     int32_t ext_condition3;

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -38,6 +38,7 @@ using OpenInterestTick = TdxOpenInterestTick;
 using MarketValueTick = TdxMarketValueTick;
 using CalendarDay = TdxCalendarDay;
 using InterestRateTick = TdxInterestRateTick;
+using SnapshotTradeTick = TdxSnapshotTradeTick;
 using TradeQuoteTick = TdxTradeQuoteTick;
 // OptionContract uses std::string for root to avoid use-after-free.
 // The C FFI TdxOptionContract uses a raw char* that is freed with the array,


### PR DESCRIPTION
## Summary

Reverts PR #232 which incorrectly removed `TdxSnapshotTradeTick` from the C++ SDK header.

The struct mirrors `tdbe::SnapshotTradeTick` which IS used by snapshot trade endpoints. It was missing FFI array/free plumbing (tracked in #216), but the struct itself should stay. Wiring the FFI exports is a separate task.

Reopens #227 (will be closed differently — by adding FFI plumbing instead of deleting the struct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)