### PR TITLE
fix(docs): update stale version 5.4 → 7.0 + checker guard

### DIFF
--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -11,7 +11,7 @@ description: Install ThetaDataDx, configure credentials, and run your first quer
 ```toml [Rust]
 # Add to your Cargo.toml
 [dependencies]
-thetadatadx = "5.4"
+thetadatadx = "7.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 ```bash [Python]

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ description: Install ThetaDataDx for Rust, Python, Go, or C++.
 ```toml [Rust]
 # Add to your Cargo.toml
 [dependencies]
-thetadatadx = "5.4"
+thetadatadx = "7.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 ```bash [Python]

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -106,7 +106,15 @@ def check_static_docs() -> None:
         ROOT / "docs-site/docs/tools/mcp.md",
         f"{len(REGISTRY_ENDPOINTS)} data endpoints + ping + all_greeks + implied_volatility = {EXPECTED_TOOL_COUNT} tools.",
     )
-    # Migration guide removed in v7 (L14). No longer enforced.
+    # Version strings in getting-started docs must match the workspace version.
+    expect_contains(
+        ROOT / "docs-site/docs/getting-started.md",
+        'thetadatadx = "7.0"',
+    )
+    expect_contains(
+        ROOT / "docs-site/docs/getting-started/installation.md",
+        'thetadatadx = "7.0"',
+    )
     expect_contains(
         ROOT / "docs-site/docs/tools/mcp.md",
         'Use `"strike":"0"` when you want a bulk chain-style response',


### PR DESCRIPTION
Two getting-started pages referenced thetadatadx = \"5.4\". Updated to \"7.0\".

Added consistency checker assertions so stale version strings fail CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)