### PR TITLE
refactor(validator): structured field-level diff in cross-language agreement (W4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
       - run: python3 scripts/check_docs_consistency.py
+      - run: python3 scripts/validate_agreement_test.py
+      - run: python3 scripts/check_first_row_schema_alignment.py
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       - run: cargo clippy --manifest-path tools/mcp/Cargo.toml --locked -- -D warnings
       - run: cargo test --manifest-path tools/mcp/Cargo.toml --locked

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/postamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/postamble.py.tmpl
@@ -7,47 +7,90 @@ creds = sys.argv[1]
 pass_count = skip_count = fail_count = 0
 records: list[dict] = []  # one record per cell for the agreement check
 
-def _json_row_count(output: str) -> int:
-    """Count top-level rows from the CLI's --format json response.
-
-    The CLI emits pretty-printed JSON (multi-line), so we parse the
-    whole stdout rather than just the last line. For list responses
-    returns len(list). For dict responses that look columnar (values
-    are lists), returns len of any column. For dict responses that
-    are a single object (e.g. calendar_open_today), returns 1.
-    Non-JSON output returns 0.
+def _parse_json(output: str):
+    """Parse the CLI's --format json-raw output, returning None on parse
+    failure. The CLI pretty-prints multi-line JSON so we can't slice off
+    the last line; walk the stripped output looking for the first `[`
+    or `{` and parse from there. Any preceding warning / progress lines
+    (e.g. tier-badge mismatches) are skipped over.
     """
     stripped = output.strip()
     if not stripped:
-        return 0
-    # The CLI may prefix with a warning / progress line before the JSON.
-    # Walk backwards through possible JSON start tokens to find the
-    # first that parses.
+        return None
     for start_token in ("[", "{"):
         idx = stripped.find(start_token)
         if idx == -1:
             continue
         try:
-            parsed = json.loads(stripped[idx:])
+            return json.loads(stripped[idx:])
         except json.JSONDecodeError:
             continue
-        if isinstance(parsed, list):
-            return len(parsed)
-        if isinstance(parsed, dict):
-            # Columnar dict: treat any list-valued column as the row
-            # vector. Keeps agreement with the Python SDK.
-            for v in parsed.values():
-                if isinstance(v, list):
-                    return len(v)
-            return 1
+    return None
+
+def _json_row_count(parsed) -> int:
+    """Row count from a parsed JSON value. Lists -> len. Columnar
+    dicts (any value is a list) -> len of any column (matches Python
+    SDK convention). Single-object dicts (e.g. calendar_open_today)
+    -> 1. Non-JSON / None -> 0.
+    """
+    if isinstance(parsed, list):
+        return len(parsed)
+    if isinstance(parsed, dict):
+        for v in parsed.values():
+            if isinstance(v, list):
+                return len(v)
+        return 1
     return 0
+
+def _canonicalize(value):
+    """Light producer-side canonicalization for first_row values:
+    lowercase dict keys, round floats to 6 decimals, recurse into dicts
+    and lists. The validator consumer (scripts/validate_agreement.py)
+    is the authoritative enforcer, so this is defense in depth; the
+    consumer also handles sentinels (date==0, ms<0, strike==0, right="")
+    and NaN/Inf, plus omit-equivalence stripping.
+    """
+    if isinstance(value, dict):
+        return {str(k).lower(): _canonicalize(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_canonicalize(v) for v in value]
+    if isinstance(value, float):
+        return round(value, 6)
+    return value
+
+def _extract_first_row(parsed):
+    """Return a canonicalized dict for the first row of the response,
+    or None if there's nothing to compare.
+
+      list of dicts -> first dict
+      columnar dict  -> one dict built from column[0] of each list column
+                        (matches how the Python SDK surfaces a single row)
+      single-object dict (calendar_open_today, etc.) -> the dict itself
+      anything else  -> None
+    """
+    if isinstance(parsed, list):
+        if not parsed:
+            return None
+        first = parsed[0]
+        return _canonicalize(first) if isinstance(first, dict) else None
+    if isinstance(parsed, dict):
+        columnar = {k: v for k, v in parsed.items() if isinstance(v, list)}
+        if columnar and all(len(v) > 0 for v in columnar.values()):
+            return _canonicalize({k: v[0] for k, v in columnar.items()})
+        if columnar:
+            return None
+        return _canonicalize(parsed)
+    return None
 
 for endpoint, mode, min_tier, rationale, argv in CELLS:
     label = f"{endpoint}::{mode}"
     t0 = time.monotonic()
     try:
         proc = subprocess.run(
-            [str(TDX), "--creds", creds, *argv, "--format", "json"],
+            # --format json-raw keeps dates as YYYYMMDD ints and ms_of_day as raw
+            # i32 ms so first_row matches the raw form Python/Go/C++ SDKs expose.
+            # See scripts/validate_agreement.py for the canonical contract.
+            [str(TDX), "--creds", creds, *argv, "--format", "json-raw"],
             cwd=REPO,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -68,10 +111,13 @@ for endpoint, mode, min_tier, rationale, argv in CELLS:
     output = (proc.stdout or b"").decode("utf-8", errors="replace")
     msg = output.lower()
     row_count = 0
+    first_row = None
     status: str
     detail: str = ""
     if proc.returncode == 0:
-        row_count = _json_row_count(output)
+        parsed = _parse_json(output)
+        row_count = _json_row_count(parsed)
+        first_row = _extract_first_row(parsed)
         status = "PASS"
         print(f"  {label:60s} PASS")
         pass_count += 1
@@ -93,11 +139,14 @@ for endpoint, mode, min_tier, rationale, argv in CELLS:
         detail = output.strip().replace("\n", "\\n").replace("\r", "\\r")[:200]
         print(f"  {label:60s} FAIL  {output.strip()}")
         fail_count += 1
-    records.append({
+    record = {
         "endpoint": endpoint, "mode": mode, "rationale": rationale,
         "status": status,
         "row_count": row_count, "duration_ms": duration_ms, "detail": detail,
-    })
+    }
+    if first_row is not None:
+        record["first_row"] = first_row
+    records.append(record)
 
 print(f"\nCLI: {pass_count} PASS, {skip_count} SKIP, {fail_count} FAIL")
 print(f"COUNTS:{pass_count}:{skip_count}:{fail_count}")

--- a/scripts/check_first_row_schema_alignment.py
+++ b/scripts/check_first_row_schema_alignment.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Static cross-check that CLI `--format json-raw` field schemas match
+the canonical SDK schemas in `sdks/python/src/tick_columnar.rs`.
+
+The agreement validator compares CLI vs Python/Go cell-by-cell on
+`first_row` content. If the CLI emits `time` while Python emits
+`ms_of_day`, or if the CLI drops `expiration`, every cell in those
+endpoints will false-diff. This script parses both files and asserts
+the field sets match per tick type.
+
+Run: `python3 scripts/check_first_row_schema_alignment.py`
+Exits 1 on schema drift; 0 on alignment.
+
+This is a static check -- no live data required. CI runs it in the
+`surfaces` job alongside `validate_agreement_test.py`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI_MAIN = ROOT / "tools" / "cli" / "src" / "main.rs"
+PYTHON_COLUMNAR = ROOT / "sdks" / "python" / "src" / "tick_columnar.rs"
+
+# Map render_* function name in CLI -> Python columnar function name.
+# Defined explicitly because the names don't auto-derive (CLI uses
+# `render_eod` / `render_ohlc` / `render_trades`; Python uses
+# `eod_ticks_to_columnar` / `ohlc_ticks_to_columnar` / `trade_ticks_to_columnar`).
+RENDERER_PAIRS: list[tuple[str, str]] = [
+    ("render_eod", "eod_ticks_to_columnar"),
+    ("render_ohlc", "ohlc_ticks_to_columnar"),
+    ("render_trades", "trade_ticks_to_columnar"),
+    ("render_quotes", "quote_ticks_to_columnar"),
+    ("render_trade_quotes", "trade_quote_ticks_to_columnar"),
+    ("render_open_interest", "open_interest_ticks_to_columnar"),
+    ("render_market_value", "market_value_ticks_to_columnar"),
+    ("render_greeks", "greeks_ticks_to_columnar"),
+    ("render_iv", "iv_ticks_to_columnar"),
+    ("render_price", "price_ticks_to_columnar"),
+    ("render_calendar", "calendar_days_to_columnar"),
+    ("render_interest_rates", "interest_rate_ticks_to_columnar"),
+    ("render_option_contracts", "option_contracts_to_columnar"),
+]
+
+
+def extract_cli_raw_headers(source: str, fn_name: str) -> list[str]:
+    """Pull the `set_raw_headers(vec![...])` field list out of a
+    `fn fn_name(...)` block in main.rs."""
+    fn_pattern = re.compile(
+        rf"fn {re.escape(fn_name)}\b[^{{]*\{{",
+    )
+    fn_match = fn_pattern.search(source)
+    if not fn_match:
+        raise SystemExit(f"error: CLI function `{fn_name}` not found in {CLI_MAIN}")
+    body = source[fn_match.end():]
+    headers_match = re.search(
+        r"set_raw_headers\(vec!\[\s*((?:\"[^\"]*\"\s*,?\s*)+)\s*\]\)",
+        body,
+    )
+    if not headers_match:
+        raise SystemExit(
+            f"error: `{fn_name}` does not call `set_raw_headers(vec![...])`"
+        )
+    inner = headers_match.group(1)
+    return re.findall(r'"([^"]+)"', inner)
+
+
+def extract_python_columnar_keys(source: str, fn_name: str) -> list[str]:
+    """Pull the `dict.set_item("key", ...)` calls out of a python
+    columnar function in tick_columnar.rs, in declaration order."""
+    fn_pattern = re.compile(
+        rf"fn {re.escape(fn_name)}\b[^{{]*\{{",
+    )
+    fn_match = fn_pattern.search(source)
+    if not fn_match:
+        raise SystemExit(
+            f"error: Python columnar function `{fn_name}` not found in {PYTHON_COLUMNAR}"
+        )
+    # Capture from the fn open brace through the matching close. Track
+    # nesting -- the function body has many `dict.set_item(...)` calls
+    # with parentheses. A simple brace counter is enough since strings
+    # in this file don't contain braces.
+    body_start = fn_match.end()
+    depth = 1
+    body_end = body_start
+    for i, ch in enumerate(source[body_start:], start=body_start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                body_end = i
+                break
+    body = source[body_start:body_end]
+    return re.findall(r'set_item\("([^"]+)"', body)
+
+
+def main() -> int:
+    cli_source = CLI_MAIN.read_text()
+    python_source = PYTHON_COLUMNAR.read_text()
+
+    failures: list[str] = []
+    print(f"Checking schema alignment between:")
+    print(f"  CLI:    {CLI_MAIN.relative_to(ROOT)}")
+    print(f"  Python: {PYTHON_COLUMNAR.relative_to(ROOT)}\n")
+
+    for cli_fn, py_fn in RENDERER_PAIRS:
+        cli_headers = extract_cli_raw_headers(cli_source, cli_fn)
+        py_keys = extract_python_columnar_keys(python_source, py_fn)
+        if cli_headers == py_keys:
+            print(f"  \u2713 {cli_fn:25s} == {py_fn:35s} ({len(cli_headers)} fields)")
+        else:
+            extra_in_cli = [k for k in cli_headers if k not in py_keys]
+            extra_in_py = [k for k in py_keys if k not in cli_headers]
+            misorderings = (
+                set(cli_headers) == set(py_keys)
+                and cli_headers != py_keys
+            )
+            failures.append(
+                f"\n  \u2717 {cli_fn} schema diverges from {py_fn}:\n"
+                f"      CLI:    {cli_headers}\n"
+                f"      Python: {py_keys}\n"
+                f"      extra in CLI: {extra_in_cli}\n"
+                f"      extra in Python: {extra_in_py}\n"
+                + (
+                    "      (same field set but different ordering)\n"
+                    if misorderings
+                    else ""
+                )
+            )
+
+    if failures:
+        print("\nSCHEMA DRIFT:", file=sys.stderr)
+        for f in failures:
+            print(f, file=sys.stderr)
+        return 1
+    print(f"\n\u2713 all {len(RENDERER_PAIRS)} renderer pairs aligned")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_agreement.py
+++ b/scripts/validate_agreement.py
@@ -3,56 +3,120 @@
 
 Loads per-language validator artifacts from `artifacts/validator_<lang>.json`
 (written by `scripts/validate_cli.py`, `scripts/validate_python.py`,
-`sdks/go/cmd/validate`, and `sdks/cpp` validator), and asserts that every
-(endpoint, mode) cell agrees across all SDKs on:
+`sdks/go/cmd/validate`, and `sdks/cpp` validator) and compares every
+(endpoint, mode) cell across SDKs on:
 
 * status (PASS / SKIP / FAIL)
-* row_count (for cells that passed)
+* row_count (for cells that all passed)
+* first_row contents (field-by-field, when the artifact carries a
+  canonicalized `first_row` dict)
 
-Cells where SDKs disagree are reported with a table showing each SDK's
-outcome. Exits non-zero on any disagreement.
+Disagreements are reported as per-cell tables that pinpoint the exact
+field values that differ across SDKs. Exits non-zero on any
+disagreement.
 
-Cells missing from any SDK's artifact are surfaced but don't fail the run by
-default, since the CLI validator deliberately skips some cell classes the
-other SDKs run (per-optional-param modes — see PR #291). Pass
+Cells missing from any SDK's artifact are surfaced as "partial" but
+don't fail the run by default, since the CLI validator deliberately
+skips some per-optional-param modes the other SDKs run (PR #291). Pass
 `--require-all-sdks` to make missing cells a hard failure.
 
-Follow-up work deliberately deferred from this iteration (tracked in
-issue #290):
+Artifact format:
 
-* first_row_hash per cell. The canonicalization rules (sort keys, round
-  floats to 6 decimals, null missing fields, sha256) require per-SDK tick
-  introspection, and the four languages have different native tick shapes
-  (Python dataclasses, Go structs with tags, C++ POD with fields of various
-  types, CLI producing JSON directly). This foundation is in place (record
-  shape has room for `first_row_hash`) but populating it is a follow-up.
-* Server-side duration / byte-count. The CLI has access via JSON metadata;
-  the SDKs would need to expose wire-level timing which they don't yet.
+    {"lang": "...",
+     "records": [
+       {"endpoint": "stock_snapshot_ohlc", "mode": "concrete",
+        "status": "PASS", "row_count": 1, "duration_ms": 120,
+        "detail": "", "first_row": {"bid": 685.86, ...}   # optional
+       }, ...
+     ]}
 
-Refs: #287, #290.
+`first_row` is optional. When at least two SDKs populate it for the
+same cell, the cell is compared field-by-field; otherwise the diff
+falls back to status + row_count.
+
+Canonical `first_row` contract
+------------------------------
+
+Every producer MUST emit raw numeric values with no presentation
+formatting. The contract is enforced consumer-side by `_canonicalize_row`
+but producers are encouraged to emit the raw form directly to keep
+artifacts human-readable:
+
+* **dates**                : YYYYMMDD ints (e.g. `20260417`), NOT strings like `"2026-04-17"`.
+                             The sentinel `0` (no date) is passed through verbatim
+                             by every SDK; the consumer collapses it to `None`.
+* **ms_of_day**            : raw i32 ms since midnight (e.g. `34200000`), NOT `"HH:MM:SS.mmm"`.
+                             Negative values (sentinel for "missing") are passed through
+                             verbatim; the consumer collapses them to `None`.
+* **prices**               : f64 rounded to 6 decimals (e.g. `685.86`)
+* **sizes / counts / ids** : raw ints (NOT sentinel-normalized -- `volume == 0` is a
+                             legitimate trading value and must stay distinct from missing)
+* **enum codes**           : raw ints (not stringified names)
+* **keys**                 : lowercase; mixed-case producers are normalized on load
+* **missing fields**       : omitted from the dict (distinguishable from `null`)
+* **non-finite floats**    : `NaN` / `Inf` normalized to `null`
+
+Presentation strings like `"2026-04-17"` would cause false diffs the
+moment a second SDK starts populating `first_row` with raw ints. The
+CLI emitter calls the `tdx` binary with `--format json-raw` so its
+output matches the contract; adding that flag was part of PR #293.
+
+Consumer-side canonicalization (`_canonicalize_row`) handles:
+
+1. recursive lowercase dict keys (so `{"Bid": ...}` compares equal to
+   `{"bid": ...}` even when one producer regressed)
+2. recursive 6-decimal float rounding (collapses 1-ULP JSON round-trip
+   noise; also catches `685.86` vs `685.860001`)
+3. NaN / +Inf / -Inf normalized to Python `None` — cross-language
+   serialization of non-finite floats is ambiguous (JSON rejects them
+   outright; CLI's f64 reparse at tools/cli/src/main.rs:270 drops them
+   silently), so we collapse all three to a single unambiguous sentinel
+4. date-shaped fields (`date`, `expiration`, or ending in `_date`):
+   value `0` -> `None`. Every SDK emits the sentinel verbatim (Python
+   `sdks/python/src/tick_columnar.rs:7,38`; Go `sdks/go/tick_structs.go:10,35`;
+   server `tools/server/src/format.rs:346`). Without this normalization,
+   a producer that happens to see `date == 0` (no-data cell, pre-market
+   snapshot) would false-diff against one that serializes the same
+   cell as `null`.
+5. ms-shaped fields (`ms_of_day`, `ms_of_day2`, `quote_ms_of_day`,
+   `open_time`, `close_time`, `time`, `quote_time`, or ending in
+   `_time`): negative value -> `None`. Same reasoning -- every SDK
+   emits negative-ms sentinels as raw ints.
+
+Defense in depth: producers SHOULD canonicalize too, but the consumer
+is the authoritative enforcer. A producer bug (mixed-case key, stray
+NaN, float precision regression, sentinel mapped to `null` vs raw int)
+won't silently turn into a false disagreement.
+
+Refs: #287, #290, #291, #292, #293.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from collections import defaultdict
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 ARTIFACTS_DIR = ROOT / "artifacts"
 
 LANGS = ("python", "cli", "go", "cpp")
 
-# Cell identity is (endpoint, mode). SDK-specific mode-expansion differences
-# surface as "cell missing from <lang>" rows, not as disagreement failures.
+# Rounding precision for float comparison in canonicalized first rows.
+# 6 decimals matches the canonicalization contract documented in the
+# per-SDK emitters. SDKs with raw float precision above this must round
+# before emitting.
+FLOAT_PRECISION = 6
 
 
-def load_artifact(lang: str) -> list[dict] | None:
-    """Load one SDK's artifact. Returns `None` if missing (treated as a
-    soft skip unless `--require-all-sdks` is on)."""
-    path = ARTIFACTS_DIR / f"validator_{lang}.json"
+def load_artifact(lang: str, artifacts_dir: Path) -> list[dict] | None:
+    """Load one SDK's artifact. Returns None if missing (treated as a
+    soft skip unless --require-all-sdks is on)."""
+    path = artifacts_dir / f"validator_{lang}.json"
     if not path.exists():
         return None
     try:
@@ -67,19 +131,453 @@ def load_artifact(lang: str) -> list[dict] | None:
     return records
 
 
+# Exact-match field names that carry YYYYMMDD date semantics. Listed
+# against the lowercased canonical form produced by `_canonicalize_row`.
+# Any i32 `0` in these fields is a sentinel for "no date" (trading data
+# never has year `0000`) and canonicalizes to None.
+_DATE_FIELD_NAMES: frozenset[str] = frozenset({"date", "expiration"})
+
+# Exact-match field names that carry ms-of-day semantics. Any value `< 0`
+# is a sentinel for "missing" (ms of day is non-negative by construction,
+# bounded by 86_400_000) and canonicalizes to None. CalendarDay's
+# `open_time` / `close_time` and CLI column aliases `time` / `quote_time`
+# are included because they hold the same i32 ms-of-day underlying value.
+_MS_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "ms_of_day",
+        "ms_of_day2",
+        "quote_ms_of_day",
+        "open_time",
+        "close_time",
+        "time",
+        "quote_time",
+    }
+)
+
+# Strike-shaped field names. Sentinel `0.0` -> None. Trading data has no
+# zero-strike options.
+_STRIKE_FIELD_NAMES: frozenset[str] = frozenset({"strike"})
+
+# Right-shaped field names. Tick types emit `right` as `"C" / "P" / ""`
+# (Python `tick_columnar.rs:41`, Go `RightStr`); `OptionContract` uses
+# raw int 67/80/0. Empty string OR int 0 are both sentinels -> None.
+_RIGHT_FIELD_NAMES: frozenset[str] = frozenset({"right"})
+
+# Union of all sentinel-shaped field names for omit-vs-null normalization.
+# A producer that omits the field (Go `omitempty`, server skip-when-zero)
+# is equivalent to one that emits `null` or the raw sentinel value (Python
+# tick_columnar emits 0/`""` verbatim). The consumer strips post-canonical
+# `None` values for these fields so all three shapes converge to "absent".
+_SENTINEL_SHAPED_FIELDS: frozenset[str] = (
+    _DATE_FIELD_NAMES | _MS_FIELD_NAMES | _STRIKE_FIELD_NAMES | _RIGHT_FIELD_NAMES
+)
+
+
+def _is_date_field(name: str) -> bool:
+    """True if `name` holds YYYYMMDD date semantics under the canonical
+    contract. Matches exact-listed names plus any `_date` suffix so
+    future tick-type additions pick up the rule automatically."""
+    return name in _DATE_FIELD_NAMES or name.endswith("_date")
+
+
+def _is_ms_field(name: str) -> bool:
+    """True if `name` holds ms-of-day semantics under the canonical
+    contract. Matches exact-listed names plus any `_time` suffix."""
+    return name in _MS_FIELD_NAMES or name.endswith("_time")
+
+
+def _is_strike_field(name: str) -> bool:
+    """True if `name` holds option-strike semantics. `0.0` is sentinel."""
+    return name in _STRIKE_FIELD_NAMES or name.endswith("_strike")
+
+
+def _is_right_field(name: str) -> bool:
+    """True if `name` holds option-right semantics. `""` and int `0` are
+    sentinels."""
+    return name in _RIGHT_FIELD_NAMES or name.endswith("_right")
+
+
+def _is_sentinel_shaped_field(name: str) -> bool:
+    """True if `name` is a contract-id field where producers diverge on
+    omit / null / sentinel-value (`0`, `""`). Consumer strips post-
+    canonical None values for these fields so all three shapes converge
+    to "absent" in the comparison."""
+    return (
+        _is_date_field(name)
+        or _is_ms_field(name)
+        or _is_strike_field(name)
+        or _is_right_field(name)
+    )
+
+
+def _canonicalize_scalar(key: str, value: Any) -> Any:
+    """Per-field scalar normalization. Runs inside the dict walk so the
+    key is available for field-name-based sentinel rules:
+
+      * float: NaN / +Inf / -Inf -> None; finite rounded to FLOAT_PRECISION
+      * date-shaped + int 0 -> None
+      * ms-shaped + int < 0 -> None
+      * strike-shaped + 0.0 (or int 0) -> None
+      * right-shaped + empty string OR int 0 -> None
+      * everything else passes through
+
+    Bool is handled before int because Python `isinstance(True, int)` is
+    True; we don't want to sentinel-normalize booleans.
+    """
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        # Strike sentinel: 0.0 in a strike-shaped field is "no strike".
+        if _is_strike_field(key) and value == 0.0:
+            return None
+        return round(value, FLOAT_PRECISION)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if _is_date_field(key) and value == 0:
+            return None
+        if _is_ms_field(key) and value < 0:
+            return None
+        # Right field as raw int (OptionContract emits int; tick types
+        # emit string -- handled below). 0 is the upstream "not set" code.
+        if _is_right_field(key) and value == 0:
+            return None
+        # Strike emitted as int (a producer that rounds to int) -- treat
+        # 0 the same as 0.0.
+        if _is_strike_field(key) and value == 0:
+            return None
+        return value
+    if isinstance(value, str):
+        # Right tick field (`"C" / "P" / ""`). Empty string is sentinel.
+        if _is_right_field(key) and value == "":
+            return None
+    return value
+
+
+def _canonicalize_row(value: Any, key: str = "") -> Any:
+    """Recursively normalize a first_row value per the canonical contract.
+
+    Applied to every loaded first_row regardless of what producers did.
+    The `key` parameter carries the (already-lowercased) dict key from
+    the caller so sentinel normalization can fire on contract-id-shaped
+    fields; for the root call and list elements it's empty.
+
+    Handles:
+      * recursive lowercase dict keys
+      * recursive 6-decimal float rounding
+      * NaN / +Inf / -Inf -> None
+      * date-shaped fields: value `0` -> None
+      * ms-shaped fields: negative value -> None
+      * strike-shaped fields: value `0.0` -> None
+      * right-shaped fields: value `""` or int `0` -> None
+      * post-canonical None -> stripped from the dict for any field in
+        `_SENTINEL_SHAPED_FIELDS`. This makes producer divergence on
+        omit-vs-null-vs-sentinel-value invisible to the diff engine
+        (Go `omitempty` strips zero contract-ids; server skips them in
+        `tools/server/src/format.rs:89`; Python emits raw `0`/`""`;
+        CLI emits raw `0`/`""` after round-3). All four shapes converge
+        to "field absent from the dict" post-canonicalization.
+
+    This is the authoritative enforcer of the first_row contract -- a
+    producer bug (mixed-case key, non-finite float, precision regression,
+    sentinel mapped to null vs raw int, omitted vs null) surfaces here
+    instead of as a spurious cross-language disagreement.
+    """
+    if isinstance(value, dict):
+        canonicalized: dict[str, Any] = {}
+        for k, v in value.items():
+            lk = str(k).lower()
+            cv = _canonicalize_row(v, lk)
+            # Strip canonical-None values for sentinel-shaped contract-id
+            # fields so omit / null / `0` / `""` all converge to absent.
+            # Non-sentinel fields keep their None (e.g. an explicit null
+            # for a regular nullable column is a real distinction from
+            # the field being missing).
+            if cv is None and _is_sentinel_shaped_field(lk):
+                continue
+            canonicalized[lk] = cv
+        return canonicalized
+    if isinstance(value, list):
+        # List elements inherit the parent key for sentinel lookup (so
+        # `dates: [0, 20260417]` would canonicalize the 0). Rare in
+        # practice but free to support.
+        return [_canonicalize_row(v, key) for v in value]
+    return _canonicalize_scalar(key, value)
+
+
 def index_by_cell(records: list[dict]) -> dict[tuple[str, str], dict]:
     """Index records by (endpoint, mode). Raise on duplicates -- each cell
