### PR TITLE
feat: permissive right parsing + align OpenAPI YAML with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- No unreleased changes yet.
+### Changed
+
+- **Centralized `right` parsing** (#270) -- new `thetadatadx::right` module exposes `parse_right` / `parse_right_strict` returning a `ParsedRight` enum that carries every downstream representation (MDDS lowercase string, FPSS `is_call` bool, short-form `"C"`/`"P"`, FPSS wire byte). `normalize_right` in `direct.rs`, `validate_right` in `validate.rs`, and `Contract::option` in `fpss/protocol.rs` all route through it.
+- **OpenAPI YAML aligned with upstream ThetaData** (#270) -- `right-param` enum in `docs-site/public/thetadatadx.yaml` extended to `[call, put, both, C, P, c, p, CALL, PUT, Call, Put, "*"]` to match what the server actually accepts (strict superset of upstream's `[call, put, both]`). Response `right` stays `type: string` with a note documenting the current `"C"`/`"P"` output shape.
+
+### Fixed
+
+- **Silent put-default on invalid `right` in `Contract::option`** (#270) -- previously `Contract::option(..., "xyz")` silently constructed a put contract because the parser only checked for call forms. Now panics with a descriptive message, consistent with the existing strike/expiration panic style.
 
 ## [7.0.0] - 2026-04-14
 

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -56,15 +56,21 @@ const TERMINAL_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Normalize the `right` parameter for the v3 MDDS server.
 ///
-/// Accepts: `"C"`, `"P"`, `"call"`, `"put"`, `"both"`, `"*"`.
-/// Maps `"C"` -> `"call"`, `"P"` -> `"put"`, `"*"` -> `"both"`.
+/// Delegates to [`crate::right::parse_right`] — the single source of truth
+/// for accepted `right` forms. Maps `C`/`call` -> `"call"`, `P`/`put` ->
+/// `"put"`, `both`/`*` -> `"both"`, case-insensitive.
+///
+/// # Panics
+///
+/// Panics with a descriptive message on unrecognised input. Endpoint-layer
+/// callers already run `validate_right` before reaching the direct client,
+/// so this path is defence-in-depth; use [`crate::right::parse_right`]
+/// directly for fallible parsing from untrusted input.
 fn normalize_right(right: &str) -> String {
-    match right {
-        "C" | "c" => "call".to_string(),
-        "P" | "p" => "put".to_string(),
-        "*" => "both".to_string(),
-        other => other.to_lowercase(),
-    }
+    crate::right::parse_right(right)
+        .unwrap_or_else(|err| panic!("{err}"))
+        .as_mdds_str()
+        .to_string()
 }
 
 /// Helper: build a `proto::ContractSpec` from the four standard option params.

--- a/crates/thetadatadx/src/fpss/protocol.rs
+++ b/crates/thetadatadx/src/fpss/protocol.rs
@@ -138,13 +138,26 @@ impl Contract {
     /// - `root`: Underlying ticker (e.g., `"AAPL"`)
     /// - `exp_date`: Expiration as `"YYYYMMDD"` (e.g., `"20260320"`)
     /// - `strike`: Strike price in dollars as string (e.g., `"550"`)
-    /// - `right`: `"C"` for call, `"P"` for put
+    /// - `right`: option right — accepts `"call"`/`"put"`/`"C"`/`"P"`
+    ///   (case-insensitive). FPSS per-contract subscriptions cannot carry
+    ///   the `both` / `*` wildcard, so those values are rejected.
+    ///
+    /// # Panics
+    ///
+    /// Panics with a descriptive message if `exp_date`, `strike`, or
+    /// `right` cannot be parsed. This matches the existing panic-on-
+    /// invalid-input style for strike/expiration. Use
+    /// [`crate::right::parse_right_strict`] upstream for fallible parsing
+    /// of untrusted input.
     pub fn option(root: impl Into<String>, exp_date: &str, strike: &str, right: &str) -> Self {
         let exp: i32 = exp_date
             .replace('-', "")
             .parse()
             .expect("invalid expiration date");
-        let is_call = right.eq_ignore_ascii_case("C") || right.eq_ignore_ascii_case("call");
+        let is_call = crate::right::parse_right_strict(right)
+            .unwrap_or_else(|err| panic!("{err}"))
+            .as_is_call()
+            .expect("parse_right_strict guarantees single-side resolution");
         let strike_dollars: f64 = strike.parse().expect("invalid strike price");
         let strike_raw = (strike_dollars * 1000.0).round() as i32;
         Self {

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -98,6 +98,7 @@ pub mod endpoint;
 pub mod error;
 pub mod fpss;
 pub mod registry;
+pub mod right;
 pub mod unified;
 pub(crate) mod validate;
 
@@ -128,4 +129,5 @@ pub use config::{DirectConfig, FpssFlushMode, ReconnectPolicy};
 pub use endpoint::{EndpointArgValue, EndpointArgs, EndpointError, EndpointOutput};
 pub use error::{AuthErrorKind, Error, FpssErrorKind};
 pub use registry::{EndpointMeta, ParamMeta, ParamType, ReturnType, ENDPOINTS};
+pub use right::{parse_right, parse_right_strict, ParsedRight};
 pub use unified::{ConnectionStatus, SubscriptionInfo, ThetaDataDx};

--- a/crates/thetadatadx/src/right.rs
+++ b/crates/thetadatadx/src/right.rs
@@ -1,0 +1,245 @@
+//! Canonical parser for the option `right` parameter.
+//!
+//! Every user-facing input boundary (MDDS endpoints, FPSS contracts, CLI,
+//! SDK surfaces) funnels `right` strings through [`parse_right`] so that
+//! the accepted vocabulary and validation rules live in exactly one place.
+//!
+//! # Accepted input
+//!
+//! The parser is intentionally permissive at the input boundary to match
+//! the ergonomics we expose across SDKs:
+//!
+//! - `"call"`, `"CALL"`, `"Call"` (any case)
+//! - `"put"`, `"PUT"`, `"Put"` (any case)
+//! - `"C"`, `"c"` (short-form call, our convention)
+//! - `"P"`, `"p"` (short-form put, our convention)
+//! - `"both"`, `"BOTH"`, `"*"` — wildcard; only valid where the endpoint
+//!   supports it (e.g. snapshot / history endpoints taking `strike="0"`)
+//!
+//! Anything else returns [`Error::Config`] with a descriptive message.
+//! No silent defaults.
+//!
+//! # Upstream vs ours
+//!
+//! ThetaData's own OpenAPI spec (`https://docs.thetadata.us/openapiv3.yaml`)
+//! defines request query `right` as `enum: [call, put, both]` with default
+//! `both`. We extend the accepted set with short-form `C`/`P` for SDK
+//! ergonomics — a strict superset, so any upstream client continues to work.
+
+use crate::error::Error;
+
+/// Parsed representation of the option `right` parameter.
+///
+/// Carries every representation downstream consumers need so that the
+/// parsing logic runs exactly once per user input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParsedRight {
+    /// Call option.
+    Call,
+    /// Put option.
+    Put,
+    /// Wildcard — both calls and puts. Only valid where the endpoint
+    /// supports it (historical / snapshot endpoints that also accept
+    /// `strike = "0"` as a wildcard).
+    Both,
+}
+
+impl ParsedRight {
+    /// Lowercase string expected by the MDDS gRPC server
+    /// (`"call"` / `"put"` / `"both"`).
+    #[must_use]
+    pub fn as_mdds_str(self) -> &'static str {
+        match self {
+            Self::Call => "call",
+            Self::Put => "put",
+            Self::Both => "both",
+        }
+    }
+
+    /// Short-form string used in our tick dicts and drop-in REST/WS
+    /// responses (`"C"` / `"P"`). `Both` has no short form — callers
+    /// must reject it if they only accept a single contract.
+    ///
+    /// Returns `None` for `Both` so the caller can surface a proper
+    /// error instead of silently picking one side.
+    #[must_use]
+    pub fn as_short_str(self) -> Option<&'static str> {
+        match self {
+            Self::Call => Some("C"),
+            Self::Put => Some("P"),
+            Self::Both => None,
+        }
+    }
+
+    /// Boolean used by the FPSS wire protocol (`true` = call, `false` = put).
+    /// `Both` is not representable on the FPSS wire and returns `None`.
+    #[must_use]
+    pub fn as_is_call(self) -> Option<bool> {
+        match self {
+            Self::Call => Some(true),
+            Self::Put => Some(false),
+            Self::Both => None,
+        }
+    }
+
+    /// Raw FPSS wire-format byte (`67` = ASCII `'C'`, `80` = ASCII `'P'`).
+    /// `Both` is not representable on the FPSS wire and returns `None`.
+    #[must_use]
+    pub fn as_wire_byte(self) -> Option<i32> {
+        match self {
+            Self::Call => Some(67),
+            Self::Put => Some(80),
+            Self::Both => None,
+        }
+    }
+}
+
+/// Parse a user-supplied `right` string.
+///
+/// Accepts `call`/`put`/`both`/`C`/`P`/`*` in any case. Returns
+/// [`Error::Config`] for anything else.
+///
+/// # Errors
+///
+/// Returns [`Error::Config`] if the input does not match any of the
+/// accepted forms.
+///
+/// # Examples
+///
+/// ```
+/// use thetadatadx::right::{parse_right, ParsedRight};
+///
+/// assert_eq!(parse_right("C").unwrap(), ParsedRight::Call);
+/// assert_eq!(parse_right("put").unwrap(), ParsedRight::Put);
+/// assert_eq!(parse_right("BOTH").unwrap(), ParsedRight::Both);
+/// assert_eq!(parse_right("*").unwrap(), ParsedRight::Both);
+/// assert!(parse_right("xyz").is_err());
+/// ```
+pub fn parse_right(input: &str) -> Result<ParsedRight, Error> {
+    // `*` is punctuation — handle before the lowercase dance.
+    if input == "*" {
+        return Ok(ParsedRight::Both);
+    }
+
+    // Lower-case once so we match `C`/`c`/`CALL`/`Call`/etc. uniformly.
+    match input.to_ascii_lowercase().as_str() {
+        "c" | "call" => Ok(ParsedRight::Call),
+        "p" | "put" => Ok(ParsedRight::Put),
+        "both" => Ok(ParsedRight::Both),
+        _ => Err(Error::Config(format!(
+            "invalid option right: '{input}' (expected one of: 'call', 'put', 'both', 'C', 'P', '*' -- case-insensitive)"
+        ))),
+    }
+}
+
+/// Parse a `right` that must resolve to a single side (call or put).
+///
+/// Returns [`Error::Config`] if the input parses to [`ParsedRight::Both`].
+/// Use this for endpoints where the wildcard is not meaningful (e.g.
+/// FPSS per-contract subscriptions).
+///
+/// # Errors
+///
+/// Returns [`Error::Config`] for invalid inputs and for the `both` /
+/// `*` wildcards.
+pub fn parse_right_strict(input: &str) -> Result<ParsedRight, Error> {
+    let parsed = parse_right(input)?;
+    if matches!(parsed, ParsedRight::Both) {
+        return Err(Error::Config(format!(
+            "option right '{input}' resolves to 'both' but this endpoint requires a single side (call or put)"
+        )));
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_call_all_cases() {
+        for form in ["call", "CALL", "Call", "CaLl", "C", "c"] {
+            assert_eq!(
+                parse_right(form).unwrap(),
+                ParsedRight::Call,
+                "failed on {form}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_put_all_cases() {
+        for form in ["put", "PUT", "Put", "PuT", "P", "p"] {
+            assert_eq!(
+                parse_right(form).unwrap(),
+                ParsedRight::Put,
+                "failed on {form}"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_both_and_wildcard() {
+        assert_eq!(parse_right("both").unwrap(), ParsedRight::Both);
+        assert_eq!(parse_right("BOTH").unwrap(), ParsedRight::Both);
+        assert_eq!(parse_right("Both").unwrap(), ParsedRight::Both);
+        assert_eq!(parse_right("*").unwrap(), ParsedRight::Both);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        for bad in ["xyz", "", " ", "calls", "p ", "0", "67", "**"] {
+            let err = parse_right(bad).unwrap_err();
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("invalid option right"),
+                "expected a descriptive error for '{bad}', got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn mdds_projection_matches_upstream_vocabulary() {
+        assert_eq!(parse_right("C").unwrap().as_mdds_str(), "call");
+        assert_eq!(parse_right("p").unwrap().as_mdds_str(), "put");
+        assert_eq!(parse_right("*").unwrap().as_mdds_str(), "both");
+    }
+
+    #[test]
+    fn short_form_projection() {
+        assert_eq!(parse_right("call").unwrap().as_short_str(), Some("C"));
+        assert_eq!(parse_right("PUT").unwrap().as_short_str(), Some("P"));
+        assert_eq!(parse_right("both").unwrap().as_short_str(), None);
+    }
+
+    #[test]
+    fn fpss_bool_projection() {
+        assert_eq!(parse_right("C").unwrap().as_is_call(), Some(true));
+        assert_eq!(parse_right("P").unwrap().as_is_call(), Some(false));
+        assert_eq!(parse_right("both").unwrap().as_is_call(), None);
+    }
+
+    #[test]
+    fn fpss_wire_byte_projection() {
+        // 'C' = 67, 'P' = 80 -- ASCII codes for the FPSS wire format.
+        assert_eq!(parse_right("call").unwrap().as_wire_byte(), Some(67));
+        assert_eq!(parse_right("put").unwrap().as_wire_byte(), Some(80));
+        assert_eq!(parse_right("*").unwrap().as_wire_byte(), None);
+    }
+
+    #[test]
+    fn strict_rejects_both() {
+        assert_eq!(parse_right_strict("C").unwrap(), ParsedRight::Call);
+        assert_eq!(parse_right_strict("put").unwrap(), ParsedRight::Put);
+
+        let err = parse_right_strict("both").unwrap_err();
+        assert!(format!("{err}").contains("resolves to 'both'"));
+
+        let err = parse_right_strict("*").unwrap_err();
+        assert!(format!("{err}").contains("resolves to 'both'"));
+
+        // Still surfaces the baseline invalid-input error for garbage.
+        let err = parse_right_strict("xyz").unwrap_err();
+        assert!(format!("{err}").contains("invalid option right"));
+    }
+}

--- a/crates/thetadatadx/src/validate.rs
+++ b/crates/thetadatadx/src/validate.rs
@@ -46,12 +46,15 @@ pub(crate) fn validate_interval(value: &str, param_name: &str) -> Result<(), End
 }
 
 pub(crate) fn validate_right(value: &str, param_name: &str) -> Result<(), EndpointError> {
-    match value.to_uppercase().as_str() {
-        "C" | "P" | "CALL" | "PUT" => Ok(()),
-        _ => Err(EndpointError::InvalidParams(format!(
-            "'{param_name}' must be C, P, call, or put, got: '{value}'"
-        ))),
-    }
+    // Delegate to the canonical parser so the accepted vocabulary stays in
+    // one place. The endpoint layer does not distinguish Call/Put/Both here
+    // -- per-endpoint logic in the direct client decides whether `both` /
+    // `*` is meaningful -- so we only care about "is this parseable at all".
+    crate::right::parse_right(value).map(|_| ()).map_err(|_| {
+        EndpointError::InvalidParams(format!(
+            "'{param_name}' must be one of: 'call', 'put', 'both', 'C', 'P', '*' (case-insensitive), got: '{value}'"
+        ))
+    })
 }
 
 pub(crate) fn validate_year(value: &str, param_name: &str) -> Result<(), EndpointError> {

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- No unreleased changes yet.
+### Changed
+
+- **Centralized `right` parsing** (#270) -- new `thetadatadx::right` module exposes `parse_right` / `parse_right_strict` returning a `ParsedRight` enum that carries every downstream representation (MDDS lowercase string, FPSS `is_call` bool, short-form `"C"`/`"P"`, FPSS wire byte). `normalize_right` in `direct.rs`, `validate_right` in `validate.rs`, and `Contract::option` in `fpss/protocol.rs` all route through it.
+- **OpenAPI YAML aligned with upstream ThetaData** (#270) -- `right-param` enum in `docs-site/public/thetadatadx.yaml` extended to `[call, put, both, C, P, c, p, CALL, PUT, Call, Put, "*"]` to match what the server actually accepts (strict superset of upstream's `[call, put, both]`). Response `right` stays `type: string` with a note documenting the current `"C"`/`"P"` output shape.
+
+### Fixed
+
+- **Silent put-default on invalid `right` in `Contract::option`** (#270) -- previously `Contract::option(..., "xyz")` silently constructed a put contract because the parser only checked for call forms. Now panics with a descriptive message, consistent with the existing strike/expiration panic style.
 
 ## [7.0.0] - 2026-04-14
 

--- a/docs-site/docs/options.md
+++ b/docs-site/docs/options.md
@@ -139,7 +139,7 @@ When you pass `"0"` for `expiration` or `strike`, the server returns data across
 If you are comparing against the v3 REST API, the same wildcard behavior is expressed with `strike=*` / `expiration=*` instead of `"0"`.
 
 ::: warning
-The `right` parameter does **not** accept `"0"` as a wildcard. Use `"C"` (call), `"P"` (put), or `"both"` (calls and puts). Only `expiration` and `strike` accept `"0"` as a wildcard.
+The `right` parameter does **not** accept `"0"` as a wildcard. Use `"C"` / `"call"` for calls, `"P"` / `"put"` for puts, or `"both"` / `"*"` for both (case-insensitive — e.g. `"CALL"`, `"Put"`, `"c"` all work). Only `expiration` and `strike` accept `"0"` as a wildcard.
 :::
 
 ::: code-group

--- a/docs-site/public/thetadatadx.yaml
+++ b/docs-site/public/thetadatadx.yaml
@@ -203,8 +203,14 @@ x-anchors:
     required: true
     schema:
       type: string
-      enum: [C, P]
-    description: Option right, "C" for call, "P" for put
+      enum: [call, put, both, C, P, c, p, CALL, PUT, Call, Put, "*"]
+    description: >-
+      Option right. Accepts `call`, `put`, `both` (upstream ThetaData
+      vocabulary; upstream default is `both`), plus our short-forms `C`
+      (call), `P` (put), and `*` (alias for `both`) for SDK ergonomics.
+      Matching is case-insensitive. The `both` / `*` wildcard is only
+      meaningful on endpoints that also accept `strike="0"` and
+      `expiration="0"` wildcards.
 
   max_dte-param: &max_dte-param
     name: max_dte
@@ -600,6 +606,11 @@ x-anchors:
                 type: string
               right:
                 type: string
+                description: >-
+                  Option right as emitted by the drop-in REST/WS server.
+                  Currently `"C"` (call) or `"P"` (put); no enum constraint
+                  so future output formats (e.g. upstream `"CALL"`/`"PUT"`)
+                  remain backward-compatible.
 
   data-table-response: &data-table-response
     description: Successful response

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -261,7 +261,7 @@ All endpoints return fully typed C++ structs. No raw JSON.
 
 All price fields (`open`, `high`, `low`, `close`, `bid`, `ask`, `price`, `strike`) are `double` (f64) -- decoded during parsing. No `price_type` in the public API.
 
-**Contract identification fields** (bold above): `expiration`, `strike`, `right` are populated by the server on wildcard queries (pass `"0"` for expiration/strike). On single-contract queries these fields are `0`. The `right` parameter accepts `"C"` (call), `"P"` (put), or `"both"` -- not `"0"`.
+**Contract identification fields** (bold above): `expiration`, `strike`, `right` are populated by the server on wildcard queries (pass `"0"` for expiration/strike). On single-contract queries these fields are `0`. The `right` input parameter accepts `"call"`, `"put"`, `"C"`, `"P"` (case-insensitive), plus `"both"`/`"*"` on endpoints that support a wildcard -- not `"0"`. Output values stay `"C"`/`"P"`.
 
 ## FPSS Streaming
 

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -272,7 +272,7 @@ defer client.Close()
 
 **Contract identification fields** (bold above): `Expiration`, `Strike` (float64), `Right` (string) are populated by the server on wildcard queries (pass `"0"` for expiration/strike). On single-contract queries these fields are zero/empty.
 
-**Right field**: In the Go SDK, `Right` is a human-readable `string` (`"C"` for call, `"P"` for put, `""` if not set).
+**Right field**: In the Go SDK, `Right` is a human-readable `string` (`"C"` for call, `"P"` for put, `""` if not set). On **input**, `right` parameters accept `"call"`, `"put"`, `"C"`, `"P"` (case-insensitive); the server output stays `"C"`/`"P"`.
 
 ## FPSS Streaming
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -190,7 +190,7 @@ Real-time streaming is accessed through the same `ThetaDataDx` instance.
 
 | Method | Description |
 |--------|-------------|
-| `subscribe_option_quotes(symbol, expiration, strike, right)` | Subscribe to option quote data. `right`: `"C"` or `"P"`. `strike`: dollar string e.g. `"550"`. |
+| `subscribe_option_quotes(symbol, expiration, strike, right)` | Subscribe to option quote data. `right`: accepts `"call"`, `"put"`, `"C"`, `"P"` (case-insensitive). `strike`: dollar string e.g. `"550"`. |
 | `subscribe_option_trades(symbol, expiration, strike, right)` | Subscribe to option trade data |
 | `subscribe_option_open_interest(symbol, expiration, strike, right)` | Subscribe to option OI data |
 | `unsubscribe_option_quotes(symbol, expiration, strike, right)` | Unsubscribe from option quotes |


### PR DESCRIPTION
## Summary

- New `thetadatadx::right` module centralizes option `right` parsing into a canonical `parse_right` / `parse_right_strict` pair returning a `ParsedRight` enum. Carries every downstream representation (MDDS lowercase, FPSS `is_call` bool, short-form `"C"`/`"P"`, FPSS wire byte) so the parsing logic runs exactly once per user input.
- `normalize_right` (direct.rs), `validate_right` (validate.rs), and `Contract::option` (fpss/protocol.rs) now route through the canonical parser.
- `docs-site/public/thetadatadx.yaml` `right-param` enum aligned with upstream ThetaData's `[call, put, both]` vocabulary, extended with short-form `C`/`P`/`*` for SDK ergonomics (strict superset of upstream). Response `right` stays `type: string` for forward-compat.

## Why

Three scattered code paths handled `right` with divergent semantics, including one silent-bug path:

- `Contract::option(..., "xyz")` silently constructed a put contract because the old code did `eq_ignore_ascii_case("C") || eq_ignore_ascii_case("call")` -- everything else fell through to the put branch.
- `normalize_right` accepted `"C"`/`"P"`/`"*"` and lowercased anything else, so garbage flowed through to MDDS.
- `validate_right` already enforced the vocabulary at the endpoint layer but wasn't reused elsewhere.
- The OpenAPI YAML declared `enum: [C, P]` -- contradicted both upstream ThetaData (`[call, put, both]`) and our own runtime permissiveness.

One module, one vocabulary, one error message. Silent-default footgun gone.

## Scope decisions

- **`Contract::option` stays panic-on-bad-right**, matching the existing panic-on-bad-strike / panic-on-bad-expiration style. Upgrading to `Result` would cascade through every generated SDK option method. Panics are loud and carry a descriptive message via the canonical parser's error, so the silent-bug concern is fully addressed.
- **Tick-dict / drop-in server output format stays `"C"`/`"P"`** -- breaking change for every downstream consumer, out of scope here. The OpenAPI response `right` was updated to `type: string` (no enum) with a description noting the current shape, so a future switch to upstream `"CALL"`/`"PUT"` remains backward-compatible at the schema level.
- **Greeks functions keep `is_call: bool`** -- pure math, not an input boundary.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] `cargo test --workspace --locked` -- 9 new `right::tests::*` unit tests added (every accepted form, rejection of garbage, strict-mode both-rejection, all four projections)
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check`
- [x] `cargo clippy --manifest-path tools/{mcp,server,cli}/Cargo.toml --locked -- -D warnings`
- [x] `cargo check --manifest-path sdks/python/Cargo.toml --locked`
- [x] `python3 scripts/check_docs_consistency.py`
- [ ] CI green (waiting)

Fixes #270