### PR TITLE
docs: sidebar landings for Historical Data and Tools sections (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - **Deleted orphan docs-site pages** (#272) -- removed top-level single-page versions (`getting-started.md`, `historical.md`, `historical/{stock,option,index-data,calendar}.md`, `streaming.md`, `tools/index.md`) superseded by the subdirectory navigation. Added a `## Client Model` section to `docs-site/docs/streaming/index.md` that makes the per-SDK split (Rust/Python unified `ThetaDataDx`, Go/C++ standalone `FpssClient`) unmistakable. Removed `ignoreDeadLinks: true` from `docs-site/docs/.vitepress/config.ts` so future link rot fails the VitePress build.
+- **Sidebar landings for Historical Data and Tools sections** (#274) -- added `link:` fields on both top-level sidebar entries so clicking the section headers lands on the category overview. Created a new `tools/index.md` overview describing the CLI / MCP / REST Server trio.
 
 ## [7.0.0] - 2026-04-14
 

--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -55,6 +55,7 @@ export default withMermaid(defineConfig({
       },
       {
         text: 'Historical Data',
+        link: '/historical/',
         collapsed: true,
         items: [
           {
@@ -254,6 +255,7 @@ export default withMermaid(defineConfig({
       },
       {
         text: 'Tools',
+        link: '/tools/',
         collapsed: true,
         items: [
           { text: 'CLI', link: '/tools/cli' },

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - **Deleted orphan docs-site pages** (#272) -- removed top-level single-page versions (`getting-started.md`, `historical.md`, `historical/{stock,option,index-data,calendar}.md`, `streaming.md`, `tools/index.md`) superseded by the subdirectory navigation. Added a `## Client Model` section to `docs-site/docs/streaming/index.md` that makes the per-SDK split (Rust/Python unified `ThetaDataDx`, Go/C++ standalone `FpssClient`) unmistakable. Removed `ignoreDeadLinks: true` from `docs-site/docs/.vitepress/config.ts` so future link rot fails the VitePress build.
+- **Sidebar landings for Historical Data and Tools sections** (#274) -- added `link:` fields on both top-level sidebar entries so clicking the section headers lands on the category overview. Created a new `tools/index.md` overview describing the CLI / MCP / REST Server trio.
 
 ## [7.0.0] - 2026-04-14
 

--- a/docs-site/docs/tools/index.md
+++ b/docs-site/docs/tools/index.md
@@ -1,0 +1,26 @@
+---
+title: Tools
+description: Command-line, MCP, and drop-in REST/WebSocket server tools built on top of the ThetaDataDx core.
+---
+
+# Tools
+
+Three first-party tools built on top of the ThetaDataDx core. Every one is a thin wrapper — they all speak to the same Rust client and share the same 61 historical endpoints plus FPSS streaming.
+
+## [CLI (`tdx`)](./cli)
+
+Command-line interface for querying ThetaData market data from your terminal. All 61 endpoints, plus offline Greeks and implied volatility. Install with `cargo install thetadatadx-cli`.
+
+Best for: ad-hoc queries, shell pipelines, cron jobs.
+
+## [MCP Server (`thetadatadx-mcp`)](./mcp)
+
+Model Context Protocol server. Exposes ThetaData tools as JSON-RPC 2.0 over stdio so any MCP-capable LLM client (Claude Desktop, Claude Code, Cursor, etc.) can query market data directly. Install with `cargo install thetadatadx-mcp`.
+
+Best for: giving LLMs live access to ThetaData without writing an integration layer.
+
+## [REST Server (`thetadatadx-server`)](./server)
+
+Drop-in HTTP/WebSocket replacement for the ThetaData Java Terminal v3 surface. Existing scripts that target the terminal's v3 routes can point at this binary with no code change. Install with `cargo install thetadatadx-server`.
+
+Best for: migrating away from the JVM terminal with zero client-side churn.


### PR DESCRIPTION
## Summary

- Added \`link: '/historical/'\` to the Historical Data sidebar header — \`historical/index.md\` was already a proper category overview, just unreachable from the sidebar.
- Added \`link: '/tools/'\` and created a new \`tools/index.md\` overview for the CLI / MCP / REST Server trio.

Fixes #274.

## Why

Both section headers were non-clickable, which broke the pattern set by \`Real-Time Streaming\` (\`link: '/streaming/'\`) and left users without a category landing page.

## Test plan

- [x] \`python3 scripts/check_docs_consistency.py\` green
- [x] \`cd docs-site && npx vitepress build docs\` builds clean (no dead links after #273 removed \`ignoreDeadLinks\`)
- [ ] Full CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)