### PR TITLE
fix: bump tdbe to 0.8.0 so v7.0.0 publishes (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Workspace version bumped from 6.0.0 to 7.0.0.
+- `tdbe` bumped from 0.7.0 to 0.8.0. `tdbe@0.7.0` was yanked from crates.io because it shipped with a broken `MarketValueTick` schema (five stale fundamental fields); the 0.8.0 release carries the corrected `market_bid` / `market_ask` / `market_price` layout.
 - Docs consistency checker now points at correct generated files.
 - `FpssControl::LoginSuccess { permissions }` documented as opaque diagnostic metadata.
 - Public endpoint and utility surfaces now project optional request parameters consistently across Rust, Python, Go, C++, CLI, MCP, and REST from the checked-in specs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 config-file = ["dep:toml"]
 
 [dependencies]
-tdbe = { version = "0.7.0", path = "../tdbe" }
+tdbe = { version = "0.8.0", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Workspace version bumped from 6.0.0 to 7.0.0.
+- `tdbe` bumped from 0.7.0 to 0.8.0. `tdbe@0.7.0` was yanked from crates.io because it shipped with a broken `MarketValueTick` schema (five stale fundamental fields); the 0.8.0 release carries the corrected `market_bid` / `market_ask` / `market_price` layout.
 - Docs consistency checker now points at correct generated files.
 - `FpssControl::LoginSuccess { permissions }` documented as opaque diagnostic metadata.
 - Public endpoint and utility surfaces now project optional request parameters consistently across Rust, Python, Go, C++, CLI, MCP, and REST from the checked-in specs.

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.7.0", path = "../crates/tdbe" }
+tdbe = { version = "0.8.0", path = "../crates/tdbe" }
 tokio = { version = "1.50.0", features = ["rt-multi-thread"] }

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1586,7 +1586,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.7.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.8.0", path = "../../crates/tdbe" }
 
 # PyO3 bindings. We target the stable ABI so one wheel per platform supports
 # every Python version from 3.9 upward.

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.7.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.8.0", path = "../../crates/tdbe" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.3"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.7.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.8.0", path = "../../crates/tdbe" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1", features = ["derive"] }
 sonic-rs = "0.3"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23", features = ["ring"] }
-tdbe = { version = "0.7.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.8.0", path = "../../crates/tdbe" }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 sonic-rs = "0.3"


### PR DESCRIPTION
## Summary

- Bumps \`tdbe\` from \`0.7.0\` to \`0.8.0\` and updates every workspace dep-spec.
- Regenerates every \`Cargo.lock\` (workspace + \`tools/mcp\`, \`tools/server\`, \`sdks/python\`).
- Notes the bump + yank plan in both \`CHANGELOG.md\` and \`docs-site/docs/changelog.md\` under v7.0.0.

Fixes #268.

## Why

\`tdbe@0.7.0\` is on crates.io with the **wrong** \`MarketValueTick\` schema (five stale \`i64\` fundamental fields). PR #262 corrected the schema in-tree to \`market_bid\` / \`market_ask\` / \`market_price\` as \`f64\`, but kept tdbe at 0.7.0 — so the registry copy is permanently incompatible with the current source.

When the v7.0.0 release CI ran, \`cargo publish -p thetadatadx\` pulled tdbe@0.7.0 from crates.io for verification and failed with:

\`\`\`
error[E0560]: struct \`tdbe::MarketValueTick\` has no field named \`market_bid\`
error[E0560]: struct \`tdbe::MarketValueTick\` has no field named \`market_ask\`
error[E0560]: struct \`tdbe::MarketValueTick\` has no field named \`market_price\`
\`\`\`

\`thetadatadx 7.0.0\` never made it to crates.io. After this merges, tdbe@0.7.0 will be yanked and the \`v7.0.0\` tag will be recycled onto the fixed main.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --locked -- -D warnings\`
- [x] \`cargo test --workspace --locked\`
- [x] \`cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check\`
- [x] \`cargo clippy --manifest-path tools/{mcp,server,cli}/Cargo.toml --locked -- -D warnings\`
- [x] \`cargo check --manifest-path sdks/python/Cargo.toml --locked\`
- [x] \`python3 scripts/check_docs_consistency.py\`
- [ ] Full CI green on this PR
- [ ] After merge: yank tdbe@0.7.0, delete+re-push \`v7.0.0\` tag, release CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)