-    should appear at most once per SDK."""
+    should appear at most once per SDK. Canonicalizes `first_row` on load
+    so producer-side divergence (key case, float precision, non-finite
+    floats) doesn't surface as a spurious disagreement."""
     idx: dict[tuple[str, str], dict] = {}
     for rec in records:
         key = (rec.get("endpoint", ""), rec.get("mode", ""))
         if key in idx:
             raise ValueError(f"duplicate cell in artifact: {key}")
+        first_row = rec.get("first_row")
+        if isinstance(first_row, dict):
+            rec = {**rec, "first_row": _canonicalize_row(first_row)}
         idx[key] = rec
     return idx
 
 
-def main() -> int:
+# Sentinel for "field not present in this SDK's canonical first row".
+# Needs a distinct identity so we don't confuse it with a real `None`
+# that an SDK explicitly emitted for a nullable field.
+class _Missing:
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<missing>"
+
+
+MISSING = _Missing()
+
+
+def _values_equal(a: Any, b: Any) -> bool:
+    """Equality that treats floats within FLOAT_PRECISION as equal.
+
+    Canonicalization rounds floats to 6 decimals before emission, but
+    emitters in different languages can still disagree by 1 ULP after
+    the round-trip through JSON. Compare at the rounded precision to
+    keep the diff engine honest about which fields truly differ.
+    NaN never equals NaN -- both sides have to agree on being numeric.
+    """
+    if isinstance(a, _Missing) or isinstance(b, _Missing):
+        return type(a) is type(b)
+    if a is None or b is None:
+        return a is b
+    if isinstance(a, float) or isinstance(b, float):
+        try:
+            af = float(a)
+            bf = float(b)
+        except (TypeError, ValueError):
+            return False
+        if math.isnan(af) or math.isnan(bf):
+            return False
+        return round(af, FLOAT_PRECISION) == round(bf, FLOAT_PRECISION)
+    return a == b
+
+
+def _flatten(obj: Any, prefix: str = "") -> dict[str, Any]:
+    """Flatten a JSON-like object to a dotted-path map of leaf values.
+
+    {"a": {"b": 1}, "c": [2, 3]}  ->  {"a.b": 1, "c[0]": 2, "c[1]": 3}
+
+    Keeps the walk shallow-stable so two SDKs producing the same
+    structure produce the same key set. Lists are indexed by position;
+    dicts by key name. Leaves are anything that isn't a dict or list
+    (strings, numbers, bools, None).
+
+    Empty dicts and empty lists contribute zero entries -- there's
+    nothing to diff inside them, and treating "no fields" as a sentinel
+    `<root>` entry would flag a noisy mismatch any time post-canonical
+    sentinel stripping leaves one SDK with an empty contract-id block.
+    """
+    out: dict[str, Any] = {}
+    if isinstance(obj, dict):
+        for k in sorted(obj):
+            v = obj[k]
+            path = f"{prefix}.{k}" if prefix else str(k)
+            out.update(_flatten(v, path))
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            path = f"{prefix}[{i}]"
+            out.update(_flatten(v, path))
+    else:
+        out[prefix or "<root>"] = obj
+    return out
+
+
+def _diff_first_row(
+    first_rows: dict[str, dict],
+) -> list[tuple[str, dict[str, Any]]]:
+    """Walk first_row dicts field-by-field and return differing fields.
+
+    Input: {lang: first_row_dict}. Output: list of (field_path,
+    {lang: value_or_MISSING}) tuples, one per field that disagrees.
+    """
+    flat_per_lang = {lang: _flatten(fr) for lang, fr in first_rows.items()}
+    all_fields: set[str] = set()
+    for flat in flat_per_lang.values():
+        all_fields.update(flat)
+
+    diffs: list[tuple[str, dict[str, Any]]] = []
+    for field in sorted(all_fields):
+        values = {lang: flat.get(field, MISSING) for lang, flat in flat_per_lang.items()}
+        langs = list(values)
+        agree = True
+        for i in range(len(langs)):
+            for j in range(i + 1, len(langs)):
+                if not _values_equal(values[langs[i]], values[langs[j]]):
+                    agree = False
+                    break
+            if not agree:
+                break
+        if not agree:
+            diffs.append((field, values))
+    return diffs
+
+
+def _fmt_value(v: Any) -> str:
+    """Single-line representation for the diff table. Floats render at
+    FLOAT_PRECISION so they line up across SDKs."""
+    if isinstance(v, _Missing):
+        return "<missing>"
+    if v is None:
+        return "null"
+    if isinstance(v, float):
+        return f"{round(v, FLOAT_PRECISION):.{FLOAT_PRECISION}f}"
+    if isinstance(v, str):
+        return repr(v) if len(v) <= 60 else repr(v[:57] + "...")
+    return repr(v)
+
+
+def _format_cell_diff(
+    cell: tuple[str, str],
+    present: dict[str, dict],
+    disagreement_kind: str,
+    stream,
+) -> None:
+    """Print one cell's diff to `stream`. disagreement_kind is one of
+    status | row_count | first_row | mixed.
+    """
+    endpoint, mode = cell
+    label = f"{endpoint}::{mode}"
+    langs = sorted(present)
+    stream.write(f"\n  {label}  [{disagreement_kind} disagreement]\n")
+
+    # Carry forward the per-cell rationale W6 (#297) attached to each
+    # validator artifact -- it tells the reader what the cell was supposed
+    # to prove. All SDKs see the same generator output for a given cell,
+    # so rationale is identical across present[lang]; pick whichever is
+    # available. Fall back to "(missing)" for older artifacts written
+    # before the field landed.
+    rationale = next(
+        (rec.get("rationale") for rec in present.values() if rec.get("rationale")),
+        None,
+    )
+    if rationale:
+        stream.write(f"    rationale: {rationale}\n")
+
+    header = "    {:8s} | {:<8s} | {:<8s} | {:<40s}".format("sdk", "status", "rows", "detail")
+    stream.write(header + "\n")
+    stream.write("    " + "-" * (len(header) - 4) + "\n")
+    for lang in langs:
+        rec = present[lang]
+        detail = str(rec.get("detail", ""))
+        if len(detail) > 40:
+            detail = detail[:37] + "..."
+        stream.write(
+            "    {:8s} | {:<8s} | {:<8s} | {:<40s}\n".format(
+                lang,
+                str(rec.get("status", "")),
+                str(rec.get("row_count", "")),
+                detail,
+            )
+        )
+
+    if disagreement_kind in ("first_row", "mixed"):
+        first_rows = {
+            lang: present[lang]["first_row"]
+            for lang in langs
+            if isinstance(present[lang].get("first_row"), dict)
+        }
+        if len(first_rows) >= 2:
+            field_diffs = _diff_first_row(first_rows)
+            if field_diffs:
+                stream.write("\n    field-level diff:\n")
+                col_header = "    {:<32s}".format("field")
+                for lang in langs:
+                    col_header += " | {:<20s}".format(lang)
+                stream.write(col_header + "\n")
+                stream.write("    " + "-" * (len(col_header) - 4) + "\n")
+                for field, values in field_diffs:
+                    row = "    {:<32s}".format(field[:32])
+                    for lang in langs:
+                        row += " | {:<20s}".format(_fmt_value(values.get(lang, MISSING))[:20])
+                    stream.write(row + "\n")
+
+
+def _classify_cell(present: dict[str, dict]) -> str | None:
+    """Return disagreement kind for a cell, or None if all SDKs agree.
+
+    status    - some SDKs PASS, others FAIL/SKIP
+    row_count - all PASS but row_count differs
+    first_row - status + row_count match but first_row fields differ
+    mixed     - status agrees but both row_count and first_row disagree
+    """
+    statuses = {rec.get("status") for rec in present.values()}
+    if len(statuses) > 1:
+        return "status"
+
+    pass_recs = {lang: rec for lang, rec in present.items() if rec.get("status") == "PASS"}
+    if len(pass_recs) < 2:
+        return None
+
+    row_counts = {rec.get("row_count", 0) for rec in pass_recs.values()}
+    row_count_differs = len(row_counts) > 1
+
+    first_rows = {
+        lang: rec["first_row"]
+        for lang, rec in pass_recs.items()
+        if isinstance(rec.get("first_row"), dict)
+    }
+    first_row_differs = False
+    if len(first_rows) >= 2:
+        field_diffs = _diff_first_row(first_rows)
+        first_row_differs = bool(field_diffs)
+
+    if row_count_differs and first_row_differs:
+        return "mixed"
+    if row_count_differs:
+        return "row_count"
+    if first_row_differs:
+        return "first_row"
+    return None
+
+
+def compare(
+    per_lang: dict[str, dict[tuple[str, str], dict]],
+    max_cell_diff_rows: int,
+    stream,
+) -> tuple[int, int, int]:
+    """Compare cells across SDKs, print diffs, return (total_cells,
+    disagreement_count, partial_count)."""
+    all_cells: set[tuple[str, str]] = set()
+    for idx in per_lang.values():
+        all_cells.update(idx.keys())
+
+    disagreements: list[tuple[tuple[str, str], dict[str, dict], str]] = []
+    missing_per_cell: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+    for cell in sorted(all_cells):
+        present = {lang: idx[cell] for lang, idx in per_lang.items() if cell in idx}
+        absent = [lang for lang, idx in per_lang.items() if cell not in idx]
+        if absent:
+            missing_per_cell[cell] = absent
+        if len(present) < 2:
+            continue
+        kind = _classify_cell(present)
+        if kind is not None:
+            disagreements.append((cell, present, kind))
+
+    partial_count = sum(1 for v in missing_per_cell.values() if v)
+
+    if disagreements:
+        stream.write("\nDISAGREEMENTS:\n")
+        for cell, present, kind in disagreements[:max_cell_diff_rows]:
+            _format_cell_diff(cell, present, kind, stream)
+        if len(disagreements) > max_cell_diff_rows:
+            stream.write(
+                f"\n  ... and {len(disagreements) - max_cell_diff_rows} more cells\n",
+            )
+
+    return len(all_cells), len(disagreements), partial_count
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
     parser.add_argument(
         "--require-all-sdks",
@@ -90,14 +588,22 @@ def main() -> int:
         "--max-cell-diff-rows",
         type=int,
         default=50,
-        help="Cap on disagreement rows printed to stderr (others summarized).",
+        help="Cap on disagreement cells printed (others summarized).",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        default=None,
+        help="Override artifacts directory (for testing). Default: artifacts/.",
+    )
+    args = parser.parse_args(argv)
+
+    artifacts_dir = args.artifacts_dir if args.artifacts_dir is not None else ARTIFACTS_DIR
 
     per_lang: dict[str, dict[tuple[str, str], dict]] = {}
     missing: list[str] = []
     for lang in LANGS:
