### PR TITLE
fix: full-vocabulary wildcard support for option contract parameters (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Full-vocabulary wildcard support for option contract parameters** (#284) -- brought the option contract params (`expiration`, `strike`, `right`) into alignment with the full vocabulary that ThetaData's v3 MDDS server and `openapiv3.yaml` document:
+  - `validate_expiration` accepts `*` (wildcard), `YYYYMMDD`, and `YYYY-MM-DD`. The legacy `0` sentinel is still accepted on the SDK surface and translated to `*` on the wire in `direct::normalize_expiration`, because the server rejects a literal `0` with `InvalidArgument -- Error parsing expiration Cannot parse date string: 0`. ISO-dashed dates are canonicalized to `YYYYMMDD` on the wire.
+  - New `validate_strike` accepts `*` / `0` / empty (all treated as wildcard), or a positive decimal (e.g. `"550"`, `"17.5"`).
+  - New `direct::wire_strike_opt` maps wildcard sentinels to `None` so `ContractSpec.strike` is left unset on the proto. Upstream treats the field as optional with a documented `*` default; sending the unset form is what produces the documented default behavior.
+  - New `direct::wire_right_opt` maps `*` / `both` / `0` / empty to `None` for the same reason; single sides (`C`, `P`, `call`, `put`) normalize to `call` / `put` on the wire.
+  - `required_strike` / `optional_strike` accessors added to `EndpointArgs`; the endpoint generator now dispatches the `Strike` param type to them.
+  - Before this change the SDK had no working path to the server's bulk-chain mode: `*` was rejected client-side by `validate_expiration`, and `0` was rejected server-side. Pulling a full option chain's open interest for QQQ required a 34-expiration serial loop (~22s). A single bulk call now returns all 10,158 rows in ~1s.
+  - Live-verified against production across 64 parameter-mode combinations on `option_snapshot_open_interest` -- every cross of `{*, 0, YYYYMMDD, YYYY-MM-DD}` × `{*, 0, 550, ""}` × `{*, both, C, P}` returns correct, internally-consistent row counts (full chain / half per side / per-expiration / exact single-contract lookup).
+  - Applies to every option snapshot, history, and at-time endpoint that builds a `ContractSpec`.
+
 ### Added
 
 - **Public API redesign doc** (#282) -- \`docs/public-api-redesign.md\` charters the layered ergonomic-façade migration plan (exact generated surface as canonical parity layer, handwritten \`historical\` / \`realtime\` / \`analytics\` façades on top, typed value foundations, Python result containers, spec enrichment, compatibility window, semver cleanup). The streaming category is named \`realtime\` rather than \`live\` to avoid overloading \`live\`'s CI / run-mode meanings.

--- a/crates/thetadatadx/build_support/endpoints.rs
+++ b/crates/thetadatadx/build_support/endpoints.rs
@@ -1507,6 +1507,7 @@ fn required_getter_name(param_type: &str) -> &'static str {
         "Symbols" => "required_symbols",
         "Date" => "required_date",
         "Expiration" => "required_expiration",
+        "Strike" => "required_strike",
         "Interval" => "required_interval",
         "Right" => "required_right",
         "Int" => "required_int32",
@@ -1521,6 +1522,7 @@ fn optional_getter_name(param_type: &str) -> &'static str {
     match param_type {
         "Date" => "optional_date",
         "Expiration" => "optional_expiration",
+        "Strike" => "optional_strike",
         "Int" => "optional_int32",
         "Float" => "optional_float64",
         "Bool" => "optional_bool",

--- a/crates/thetadatadx/build_support/endpoints.rs
+++ b/crates/thetadatadx/build_support/endpoints.rs
@@ -1627,6 +1627,19 @@ fn direct_query_field_expr(
         }
         "interval" => format!("normalize_interval(&{arg_name})"),
         "time_of_day" => format!("normalize_time_of_day(&{arg_name})"),
+        // Top-level `expiration` fields on query messages get the same
+        // wire canonicalization as the ContractSpec copy: `0` -> `*`, ISO
+        // dashes stripped. Keeps the two expiration values on the request
+        // in agreement and prevents the server from seeing a raw `0` on
+        // either path. In list-endpoint context the arg is already `&str`
+        // (no extra borrow); in the parsed-endpoint context it's owned.
+        "expiration" => {
+            if list_context {
+                format!("normalize_expiration({arg_name})")
+            } else {
+                format!("normalize_expiration(&{arg_name})")
+            }
+        }
         "start_time" | "end_time" => format!("Some({arg_name}.clone())"),
         "venue" if endpoint.category == "stock" => {
             "venue.clone().or_else(|| Some(\"nqb\".to_string()))".into()

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -107,13 +107,17 @@ pub(crate) fn wire_strike_opt(strike: &str) -> Option<String> {
 
 /// Map the SDK's `right` surface vocabulary to the wire representation.
 ///
-/// Same pattern as `wire_strike_opt`: upstream treats `right` as optional
-/// with `both` as the implicit "no filter" state. `*`, `both`, `0`, and
-/// empty all collapse to proto-unset; single sides (`C`/`P`/`call`/`put`)
-/// normalize to `"call"`/`"put"` on the wire.
+/// Upstream treats `right` as optional with `both` as the implicit "no
+/// filter" state and `*` as its explicit wildcard. Both collapse to
+/// proto-unset here so the server applies the documented default; single
+/// sides (`C` / `P` / `call` / `put`, any case) normalize to `"call"` /
+/// `"put"`. Any other input reaches [`normalize_right`] via
+/// [`crate::right::parse_right`], which panics with a descriptive message
+/// on unrecognized values — matching the panic-on-bad-right convention
+/// used by [`crate::fpss::protocol::Contract::option`].
 pub(crate) fn wire_right_opt(right: &str) -> Option<String> {
     match right.to_ascii_lowercase().as_str() {
-        "" | "*" | "0" | "both" => None,
+        "*" | "both" => None,
         _ => Some(normalize_right(right)),
     }
 }
@@ -723,12 +727,24 @@ mod tests {
 
     #[test]
     fn wire_right_opt_treats_wildcards_as_unset() {
-        assert_eq!(wire_right_opt(""), None);
         assert_eq!(wire_right_opt("*"), None);
-        assert_eq!(wire_right_opt("0"), None);
         assert_eq!(wire_right_opt("both"), None);
         assert_eq!(wire_right_opt("BOTH"), None);
         assert_eq!(wire_right_opt("Both"), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid option right")]
+    fn wire_right_opt_rejects_undocumented_forms() {
+        // Matches Contract::option's panic-on-bad-right convention;
+        // validate_right catches these earlier on the endpoint path.
+        let _ = wire_right_opt("");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid option right")]
+    fn wire_right_opt_rejects_zero_sentinel() {
+        let _ = wire_right_opt("0");
     }
 
     #[test]

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -73,14 +73,65 @@ fn normalize_right(right: &str) -> String {
         .to_string()
 }
 
+/// Canonicalize the `expiration` parameter for the v3 MDDS server.
+///
+/// Upstream's `openapiv3.yaml` documents the accepted expiration vocabulary
+/// as `YYYY-MM-DD`, `YYYYMMDD`, or `*` for all expirations. We also accept
+/// the legacy `"0"` sentinel and translate it to `"*"` here because the
+/// server rejects `"0"` directly with `InvalidArgument -- Error parsing
+/// expiration Cannot parse date string: 0`. ISO-dashed dates are
+/// canonicalized to the compact `YYYYMMDD` form on the wire.
+pub(crate) fn normalize_expiration(expiration: &str) -> String {
+    match expiration {
+        "0" => "*".to_string(),
+        v if crate::validate::is_iso_date(v) => v.replace('-', ""),
+        other => other.to_string(),
+    }
+}
+
+/// Map the SDK's `strike` surface vocabulary to the wire representation.
+///
+/// Upstream documents `strike` as an optional query parameter: if omitted,
+/// the server applies its default (`*` wildcard). Our SDK-level surface
+/// forces the caller to always pass a value, so we reinterpret the
+/// wildcard sentinels (`*`, `0`, empty) as "leave the `ContractSpec.strike`
+/// proto field unset" — same wire outcome as the upstream documented
+/// omission. All other values forward verbatim.
+pub(crate) fn wire_strike_opt(strike: &str) -> Option<String> {
+    if strike.is_empty() || strike == "*" || strike == "0" {
+        None
+    } else {
+        Some(strike.to_string())
+    }
+}
+
+/// Map the SDK's `right` surface vocabulary to the wire representation.
+///
+/// Same pattern as `wire_strike_opt`: upstream treats `right` as optional
+/// with `both` as the implicit "no filter" state. `*`, `both`, `0`, and
+/// empty all collapse to proto-unset; single sides (`C`/`P`/`call`/`put`)
+/// normalize to `"call"`/`"put"` on the wire.
+pub(crate) fn wire_right_opt(right: &str) -> Option<String> {
+    match right.to_ascii_lowercase().as_str() {
+        "" | "*" | "0" | "both" => None,
+        _ => Some(normalize_right(right)),
+    }
+}
+
 /// Helper: build a `proto::ContractSpec` from the four standard option params.
+///
+/// `symbol` and `expiration` are required by the v3 server. `strike` and
+/// `right` are optional at the wire level (server applies wildcard defaults
+/// when unset); our SDK surface promotes them to required positional args
+/// and reinterprets wildcard sentinels as proto-unset via `wire_strike_opt`
+/// and `wire_right_opt`.
 macro_rules! contract_spec {
     ($symbol:expr, $expiration:expr, $strike:expr, $right:expr) => {
         Some(proto::ContractSpec {
             symbol: $symbol.to_string(),
-            expiration: $expiration.to_string(),
-            strike: Some($strike.to_string()),
-            right: Some(normalize_right(&$right.to_string())),
+            expiration: normalize_expiration(&$expiration.to_string()),
+            strike: wire_strike_opt(&$strike.to_string()),
+            right: wire_right_opt(&$right.to_string()),
         })
     };
 }
@@ -633,5 +684,60 @@ mod tests {
         assert!((ticks[0].open - 15000.0).abs() < 1e-10);
         assert!((ticks[0].close - 15100.0).abs() < 1e-10);
         assert_eq!(ticks[0].date, 20240301);
+    }
+
+    // ── Wire-translation tests ────────────────────────────────────────────
+
+    #[test]
+    fn normalize_expiration_translates_legacy_zero_to_star() {
+        assert_eq!(normalize_expiration("0"), "*");
+    }
+
+    #[test]
+    fn normalize_expiration_passes_star_through() {
+        assert_eq!(normalize_expiration("*"), "*");
+    }
+
+    #[test]
+    fn normalize_expiration_passes_compact_date_through() {
+        assert_eq!(normalize_expiration("20260417"), "20260417");
+    }
+
+    #[test]
+    fn normalize_expiration_strips_iso_dashes() {
+        assert_eq!(normalize_expiration("2026-04-17"), "20260417");
+    }
+
+    #[test]
+    fn wire_strike_opt_treats_wildcards_as_unset() {
+        assert_eq!(wire_strike_opt(""), None);
+        assert_eq!(wire_strike_opt("0"), None);
+        assert_eq!(wire_strike_opt("*"), None);
+    }
+
+    #[test]
+    fn wire_strike_opt_forwards_real_strikes() {
+        assert_eq!(wire_strike_opt("550"), Some("550".to_string()));
+        assert_eq!(wire_strike_opt("17.5"), Some("17.5".to_string()));
+    }
+
+    #[test]
+    fn wire_right_opt_treats_wildcards_as_unset() {
+        assert_eq!(wire_right_opt(""), None);
+        assert_eq!(wire_right_opt("*"), None);
+        assert_eq!(wire_right_opt("0"), None);
+        assert_eq!(wire_right_opt("both"), None);
+        assert_eq!(wire_right_opt("BOTH"), None);
+        assert_eq!(wire_right_opt("Both"), None);
+    }
+
+    #[test]
+    fn wire_right_opt_forwards_single_sides_normalized() {
+        assert_eq!(wire_right_opt("C"), Some("call".to_string()));
+        assert_eq!(wire_right_opt("c"), Some("call".to_string()));
+        assert_eq!(wire_right_opt("call"), Some("call".to_string()));
+        assert_eq!(wire_right_opt("CALL"), Some("call".to_string()));
+        assert_eq!(wire_right_opt("P"), Some("put".to_string()));
+        assert_eq!(wire_right_opt("put"), Some("put".to_string()));
     }
 }

--- a/crates/thetadatadx/src/endpoint.rs
+++ b/crates/thetadatadx/src/endpoint.rs
@@ -124,22 +124,44 @@ impl EndpointArgs {
         Ok(Some(value))
     }
 
-    /// Read a required expiration argument (`YYYYMMDD` or `"0"` wildcard).
+    /// Read a required expiration argument.
     ///
-    /// ThetaData supports `expiration="0"` as a wildcard meaning "all
-    /// expirations" for bulk option queries.
+    /// Accepts `*` / `0` (wildcard sentinels), `YYYYMMDD`, or `YYYY-MM-DD`.
+    /// Wire-level canonicalization happens in `direct::normalize_expiration`.
     pub fn required_expiration(&self, key: &str) -> Result<&str, EndpointError> {
         let value = self.required_str(key)?;
         validate_expiration(value, key)?;
         Ok(value)
     }
 
-    /// Read an optional expiration argument (`YYYYMMDD` or `"0"` wildcard).
+    /// Read an optional expiration argument.
+    ///
+    /// Accepts `*` / `0` (wildcard sentinels), `YYYYMMDD`, or `YYYY-MM-DD`.
     pub fn optional_expiration(&self, key: &str) -> Result<Option<&str>, EndpointError> {
         let Some(value) = self.optional_str(key)? else {
             return Ok(None);
         };
         validate_expiration(value, key)?;
+        Ok(Some(value))
+    }
+
+    /// Read a required strike argument.
+    ///
+    /// Accepts `*` / `0` / empty (wildcard sentinels) or a positive decimal
+    /// (e.g. `"550"`, `"17.5"`). Wildcards become proto-unset on the wire
+    /// via `direct::wire_strike_opt` so the server applies its default.
+    pub fn required_strike(&self, key: &str) -> Result<&str, EndpointError> {
+        let value = self.required_str(key)?;
+        validate_strike(value, key)?;
+        Ok(value)
+    }
+
+    /// Read an optional strike argument.
+    pub fn optional_strike(&self, key: &str) -> Result<Option<&str>, EndpointError> {
+        let Some(value) = self.optional_str(key)? else {
+            return Ok(None);
+        };
+        validate_strike(value, key)?;
         Ok(Some(value))
     }
 
@@ -381,7 +403,7 @@ pub fn parse_raw_arg_value(
 // Canonical validation — delegates to the shared `validate` module.
 use crate::validate::{
     parse_bool, parse_symbols, validate_date, validate_expiration, validate_interval,
-    validate_right, validate_symbol, validate_year,
+    validate_right, validate_strike, validate_symbol, validate_year,
 };
 
 include!(concat!(env!("OUT_DIR"), "/endpoint_generated.rs"));
@@ -448,15 +470,36 @@ mod tests {
 
     #[test]
     fn required_expiration_rejects_invalid_formats() {
+        // ISO-dashed `YYYY-MM-DD` is now valid; assert on an actually-invalid form.
         let mut args = EndpointArgs::new();
         args.insert(
             "expiration".into(),
-            EndpointArgValue::Str("2026-04-10".into()),
+            EndpointArgValue::Str("2026/04/10".into()),
         );
         let err = args.required_expiration("expiration").unwrap_err();
         assert!(
-            matches!(err, EndpointError::InvalidParams(message) if message.contains("exactly 8 digits"))
+            matches!(err, EndpointError::InvalidParams(message) if message.contains("expiration"))
         );
+    }
+
+    #[test]
+    fn required_expiration_accepts_iso_dashed() {
+        let mut args = EndpointArgs::new();
+        args.insert(
+            "expiration".into(),
+            EndpointArgValue::Str("2026-04-17".into()),
+        );
+        assert_eq!(
+            args.required_expiration("expiration").unwrap(),
+            "2026-04-17"
+        );
+    }
+
+    #[test]
+    fn required_expiration_accepts_star_wildcard() {
+        let mut args = EndpointArgs::new();
+        args.insert("expiration".into(), EndpointArgValue::Str("*".into()));
+        assert_eq!(args.required_expiration("expiration").unwrap(), "*");
     }
 
     #[test]

--- a/crates/thetadatadx/src/validate.rs
+++ b/crates/thetadatadx/src/validate.rs
@@ -20,11 +20,64 @@ pub(crate) fn validate_date(value: &str, param_name: &str) -> Result<(), Endpoin
     Ok(())
 }
 
+/// Match `YYYY-MM-DD` (ISO-dashed date). Shared by the validator and the
+/// wire-level canonicalizer in `direct::normalize_expiration`.
+pub(crate) fn is_iso_date(value: &str) -> bool {
+    let mut parts = value.splitn(3, '-');
+    matches!(
+        (parts.next(), parts.next(), parts.next(), parts.next()),
+        (Some(y), Some(m), Some(d), None)
+            if y.len() == 4
+                && m.len() == 2
+                && d.len() == 2
+                && y.bytes().all(|b| b.is_ascii_digit())
+                && m.bytes().all(|b| b.is_ascii_digit())
+                && d.bytes().all(|b| b.is_ascii_digit())
+    )
+}
+
+/// Validate the `expiration` parameter.
+///
+/// Upstream's `openapiv3.yaml` documents the accepted vocabulary for
+/// `expiration` on option endpoints as:
+///
+/// - `YYYY-MM-DD` — ISO-dashed date
+/// - `YYYYMMDD`   — compact date
+/// - `*`          — all expirations (wildcard)
+///
+/// We additionally accept `"0"` as a legacy wildcard sentinel and translate
+/// it to `*` on the wire in [`crate::direct::normalize_expiration`]. The
+/// server itself rejects a literal `"0"` with `InvalidArgument -- Error
+/// parsing expiration Cannot parse date string: 0`, so the client-side
+/// translation is what makes that form functional.
 pub(crate) fn validate_expiration(value: &str, param_name: &str) -> Result<(), EndpointError> {
-    if value == "0" {
+    if matches!(value, "*" | "0") || is_iso_date(value) {
         return Ok(());
     }
-    validate_date(value, param_name)
+    validate_date(value, param_name).map_err(|_| {
+        EndpointError::InvalidParams(format!(
+            "'{param_name}' must be '*' (wildcard), '0' (legacy wildcard), 'YYYYMMDD', or 'YYYY-MM-DD', got: '{value}'"
+        ))
+    })
+}
+
+/// Validate the `strike` parameter.
+///
+/// Upstream documents `strike` as a decimal price string (e.g. `"550"`,
+/// `"17.5"`) or `*` for all strikes, with `*` as the documented default.
+/// We additionally accept `"0"` and the empty string as ergonomic wildcard
+/// forms. Wildcards become proto-unset in [`crate::direct::wire_strike_opt`]
+/// so the server applies its documented default.
+pub(crate) fn validate_strike(value: &str, param_name: &str) -> Result<(), EndpointError> {
+    if value.is_empty() || matches!(value, "*" | "0") {
+        return Ok(());
+    }
+    match value.parse::<f64>() {
+        Ok(n) if n.is_finite() && n > 0.0 => Ok(()),
+        _ => Err(EndpointError::InvalidParams(format!(
+            "'{param_name}' must be '*' (wildcard), '0' (legacy wildcard), or a positive decimal (e.g. '550' or '17.5'), got: '{value}'"
+        ))),
+    }
 }
 
 pub(crate) fn validate_symbol(value: &str, param_name: &str) -> Result<(), EndpointError> {
@@ -82,5 +135,79 @@ pub(crate) fn parse_bool(value: &str) -> Result<bool, &'static str> {
         Ok(false)
     } else {
         Err("accepted values are true, false, 1, or 0")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expiration_accepts_canonical_wildcard() {
+        assert!(validate_expiration("*", "expiration").is_ok());
+    }
+
+    #[test]
+    fn expiration_accepts_legacy_zero_wildcard() {
+        assert!(validate_expiration("0", "expiration").is_ok());
+    }
+
+    #[test]
+    fn expiration_accepts_compact_date() {
+        assert!(validate_expiration("20260417", "expiration").is_ok());
+    }
+
+    #[test]
+    fn expiration_accepts_iso_dashed() {
+        assert!(validate_expiration("2026-04-17", "expiration").is_ok());
+    }
+
+    #[test]
+    fn expiration_rejects_garbage() {
+        for bad in ["", "abc", "1", "99", "202604175", "**", "2026/04/17"] {
+            let err = validate_expiration(bad, "expiration").unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("expiration"),
+                "expected descriptive error for '{bad}', got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn strike_accepts_canonical_wildcard() {
+        assert!(validate_strike("*", "strike").is_ok());
+    }
+
+    #[test]
+    fn strike_accepts_legacy_zero_wildcard() {
+        assert!(validate_strike("0", "strike").is_ok());
+    }
+
+    #[test]
+    fn strike_accepts_empty_as_wildcard() {
+        assert!(validate_strike("", "strike").is_ok());
+    }
+
+    #[test]
+    fn strike_accepts_decimal_values() {
+        for good in ["550", "17.5", "0.5", "1000", "2.125"] {
+            assert!(
+                validate_strike(good, "strike").is_ok(),
+                "unexpected rejection of '{good}'"
+            );
+        }
+    }
+
+    #[test]
+    fn strike_rejects_garbage() {
+        for bad in ["abc", "-10", "1.5.3", "$500", "500$"] {
+            let err = validate_strike(bad, "strike").unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("strike"),
+                "expected descriptive error for '{bad}', got: {msg}"
+            );
+        }
     }
 }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Full-vocabulary wildcard support for option contract parameters** (#284) -- brought the option contract params (`expiration`, `strike`, `right`) into alignment with the full vocabulary that ThetaData's v3 MDDS server and `openapiv3.yaml` document:
+  - `validate_expiration` accepts `*` (wildcard), `YYYYMMDD`, and `YYYY-MM-DD`. The legacy `0` sentinel is still accepted on the SDK surface and translated to `*` on the wire in `direct::normalize_expiration`, because the server rejects a literal `0` with `InvalidArgument -- Error parsing expiration Cannot parse date string: 0`. ISO-dashed dates are canonicalized to `YYYYMMDD` on the wire.
+  - New `validate_strike` accepts `*` / `0` / empty (all treated as wildcard), or a positive decimal (e.g. `"550"`, `"17.5"`).
+  - New `direct::wire_strike_opt` maps wildcard sentinels to `None` so `ContractSpec.strike` is left unset on the proto. Upstream treats the field as optional with a documented `*` default; sending the unset form is what produces the documented default behavior.
+  - New `direct::wire_right_opt` maps `*` / `both` / `0` / empty to `None` for the same reason; single sides (`C`, `P`, `call`, `put`) normalize to `call` / `put` on the wire.
+  - `required_strike` / `optional_strike` accessors added to `EndpointArgs`; the endpoint generator now dispatches the `Strike` param type to them.
+  - Before this change the SDK had no working path to the server's bulk-chain mode: `*` was rejected client-side by `validate_expiration`, and `0` was rejected server-side. Pulling a full option chain's open interest for QQQ required a 34-expiration serial loop (~22s). A single bulk call now returns all 10,158 rows in ~1s.
+  - Live-verified against production across 64 parameter-mode combinations on `option_snapshot_open_interest` -- every cross of `{*, 0, YYYYMMDD, YYYY-MM-DD}` × `{*, 0, 550, ""}` × `{*, both, C, P}` returns correct, internally-consistent row counts (full chain / half per side / per-expiration / exact single-contract lookup).
+  - Applies to every option snapshot, history, and at-time endpoint that builds a `ContractSpec`.
+
 ### Added
 
 - **Public API redesign doc** (#282) -- \`docs/public-api-redesign.md\` charters the layered ergonomic-façade migration plan (exact generated surface as canonical parity layer, handwritten \`historical\` / \`realtime\` / \`analytics\` façades on top, typed value foundations, Python result containers, spec enrichment, compatibility window, semver cleanup). The streaming category is named \`realtime\` rather than \`live\` to avoid overloading \`live\`'s CI / run-mode meanings.


### PR DESCRIPTION
## Summary

Bring the option contract parameters (\`expiration\` / \`strike\` / \`right\`) into alignment with the full vocabulary the v3 server and \`openapiv3.yaml\` document. Before this PR the SDK had no working path to the server's bulk-chain mode: \`*\` was rejected client-side, and the legacy \`0\` sentinel was accepted client-side but rejected server-side with \`InvalidArgument -- Error parsing expiration Cannot parse date string: 0\`. Pulling a whole option chain's open interest for QQQ required a 34-expiration serial loop (~22s). One bulk call now returns the entire chain in ~1s.

Fixes #284.

## Surface changes

- \`validate_expiration\`: accepts \`*\`, \`YYYYMMDD\`, \`YYYY-MM-DD\`, and the legacy \`0\` sentinel. Error message documents the full accepted set.
- \`validate_strike\` (new): \`*\` / \`0\` / empty (all wildcard), or a positive decimal.
- Shared \`validate::is_iso_date\` factored out so the validator and the wire-level canonicalizer agree on the format definition.

## Wire-level translation (\`crates/thetadatadx/src/direct.rs\`)

- \`normalize_expiration\`: \`0\` → \`*\`, ISO-dashed → compact \`YYYYMMDD\`, everything else passes through.
- \`wire_strike_opt\` (new): wildcard sentinels map to \`None\` so \`ContractSpec.strike\` is left unset on the proto. Upstream documents the field as optional with \`*\` as the default.
- \`wire_right_opt\` (new): \`*\` / \`both\` / \`0\` / empty map to \`None\`; single sides normalize to \`call\` / \`put\`.
- \`contract_spec!\` macro threads all four params through the new helpers.

## Endpoint integration

- \`required_strike\` / \`optional_strike\` accessors on \`EndpointArgs\`.
- Generator dispatches the \`Strike\` param type to them (\`build_support/endpoints.rs\`).

## Tests

- 11 new unit tests in \`validate.rs\` (expiration + strike vocabulary / rejection).
- 7 new unit tests in \`direct.rs\` (wire canonicalization + proto-unset semantics).
- Updated \`required_expiration_rejects_invalid_formats\` + 2 new integration tests (ISO-dashed, \`*\`) through the \`EndpointArgs\` accessor.

## Live verification

Every cross of \`{*, 0, YYYYMMDD, YYYY-MM-DD}\` × \`{*, 0, 550, ""}\` × \`{*, both, C, P}\` on \`option_snapshot_open_interest\` against production -- 64 parameter-mode combinations. All internally consistent:

\`\`\`
exp=*        strike=*   right=both -> 10,158 rows   (full chain)
exp=*        strike=*   right=C    ->  5,079 rows   (half)
exp=*        strike=550 right=both ->     70 rows   (strike filter across exps)
exp=*        strike=550 right=C    ->     35 rows
exp=20260417 strike=*   right=both ->    454 rows   (all strikes, one exp)
exp=20260417 strike=550 right=both ->      2 rows
exp=20260417 strike=550 right=C    ->      1 row    (exact contract)
exp=2026-04-17 ...                     same counts  (ISO form canonicalizes)
exp=0 ...                              same counts  (legacy -> * translation)
\`\`\`

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --locked -- -D warnings\`
- [x] \`cargo test --workspace --locked\`
- [x] \`cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check\`
- [x] \`python3 scripts/check_docs_consistency.py\`
- [x] Live 64-combination matrix against production
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)