-        records = load_artifact(lang)
+        records = load_artifact(lang, artifacts_dir)
         if records is None:
             missing.append(lang)
             continue
@@ -111,7 +617,7 @@ def main() -> int:
     if missing:
         print(
             f"warning: no artifact for {', '.join(missing)} "
-            f"(expected at artifacts/validator_<lang>.json)",
+            f"(expected at {artifacts_dir}/validator_<lang>.json)",
             file=sys.stderr,
         )
         if args.require_all_sdks:
@@ -126,85 +632,20 @@ def main() -> int:
         )
         return 1
 
-    # Cell universe: union of all cells seen in any SDK.
-    all_cells: set[tuple[str, str]] = set()
-    for idx in per_lang.values():
-        all_cells.update(idx.keys())
+    total, disagreements, partial = compare(per_lang, args.max_cell_diff_rows, sys.stderr)
 
-    disagreements: list[tuple[tuple[str, str], dict[str, dict]]] = []
-    missing_per_cell: dict[tuple[str, str], list[str]] = defaultdict(list)
-
-    for cell in sorted(all_cells):
-        present = {lang: idx[cell] for lang, idx in per_lang.items() if cell in idx}
-        absent = [lang for lang, idx in per_lang.items() if cell not in idx]
-        if absent:
-            missing_per_cell[cell] = absent
-
-        if len(present) < 2:
-            continue
-
-        # Compare status across SDKs that ran this cell.
-        statuses = {lang: rec.get("status") for lang, rec in present.items()}
-        if len(set(statuses.values())) > 1:
-            disagreements.append((cell, present))
-            continue
-
-        # Compare row_count on cells that all PASSed.
-        if all(s == "PASS" for s in statuses.values()):
-            row_counts = {lang: rec.get("row_count", 0) for lang, rec in present.items()}
-            if len(set(row_counts.values())) > 1:
-                disagreements.append((cell, present))
-
-    print(
-        f"\nagreement: {len(all_cells)} cells across {len(per_lang)} SDKs, "
-        f"{len(disagreements)} disagreements, "
-        f"{sum(1 for v in missing_per_cell.values() if v)} cells partial"
-    )
-
-    if disagreements:
-        print("\nDISAGREEMENTS:", file=sys.stderr)
-        for (endpoint, mode), present in disagreements[: args.max_cell_diff_rows]:
-            # Determine the disagreement kind so the header carries useful
-            # context (status mismatch vs. row-count mismatch on PASS).
-            statuses = {rec.get("status") for rec in present.values()}
-            kind = "status disagreement" if len(statuses) > 1 else "row-count disagreement"
-            label = f"{endpoint}::{mode}"
-            # All SDKs see the same generator output for a given cell, so
-            # rationale is identical across present[lang]; pick whichever is
-            # available. Fall back to "(missing)" if no SDK populated it
-            # (older artifacts written before this field landed).
-            rationale = next(
-                (rec.get("rationale") for rec in present.values() if rec.get("rationale")),
-                "(missing)",
-            )
-            print(f"  {label}  [{kind}]", file=sys.stderr)
-            print(f"    rationale: {rationale}", file=sys.stderr)
-            print(
-                f"    {'sdk':8s} | {'status':6s} | {'rows':5s} | detail",
-                file=sys.stderr,
-            )
-            for lang in sorted(present):
-                rec = present[lang]
-                print(
-                    f"    {lang:8s} | {str(rec.get('status', '')):6s} | "
-                    f"{str(rec.get('row_count', '')):5s} | "
-                    f"{(rec.get('detail') or '')[:80]}",
-                    file=sys.stderr,
-                )
-        if len(disagreements) > args.max_cell_diff_rows:
-            print(
-                f"  ... and {len(disagreements) - args.max_cell_diff_rows} more",
-                file=sys.stderr,
-            )
-
-    # Partial cells (present in some SDKs but not others) -- info only by
-    # default, since CLI deliberately skips per-optional-param modes.
-    partial = {c: langs for c, langs in missing_per_cell.items() if langs}
-    if partial:
-        # Only flag as a warning; inside the summary the count is already
-        # shown. Callers use --require-all-sdks if they want it strict.
+    if disagreements == 0:
+        sdk_set = ", ".join(sorted(per_lang))
+        print(f"\n\u2713 {total} cells agree across {{{sdk_set}}}")
+    else:
         print(
-            f"\nnote: {len(partial)} cells missing from at least one SDK "
+            f"\nagreement: {total} cells across {len(per_lang)} SDKs, "
+            f"{disagreements} disagreements, {partial} cells partial",
+        )
+
+    if partial:
+        print(
+            f"\nnote: {partial} cells missing from at least one SDK "
             "(CLI skips per-optional-param modes by design -- see PR #291)",
             file=sys.stderr,
         )

--- a/scripts/validate_agreement.py
+++ b/scripts/validate_agreement.py
@@ -83,6 +83,31 @@ Consumer-side canonicalization (`_canonicalize_row`) handles:
    `_time`): negative value -> `None`. Same reasoning -- every SDK
    emits negative-ms sentinels as raw ints.
 
+Empty-container rule (Codex r5)
+-------------------------------
+
+Sentinel stripping applies only to LEAF values (scalars whose field
+name puts them in the sentinel set). Sub-dicts and sub-lists are never
+elided from their parent, even if all their children get stripped:
+
+  {"contract": {"expiration": 0}}     canonicalizes to
+  {"contract": {}}                    (sentinel leaf stripped, container
+                                       preserved as empty dict)
+
+The flatten phase then emits `contract: {}` as a distinct field path,
+so a producer that legitimately emits an empty container (e.g.
+`{"meta": {}}`) still differs from one that omits the key entirely
+(`{}` emits `<root>: {}`). This was the Codex round-5 finding: earlier
+rounds elided stripped-empty containers and caused `{"meta": {}}` to
+false-pass against `{}`.
+
+Downstream consequence: `{"contract": {"expiration": 0}}` and `{}`
+DISAGREE post-canonicalization. That's intentional -- real producers
+emit contract-id fields at the top level of `first_row` (never nested),
+so any nested structure is hypothetical, and surfacing divergence is
+safer than silently eliding "producer A emitted an empty container
+here; producer B didn't".
+
 Defense in depth: producers SHOULD canonicalize too, but the consumer
 is the authoritative enforcer. A producer bug (mixed-case key, stray
 NaN, float precision regression, sentinel mapped to `null` vs raw int)
@@ -270,13 +295,21 @@ def _canonicalize_row(value: Any, key: str = "") -> Any:
       * ms-shaped fields: negative value -> None
       * strike-shaped fields: value `0.0` -> None
       * right-shaped fields: value `""` or int `0` -> None
-      * post-canonical None -> stripped from the dict for any field in
-        `_SENTINEL_SHAPED_FIELDS`. This makes producer divergence on
-        omit-vs-null-vs-sentinel-value invisible to the diff engine
-        (Go `omitempty` strips zero contract-ids; server skips them in
-        `tools/server/src/format.rs:89`; Python emits raw `0`/`""`;
-        CLI emits raw `0`/`""` after round-3). All four shapes converge
-        to "field absent from the dict" post-canonicalization.
+      * post-canonical None -> stripped from the dict for LEAF fields
+        whose name is in `_SENTINEL_SHAPED_FIELDS`. This makes producer
+        divergence on omit-vs-null-vs-sentinel-value invisible to the
+        diff engine (Go `omitempty` strips zero contract-ids; server
+        skips them in `tools/server/src/format.rs:89`; Python emits raw
+        `0`/`""`; CLI emits raw `0`/`""` after round-3). All four
+        shapes converge to "field absent from the dict" post-
+        canonicalization.
+
+    Sub-dicts and sub-lists are NEVER elided from their parent, even if
+    all their children get stripped. `{"contract": {"expiration": 0}}`
+    canonicalizes to `{"contract": {}}` (empty container preserved),
+    not `{}` (container elided). This distinguishes "producer emitted
+    an empty container here" from "producer omitted the container
+    entirely" -- see module docstring "Empty-container rule" for why.
 
     This is the authoritative enforcer of the first_row contract -- a
     producer bug (mixed-case key, non-finite float, precision regression,
@@ -370,18 +403,30 @@ def _flatten(obj: Any, prefix: str = "") -> dict[str, Any]:
     dicts by key name. Leaves are anything that isn't a dict or list
     (strings, numbers, bools, None).
 
-    Empty dicts and empty lists contribute zero entries -- there's
-    nothing to diff inside them, and treating "no fields" as a sentinel
-    `<root>` entry would flag a noisy mismatch any time post-canonical
-    sentinel stripping leaves one SDK with an empty contract-id block.
+    Empty dicts and empty lists emit a dedicated marker at their path
+    (the empty container itself). This makes `{"meta": {}}` differ from
+    `{}` (the `meta` key emits `meta: {}` while `{}` emits `<root>: {}`
+    -- distinct field paths), so a producer that legitimately emits an
+    empty container doesn't false-pass against one that omits the key.
+    Sentinel stripping in `_canonicalize_row` strips only LEAF sentinels,
+    never sub-dicts, so a container that becomes empty via stripping
+    (e.g., `{"contract": {"expiration": 0}}` -> `{"contract": {}}`) still
+    emits its `contract: {}` marker -- treated as a real data point
+    identical to a producer that emitted `{"contract": {}}` directly.
     """
     out: dict[str, Any] = {}
     if isinstance(obj, dict):
+        if not obj:
+            out[prefix or "<root>"] = {}
+            return out
         for k in sorted(obj):
             v = obj[k]
             path = f"{prefix}.{k}" if prefix else str(k)
             out.update(_flatten(v, path))
     elif isinstance(obj, list):
+        if not obj:
+            out[prefix or "<root>"] = []
+            return out
         for i, v in enumerate(obj):
             path = f"{prefix}[{i}]"
             out.update(_flatten(v, path))

--- a/scripts/validate_agreement_test.py
+++ b/scripts/validate_agreement_test.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""Synthetic tests for scripts/validate_agreement.py.
+
+Constructs four mock SDK artifacts with intentional disagreements and
+asserts the diff engine's output names the right fields. Uses only
+stdlib so it runs in CI without extra deps. Invoke via:
+
+    python3 scripts/validate_agreement_test.py
+
+Exits non-zero on the first failing assertion.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import validate_agreement  # noqa: E402
+
+
+def _write_artifact(base: Path, lang: str, records: list[dict]) -> None:
+    path = base / f"validator_{lang}.json"
+    path.write_text(json.dumps({"lang": lang, "records": records}, indent=2, sort_keys=True))
+
+
+def _base_record(
+    endpoint: str,
+    mode: str,
+    status: str = "PASS",
+    row_count: int = 1,
+    detail: str = "",
+    first_row: dict | None = None,
+) -> dict:
+    rec = {
+        "endpoint": endpoint,
+        "mode": mode,
+        "status": status,
+        "row_count": row_count,
+        "duration_ms": 100,
+        "detail": detail,
+    }
+    if first_row is not None:
+        rec["first_row"] = first_row
+    return rec
+
+
+class AgreementTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.artifacts = Path(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def _run(self, extra_args: list[str] | None = None) -> tuple[int, str, str]:
+        """Run main() with captured stdout/stderr against self.artifacts."""
+        argv = ["--artifacts-dir", str(self.artifacts)]
+        if extra_args:
+            argv.extend(extra_args)
+        out_buf = io.StringIO()
+        err_buf = io.StringIO()
+        orig_out, orig_err = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = out_buf, err_buf
+        try:
+            code = validate_agreement.main(argv)
+        finally:
+            sys.stdout, sys.stderr = orig_out, orig_err
+        return code, out_buf.getvalue(), err_buf.getvalue()
+
+    def test_all_agree_exits_zero(self) -> None:
+        for lang in validate_agreement.LANGS:
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [
+                    _base_record("stock_snapshot_ohlc", "concrete", row_count=1),
+                    _base_record("stock_list_dates", "basic", row_count=42),
+                ],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"expected exit 0, got {code}; out={out!r}")
+        self.assertIn("2 cells agree across", out)
+
+    def test_field_level_diff_pinpoints_bid(self) -> None:
+        # All four SDKs passed, row_count matches (1 row each), but
+        # go got a different bid price. The diff must name `bid` as
+        # the differing field.
+        base_row = {
+            "ask": 685.88,
+            "bid": 685.86,
+            "bid_size": 100,
+            "ask_size": 200,
+            "date": "20250303",
+        }
+        for lang in ("python", "cli", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_snapshot_quote", "concrete", first_row=dict(base_row))],
+            )
+        go_row = dict(base_row)
+        go_row["bid"] = 685.87
+        _write_artifact(
+            self.artifacts,
+            "go",
+            [_base_record("stock_snapshot_quote", "concrete", first_row=go_row)],
+        )
+
+        code, _, err = self._run()
+        self.assertEqual(code, 1, f"expected exit 1 on disagreement; stderr={err!r}")
+        self.assertIn("stock_snapshot_quote::concrete", err)
+        self.assertIn("first_row disagreement", err)
+        self.assertIn("field-level diff", err)
+        self.assertIn("bid", err)
+        self.assertIn("685.860000", err)
+        self.assertIn("685.870000", err)
+        # Fields that agree must NOT appear in the diff rows.
+        self.assertNotIn("ask_size", _diff_section(err))
+
+    def test_row_count_disagreement_without_first_row(self) -> None:
+        # Legacy artifacts: no first_row field. Diff engine must fall
+        # back to row_count comparison and still report the mismatch.
+        for lang, rc in (("python", 10), ("cli", 10), ("go", 9), ("cpp", 10)):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_history_ohlc", "concrete", row_count=rc)],
+            )
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn("stock_history_ohlc::concrete", err)
+        self.assertIn("row_count disagreement", err)
+        # Per-SDK status table still names each SDK and its row count.
+        self.assertIn("go", err)
+        self.assertIn("9", err)
+        self.assertIn("10", err)
+
+    def test_status_disagreement(self) -> None:
+        # Python passed, CLI/go/cpp failed. Diff must flag as status
+        # disagreement and show each SDK's status + detail.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("option_snapshot_trade", "concrete")],
+        )
+        for lang in ("cli", "go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [
+                    _base_record(
+                        "option_snapshot_trade",
+                        "concrete",
+                        status="FAIL",
+                        row_count=0,
+                        detail="wire-format error: unexpected tick kind",
+                    )
+                ],
+            )
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn("option_snapshot_trade::concrete", err)
+        self.assertIn("status disagreement", err)
+        self.assertIn("wire-format error", err)
+
+    def test_nested_first_row_diff(self) -> None:
+        # first_row with nested dict + list. Diff engine must walk
+        # into the nested structure and name `greeks.delta[0]` as the
+        # differing field, not just `greeks`.
+        base_row = {
+            "symbol": "SPY",
+            "greeks": {"delta": [0.5, 0.6], "gamma": 0.01},
+        }
+        for lang in ("python", "cli", "go"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("option_snapshot_greeks_all", "concrete", first_row=json.loads(json.dumps(base_row)))],
+            )
+        cpp_row = json.loads(json.dumps(base_row))
+        cpp_row["greeks"]["delta"][0] = 0.55
+        _write_artifact(
+            self.artifacts,
+            "cpp",
+            [_base_record("option_snapshot_greeks_all", "concrete", first_row=cpp_row)],
+        )
+
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn("greeks.delta[0]", err)
+        # `greeks.gamma` and `greeks.delta[1]` are equal across SDKs
+        # and must not appear in the field-level diff rows.
+        diff_only = _diff_section(err)
+        self.assertNotIn("greeks.gamma", diff_only)
+        self.assertNotIn("greeks.delta[1]", diff_only)
+
+    def test_missing_field_in_one_sdk(self) -> None:
+        # cpp omits the `volume` field entirely (tick type doesn't
+        # surface it). Diff must mark volume as <missing> for cpp and
+        # show the real value for the others.
+        full_row = {"price": 100.0, "volume": 5000}
+        for lang in ("python", "cli", "go"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_history_trade", "concrete", first_row=dict(full_row))],
+            )
+        partial_row = {"price": 100.0}
+        _write_artifact(
+            self.artifacts,
+            "cpp",
+            [_base_record("stock_history_trade", "concrete", first_row=partial_row)],
+        )
+
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        self.assertIn("volume", err)
+        self.assertIn("<missing>", err)
+
+    def test_soft_skip_missing_sdk_without_require(self) -> None:
+        # Only 3 SDKs reported; without --require-all-sdks this is a
+        # warning, not a failure.
+        for lang in ("python", "cli", "go"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("calendar_open_today", "basic", row_count=1)],
+            )
+        code, out, err = self._run()
+        self.assertEqual(code, 0)
+        self.assertIn("warning: no artifact for cpp", err)
+        self.assertIn("1 cells agree across", out)
+
+    def test_require_all_sdks_fails_on_missing(self) -> None:
+        for lang in ("python", "cli", "go"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("calendar_open_today", "basic", row_count=1)],
+            )
+        code, _, err = self._run(["--require-all-sdks"])
+        self.assertEqual(code, 1)
+        self.assertIn("--require-all-sdks set", err)
+
+    def test_float_precision_tolerance(self) -> None:
+        # 685.860000 == 685.8600004 after 6-decimal rounding. These
+        # must compare equal; the diff engine must not flag a false
+        # positive on 1-ULP float noise.
+        for lang, bid in (("python", 685.86), ("cli", 685.8600004), ("go", 685.86), ("cpp", 685.8599996)):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_snapshot_quote", "concrete", first_row={"bid": bid})],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0)
+        self.assertIn("1 cells agree across", out)
+
+    def test_partial_cells_note(self) -> None:
+        # CLI skips per-optional-param mode; the other three SDKs run
+        # it. Not a disagreement, but the summary must mention partial.
+        for lang in ("python", "go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [
+                    _base_record("stock_snapshot_ohlc", "concrete", row_count=1),
+                    _base_record("stock_snapshot_ohlc", "with_venue", row_count=1),
+                ],
+            )
+        _write_artifact(
+            self.artifacts,
+            "cli",
+            [_base_record("stock_snapshot_ohlc", "concrete", row_count=1)],
+        )
+        code, out, err = self._run()
+        self.assertEqual(code, 0)
+        self.assertIn("cells missing from at least one SDK", err)
+
+    def test_mixed_case_keys_canonicalize(self) -> None:
+        # A producer regression that leaves keys in mixed case
+        # (`{"Bid": 685.86}`) must compare equal to the canonical
+        # lowercase form. Consumer-side canonicalization is the
+        # authoritative enforcer -- producers can't be trusted to
+        # emit lowercase 100% of the time.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("stock_snapshot_quote", "concrete", first_row={"Bid": 685.86, "Ask": 685.88})],
+        )
+        for lang in ("cli", "go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_snapshot_quote", "concrete", first_row={"bid": 685.86, "ask": 685.88})],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"mixed-case keys must canonicalize to equal; got exit {code}")
+        self.assertIn("1 cells agree across", out)
+
+    def test_mixed_case_key_nested_canonicalize(self) -> None:
+        # Canonicalization must recurse into nested dicts. A producer
+        # that regressed ONLY on a nested key ({"Greeks": {"Delta": ...}})
+        # still has to compare equal to the canonical form.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [
+                _base_record(
+                    "option_snapshot_greeks_all",
+                    "concrete",
+                    first_row={"Greeks": {"Delta": 0.5, "Gamma": 0.01}},
+                )
+            ],
+        )
+        for lang in ("cli", "go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [
+                    _base_record(
+                        "option_snapshot_greeks_all",
+                        "concrete",
+                        first_row={"greeks": {"delta": 0.5, "gamma": 0.01}},
+                    )
+                ],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0)
+        self.assertIn("1 cells agree across", out)
+
+    def test_nan_normalizes_to_null(self) -> None:
+        # NaN is not equal to NaN under IEEE semantics, and cross-language
+        # serialization of non-finite floats is ambiguous (JSON rejects
+        # them; CLI's f64 reparse drops them silently). Consumer-side
+        # canonicalization collapses NaN / +Inf / -Inf to Python None so
+        # two producers emitting "missing / sentinel" in different shapes
+        # converge on the same canonical value.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("option_snapshot_greeks_all", "concrete", first_row={"delta": float("nan")})],
+        )
+        for lang in ("cli", "go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("option_snapshot_greeks_all", "concrete", first_row={"delta": None})],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"NaN must canonicalize to None; got exit {code}")
+        self.assertIn("1 cells agree across", out)
+
+    def test_infinity_normalizes_to_null(self) -> None:
+        # +Inf / -Inf same treatment as NaN.
+        for lang, val in (
+            ("python", float("inf")),
+            ("cli", float("-inf")),
+            ("go", None),
+            ("cpp", None),
+        ):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("option_snapshot_greeks_all", "concrete", first_row={"delta": val})],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"±Inf must canonicalize to None; got exit {code}")
+        self.assertIn("1 cells agree across", out)
+
+    def test_real_disagreement_still_detected_after_canonicalization(self) -> None:
+        # Sanity check: canonicalization must NOT hide real diffs. Even
+        # with mixed-case keys across producers, a genuinely different
+        # value at the same canonical field still produces a diff row
+        # naming the lowercased field.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("stock_snapshot_quote", "concrete", first_row={"Bid": 685.86})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "go",
+            [_base_record("stock_snapshot_quote", "concrete", first_row={"bid": 685.87})],
+        )
+        for lang in ("cli", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_snapshot_quote", "concrete", first_row={"bid": 685.86})],
+            )
+        code, _, err = self._run()
+        self.assertEqual(code, 1)
+        # Diff table names the LOWERCASED field even though python sent
+        # the mixed-case version; that's what makes field diffs readable
+        # when producers disagree on case AND value.
+        self.assertIn("bid", _diff_section(err))
+        self.assertIn("685.870000", err)
+
+    def test_date_zero_sentinel_normalizes_to_null(self) -> None:
+        # CLI emits `date: 0` verbatim under the round-3 json-raw contract
+        # (tools/cli/src/main.rs `raw_date`), while another producer might
+        # serialize the same "no date" cell as JSON null. Both shapes must
+        # canonicalize to None so they compare equal. Rationale: trading
+        # data never has year 0000; `0` is always a sentinel.
+        for lang, val in (
+            ("python", 0),
+            ("cli", 0),
+            ("go", None),
+            ("cpp", None),
+        ):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_history_ohlc", "concrete", first_row={"date": val})],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"date=0 must canonicalize to None; got exit {code}")
+        self.assertIn("1 cells agree across", out)
+
+    def test_ms_of_day_negative_sentinel_normalizes_to_null(self) -> None:
+        # Similar to date=0: ms-of-day is non-negative by construction
+        # (bounded 0..86_400_000). Negative values are sentinels that some
+        # producers emit as raw ints and others as JSON null. Both must
+        # canonicalize to None.
+        for lang, val in (
+            ("python", -1),
+            ("cli", -1),
+            ("go", None),
+            ("cpp", None),
+        ):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_history_trade", "concrete", first_row={"ms_of_day": val})],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"ms_of_day<0 must canonicalize to None; got exit {code}")
+        self.assertIn("1 cells agree across", out)
+
+    def test_sentinel_vs_real_value_still_disagrees(self) -> None:
+        # Sanity: sentinel normalization must NOT hide genuine diffs.
+        # One producer emits `date: 20260417` (real date), another emits
+        # `date: 0` (sentinel -> None). These are genuinely different
+        # cells and the diff engine must report it.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"date": 20260417})],
+        )
+        for lang in ("cli", "go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_history_ohlc", "concrete", first_row={"date": 0})],
+            )
+        code, _, err = self._run()
+        self.assertEqual(code, 1, "real date vs sentinel 0 must disagree")
+        self.assertIn("date", _diff_section(err))
+        # Python's 20260417 should appear in the diff table; the other
+        # three SDKs' sentinel `0` is canonicalized to None and stripped
+        # from the dict (Option B: omit-equivalence), so they show up as
+        # `<missing>` in the field-level table.
+        self.assertIn("20260417", err)
+        self.assertIn("<missing>", _diff_section(err))
+
+    def test_expiration_zero_sentinel_and_time_alias(self) -> None:
+        # Covers two extra field-name patterns the canonicalization rule
+        # must catch: `expiration` (date-shaped, server omits-when-zero)
+        # and `time` (ms-shaped alias used by CLI OHLC / trade columns).
+        for lang, row in (
+            ("python", {"expiration": 0, "time": -1}),
+            ("cli", {"expiration": 0, "time": -1}),
+            ("go", {"expiration": None, "time": None}),
+            ("cpp", {"expiration": None, "time": None}),
+        ):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("option_history_ohlc", "concrete", first_row=row)],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"expiration=0 + time=-1 must canonicalize; got exit {code}")
+        self.assertIn("1 cells agree across", out)
+
+    def test_zero_is_not_sentinel_for_non_date_fields(self) -> None:
+        # Regression test: the field-name rule must be narrow. `volume=0`
+        # is a legitimate trading value (no trades in the bar) and MUST
+        # stay distinct from `volume=null`. Same for `bid_size=0`,
+        # `count=0`, etc. Previously a by-value rule ("any int 0 in a
+        # tick-shaped field") would have been far too aggressive.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"volume": 0})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "cli",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"volume": None})],
+        )
+        code, _, err = self._run()
+        self.assertEqual(code, 1, "volume=0 and volume=null are distinct; must disagree")
+        self.assertIn("volume", _diff_section(err))
+
+    # ------------------------------------------------------------------
+    # Round 4 -- omit-vs-null-vs-sentinel-value equivalence (Codex r4).
+    # Producers diverge on contract-id field shape:
+    #   - Python emits `expiration: 0` always
+    #   - Go's `omitempty` strips zero-valued fields from JSON
+    #   - Server's `insert_contract_id_fields` skips when expiration==0
+    #   - CLI raw helpers emit `expiration: 0` verbatim (round-3 fix)
+    # All four shapes must canonicalize to the same thing.
+    # ------------------------------------------------------------------
+
+    def test_omit_vs_null_for_expiration_agrees(self) -> None:
+        # Two producers omit `expiration` entirely (Go omitempty, server
+        # skip-when-zero). One producer emits `expiration: null`. After
+        # canonicalization, all three shapes must agree.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"expiration": None})],
+        )
+        for lang in ("cli", "go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_history_ohlc", "concrete", first_row={})],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(
+            code, 0,
+            "expiration:null and omitted expiration must agree post-canonicalization",
+        )
+        self.assertIn("1 cells agree across", out)
+
+    def test_omit_vs_zero_for_expiration_agrees(self) -> None:
+        # Three producers emit `expiration: 0` (Python tick_columnar,
+        # CLI raw helpers). One producer omits it (Go omitempty / server
+        # skip-when-zero). Both shapes must canonicalize to "absent".
+        for lang in ("python", "cli", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_history_ohlc", "concrete", first_row={"expiration": 0})],
+            )
+        _write_artifact(
+            self.artifacts,
+            "go",
+            [_base_record("stock_history_ohlc", "concrete", first_row={})],
+        )
+        code, out, _ = self._run()
+        self.assertEqual(
+            code, 0,
+            "expiration:0 and omitted expiration must agree post-canonicalization",
+        )
+        self.assertIn("1 cells agree across", out)
+
+    def test_omit_for_non_sentinel_field_still_differs(self) -> None:
+        # The omit-equivalence rule only fires for sentinel-shaped fields
+        # (date / expiration / strike / right / ms-of-day). A regular
+        # nullable column like `volume` must keep distinguishing
+        # "absent" from "explicitly null" -- the field set difference IS
+        # the disagreement.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"volume": None})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "cli",
+            [_base_record("stock_history_ohlc", "concrete", first_row={})],
+        )
+        code, _, err = self._run()
+        self.assertEqual(
+            code, 1,
+            "volume:null vs omitted volume must DISAGREE (omit-equiv only for sentinel fields)",
+        )
+        self.assertIn("volume", _diff_section(err))
+
+    def test_strike_zero_sentinel_canonicalizes(self) -> None:
+        # `strike: 0.0` (Python) vs omitted strike (Go omitempty) must
+        # agree. Strike is a contract-id sentinel.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"strike": 0.0})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "cli",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"strike": 0.0})],
+        )
+        for lang in ("go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("stock_history_ohlc", "concrete", first_row={})],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"strike=0.0 must canonicalize; got exit {code}")
+        self.assertIn("1 cells agree across", out)
+
+    def test_right_empty_string_and_zero_canonicalize(self) -> None:
+        # Right field has two valid sentinel shapes: empty string `""`
+        # (Python tick_columnar `right: "C"/"P"/""`, Go RightStr) and raw
+        # int `0` (server's right_label fall-through, OptionContract).
+        # Both must canonicalize to "absent" so `right: ""` (Python),
+        # `right: 0` (server / OptionContract emitter), and omitted
+        # `right` (Go omitempty) all agree.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"right": ""})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "cli",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"right": ""})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "go",
+            [_base_record("stock_history_ohlc", "concrete", first_row={})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "cpp",
+            [_base_record("stock_history_ohlc", "concrete", first_row={"right": 0})],
+        )
+        code, out, _ = self._run()
+        self.assertEqual(code, 0, f"right empty/zero/omit must agree; got exit {code}")
+        self.assertIn("1 cells agree across", out)
+
+    def test_real_right_value_still_disagrees(self) -> None:
+        # Sanity: omit-equivalence must not hide real right disagreement.
+        # Python emits `right: "C"` (a real call), one SDK emits `"P"` (a
+        # real put). Different actual options -- diff must report it.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("option_history_ohlc", "concrete", first_row={"right": "C"})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "go",
+            [_base_record("option_history_ohlc", "concrete", first_row={"right": "P"})],
+        )
+        for lang in ("cli", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("option_history_ohlc", "concrete", first_row={"right": "C"})],
+            )
+        code, _, err = self._run()
+        self.assertEqual(code, 1, "right C vs P is a real disagreement")
+        self.assertIn("right", _diff_section(err))
+
+
+def _diff_section(text: str) -> str:
+    """Return just the field-level diff rows, stripping headers / status
+    tables. Used to make "field X doesn't appear" assertions precise."""
+    lines = text.splitlines()
+    out_lines: list[str] = []
+    in_diff = False
+    for line in lines:
+        if "field-level diff" in line:
+            in_diff = True
+            continue
+        if in_diff:
+            if not line.strip() or line.lstrip().startswith("sdk "):
+                in_diff = False
+                continue
+            if set(line.strip()) <= {"-", " "}:
+                continue
+            out_lines.append(line)
+    return "\n".join(out_lines)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/validate_agreement_test.py
+++ b/scripts/validate_agreement_test.py
@@ -665,6 +665,111 @@ class AgreementTests(unittest.TestCase):
         self.assertEqual(code, 1, "right C vs P is a real disagreement")
         self.assertIn("right", _diff_section(err))
 
+    # ------------------------------------------------------------------
+    # Round 5 -- nested empty-container handling (Codex r5 finding).
+    # Earlier rounds elided stripped-empty containers and made
+    # `{"meta": {}}` false-pass against `{}`. Fix: `_canonicalize_row`
+    # strips only LEAF sentinels; sub-dicts and sub-lists are preserved
+    # even when they become empty via stripping. `_flatten` re-emits
+    # empty containers with their path as a marker.
+    # ------------------------------------------------------------------
+
+    def test_originally_empty_container_does_not_false_pass(self) -> None:
+        # `{"meta": {}}` (producer intentionally emitted an empty meta
+        # sub-dict as a real data point) must DISAGREE with `{}` (meta
+        # is completely absent). Earlier rounds silently elided both to
+        # empty flat-maps and false-passed -- Codex r5 caught this.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record("option_history_ohlc", "concrete", first_row={"meta": {}})],
+        )
+        _write_artifact(
+            self.artifacts,
+            "go",
+            [_base_record("option_history_ohlc", "concrete", first_row={})],
+        )
+        for lang in ("cli", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("option_history_ohlc", "concrete", first_row={})],
+            )
+        code, _, err = self._run()
+        self.assertEqual(
+            code, 1,
+            "present-empty container must NOT false-pass against absent key",
+        )
+        # Diff should surface the field `meta` (python has it as empty
+        # dict; others don't have it at all).
+        self.assertIn("meta", err)
+
+    def test_stripped_empty_container_via_sentinel_agrees(self) -> None:
+        # `{"contract": {"expiration": null}}` strips the leaf sentinel
+        # but preserves the empty `contract` container. Compares equal
+        # to `{"contract": {}}` (producer emitted empty container
+        # directly). Both canonicalize to `{"contract": {}}`.
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record(
+                "option_history_ohlc", "concrete",
+                first_row={"contract": {"expiration": None}},
+            )],
+        )
+        for lang in ("cli", "go", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record(
+                    "option_history_ohlc", "concrete",
+                    first_row={"contract": {}},
+                )],
+            )
+        code, out, _ = self._run()
+        self.assertEqual(
+            code, 0,
+            "stripped-empty container must agree with originally-empty container",
+        )
+        self.assertIn("1 cells agree across", out)
+
+    def test_stripped_empty_container_vs_absent_parent_disagrees(self) -> None:
+        # Team-lead flagged this case as debatable. We pick DISAGREE
+        # because real first_row schemas emit contract-id fields at the
+        # TOP level -- no producer in the ecosystem (Python tick_columnar,
+        # Go tick_structs, server format.rs) nests a `contract` sub-dict.
+        # If a hypothetical producer started doing so, surfacing the
+        # divergence is safer than silently eliding it.
+        #
+        # Sub-dicts are preserved as empty dicts by _canonicalize_row;
+        # `{"contract": {"expiration": 0}}` -> `{"contract": {}}` which
+        # differs from `{}` (which flattens to `<root>: {}`).
+        _write_artifact(
+            self.artifacts,
+            "python",
+            [_base_record(
+                "option_history_ohlc", "concrete",
+                first_row={"contract": {"expiration": 0}},
+            )],
+        )
+        _write_artifact(
+            self.artifacts,
+            "go",
+            [_base_record("option_history_ohlc", "concrete", first_row={})],
+        )
+        for lang in ("cli", "cpp"):
+            _write_artifact(
+                self.artifacts,
+                lang,
+                [_base_record("option_history_ohlc", "concrete", first_row={})],
+            )
+        code, _, err = self._run()
+        self.assertEqual(
+            code, 1,
+            "container present (stripped-empty) vs container absent must disagree",
+        )
+        self.assertIn("contract", err)
+
 
 def _diff_section(text: str) -> str:
     """Return just the field-level diff rows, stripping headers / status

--- a/scripts/validate_cli.py
+++ b/scripts/validate_cli.py
@@ -448,47 +448,90 @@ creds = sys.argv[1]
 pass_count = skip_count = fail_count = 0
 records: list[dict] = []  # one record per cell for the agreement check
 
-def _json_row_count(output: str) -> int:
-    """Count top-level rows from the CLI's --format json response.
-
-    The CLI emits pretty-printed JSON (multi-line), so we parse the
-    whole stdout rather than just the last line. For list responses
-    returns len(list). For dict responses that look columnar (values
-    are lists), returns len of any column. For dict responses that
-    are a single object (e.g. calendar_open_today), returns 1.
-    Non-JSON output returns 0.
+def _parse_json(output: str):
+    """Parse the CLI's --format json-raw output, returning None on parse
+    failure. The CLI pretty-prints multi-line JSON so we can't slice off
+    the last line; walk the stripped output looking for the first `[`
+    or `{` and parse from there. Any preceding warning / progress lines
+    (e.g. tier-badge mismatches) are skipped over.
     """
     stripped = output.strip()
     if not stripped:
-        return 0
-    # The CLI may prefix with a warning / progress line before the JSON.
-    # Walk backwards through possible JSON start tokens to find the
-    # first that parses.
+        return None
     for start_token in ("[", "{"):
         idx = stripped.find(start_token)
         if idx == -1:
             continue
         try:
-            parsed = json.loads(stripped[idx:])
+            return json.loads(stripped[idx:])
         except json.JSONDecodeError:
             continue
-        if isinstance(parsed, list):
-            return len(parsed)
-        if isinstance(parsed, dict):
-            # Columnar dict: treat any list-valued column as the row
-            # vector. Keeps agreement with the Python SDK.
-            for v in parsed.values():
-                if isinstance(v, list):
-                    return len(v)
-            return 1
+    return None
+
+def _json_row_count(parsed) -> int:
+    """Row count from a parsed JSON value. Lists -> len. Columnar
+    dicts (any value is a list) -> len of any column (matches Python
+    SDK convention). Single-object dicts (e.g. calendar_open_today)
+    -> 1. Non-JSON / None -> 0.
+    """
+    if isinstance(parsed, list):
+        return len(parsed)
+    if isinstance(parsed, dict):
+        for v in parsed.values():
+            if isinstance(v, list):
+                return len(v)
+        return 1
     return 0
+
+def _canonicalize(value):
+    """Light producer-side canonicalization for first_row values:
+    lowercase dict keys, round floats to 6 decimals, recurse into dicts
+    and lists. The validator consumer (scripts/validate_agreement.py)
+    is the authoritative enforcer, so this is defense in depth; the
+    consumer also handles sentinels (date==0, ms<0, strike==0, right="")
+    and NaN/Inf, plus omit-equivalence stripping.
+    """
+    if isinstance(value, dict):
+        return {str(k).lower(): _canonicalize(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_canonicalize(v) for v in value]
+    if isinstance(value, float):
+        return round(value, 6)
+    return value
+
+def _extract_first_row(parsed):
+    """Return a canonicalized dict for the first row of the response,
+    or None if there's nothing to compare.
+
+      list of dicts -> first dict
+      columnar dict  -> one dict built from column[0] of each list column
+                        (matches how the Python SDK surfaces a single row)
+      single-object dict (calendar_open_today, etc.) -> the dict itself
+      anything else  -> None
+    """
+    if isinstance(parsed, list):
+        if not parsed:
+            return None
+        first = parsed[0]
+        return _canonicalize(first) if isinstance(first, dict) else None
+    if isinstance(parsed, dict):
+        columnar = {k: v for k, v in parsed.items() if isinstance(v, list)}
+        if columnar and all(len(v) > 0 for v in columnar.values()):
+            return _canonicalize({k: v[0] for k, v in columnar.items()})
+        if columnar:
+            return None
+        return _canonicalize(parsed)
+    return None
 
 for endpoint, mode, min_tier, rationale, argv in CELLS:
     label = f"{endpoint}::{mode}"
     t0 = time.monotonic()
     try:
         proc = subprocess.run(
-            [str(TDX), "--creds", creds, *argv, "--format", "json"],
+            # --format json-raw keeps dates as YYYYMMDD ints and ms_of_day as raw
+            # i32 ms so first_row matches the raw form Python/Go/C++ SDKs expose.
+            # See scripts/validate_agreement.py for the canonical contract.
+            [str(TDX), "--creds", creds, *argv, "--format", "json-raw"],
             cwd=REPO,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -509,10 +552,13 @@ for endpoint, mode, min_tier, rationale, argv in CELLS:
     output = (proc.stdout or b"").decode("utf-8", errors="replace")
     msg = output.lower()
     row_count = 0
+    first_row = None
     status: str
     detail: str = ""
     if proc.returncode == 0:
-        row_count = _json_row_count(output)
+        parsed = _parse_json(output)
+        row_count = _json_row_count(parsed)
+        first_row = _extract_first_row(parsed)
         status = "PASS"
         print(f"  {label:60s} PASS")
         pass_count += 1
@@ -534,11 +580,14 @@ for endpoint, mode, min_tier, rationale, argv in CELLS:
         detail = output.strip().replace("\n", "\\n").replace("\r", "\\r")[:200]
         print(f"  {label:60s} FAIL  {output.strip()}")
         fail_count += 1
-    records.append({
+    record = {
         "endpoint": endpoint, "mode": mode, "rationale": rationale,
         "status": status,
         "row_count": row_count, "duration_ms": duration_ms, "detail": detail,
-    })
+    }
+    if first_row is not None:
+        record["first_row"] = first_row
+    records.append(record)
 
 print(f"\nCLI: {pass_count} PASS, {skip_count} SKIP, {fail_count} FAIL")
 print(f"COUNTS:{pass_count}:{skip_count}:{fail_count}")

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -44,8 +44,13 @@ fn build_cli() -> Command {
                 .long("format")
                 .global(true)
                 .default_value("table")
-                .value_parser(["table", "json", "csv"])
-                .help("Output format"),
+                .value_parser(["table", "json", "json-raw", "csv"])
+                .help(
+                    "Output format. `json-raw` emits dates as YYYYMMDD ints and \
+                     ms_of_day as raw i32 ms (vs `json` which presentation-formats \
+                     them); consumed by scripts/validate_agreement.py for \
+                     cross-language agreement checks.",
+                ),
         );
 
     app = add_generated_utility_commands(app);
@@ -137,6 +142,14 @@ include!("utilities.rs");
 enum OutputFormat {
     Table,
     Json,
+    /// Same schema as `Json` but fields keep their raw numeric form: dates
+    /// stay as YYYYMMDD ints (not `"YYYY-MM-DD"` strings), ms-of-day stays
+    /// as raw i32 ms (not `"HH:MM:SS.mmm"`), and prices stay as unformatted
+    /// f64 (not `"685.860000"` strings). Consumed by
+    /// `scripts/validate_agreement.py` so cross-language agreement doesn't
+    /// get false diffs on presentation formatting. Renderers that don't
+    /// populate a raw parallel row fall back to `Json` behavior.
+    JsonRaw,
     Csv,
 }
 
@@ -144,6 +157,7 @@ impl OutputFormat {
     fn from_str(s: &str) -> Self {
         match s {
             "json" => Self::Json,
+            "json-raw" => Self::JsonRaw,
             "csv" => Self::Csv,
             _ => Self::Table,
         }
@@ -203,9 +217,26 @@ fn format_date(date: i32) -> String {
 // ═══════════════════════════════════════════════════════════════════════════
 
 /// A row-oriented data structure that all output formatters consume.
+///
+/// Carries two independent header/row pairs:
+/// * `headers` + `rows` — presentation layer. CLI-friendly aliases
+///   (`time` for ms-of-day, `iv` for implied_volatility, dropped contract-id
+///   columns when the tick isn't an option) drive `--format table | json | csv`.
+/// * `raw_headers` + `raw_rows` — canonical SDK schema. Field names match
+///   `sdks/python/src/tick_columnar.rs` exactly so `scripts/validate_agreement.py`
+///   can compare CLI `first_row` against Python / Go / server cell-by-cell
+///   without renaming surgery. Populated only by tick renderers via
+///   `push_with_raw`; non-tick renderers leave it empty and `--format json-raw`
+///   falls back to the string-reparse path.
+///
+/// The two header lists CAN differ in length and ordering. The presentation
+/// row is what humans read; the raw row is what cross-language agreement
+/// compares against.
 struct TabularData {
     headers: Vec<String>,
     rows: Vec<Vec<String>>,
+    raw_headers: Vec<String>,
+    raw_rows: Vec<Vec<sonic_rs::Value>>,
 }
 
 impl TabularData {
@@ -216,6 +247,8 @@ impl TabularData {
                 .map(std::string::ToString::to_string)
                 .collect(),
             rows: Vec::new(),
+            raw_headers: Vec::new(),
+            raw_rows: Vec::new(),
         }
     }
 
@@ -223,10 +256,39 @@ impl TabularData {
         self.rows.push(row);
     }
 
+    /// Set the canonical-schema headers used by `--format json-raw`.
+    /// Field names must exactly match the canonical SDK schema (i.e.
+    /// `sdks/python/src/tick_columnar.rs`) so the cross-language
+    /// agreement check doesn't false-diff on field-name disagreements.
+    fn set_raw_headers(&mut self, headers: Vec<&str>) {
+        self.raw_headers = headers
+            .into_iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+    }
+
+    /// Push a presentation row alongside its canonical-schema raw row.
+    /// `row` matches `headers` (presentation columns, length-equal). `raw`
+    /// matches `raw_headers` (canonical SDK columns, length-equal). The
+    /// two vectors are independent — CLI presentation drops contract-id
+    /// columns when the tick isn't an option, but the raw row always
+    /// carries the full canonical schema.
+    fn push_with_raw(&mut self, row: Vec<String>, raw: Vec<sonic_rs::Value>) {
+        debug_assert_eq!(row.len(), self.headers.len(), "row length mismatch");
+        debug_assert_eq!(
+            raw.len(),
+            self.raw_headers.len(),
+            "raw row length mismatch -- did you forget set_raw_headers?",
+        );
+        self.rows.push(row);
+        self.raw_rows.push(raw);
+    }
+
     fn render(&self, fmt: &OutputFormat) {
         match fmt {
             OutputFormat::Table => self.render_table(),
             OutputFormat::Json => self.render_json(),
+            OutputFormat::JsonRaw => self.render_json_raw(),
             OutputFormat::Csv => self.render_csv(),
         }
     }
@@ -289,6 +351,36 @@ impl TabularData {
         );
     }
 
+    /// Emit the canonical JSON form consumed by scripts/validate_agreement.py.
+    ///
+    /// Uses `raw_headers` (canonical SDK schema, matching
+    /// `sdks/python/src/tick_columnar.rs`) and `raw_rows` (raw values, no
+    /// presentation formatting). When the renderer didn't populate raw
+    /// data (non-tick subcommands), falls back to `render_json` so this
+    /// never silently emits stale data.
+    fn render_json_raw(&self) {
+        if self.raw_rows.is_empty() || self.raw_headers.is_empty() {
+            self.render_json();
+            return;
+        }
+        let arr: Vec<sonic_rs::Value> = self
+            .raw_rows
+            .iter()
+            .map(|row| {
+                let mut obj = sonic_rs::Object::new();
+                for (i, h) in self.raw_headers.iter().enumerate() {
+                    let val = row.get(i).cloned().unwrap_or(sonic_rs::Value::new_null());
+                    obj.insert(&h, val);
+                }
+                sonic_rs::Value::from(obj)
+            })
+            .collect();
+        println!(
+            "{}",
+            sonic_rs::to_string_pretty(&arr).unwrap_or_else(|_| "[]".into())
+        );
+    }
+
     fn render_csv(&self) {
         println!("{}", self.headers.join(","));
         for row in &self.rows {
@@ -336,6 +428,69 @@ async fn connect(
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+//  Raw-value helpers for json-raw output
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// These build `sonic_rs::Value` directly from the raw tick struct fields so
+// the cross-language agreement check can compare apples-to-apples with the
+// Python / Go / C++ SDKs, which expose raw ints for dates and ms-of-day. See
+// scripts/validate_agreement.py for the canonical contract.
+//
+// Sentinel semantics (`date == 0`, `ms_of_day < 0`) are preserved verbatim
+// here -- Python (sdks/python/src/tick_columnar.rs) and Go (sdks/go/tick_structs.go)
+// emit those same sentinels as raw ints, and the server emitter
+// (tools/server/src/format.rs:346) does too. Normalization to `null` lives
+// entirely on the consumer side in scripts/validate_agreement.py so all
+// producers can stay stupid-simple passthroughs and the agreement check has
+// one authoritative canonicalization rule. If this side mapped `0 -> null`,
+// it would silently disagree with every other producer.
+
+/// Raw YYYYMMDD int. `0` passes through verbatim; consumer-side
+/// canonicalization in validate_agreement.py normalizes it to null for
+/// comparison with SDKs that legitimately emit `0` as a sentinel.
+fn raw_date(date: i32) -> sonic_rs::Value {
+    sonic_rs::Value::from(sonic_rs::Number::from(date))
+}
+
+/// Raw milliseconds-since-midnight int. Negative values pass through
+/// verbatim; consumer-side canonicalization normalizes them to null for
+/// cross-language agreement.
+fn raw_ms(ms: i32) -> sonic_rs::Value {
+    sonic_rs::Value::from(sonic_rs::Number::from(ms))
+}
+
+/// Non-finite f64 -> JSON null. JSON itself rejects NaN / +Inf / -Inf in
+/// standards-compliant encoders, so we must collapse here or serialization
+/// fails. Matches validator's canonicalization rule.
+fn raw_f64(value: f64) -> sonic_rs::Value {
+    sonic_rs::Number::from_f64(value).map_or_else(sonic_rs::Value::new_null, sonic_rs::Value::from)
+}
+
+/// Raw integer value as JSON number.
+fn raw_i32(value: i32) -> sonic_rs::Value {
+    sonic_rs::Value::from(sonic_rs::Number::from(value))
+}
+
+/// Raw string (tick fields like `OptionContract::root`).
+fn raw_str(value: &str) -> sonic_rs::Value {
+    sonic_rs::Value::from(value)
+}
+
+/// Canonical `right` representation for tick types (NOT `OptionContract`).
+/// Matches `sdks/python/src/tick_columnar.rs` (`"C"` / `"P"` / `""`) and
+/// `sdks/go/tick_structs.go` `RightStr` (same mapping). Server uses the
+/// same mapping for the option-tick contract-id helper.
+fn raw_right_label(is_call: bool, is_put: bool) -> sonic_rs::Value {
+    if is_call {
+        sonic_rs::Value::from("C")
+    } else if is_put {
+        sonic_rs::Value::from("P")
+    } else {
+        sonic_rs::Value::from("")
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 //  Tick rendering helpers — reduce repetition across subcommands
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -359,26 +514,76 @@ fn render_eod(ticks: &[tdbe::types::tick::EodTick], fmt: &OutputFormat) {
         "ask",
         "ask_condition",
     ]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:21-64
+    // (eod_ticks_to_columnar): ms_of_day, ms_of_day2, open, high, low, close,
+    // volume, count, bid_size, bid_exchange, bid, bid_condition, ask_size,
+    // ask_exchange, ask, ask_condition, date, expiration, strike, right.
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "ms_of_day2",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "count",
+        "bid_size",
+        "bid_exchange",
+        "bid",
+        "bid_condition",
+        "ask_size",
+        "ask_exchange",
+        "ask",
+        "ask_condition",
+        "date",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format_ms(t.ms_of_day2),
-            format_price_f64(t.open),
-            format_price_f64(t.high),
-            format_price_f64(t.low),
-            format_price_f64(t.close),
-            format!("{}", t.volume),
-            format!("{}", t.count),
-            format!("{}", t.bid_size),
-            format!("{}", t.bid_exchange),
-            format_price_f64(t.bid),
-            format!("{}", t.bid_condition),
-            format!("{}", t.ask_size),
-            format!("{}", t.ask_exchange),
-            format_price_f64(t.ask),
-            format!("{}", t.ask_condition),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format_ms(t.ms_of_day2),
+                format_price_f64(t.open),
+                format_price_f64(t.high),
+                format_price_f64(t.low),
+                format_price_f64(t.close),
+                format!("{}", t.volume),
+                format!("{}", t.count),
+                format!("{}", t.bid_size),
+                format!("{}", t.bid_exchange),
+                format_price_f64(t.bid),
+                format!("{}", t.bid_condition),
+                format!("{}", t.ask_size),
+                format!("{}", t.ask_exchange),
+                format_price_f64(t.ask),
+                format!("{}", t.ask_condition),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_ms(t.ms_of_day2),
+                raw_f64(t.open),
+                raw_f64(t.high),
+                raw_f64(t.low),
+                raw_f64(t.close),
+                raw_i32(t.volume),
+                raw_i32(t.count),
+                raw_i32(t.bid_size),
+                raw_i32(t.bid_exchange),
+                raw_f64(t.bid),
+                raw_i32(t.bid_condition),
+                raw_i32(t.ask_size),
+                raw_i32(t.ask_exchange),
+                raw_f64(t.ask),
+                raw_i32(t.ask_condition),
+                raw_date(t.date),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
@@ -387,17 +592,47 @@ fn render_ohlc(ticks: &[tdbe::types::tick::OhlcTick], fmt: &OutputFormat) {
     let mut td = TabularData::new(vec![
         "date", "time", "open", "high", "low", "close", "volume", "count",
     ]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:176-201
+    // (ohlc_ticks_to_columnar).
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "count",
+        "date",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format_price_f64(t.open),
-            format_price_f64(t.high),
-            format_price_f64(t.low),
-            format_price_f64(t.close),
-            format!("{}", t.volume),
-            format!("{}", t.count),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format_price_f64(t.open),
+                format_price_f64(t.high),
+                format_price_f64(t.low),
+                format_price_f64(t.close),
+                format!("{}", t.volume),
+                format!("{}", t.count),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_f64(t.open),
+                raw_f64(t.high),
+                raw_f64(t.low),
+                raw_f64(t.close),
+                raw_i32(t.volume),
+                raw_i32(t.count),
+                raw_date(t.date),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
@@ -412,16 +647,62 @@ fn render_trades(ticks: &[tdbe::types::tick::TradeTick], fmt: &OutputFormat) {
         "condition",
         "sequence",
     ]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:336-374
+    // (trade_ticks_to_columnar). Adds ext_condition1-4, condition_flags,
+    // price_flags, volume_type, records_back fields the CLI presentation
+    // table doesn't surface but the SDKs do.
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "sequence",
+        "ext_condition1",
+        "ext_condition2",
+        "ext_condition3",
+        "ext_condition4",
+        "condition",
+        "size",
+        "exchange",
+        "price",
+        "condition_flags",
+        "price_flags",
+        "volume_type",
+        "records_back",
+        "date",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format_price_f64(t.price),
-            format!("{}", t.size),
-            format!("{}", t.exchange),
-            format!("{}", t.condition),
-            format!("{}", t.sequence),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format_price_f64(t.price),
+                format!("{}", t.size),
+                format!("{}", t.exchange),
+                format!("{}", t.condition),
+                format!("{}", t.sequence),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_i32(t.sequence),
+                raw_i32(t.ext_condition1),
+                raw_i32(t.ext_condition2),
+                raw_i32(t.ext_condition3),
+                raw_i32(t.ext_condition4),
+                raw_i32(t.condition),
+                raw_i32(t.size),
+                raw_i32(t.exchange),
+                raw_f64(t.price),
+                raw_i32(t.condition_flags),
+                raw_i32(t.price_flags),
+                raw_i32(t.volume_type),
+                raw_i32(t.records_back),
+                raw_date(t.date),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
@@ -439,19 +720,56 @@ fn render_quotes(ticks: &[tdbe::types::tick::QuoteTick], fmt: &OutputFormat) {
         "ask",
         "ask_condition",
     ]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:244-275
+    // (quote_ticks_to_columnar). Includes `midpoint` field that the CLI
+    // presentation table doesn't surface.
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "bid_size",
+        "bid_exchange",
+        "bid",
+        "bid_condition",
+        "ask_size",
+        "ask_exchange",
+        "ask",
+        "ask_condition",
+        "date",
+        "midpoint",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format!("{}", t.bid_size),
-            format!("{}", t.bid_exchange),
-            format_price_f64(t.bid),
-            format!("{}", t.bid_condition),
-            format!("{}", t.ask_size),
-            format!("{}", t.ask_exchange),
-            format_price_f64(t.ask),
-            format!("{}", t.ask_condition),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format!("{}", t.bid_size),
+                format!("{}", t.bid_exchange),
+                format_price_f64(t.bid),
+                format!("{}", t.bid_condition),
+                format!("{}", t.ask_size),
+                format!("{}", t.ask_exchange),
+                format_price_f64(t.ask),
+                format!("{}", t.ask_condition),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_i32(t.bid_size),
+                raw_i32(t.bid_exchange),
+                raw_f64(t.bid),
+                raw_i32(t.bid_condition),
+                raw_i32(t.ask_size),
+                raw_i32(t.ask_exchange),
+                raw_f64(t.ask),
+                raw_i32(t.ask_condition),
+                raw_date(t.date),
+                raw_f64(t.midpoint),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
@@ -479,33 +797,118 @@ fn render_trade_quotes(ticks: &[tdbe::types::tick::TradeQuoteTick], fmt: &Output
         "ask",
         "ask_size",
     ]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:277-334
+    // (trade_quote_ticks_to_columnar). Adds ext_condition1-4,
+    // condition_flags, price_flags, volume_type, records_back,
+    // bid_exchange, bid_condition, ask_exchange, ask_condition fields
+    // the CLI presentation table doesn't surface.
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "sequence",
+        "ext_condition1",
+        "ext_condition2",
+        "ext_condition3",
+        "ext_condition4",
+        "condition",
+        "size",
+        "exchange",
+        "price",
+        "condition_flags",
+        "price_flags",
+        "volume_type",
+        "records_back",
+        "quote_ms_of_day",
+        "bid_size",
+        "bid_exchange",
+        "bid",
+        "bid_condition",
+        "ask_size",
+        "ask_exchange",
+        "ask",
+        "ask_condition",
+        "date",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format_price_f64(t.price),
-            format!("{}", t.size),
-            format!("{}", t.exchange),
-            format!("{}", t.condition),
-            format!("{}", t.sequence),
-            format_ms(t.quote_ms_of_day),
-            format_price_f64(t.bid),
-            format!("{}", t.bid_size),
-            format_price_f64(t.ask),
-            format!("{}", t.ask_size),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format_price_f64(t.price),
+                format!("{}", t.size),
+                format!("{}", t.exchange),
+                format!("{}", t.condition),
+                format!("{}", t.sequence),
+                format_ms(t.quote_ms_of_day),
+                format_price_f64(t.bid),
+                format!("{}", t.bid_size),
+                format_price_f64(t.ask),
+                format!("{}", t.ask_size),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_i32(t.sequence),
+                raw_i32(t.ext_condition1),
+                raw_i32(t.ext_condition2),
+                raw_i32(t.ext_condition3),
+                raw_i32(t.ext_condition4),
+                raw_i32(t.condition),
+                raw_i32(t.size),
+                raw_i32(t.exchange),
+                raw_f64(t.price),
+                raw_i32(t.condition_flags),
+                raw_i32(t.price_flags),
+                raw_i32(t.volume_type),
+                raw_i32(t.records_back),
+                raw_ms(t.quote_ms_of_day),
+                raw_i32(t.bid_size),
+                raw_i32(t.bid_exchange),
+                raw_f64(t.bid),
+                raw_i32(t.bid_condition),
+                raw_i32(t.ask_size),
+                raw_i32(t.ask_exchange),
+                raw_f64(t.ask),
+                raw_i32(t.ask_condition),
+                raw_date(t.date),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
 
 fn render_open_interest(ticks: &[tdbe::types::tick::OpenInterestTick], fmt: &OutputFormat) {
     let mut td = TabularData::new(vec!["date", "ms_of_day", "open_interest"]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:203-218
+    // (open_interest_ticks_to_columnar).
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "open_interest",
+        "date",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format!("{}", t.open_interest),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format!("{}", t.open_interest),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_i32(t.open_interest),
+                raw_date(t.date),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
@@ -518,14 +921,38 @@ fn render_market_value(ticks: &[tdbe::types::tick::MarketValueTick], fmt: &Outpu
         "market_ask",
         "market_price",
     ]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:155-174
+    // (market_value_ticks_to_columnar).
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "market_bid",
+        "market_ask",
+        "market_price",
+        "date",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format!("{:.4}", t.market_bid),
-            format!("{:.4}", t.market_ask),
-            format!("{:.4}", t.market_price),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format!("{:.4}", t.market_bid),
+                format!("{:.4}", t.market_ask),
+                format!("{:.4}", t.market_price),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_f64(t.market_bid),
+                raw_f64(t.market_ask),
+                raw_f64(t.market_price),
+                raw_date(t.date),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
@@ -557,97 +984,220 @@ fn render_greeks(ticks: &[tdbe::types::tick::GreeksTick], fmt: &OutputFormat) {
         "lambda",
         "vera",
     ]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:66-123
+    // (greeks_ticks_to_columnar). Note `implied_volatility` (not the CLI
+    // presentation alias `iv`).
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "implied_volatility",
+        "delta",
+        "gamma",
+        "theta",
+        "vega",
+        "rho",
+        "iv_error",
+        "vanna",
+        "charm",
+        "vomma",
+        "veta",
+        "speed",
+        "zomma",
+        "color",
+        "ultima",
+        "d1",
+        "d2",
+        "dual_delta",
+        "dual_gamma",
+        "epsilon",
+        "lambda",
+        "vera",
+        "date",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format!("{:.6}", t.implied_volatility),
-            format!("{:.6}", t.delta),
-            format!("{:.6}", t.gamma),
-            format!("{:.6}", t.theta),
-            format!("{:.6}", t.vega),
-            format!("{:.6}", t.rho),
-            format!("{:.6}", t.iv_error),
-            format!("{:.6}", t.vanna),
-            format!("{:.6}", t.charm),
-            format!("{:.6}", t.vomma),
-            format!("{:.6}", t.veta),
-            format!("{:.6}", t.speed),
-            format!("{:.6}", t.zomma),
-            format!("{:.6}", t.color),
-            format!("{:.6}", t.ultima),
-            format!("{:.6}", t.d1),
-            format!("{:.6}", t.d2),
-            format!("{:.6}", t.dual_delta),
-            format!("{:.6}", t.dual_gamma),
-            format!("{:.6}", t.epsilon),
-            format!("{:.6}", t.lambda),
-            format!("{:.6}", t.vera),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format!("{:.6}", t.implied_volatility),
+                format!("{:.6}", t.delta),
+                format!("{:.6}", t.gamma),
+                format!("{:.6}", t.theta),
+                format!("{:.6}", t.vega),
+                format!("{:.6}", t.rho),
+                format!("{:.6}", t.iv_error),
+                format!("{:.6}", t.vanna),
+                format!("{:.6}", t.charm),
+                format!("{:.6}", t.vomma),
+                format!("{:.6}", t.veta),
+                format!("{:.6}", t.speed),
+                format!("{:.6}", t.zomma),
+                format!("{:.6}", t.color),
+                format!("{:.6}", t.ultima),
+                format!("{:.6}", t.d1),
+                format!("{:.6}", t.d2),
+                format!("{:.6}", t.dual_delta),
+                format!("{:.6}", t.dual_gamma),
+                format!("{:.6}", t.epsilon),
+                format!("{:.6}", t.lambda),
+                format!("{:.6}", t.vera),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_f64(t.implied_volatility),
+                raw_f64(t.delta),
+                raw_f64(t.gamma),
+                raw_f64(t.theta),
+                raw_f64(t.vega),
+                raw_f64(t.rho),
+                raw_f64(t.iv_error),
+                raw_f64(t.vanna),
+                raw_f64(t.charm),
+                raw_f64(t.vomma),
+                raw_f64(t.veta),
+                raw_f64(t.speed),
+                raw_f64(t.zomma),
+                raw_f64(t.color),
+                raw_f64(t.ultima),
+                raw_f64(t.d1),
+                raw_f64(t.d2),
+                raw_f64(t.dual_delta),
+                raw_f64(t.dual_gamma),
+                raw_f64(t.epsilon),
+                raw_f64(t.lambda),
+                raw_f64(t.vera),
+                raw_date(t.date),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
 
 fn render_iv(ticks: &[tdbe::types::tick::IvTick], fmt: &OutputFormat) {
     let mut td = TabularData::new(vec!["date", "ms_of_day", "implied_volatility", "iv_error"]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:136-153
+    // (iv_ticks_to_columnar).
+    td.set_raw_headers(vec![
+        "ms_of_day",
+        "implied_volatility",
+        "iv_error",
+        "date",
+        "expiration",
+        "strike",
+        "right",
+    ]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format!("{:.6}", t.implied_volatility),
-            format!("{:.6}", t.iv_error),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format!("{:.6}", t.implied_volatility),
+                format!("{:.6}", t.iv_error),
+            ],
+            vec![
+                raw_ms(t.ms_of_day),
+                raw_f64(t.implied_volatility),
+                raw_f64(t.iv_error),
+                raw_date(t.date),
+                raw_i32(t.expiration),
+                raw_f64(t.strike),
+                raw_right_label(t.is_call(), t.is_put()),
+            ],
+        );
     }
     td.render(fmt);
 }
 
 fn render_price(ticks: &[tdbe::types::tick::PriceTick], fmt: &OutputFormat) {
     let mut td = TabularData::new(vec!["date", "ms_of_day", "price"]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:233-242
+    // (price_ticks_to_columnar). PriceTick has no contract-id fields.
+    td.set_raw_headers(vec!["ms_of_day", "price", "date"]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format_price_f64(t.price),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format_price_f64(t.price),
+            ],
+            vec![raw_ms(t.ms_of_day), raw_f64(t.price), raw_date(t.date)],
+        );
     }
     td.render(fmt);
 }
 
 fn render_calendar(days: &[tdbe::types::tick::CalendarDay], fmt: &OutputFormat) {
     let mut td = TabularData::new(vec!["date", "is_open", "open_time", "close_time", "status"]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:6-19
+    // (calendar_days_to_columnar). is_open is i32 (matches Python columnar
+    // form, not the Go bool projection).
+    td.set_raw_headers(vec!["date", "is_open", "open_time", "close_time", "status"]);
     for d in days {
-        td.push(vec![
-            format_date(d.date),
-            format!("{}", d.is_open),
-            format_ms(d.open_time),
-            format_ms(d.close_time),
-            format!("{}", d.status),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(d.date),
+                format!("{}", d.is_open),
+                format_ms(d.open_time),
+                format_ms(d.close_time),
+                format!("{}", d.status),
+            ],
+            vec![
+                raw_date(d.date),
+                raw_i32(d.is_open),
+                raw_ms(d.open_time),
+                raw_ms(d.close_time),
+                raw_i32(d.status),
+            ],
+        );
     }
     td.render(fmt);
 }
 
 fn render_interest_rates(ticks: &[tdbe::types::tick::InterestRateTick], fmt: &OutputFormat) {
     let mut td = TabularData::new(vec!["date", "ms_of_day", "rate"]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:125-134
+    // (interest_rate_ticks_to_columnar).
+    td.set_raw_headers(vec!["ms_of_day", "rate", "date"]);
     for t in ticks {
-        td.push(vec![
-            format_date(t.date),
-            format_ms(t.ms_of_day),
-            format!("{:.6}", t.rate),
-        ]);
+        td.push_with_raw(
+            vec![
+                format_date(t.date),
+                format_ms(t.ms_of_day),
+                format!("{:.6}", t.rate),
+            ],
+            vec![raw_ms(t.ms_of_day), raw_f64(t.rate), raw_date(t.date)],
+        );
     }
     td.render(fmt);
 }
 
 fn render_option_contracts(contracts: &[tdbe::types::tick::OptionContract], fmt: &OutputFormat) {
     let mut td = TabularData::new(vec!["root", "expiration", "strike", "right"]);
+    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:220-231
+    // (option_contracts_to_columnar). Note: Python emits `right` as a raw
+    // i32 here (NOT the "C"/"P"/"" string mapping used for tick types),
+    // because OptionContract carries the raw upstream code.
+    td.set_raw_headers(vec!["root", "expiration", "strike", "right"]);
     for c in contracts {
-        td.push(vec![
-            c.root.clone(),
-            format!("{}", c.expiration),
-            format_price_f64(c.strike),
-            format!("{}", c.right),
-        ]);
+        td.push_with_raw(
+            vec![
+                c.root.clone(),
+                format!("{}", c.expiration),
+                format_price_f64(c.strike),
+                format!("{}", c.right),
+            ],
+            vec![
+                raw_str(&c.root),
+                raw_date(c.expiration),
+                raw_f64(c.strike),
+                raw_i32(c.right),
+            ],
+        );
     }
     td.render(fmt);
 }
@@ -754,4 +1304,112 @@ async fn run(matches: ArgMatches) -> Result<(), thetadatadx::Error> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{raw_date, raw_f64, raw_i32, raw_ms, raw_right_label, OutputFormat, TabularData};
+    use sonic_rs::JsonValueTrait;
+
+    #[test]
+    fn json_raw_format_parses_from_string() {
+        assert!(matches!(
+            OutputFormat::from_str("json-raw"),
+            OutputFormat::JsonRaw
+        ));
+        assert!(matches!(OutputFormat::from_str("json"), OutputFormat::Json));
+        assert!(matches!(OutputFormat::from_str("csv"), OutputFormat::Csv));
+        assert!(matches!(
+            OutputFormat::from_str("table"),
+            OutputFormat::Table
+        ));
+        assert!(matches!(
+            OutputFormat::from_str("unknown"),
+            OutputFormat::Table
+        ));
+    }
+
+    #[test]
+    fn raw_date_passes_through_sentinel() {
+        // `0` is a sentinel for "no date" but we pass it through verbatim.
+        // Python/Go SDKs emit `0` as raw i32 too; normalizing to null here
+        // would silently disagree with them. The validator consumer
+        // canonicalizes both shapes to None for comparison.
+        assert!(raw_date(0).is_number());
+        assert!(raw_date(20260417).is_number());
+    }
+
+    #[test]
+    fn raw_ms_passes_through_sentinel() {
+        // Negative ms is a sentinel for "missing" but we pass it through
+        // verbatim to match Python/Go SDK behavior. Consumer-side
+        // canonicalization collapses it to None for agreement checks.
+        assert!(raw_ms(-1).is_number());
+        assert!(raw_ms(0).is_number());
+        assert!(raw_ms(34_200_000).is_number());
+    }
+
+    #[test]
+    fn raw_f64_non_finite_is_null() {
+        assert!(raw_f64(f64::NAN).is_null());
+        assert!(raw_f64(f64::INFINITY).is_null());
+        assert!(raw_f64(f64::NEG_INFINITY).is_null());
+        assert!(!raw_f64(0.0).is_null());
+        assert!(!raw_f64(685.86).is_null());
+    }
+
+    #[test]
+    fn tabular_data_push_with_raw_stores_both() {
+        let mut td = TabularData::new(vec!["date", "price"]);
+        td.set_raw_headers(vec!["date", "price"]);
+        td.push_with_raw(
+            vec!["2026-04-17".into(), "685.860000".into()],
+            vec![raw_date(20260417), raw_f64(685.86)],
+        );
+        assert_eq!(td.rows.len(), 1);
+        assert_eq!(td.raw_rows.len(), 1);
+        assert_eq!(td.rows[0][0], "2026-04-17");
+        assert!(td.raw_rows[0][0].is_number());
+    }
+
+    #[test]
+    fn tabular_data_independent_presentation_and_raw_schemas() {
+        // The presentation row (`time`, dropped contract-id) and the raw
+        // row (canonical `ms_of_day`, full contract-id) can have different
+        // lengths and field orderings. push_with_raw enforces row==headers
+        // and raw==raw_headers length-equality.
+        let mut td = TabularData::new(vec!["date", "time", "price"]);
+        td.set_raw_headers(vec![
+            "ms_of_day",
+            "price",
+            "date",
+            "expiration",
+            "strike",
+            "right",
+        ]);
+        td.push_with_raw(
+            vec!["2026-04-17".into(), "09:30:00.000".into(), "5.42".into()],
+            vec![
+                raw_ms(34_200_000),
+                raw_f64(5.42),
+                raw_date(20260417),
+                raw_i32(20260321),
+                raw_f64(570.0),
+                raw_right_label(true, false),
+            ],
+        );
+        assert_eq!(td.headers.len(), 3);
+        assert_eq!(td.raw_headers.len(), 6);
+        assert_eq!(td.raw_rows[0].len(), 6);
+        assert_eq!(td.raw_headers[0], "ms_of_day"); // canonical, not "time"
+    }
+
+    #[test]
+    fn raw_right_label_matches_python_string_mapping() {
+        // Mirrors sdks/python/src/tick_columnar.rs:41 ("C" / "P" / "")
+        // and Go RightStr at sdks/go/tick_structs.go:215.
+        assert_eq!(raw_right_label(true, false).as_str(), Some("C"));
+        assert_eq!(raw_right_label(false, true).as_str(), Some("P"));
+        assert_eq!(raw_right_label(false, false).as_str(), Some(""));
+    }
 }


### PR DESCRIPTION
Closes #292. Follow-up to #290 / PR #291.

## Summary

- Rewrite `scripts/validate_agreement.py` to emit per-cell, per-field disagreement tables instead of a status + row_count summary.
- Introduce optional `first_row` dict on each SDK artifact record (canonicalized: keys lowercased, floats rounded to 6 decimals, recursive). When present, the diff engine walks it field-by-field; when absent, it falls back to row_count comparison. Lets SDKs adopt one at a time.
- Populate `first_row` in the CLI validator now (easiest — CLI already emits JSON). Python/Go/C++ emitter updates are separate follow-ups and don't block this diff-engine change.
- Add `scripts/validate_agreement_test.py`: 10 synthetic tests covering status disagreement, row_count disagreement, field-level first_row diff (including nested dict + list), float-precision tolerance, missing fields, partial cells, and `--require-all-sdks`. Runs in CI with zero deps.

## Sample output

Given four mock artifacts where Go's `bid` is 1 cent high and Python FAILed one endpoint, the new output is:

```
DISAGREEMENTS:

  option_snapshot_trade::concrete  [status disagreement]
    sdk      | status   | rows     | detail
    -------------------------------------------------------------------------
    cli      | PASS     | 1        |
    cpp      | PASS     | 1        |
    go       | PASS     | 1        |
    python   | FAIL     | 0        | wire-format error: unexpected tick kind

  stock_snapshot_quote::concrete  [first_row disagreement]
    sdk      | status   | rows     | detail
    -------------------------------------------------------------------------
    cli      | PASS     | 1        |
    cpp      | PASS     | 1        |
    go       | PASS     | 1        |
    python   | PASS     | 1        |

    field-level diff:
    field                            | cli                  | cpp                  | go                   | python
    ----------------------------------------------------------------------------------------------------------------------------
    bid                              | 685.860000           | 685.860000           | 685.870000           | 685.860000

agreement: 2 cells across 4 SDKs, 2 disagreements, 0 cells partial
```

Agreement case prints a single `✓ N cells agree across {cli, cpp, go, python}` line.

## Changes to the artifact format

Backward-compatible. `first_row` is a new optional key on the record object; absent from existing artifacts means the old row_count-only comparison path is used. CLI artifact is the only SDK that populates it in this PR; the other three continue to emit records without it and participate via the row_count + status path.

```json
{
  "endpoint": "stock_snapshot_quote",
  "mode": "concrete",
  "status": "PASS",
  "row_count": 1,
  "duration_ms": 120,
  "detail": "",
  "first_row": { "bid": 685.86, "ask": 685.88, ... }   // new, optional
}
```

## Test plan

- [x] `python3 scripts/validate_agreement_test.py` → 10/10 pass, covering status / row_count / first_row / nested structure / float tolerance / missing-field / partial-cell / require-all-sdks.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check` (no drift after regenerating `scripts/validate_cli.py`)
- [x] `python3 scripts/check_docs_consistency.py`
- [ ] Live matrix CI (runs on merge with creds; downstream of the deferred Python/Go/C++ emitter follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)