### PR TITLE
refactor(ssot): move test-mode fixtures from Rust to TOML (W1)

### DIFF
--- a/crates/thetadatadx/build_support/endpoints/helpers.rs
+++ b/crates/thetadatadx/build_support/endpoints/helpers.rs
@@ -757,17 +757,6 @@ pub(super) fn cpp_builder_setter(
 
 // ───────────────────────── CLI / validator scaffolding ─────────────────────
 
-/// Map a `param_type` from the endpoint surface to a dummy value for Python validation.
-pub(super) fn validation_symbol(endpoint: &GeneratedEndpoint) -> &'static str {
-    match endpoint.category.as_str() {
-        "stock" => "AAPL",
-        "option" => "SPY",
-        "index" => "SPX",
-        "rate" => "SOFR",
-        other => panic!("unsupported validation endpoint category: {other}"),
-    }
-}
-
 pub(super) fn cli_command_name(endpoint: &GeneratedEndpoint) -> String {
     match endpoint.category.as_str() {
         "stock" | "option" | "index" | "calendar" => endpoint

--- a/crates/thetadatadx/build_support/endpoints/model.rs
+++ b/crates/thetadatadx/build_support/endpoints/model.rs
@@ -22,6 +22,33 @@ pub(super) struct SurfaceSpec {
     #[serde(default)]
     pub(super) templates: HashMap<String, SurfaceTemplate>,
     pub(super) endpoints: Vec<SurfaceEndpoint>,
+    pub(super) test_fixtures: SurfaceTestFixtures,
+}
+
+/// Representative fixture values feeding the live-validator parameter-mode
+/// matrix. Split so every hardcoded value in the Rust generator maps to a
+/// single TOML row.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct SurfaceTestFixtures {
+    /// Anchor symbol per endpoint category. Feeds `Symbol`/`Symbols` fixtures.
+    pub(super) category_symbol: HashMap<String, String>,
+    /// Concrete (no-wildcard) fixture keyed on the wire `param_type`. Covers
+    /// everything except `Symbol`/`Symbols`, which route through
+    /// `category_symbol`.
+    pub(super) concrete_by_type: HashMap<String, String>,
+    /// Per-param-name overrides that beat `concrete_by_type` matching (e.g.
+    /// the compressed `end_date` that keeps bulk cells inside the 60s
+    /// per-cell timeout). See issue #290.
+    #[serde(default)]
+    pub(super) concrete_overrides: HashMap<String, String>,
+    /// Per-mode param-name overrides for option ContractSpec variants
+    /// (`concrete_iso`, `all_strikes_one_exp`, wildcard/zero-sentinel cells).
+    #[serde(default)]
+    pub(super) mode_overrides: HashMap<String, HashMap<String, String>>,
+    /// Representative values for builder-bound optional params. Drives
+    /// `with_<name>` and `all_optionals` modes.
+    pub(super) optional_defaults: HashMap<String, String>,
 }
 
 /// A reusable parameter group declared in `endpoint_surface.toml`.
@@ -190,4 +217,17 @@ pub(super) struct GeneratedEndpoint {
 #[derive(Debug, Clone)]
 pub(super) struct ParsedEndpoints {
     pub(super) endpoints: Vec<GeneratedEndpoint>,
+    pub(super) fixtures: TestFixtures,
+}
+
+/// Resolved fixture tables consumed by `modes.rs`. Wire-compatible 1:1 with
+/// `SurfaceTestFixtures` after TOML load — the indirection keeps the build-
+/// support shape separate from the proto-parser output type.
+#[derive(Debug, Clone, Default)]
+pub(super) struct TestFixtures {
+    pub(super) category_symbol: HashMap<String, String>,
+    pub(super) concrete_by_type: HashMap<String, String>,
+    pub(super) concrete_overrides: HashMap<String, String>,
+    pub(super) mode_overrides: HashMap<String, HashMap<String, String>>,
+    pub(super) optional_defaults: HashMap<String, String>,
 }

--- a/crates/thetadatadx/build_support/endpoints/modes.rs
+++ b/crates/thetadatadx/build_support/endpoints/modes.rs
@@ -266,7 +266,11 @@ fn args_for_mode(
 /// Whether the endpoint's method-call params include the full ContractSpec
 /// quartet (symbol, expiration, strike, right). Drives wildcard mode
 /// generation for option snapshot / history / at-time endpoints.
-fn has_full_contract_spec(endpoint: &GeneratedEndpoint) -> bool {
+///
+/// Exposed to `parser.rs::validate_test_fixtures` so the required-mode and
+/// per-mode closed-vocabulary checks stay in lockstep with the emission
+/// logic in [`test_modes_for`].
+pub(super) fn has_full_contract_spec(endpoint: &GeneratedEndpoint) -> bool {
     let names: HashSet<&str> = method_params(endpoint)
         .iter()
         .map(|p| p.name.as_str())
@@ -290,7 +294,11 @@ fn has_full_contract_spec(endpoint: &GeneratedEndpoint) -> bool {
 /// `true` — they don't participate in the wildcard matrix anyway (streaming
 /// is skipped upstream of this call, and the SDK-only endpoints don't take
 /// an expiration parameter).
-fn endpoint_supports_expiration_wildcard(name: &str) -> bool {
+///
+/// Exposed to `parser.rs::validate_test_fixtures` so wildcard-mode
+/// required-row and per-mode vocabulary checks stay in lockstep with
+/// [`test_modes_for`].
+pub(super) fn endpoint_supports_expiration_wildcard(name: &str) -> bool {
     let spec = super::super::upstream_openapi::UpstreamOpenApi::load();
     spec.endpoint(name)
         .map(|endpoint| endpoint.supports_expiration_wildcard)

--- a/crates/thetadatadx/build_support/endpoints/modes.rs
+++ b/crates/thetadatadx/build_support/endpoints/modes.rs
@@ -6,6 +6,11 @@
 //! endpoints get the full wildcard cross-product, and so on. Tier information
 //! flows from the pinned upstream OpenAPI snapshot.
 //!
+//! Every representative value (symbols, dates, expirations, wildcard
+//! sentinels, optional defaults) comes from the `[test_fixtures]` block in
+//! `endpoint_surface.toml`. `modes.rs` carries no fixture literals — swap
+//! `20250303` for `20260303` by editing one TOML row, not this file.
+//!
 //! Renderers in `render/*_validate.rs` format each mode for their target
 //! language.
 
@@ -13,9 +18,8 @@ use std::collections::HashSet;
 
 use super::helpers::{
     builder_params, is_simple_list_endpoint, is_streaming_endpoint, method_params,
-    validation_symbol,
 };
-use super::model::{GeneratedEndpoint, GeneratedParam};
+use super::model::{GeneratedEndpoint, GeneratedParam, TestFixtures};
 
 // ───────────────────────── Multi-mode parameter matrix ──────────────────────
 //
@@ -175,53 +179,86 @@ fn sdk_only_min_tier(name: &str) -> Option<&'static str> {
     })
 }
 
+/// Resolve the anchor symbol fixture for an endpoint's category. Panics on
+/// missing rows so a category without a fixture fails loudly at generator
+/// time rather than silently producing empty cells. Pre-flight check in
+/// `parser.rs::validate_test_fixtures` guarantees this never trips for
+/// known-good TOML.
+fn category_symbol<'a>(fixtures: &'a TestFixtures, category: &str) -> &'a str {
+    fixtures
+        .category_symbol
+        .get(category)
+        .map(String::as_str)
+        .unwrap_or_else(|| {
+            panic!(
+                "test_fixtures.category_symbol is missing an entry for category '{category}' in \
+                 endpoint_surface.toml"
+            )
+        })
+}
+
 /// Render the language-agnostic value for a method-call parameter at a
 /// concrete fixture (no wildcards, compact dates).
 ///
-/// Date range is deliberately narrowed to a single day (20250303 = Mon)
-/// to keep the matrix within the ~10-minute live-run budget even when
-/// bulk-expiration / bulk-strike cells stack multiple 60s timeouts.
-/// Widening this back to a multi-day window is the first lever to pull
-/// if a cell's volume coverage matters more than runtime. See #290.
-fn concrete_value(endpoint: &GeneratedEndpoint, param: &GeneratedParam) -> String {
-    if param.name == "end_date" {
-        return "20250303".into();
+/// Resolution order:
+///   1. `test_fixtures.concrete_overrides[param.name]` — per-name overrides
+///      (e.g. compressed `end_date` keeping bulk cells under the 60s
+///      per-cell timeout; see issue #290).
+///   2. `test_fixtures.category_symbol[endpoint.category]` — for
+///      `Symbol`/`Symbols` params.
+///   3. `test_fixtures.concrete_by_type[param.param_type]` — default
+///      representative value per wire type.
+fn concrete_value(
+    endpoint: &GeneratedEndpoint,
+    param: &GeneratedParam,
+    fixtures: &TestFixtures,
+) -> String {
+    if let Some(value) = fixtures.concrete_overrides.get(&param.name) {
+        return value.clone();
     }
     match param.param_type.as_str() {
-        "Symbol" | "Symbols" => validation_symbol(endpoint).into(),
-        "Date" => "20250303".into(),
-        "Expiration" => "20250321".into(),
-        "Strike" => "570".into(),
-        "Right" => "C".into(),
-        "Interval" => "60000".into(),
-        "RequestType" => "TRADE".into(),
-        "Year" => "2025".into(),
-        "Str" => "12:00:00.000".into(),
-        other => panic!("concrete_value: unsupported param type {other}"),
+        "Symbol" | "Symbols" => category_symbol(fixtures, &endpoint.category).to_string(),
+        other => fixtures
+            .concrete_by_type
+            .get(other)
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!(
+                    "test_fixtures.concrete_by_type is missing an entry for param_type '{other}' \
+                     (required by '{}.{}'); add a row in endpoint_surface.toml",
+                    endpoint.name, param.name
+                )
+            }),
     }
 }
 
 /// Build the args vector for a concrete (no-wildcard) call.
-fn concrete_args(endpoint: &GeneratedEndpoint) -> Vec<String> {
+fn concrete_args(endpoint: &GeneratedEndpoint, fixtures: &TestFixtures) -> Vec<String> {
     method_params(endpoint)
         .iter()
-        .map(|param| concrete_value(endpoint, param))
+        .map(|param| concrete_value(endpoint, param, fixtures))
         .collect()
 }
 
-/// Build args for a mode that overrides specific parameter names with given
-/// values — everything else falls back to [`concrete_value`].
-fn args_with_overrides(
+/// Build args for a named mode whose overrides live under
+/// `[test_fixtures.mode_overrides.<mode_name>]`. Any param not listed in the
+/// TOML block falls back to its concrete fixture.
+fn args_for_mode(
     endpoint: &GeneratedEndpoint,
-    overrides: &[(&'static str, &str)],
+    fixtures: &TestFixtures,
+    mode_name: &str,
 ) -> Vec<String> {
+    let overrides = fixtures.mode_overrides.get(mode_name).unwrap_or_else(|| {
+        panic!(
+            "test_fixtures.mode_overrides is missing an entry for mode '{mode_name}'; \
+             add one in endpoint_surface.toml"
+        )
+    });
     method_params(endpoint)
         .iter()
-        .map(|param| {
-            overrides
-                .iter()
-                .find_map(|(name, value)| (*name == param.name).then(|| (*value).to_string()))
-                .unwrap_or_else(|| concrete_value(endpoint, param))
+        .map(|param| match overrides.get(&param.name) {
+            Some(value) => value.clone(),
+            None => concrete_value(endpoint, param, fixtures),
         })
         .collect()
 }
@@ -274,7 +311,10 @@ fn endpoint_supports_expiration_wildcard(name: &str) -> bool {
 ///
 /// Stream endpoints are covered by `scripts/fpss_smoke.py` /
 /// `scripts/fpss_soak.py` and intentionally skipped here.
-pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
+pub(super) fn test_modes_for(
+    endpoint: &GeneratedEndpoint,
+    fixtures: &TestFixtures,
+) -> Vec<TestMode> {
     if is_streaming_endpoint(endpoint) {
         return Vec::new();
     }
@@ -286,11 +326,12 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             endpoint,
             append_optional_modes(
                 endpoint,
+                fixtures,
                 endpoint_tier,
                 vec![TestMode {
                     name: "basic".to_string(),
                     rationale: rationale_for_mode("basic"),
-                    args: concrete_args(endpoint),
+                    args: concrete_args(endpoint, fixtures),
                     min_tier: endpoint_tier,
                     expect: "non_empty",
                     builder_overrides: Vec::new(),
@@ -305,11 +346,12 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             endpoint,
             append_optional_modes(
                 endpoint,
+                fixtures,
                 endpoint_tier,
                 vec![TestMode {
                     name: "basic".to_string(),
                     rationale: rationale_for_mode("basic"),
-                    args: concrete_args(endpoint),
+                    args: concrete_args(endpoint, fixtures),
                     min_tier: endpoint_tier,
                     expect: "non_empty",
                     builder_overrides: Vec::new(),
@@ -330,7 +372,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             TestMode {
                 name: "concrete".to_string(),
                 rationale: rationale_for_mode("concrete"),
-                args: concrete_args(endpoint),
+                args: concrete_args(endpoint, fixtures),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
                 builder_overrides: Vec::new(),
@@ -338,7 +380,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             TestMode {
                 name: "concrete_iso".to_string(),
                 rationale: rationale_for_mode("concrete_iso"),
-                args: args_with_overrides(endpoint, &[("expiration", "2025-03-21")]),
+                args: args_for_mode(endpoint, fixtures, "concrete_iso"),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
                 builder_overrides: Vec::new(),
@@ -346,7 +388,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             TestMode {
                 name: "all_strikes_one_exp".to_string(),
                 rationale: rationale_for_mode("all_strikes_one_exp"),
-                args: args_with_overrides(endpoint, &[("strike", "*"), ("right", "both")]),
+                args: args_for_mode(endpoint, fixtures, "all_strikes_one_exp"),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
                 builder_overrides: Vec::new(),
@@ -357,7 +399,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
                 TestMode {
                     name: "all_exps_one_strike".to_string(),
                     rationale: rationale_for_mode("all_exps_one_strike"),
-                    args: args_with_overrides(endpoint, &[("expiration", "*"), ("right", "both")]),
+                    args: args_for_mode(endpoint, fixtures, "all_exps_one_strike"),
                     min_tier: endpoint_tier,
                     expect: "non_empty",
                     builder_overrides: Vec::new(),
@@ -365,10 +407,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
                 TestMode {
                     name: "bulk_chain".to_string(),
                     rationale: rationale_for_mode("bulk_chain"),
-                    args: args_with_overrides(
-                        endpoint,
-                        &[("expiration", "*"), ("strike", "*"), ("right", "both")],
-                    ),
+                    args: args_for_mode(endpoint, fixtures, "bulk_chain"),
                     min_tier: endpoint_tier,
                     expect: "non_empty",
                     builder_overrides: Vec::new(),
@@ -376,10 +415,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
                 TestMode {
                     name: "legacy_zero_wildcard".to_string(),
                     rationale: rationale_for_mode("legacy_zero_wildcard"),
-                    args: args_with_overrides(
-                        endpoint,
-                        &[("expiration", "0"), ("strike", "0"), ("right", "both")],
-                    ),
+                    args: args_for_mode(endpoint, fixtures, "legacy_zero_wildcard"),
                     min_tier: endpoint_tier,
                     expect: "non_empty",
                     builder_overrides: Vec::new(),
@@ -389,7 +425,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
         modes.dedup_by(|a, b| a.args == b.args && a.name == b.name);
         return collapse_redundant_wires(
             endpoint,
-            append_optional_modes(endpoint, endpoint_tier, modes),
+            append_optional_modes(endpoint, fixtures, endpoint_tier, modes),
         );
     }
 
@@ -405,11 +441,12 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
         endpoint,
         append_optional_modes(
             endpoint,
+            fixtures,
             endpoint_tier,
             vec![TestMode {
                 name: "concrete".to_string(),
                 rationale: rationale_for_mode("concrete"),
-                args: concrete_args(endpoint),
+                args: concrete_args(endpoint, fixtures),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
                 builder_overrides: Vec::new(),
@@ -418,33 +455,41 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
     )
 }
 
-/// Representative value to feed each builder-bound (optional) parameter in
-/// `with_<name>` and `all_optionals` modes. Kept dense here so callers see
-/// the full matrix at a glance.
-///
-/// Covers every optional currently exposed in `endpoint_surface.toml`. If a
-/// future builder param isn't listed, the generator falls back to `None`,
-/// which drops the mode (avoids emitting a cell with no actual coverage).
-fn optional_fixture_value(param_name: &str) -> Option<&'static str> {
-    Some(match param_name {
-        "max_dte" => "30",
-        "strike_range" => "10",
-        "min_time" => "09:45:00",
-        "venue" => "nqb",
-        "start_time" => "09:30:00",
-        "end_time" => "10:00:00",
-        "start_date" => "20250303",
-        "end_date" => "20250303",
-        "exclusive" => "true",
-        "annual_dividend" => "0.015",
-        "rate_type" => "sofr",
-        "rate_value" => "0.05",
-        "stock_price" => "150.0",
-        "version" => "dg3",
-        "use_market_value" => "true",
-        "underlyer_use_nbbo" => "true",
-        _ => return None,
-    })
+/// Look up the representative value for a builder-bound optional parameter
+/// from `[test_fixtures.optional_defaults]`. Returns `None` if the TOML has
+/// no entry; the pre-flight check in `parser.rs::validate_test_fixtures`
+/// rejects every endpoint whose builder param lacks an entry, so the `None`
+/// branch is a defense in depth — only fires if the validator is bypassed.
+fn optional_fixture_value<'a>(fixtures: &'a TestFixtures, param_name: &str) -> Option<&'a str> {
+    fixtures
+        .optional_defaults
+        .get(param_name)
+        .map(String::as_str)
+}
+
+/// Same as [`optional_fixture_value`] but for paired modes
+/// (`with_intraday_window`, `with_date_range`) where the fixture row is
+/// guaranteed by the design — both halves of the pair have to have
+/// fixtures because the SDK rejects the half-set wire shape. Panics with
+/// full context (endpoint, mode, key) so a missing row is debuggable
+/// without `RUST_BACKTRACE=1`.
+fn paired_optional_fixture(
+    fixtures: &TestFixtures,
+    endpoint: &GeneratedEndpoint,
+    mode_name: &str,
+    param_name: &str,
+) -> String {
+    optional_fixture_value(fixtures, param_name)
+        .unwrap_or_else(|| {
+            panic!(
+                "test_fixtures.optional_defaults is missing key '{param_name}' (needed for \
+                 {endpoint}.{mode_name}); add a row in endpoint_surface.toml. Note: \
+                 parser.rs::validate_test_fixtures should have caught this earlier — if you see \
+                 this panic, the validator was bypassed.",
+                endpoint = endpoint.name,
+            )
+        })
+        .to_string()
 }
 
 /// Expand the baseline (wildcard/concrete) modes with one `with_<name>` cell
@@ -468,6 +513,7 @@ fn optional_fixture_value(param_name: &str) -> Option<&'static str> {
 /// *only* on that cell. See PR #291 / issue #290.
 fn append_optional_modes(
     endpoint: &GeneratedEndpoint,
+    fixtures: &TestFixtures,
     endpoint_tier: &'static str,
     mut modes: Vec<TestMode>,
 ) -> Vec<TestMode> {
@@ -490,17 +536,17 @@ fn append_optional_modes(
         let overrides = vec![
             (
                 "start_time".to_string(),
-                optional_fixture_value("start_time").unwrap().to_string(),
+                paired_optional_fixture(fixtures, endpoint, "with_intraday_window", "start_time"),
             ),
             (
                 "end_time".to_string(),
-                optional_fixture_value("end_time").unwrap().to_string(),
+                paired_optional_fixture(fixtures, endpoint, "with_intraday_window", "end_time"),
             ),
         ];
         modes.push(TestMode {
             name: "with_intraday_window".to_string(),
             rationale: rationale_for_mode("with_intraday_window"),
-            args: concrete_args(endpoint),
+            args: concrete_args(endpoint, fixtures),
             min_tier: endpoint_tier,
             expect: "non_empty",
             builder_overrides: overrides,
@@ -516,17 +562,17 @@ fn append_optional_modes(
         let overrides = vec![
             (
                 "start_date".to_string(),
-                optional_fixture_value("start_date").unwrap().to_string(),
+                paired_optional_fixture(fixtures, endpoint, "with_date_range", "start_date"),
             ),
             (
                 "end_date".to_string(),
-                optional_fixture_value("end_date").unwrap().to_string(),
+                paired_optional_fixture(fixtures, endpoint, "with_date_range", "end_date"),
             ),
         ];
         modes.push(TestMode {
             name: "with_date_range".to_string(),
             rationale: rationale_for_mode("with_date_range"),
-            args: concrete_args(endpoint),
+            args: concrete_args(endpoint, fixtures),
             min_tier: endpoint_tier,
             expect: "non_empty",
             builder_overrides: overrides,
@@ -535,14 +581,21 @@ fn append_optional_modes(
         handled.insert("end_date".into());
     }
 
-    // Per-parameter `with_<name>` modes for everything else.
+    // Per-parameter `with_<name>` modes for everything else. Every entry in
+    // `optional_names` is guaranteed to have an `optional_defaults` row by
+    // `parser.rs::validate_test_fixtures`, so a missing fixture here is a
+    // bypassed-validator bug, not a routine "skip the cell" path.
     for param_name in &optional_names {
         if handled.contains(param_name) {
             continue;
         }
-        let Some(value) = optional_fixture_value(param_name) else {
-            continue;
-        };
+        let value = optional_fixture_value(fixtures, param_name).unwrap_or_else(|| {
+            panic!(
+                "test_fixtures.optional_defaults is missing key '{param_name}' (needed for \
+                 {endpoint}.with_{param_name}); add a row in endpoint_surface.toml.",
+                endpoint = endpoint.name
+            )
+        });
         // Rationale carries the exact fixture literal so the cell's text
         // can never drift from `optional_fixture_value`. `String` is
         // promoted to `&'static str` via `Box::leak` — generator runs once
@@ -552,7 +605,7 @@ fn append_optional_modes(
         modes.push(TestMode {
             name: format!("with_{param_name}"),
             rationale,
-            args: concrete_args(endpoint),
+            args: concrete_args(endpoint, fixtures),
             min_tier: endpoint_tier,
             expect: "non_empty",
             builder_overrides: vec![(param_name.clone(), value.to_string())],
@@ -562,17 +615,23 @@ fn append_optional_modes(
     // `all_optionals` mode — set every applicable optional at once. Uses
     // the compound fixtures for paired params (single intraday window, single
     // date range) so the compound cell and this one agree on wire shape.
+    // Same fail-fast contract as the `with_<name>` loop above.
     let mut all_overrides: Vec<(String, String)> = Vec::new();
     for param_name in &optional_names {
-        if let Some(value) = optional_fixture_value(param_name) {
-            all_overrides.push((param_name.clone(), value.to_string()));
-        }
+        let value = optional_fixture_value(fixtures, param_name).unwrap_or_else(|| {
+            panic!(
+                "test_fixtures.optional_defaults is missing key '{param_name}' (needed for \
+                 {endpoint}.all_optionals); add a row in endpoint_surface.toml.",
+                endpoint = endpoint.name
+            )
+        });
+        all_overrides.push((param_name.clone(), value.to_string()));
     }
     if !all_overrides.is_empty() {
         modes.push(TestMode {
             name: "all_optionals".to_string(),
             rationale: rationale_for_mode("all_optionals"),
-            args: concrete_args(endpoint),
+            args: concrete_args(endpoint, fixtures),
             min_tier: endpoint_tier,
             expect: "non_empty",
             builder_overrides: all_overrides,

--- a/crates/thetadatadx/build_support/endpoints/parser.rs
+++ b/crates/thetadatadx/build_support/endpoints/parser.rs
@@ -121,16 +121,20 @@ const KNOWN_MODE_OVERRIDES: &[&str] = &[
 
 /// Cross-check the `[test_fixtures]` block against the resolved endpoint set.
 ///
-/// Two failure modes Codex round-1 caught:
-///   1. A missing entry in `optional_defaults` silently dropped a `with_<name>`
-///      cell and excluded the key from `all_optionals`, erasing coverage with
-///      no signal.
-///   2. A typo in any fixture map (`expiratoin = "2025-03-21"`) silently
-///      fell through to the default — the cell still ran, just with the
-///      wrong (unintended) value.
+/// Prevents every silent-coverage-regression path Codex review has flagged:
 ///
-/// This pass collects every wrong row and returns one combined error so a
-/// dev fixing their TOML sees the full picture in one rebuild.
+///   * **Round 1 / 2**: a missing `optional_defaults` row silently drops the
+///     corresponding `with_<name>` cell and excludes the param from
+///     `all_optionals`. Typos in any fixture map silently fall through to
+///     a default and test the wrong value.
+///   * **Round 3**: missing rows in `category_symbol`, `concrete_by_type`, or
+///     `mode_overrides` fall through to opaque panics in `modes.rs`. Dead
+///     keys under `mode_overrides.<mode>` are accepted even when no endpoint
+///     emitting that mode binds the name (the override is silently unused).
+///
+/// Every check collects every offender across every fixture map and returns
+/// them in one combined error so a dev fixing TOML drift sees the full
+/// picture in a single rebuild, not one error per `cargo run`.
 fn validate_test_fixtures(
     fixtures: &TestFixtures,
     endpoints: &[GeneratedEndpoint],
@@ -138,24 +142,146 @@ fn validate_test_fixtures(
     let mut errors: Vec<String> = Vec::new();
 
     // ── Vocabulary derived from the resolved endpoint set ──────────────────
-    let known_method_param_names: HashSet<&str> = endpoints
+    //
+    // Streaming endpoints are skipped because `test_modes_for` returns an
+    // empty mode vec for them — they never touch the fixture maps, so their
+    // params shouldn't drive required-row checks. Non-streaming endpoints
+    // are the matrix's full consumer set.
+    let live_endpoints: Vec<&GeneratedEndpoint> =
+        endpoints.iter().filter(|ep| ep.kind != "stream").collect();
+
+    let known_method_param_names: HashSet<&str> = live_endpoints
         .iter()
         .flat_map(|ep| ep.params.iter())
         .filter(|p| p.binding == "method")
         .map(|p| p.name.as_str())
         .collect();
-    let known_builder_param_names: HashSet<&str> = endpoints
+    let known_builder_param_names: HashSet<&str> = live_endpoints
         .iter()
         .flat_map(|ep| ep.params.iter())
         .filter(|p| p.binding == "builder")
         .map(|p| p.name.as_str())
         .collect();
 
-    // ── Required-keys: every builder-bound optional needs a row in
-    //    `optional_defaults`. Without one, `with_<name>` is silently dropped
-    //    and the param is excluded from `all_optionals` — pure coverage loss.
+    // ── Required rows: one check per fixture map. Every row that `modes.rs`
+    //    will touch at emission time must exist at validation time so a
+    //    missing TOML entry never falls through to an opaque panic.
+
+    // category_symbol: every non-streaming endpoint whose method params
+    // include a Symbol/Symbols reads `category_symbol[endpoint.category]`.
+    // Build the required set from the live endpoint surface.
+    let mut required_category_rows: HashMap<&str, Vec<&str>> = HashMap::new();
+    for endpoint in &live_endpoints {
+        let has_symbol_param = endpoint.params.iter().any(|p| {
+            p.binding == "method" && matches!(p.param_type.as_str(), "Symbol" | "Symbols")
+        });
+        if !has_symbol_param {
+            continue;
+        }
+        required_category_rows
+            .entry(endpoint.category.as_str())
+            .or_default()
+            .push(endpoint.name.as_str());
+    }
+    let mut missing_category_rows: Vec<String> = required_category_rows
+        .iter()
+        .filter(|(category, _)| !fixtures.category_symbol.contains_key(**category))
+        .map(|(category, consumers)| {
+            let mut names = consumers.clone();
+            names.sort();
+            format!(
+                "  '{}' (needed for {} endpoint(s): first is {})",
+                category,
+                names.len(),
+                names.first().copied().unwrap_or("?"),
+            )
+        })
+        .collect();
+    if !missing_category_rows.is_empty() {
+        missing_category_rows.sort();
+        errors.push(format!(
+            "[test_fixtures.category_symbol] is missing required entries:\n{}",
+            missing_category_rows.join("\n")
+        ));
+    }
+
+    // concrete_by_type: every method-bound param whose `param_type` is not
+    // `Symbol`/`Symbols` (those route through `category_symbol`) reads
+    // `concrete_by_type[param.param_type]` — unless `concrete_overrides` has
+    // a row for the param name, which wins.
+    let mut required_type_rows: HashMap<&str, Vec<String>> = HashMap::new();
+    for endpoint in &live_endpoints {
+        for param in &endpoint.params {
+            if param.binding != "method"
+                || matches!(param.param_type.as_str(), "Symbol" | "Symbols")
+            {
+                continue;
+            }
+            if fixtures.concrete_overrides.contains_key(&param.name) {
+                continue;
+            }
+            required_type_rows
+                .entry(param.param_type.as_str())
+                .or_default()
+                .push(format!("{}.{}", endpoint.name, param.name));
+        }
+    }
+    let mut missing_type_rows: Vec<String> = required_type_rows
+        .iter()
+        .filter(|(ty, _)| !fixtures.concrete_by_type.contains_key(**ty))
+        .map(|(ty, consumers)| {
+            let mut consumers = consumers.clone();
+            consumers.sort();
+            format!(
+                "  '{}' (needed for {} param(s): first is {})",
+                ty,
+                consumers.len(),
+                consumers.first().map(String::as_str).unwrap_or("?")
+            )
+        })
+        .collect();
+    if !missing_type_rows.is_empty() {
+        missing_type_rows.sort();
+        errors.push(format!(
+            "[test_fixtures.concrete_by_type] is missing required entries:\n{}",
+            missing_type_rows.join("\n")
+        ));
+    }
+
+    // mode_overrides: every mode that at least one endpoint actually emits
+    // must have an entry (empty is fine; present-but-empty won't trip the
+    // opaque `.get(mode_name).unwrap_or_else(panic!())` in `args_for_mode`).
+    let mode_emitters = compute_mode_emitters(&live_endpoints);
+    let mut missing_mode_entries: Vec<String> = Vec::new();
+    for (mode_name, consumers) in &mode_emitters {
+        if consumers.is_empty() {
+            continue;
+        }
+        if !fixtures.mode_overrides.contains_key(*mode_name) {
+            let mut sample = consumers.clone();
+            sample.sort();
+            missing_mode_entries.push(format!(
+                "  '{}' (emitted by {} endpoint(s): first is {})",
+                mode_name,
+                sample.len(),
+                sample.first().copied().unwrap_or("?")
+            ));
+        }
+    }
+    if !missing_mode_entries.is_empty() {
+        missing_mode_entries.sort();
+        errors.push(format!(
+            "[test_fixtures.mode_overrides] is missing required entries:\n{}",
+            missing_mode_entries.join("\n")
+        ));
+    }
+
+    // optional_defaults: every builder-bound param the matrix references
+    // needs a row, otherwise `with_<name>` silently drops and `all_optionals`
+    // excludes the key. Walk the resolved endpoint set, report per-endpoint
+    // so the dev sees blast radius.
     let mut missing_optional_defaults: Vec<String> = Vec::new();
-    for endpoint in endpoints {
+    for endpoint in &live_endpoints {
         for param in &endpoint.params {
             if param.binding != "builder" {
                 continue;
@@ -177,7 +303,8 @@ fn validate_test_fixtures(
         ));
     }
 
-    // ── Unknown-keys: every map's keys must be in its expected vocabulary.
+    // ── Unknown / dead keys: every map's keys must match its expected
+    //    vocabulary. Typos and stale rows surface here with full context.
 
     // category_symbol → known-with-symbol categories.
     let unknown_categories: Vec<&str> = fixtures
@@ -230,17 +357,22 @@ fn validate_test_fixtures(
         ));
     }
 
-    // mode_overrides.<mode> → known mode names; inner keys → real method-call params.
+    // mode_overrides.<mode> → known mode names; inner keys → per-mode valid
+    // set (params bound by endpoints that emit that mode). A key that's
+    // method-bound globally but dead under a specific mode — e.g. `year`
+    // under `concrete_iso` where no ContractSpec endpoint binds `year` —
+    // must fail for that mode, not just for a global union.
     let mut unknown_mode_names: Vec<&str> = Vec::new();
-    let mut unknown_mode_param_keys: Vec<String> = Vec::new();
+    let mut unused_mode_param_keys: Vec<String> = Vec::new();
     for (mode_name, overrides) in &fixtures.mode_overrides {
         if !KNOWN_MODE_OVERRIDES.contains(&mode_name.as_str()) {
             unknown_mode_names.push(mode_name.as_str());
             continue;
         }
+        let valid_keys = mode_override_valid_keys(&live_endpoints, mode_name.as_str());
         for key in overrides.keys() {
-            if !known_method_param_names.contains(key.as_str()) {
-                unknown_mode_param_keys.push(format!("{mode_name}.{key}"));
+            if !valid_keys.contains(key.as_str()) {
+                unused_mode_param_keys.push(format!("{mode_name}.{key}"));
             }
         }
     }
@@ -252,12 +384,12 @@ fn validate_test_fixtures(
             KNOWN_MODE_OVERRIDES.join(", ")
         ));
     }
-    if !unknown_mode_param_keys.is_empty() {
-        unknown_mode_param_keys.sort();
+    if !unused_mode_param_keys.is_empty() {
+        unused_mode_param_keys.sort();
         errors.push(format!(
-            "[test_fixtures.mode_overrides] references param names that are not method-bound on \
-             any endpoint: {}",
-            unknown_mode_param_keys.join(", ")
+            "[test_fixtures.mode_overrides] contains dead keys — not bound by any endpoint \
+             emitting that mode: {}",
+            unused_mode_param_keys.join(", ")
         ));
     }
 
@@ -286,6 +418,66 @@ fn validate_test_fixtures(
         .into());
     }
     Ok(())
+}
+
+/// For each mode in [`KNOWN_MODE_OVERRIDES`], collect the endpoints that
+/// emit it. Mirrors the branching in `modes.rs::test_modes_for`:
+/// * `concrete_iso`, `all_strikes_one_exp` — any endpoint with the full
+///   ContractSpec quartet (symbol / expiration / strike / right).
+/// * `all_exps_one_strike`, `bulk_chain`, `legacy_zero_wildcard` — same,
+///   further restricted to endpoints upstream marks as accepting
+///   `expiration=*`.
+///
+/// Streaming endpoints are already filtered out by the caller. A mode with
+/// zero consumers doesn't need a TOML row and isn't reported as missing.
+fn compute_mode_emitters<'a>(
+    endpoints: &[&'a GeneratedEndpoint],
+) -> Vec<(&'static str, Vec<&'a str>)> {
+    let mut out: Vec<(&'static str, Vec<&'a str>)> = Vec::new();
+    for mode in KNOWN_MODE_OVERRIDES {
+        let consumers: Vec<&'a str> = endpoints
+            .iter()
+            .filter(|ep| endpoint_emits_mode(ep, mode))
+            .map(|ep| ep.name.as_str())
+            .collect();
+        out.push((*mode, consumers));
+    }
+    out
+}
+
+/// Whether the named mode appears in `test_modes_for(endpoint, ...)`'s
+/// output. Kept in lockstep with the branching in `modes.rs` — every new
+/// mode or predicate there needs a line here.
+fn endpoint_emits_mode(endpoint: &GeneratedEndpoint, mode: &str) -> bool {
+    if endpoint.kind == "stream" {
+        return false;
+    }
+    let has_contract_spec = super::modes::has_full_contract_spec(endpoint);
+    match mode {
+        "concrete_iso" | "all_strikes_one_exp" => has_contract_spec,
+        "all_exps_one_strike" | "bulk_chain" | "legacy_zero_wildcard" => {
+            has_contract_spec && super::modes::endpoint_supports_expiration_wildcard(&endpoint.name)
+        }
+        _ => false,
+    }
+}
+
+/// Union of method-param names belonging to every endpoint that emits the
+/// given mode. This is the per-mode valid-key set used to detect dead keys
+/// under `mode_overrides.<mode>`. A key that's valid globally (it's a
+/// method-bound name on some endpoint somewhere) but unused under the
+/// specific mode is flagged as dead by Codex round-3.
+fn mode_override_valid_keys<'a>(
+    endpoints: &[&'a GeneratedEndpoint],
+    mode: &str,
+) -> HashSet<&'a str> {
+    endpoints
+        .iter()
+        .filter(|ep| endpoint_emits_mode(ep, mode))
+        .flat_map(|ep| ep.params.iter())
+        .filter(|p| p.binding == "method")
+        .map(|p| p.name.as_str())
+        .collect()
 }
 
 /// Resolve the reusable spec language in `endpoint_surface.toml` into concrete endpoints.

--- a/crates/thetadatadx/build_support/endpoints/parser.rs
+++ b/crates/thetadatadx/build_support/endpoints/parser.rs
@@ -76,8 +76,14 @@ pub(super) fn load_endpoint_specs() -> Result<ParsedEndpoints, Box<dyn std::erro
     println!("cargo:rerun-if-changed={spec_path}");
 
     let fixtures = into_test_fixtures(spec.test_fixtures);
-    validate_test_fixtures(&fixtures, &endpoints)?;
 
+    // Fixture validation is intentionally NOT run here — it touches the
+    // upstream OpenAPI snapshot (via `endpoint_supports_expiration_wildcard`)
+    // which isn't packaged into the Python sdist. `build.rs` → `generate_all`
+    // never emits validators, so a missing fixture row wouldn't produce
+    // corrupted output from this path. `sdk_files.rs::render_sdk_generated_files`
+    // — the only caller that actually emits validator code and therefore
+    // needs the fixtures — invokes [`validate_test_fixtures`] explicitly.
     Ok(ParsedEndpoints {
         endpoints,
         fixtures,
@@ -135,7 +141,7 @@ const KNOWN_MODE_OVERRIDES: &[&str] = &[
 /// Every check collects every offender across every fixture map and returns
 /// them in one combined error so a dev fixing TOML drift sees the full
 /// picture in a single rebuild, not one error per `cargo run`.
-fn validate_test_fixtures(
+pub(super) fn validate_test_fixtures(
     fixtures: &TestFixtures,
     endpoints: &[GeneratedEndpoint],
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/thetadatadx/build_support/endpoints/parser.rs
+++ b/crates/thetadatadx/build_support/endpoints/parser.rs
@@ -9,7 +9,8 @@ use std::collections::{HashMap, HashSet};
 
 use super::model::{
     GeneratedEndpoint, GeneratedParam, ParsedEndpoints, ResolvedSurfaceEndpoint, ResolvedTemplate,
-    SurfaceEndpoint, SurfaceParam, SurfaceParamEntry, SurfaceSpec,
+    SurfaceEndpoint, SurfaceParam, SurfaceParamEntry, SurfaceSpec, SurfaceTestFixtures,
+    TestFixtures,
 };
 use super::proto_parser::load_proto_endpoints;
 
@@ -74,7 +75,217 @@ pub(super) fn load_endpoint_specs() -> Result<ParsedEndpoints, Box<dyn std::erro
 
     println!("cargo:rerun-if-changed={spec_path}");
 
-    Ok(ParsedEndpoints { endpoints })
+    let fixtures = into_test_fixtures(spec.test_fixtures);
+    validate_test_fixtures(&fixtures, &endpoints)?;
+
+    Ok(ParsedEndpoints {
+        endpoints,
+        fixtures,
+    })
+}
+
+/// Drop the TOML shape and expose fixtures to the rest of the generator
+/// without leaking `serde::Deserialize` plumbing.
+fn into_test_fixtures(surface: SurfaceTestFixtures) -> TestFixtures {
+    TestFixtures {
+        category_symbol: surface.category_symbol,
+        concrete_by_type: surface.concrete_by_type,
+        concrete_overrides: surface.concrete_overrides,
+        mode_overrides: surface.mode_overrides,
+        optional_defaults: surface.optional_defaults,
+    }
+}
+
+/// Closed sets the live-validator matrix in `modes.rs` knows how to consume.
+/// Anything outside these tables is a typo in the TOML and silently dropped
+/// coverage, so we reject it at build time. Keep these in lockstep with
+/// `modes.rs::test_modes_for` and the wire-type tables in `helpers.rs`.
+const KNOWN_CATEGORIES_WITH_SYMBOL: &[&str] = &["stock", "option", "index", "rate"];
+const KNOWN_WIRE_TYPES: &[&str] = &[
+    "Date",
+    "Expiration",
+    "Strike",
+    "Right",
+    "Interval",
+    "RequestType",
+    "Year",
+    "Str",
+];
+const KNOWN_MODE_OVERRIDES: &[&str] = &[
+    "concrete_iso",
+    "all_strikes_one_exp",
+    "all_exps_one_strike",
+    "bulk_chain",
+    "legacy_zero_wildcard",
+];
+
+/// Cross-check the `[test_fixtures]` block against the resolved endpoint set.
+///
+/// Two failure modes Codex round-1 caught:
+///   1. A missing entry in `optional_defaults` silently dropped a `with_<name>`
+///      cell and excluded the key from `all_optionals`, erasing coverage with
+///      no signal.
+///   2. A typo in any fixture map (`expiratoin = "2025-03-21"`) silently
+///      fell through to the default — the cell still ran, just with the
+///      wrong (unintended) value.
+///
+/// This pass collects every wrong row and returns one combined error so a
+/// dev fixing their TOML sees the full picture in one rebuild.
+fn validate_test_fixtures(
+    fixtures: &TestFixtures,
+    endpoints: &[GeneratedEndpoint],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut errors: Vec<String> = Vec::new();
+
+    // ── Vocabulary derived from the resolved endpoint set ──────────────────
+    let known_method_param_names: HashSet<&str> = endpoints
+        .iter()
+        .flat_map(|ep| ep.params.iter())
+        .filter(|p| p.binding == "method")
+        .map(|p| p.name.as_str())
+        .collect();
+    let known_builder_param_names: HashSet<&str> = endpoints
+        .iter()
+        .flat_map(|ep| ep.params.iter())
+        .filter(|p| p.binding == "builder")
+        .map(|p| p.name.as_str())
+        .collect();
+
+    // ── Required-keys: every builder-bound optional needs a row in
+    //    `optional_defaults`. Without one, `with_<name>` is silently dropped
+    //    and the param is excluded from `all_optionals` — pure coverage loss.
+    let mut missing_optional_defaults: Vec<String> = Vec::new();
+    for endpoint in endpoints {
+        for param in &endpoint.params {
+            if param.binding != "builder" {
+                continue;
+            }
+            if !fixtures.optional_defaults.contains_key(&param.name) {
+                missing_optional_defaults.push(format!(
+                    "  '{}' (needed for {}.with_{})",
+                    param.name, endpoint.name, param.name
+                ));
+            }
+        }
+    }
+    if !missing_optional_defaults.is_empty() {
+        missing_optional_defaults.sort();
+        missing_optional_defaults.dedup();
+        errors.push(format!(
+            "[test_fixtures.optional_defaults] is missing required entries:\n{}",
+            missing_optional_defaults.join("\n")
+        ));
+    }
+
+    // ── Unknown-keys: every map's keys must be in its expected vocabulary.
+
+    // category_symbol → known-with-symbol categories.
+    let unknown_categories: Vec<&str> = fixtures
+        .category_symbol
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !KNOWN_CATEGORIES_WITH_SYMBOL.contains(name))
+        .collect();
+    if !unknown_categories.is_empty() {
+        let mut sorted = unknown_categories;
+        sorted.sort();
+        errors.push(format!(
+            "[test_fixtures.category_symbol] has unknown categories: {} (expected one of: {})",
+            sorted.join(", "),
+            KNOWN_CATEGORIES_WITH_SYMBOL.join(", ")
+        ));
+    }
+
+    // concrete_by_type → known wire types.
+    let unknown_wire_types: Vec<&str> = fixtures
+        .concrete_by_type
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !KNOWN_WIRE_TYPES.contains(name))
+        .collect();
+    if !unknown_wire_types.is_empty() {
+        let mut sorted = unknown_wire_types;
+        sorted.sort();
+        errors.push(format!(
+            "[test_fixtures.concrete_by_type] has unknown wire types: {} (expected one of: {})",
+            sorted.join(", "),
+            KNOWN_WIRE_TYPES.join(", ")
+        ));
+    }
+
+    // concrete_overrides → real method-call param names.
+    let unknown_concrete_overrides: Vec<&str> = fixtures
+        .concrete_overrides
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !known_method_param_names.contains(name))
+        .collect();
+    if !unknown_concrete_overrides.is_empty() {
+        let mut sorted = unknown_concrete_overrides;
+        sorted.sort();
+        errors.push(format!(
+            "[test_fixtures.concrete_overrides] references param names that are not method-bound \
+             on any endpoint: {}",
+            sorted.join(", ")
+        ));
+    }
+
+    // mode_overrides.<mode> → known mode names; inner keys → real method-call params.
+    let mut unknown_mode_names: Vec<&str> = Vec::new();
+    let mut unknown_mode_param_keys: Vec<String> = Vec::new();
+    for (mode_name, overrides) in &fixtures.mode_overrides {
+        if !KNOWN_MODE_OVERRIDES.contains(&mode_name.as_str()) {
+            unknown_mode_names.push(mode_name.as_str());
+            continue;
+        }
+        for key in overrides.keys() {
+            if !known_method_param_names.contains(key.as_str()) {
+                unknown_mode_param_keys.push(format!("{mode_name}.{key}"));
+            }
+        }
+    }
+    if !unknown_mode_names.is_empty() {
+        unknown_mode_names.sort();
+        errors.push(format!(
+            "[test_fixtures.mode_overrides] has unknown mode names: {} (expected one of: {})",
+            unknown_mode_names.join(", "),
+            KNOWN_MODE_OVERRIDES.join(", ")
+        ));
+    }
+    if !unknown_mode_param_keys.is_empty() {
+        unknown_mode_param_keys.sort();
+        errors.push(format!(
+            "[test_fixtures.mode_overrides] references param names that are not method-bound on \
+             any endpoint: {}",
+            unknown_mode_param_keys.join(", ")
+        ));
+    }
+
+    // optional_defaults → real builder-bound param names.
+    let unknown_optional_defaults: Vec<&str> = fixtures
+        .optional_defaults
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !known_builder_param_names.contains(name))
+        .collect();
+    if !unknown_optional_defaults.is_empty() {
+        let mut sorted = unknown_optional_defaults;
+        sorted.sort();
+        errors.push(format!(
+            "[test_fixtures.optional_defaults] references param names that are not builder-bound \
+             on any endpoint: {}",
+            sorted.join(", ")
+        ));
+    }
+
+    if !errors.is_empty() {
+        return Err(format!(
+            "endpoint_surface.toml [test_fixtures] validation failed:\n\n{}",
+            errors.join("\n\n")
+        )
+        .into());
+    }
+    Ok(())
 }
 
 /// Resolve the reusable spec language in `endpoint_surface.toml` into concrete endpoints.

--- a/crates/thetadatadx/build_support/endpoints/proto_parser.rs
+++ b/crates/thetadatadx/build_support/endpoints/proto_parser.rs
@@ -7,7 +7,9 @@
 
 use std::collections::HashMap;
 
-use super::model::{GeneratedEndpoint, GeneratedParam, ParsedEndpoints, ProtoField, Rpc};
+use super::model::{
+    GeneratedEndpoint, GeneratedParam, ParsedEndpoints, ProtoField, Rpc, TestFixtures,
+};
 
 /// Parse endpoint metadata from `external.proto` into a reusable intermediate form.
 ///
@@ -122,7 +124,10 @@ pub(super) fn load_proto_endpoints() -> Result<ParsedEndpoints, Box<dyn std::err
         endpoints.push(range);
     }
 
-    Ok(ParsedEndpoints { endpoints })
+    Ok(ParsedEndpoints {
+        endpoints,
+        fixtures: TestFixtures::default(),
+    })
 }
 
 fn is_simple_list_method(method: &str) -> bool {

--- a/crates/thetadatadx/build_support/endpoints/render/cli_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/cli_validate.rs
@@ -8,11 +8,14 @@
 use std::fmt::Write as _;
 
 use super::super::helpers::{cli_command_tokens_for_mode, is_streaming_endpoint};
-use super::super::model::GeneratedEndpoint;
+use super::super::model::{GeneratedEndpoint, TestFixtures};
 use super::super::modes::test_modes_for;
 
 /// Generate the CLI validator (one row per (endpoint, mode) pair).
-pub(super) fn render_cli_validate(endpoints: &[GeneratedEndpoint]) -> String {
+pub(super) fn render_cli_validate(
+    endpoints: &[GeneratedEndpoint],
+    fixtures: &TestFixtures,
+) -> String {
     let mut out = String::from(include_str!("templates/validate_cli/preamble.py.tmpl"));
     for endpoint in endpoints
         .iter()
@@ -27,7 +30,7 @@ pub(super) fn render_cli_validate(endpoints: &[GeneratedEndpoint]) -> String {
         // The cross-language agreement script already handles cells missing
         // from one SDK as an info-level note. Follow-up: convert the CLI to
         // flag-style optionals (#290).
-        for mode in test_modes_for(endpoint)
+        for mode in test_modes_for(endpoint, fixtures)
             .into_iter()
             .filter(|mode| mode.builder_overrides.is_empty())
         {

--- a/crates/thetadatadx/build_support/endpoints/render/cpp_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/cpp_validate.rs
@@ -11,18 +11,21 @@ use std::fmt::Write as _;
 use super::super::helpers::{
     cpp_arg_literal, cpp_builder_setter, is_streaming_endpoint, method_params,
 };
-use super::super::model::GeneratedEndpoint;
+use super::super::model::{GeneratedEndpoint, TestFixtures};
 use super::super::modes::test_modes_for;
 
 /// Generate the C++ SDK validator (one row per (endpoint, mode) pair).
-pub(super) fn render_cpp_validate(endpoints: &[GeneratedEndpoint]) -> String {
+pub(super) fn render_cpp_validate(
+    endpoints: &[GeneratedEndpoint],
+    fixtures: &TestFixtures,
+) -> String {
     let mut out = String::from(include_str!("templates/validate_cpp/preamble.cpp.tmpl"));
     for endpoint in endpoints
         .iter()
         .filter(|endpoint| !is_streaming_endpoint(endpoint))
     {
         let mp = method_params(endpoint);
-        for mode in test_modes_for(endpoint) {
+        for mode in test_modes_for(endpoint, fixtures) {
             let mut args_parts: Vec<String> = mp
                 .iter()
                 .zip(mode.args.iter())

--- a/crates/thetadatadx/build_support/endpoints/render/go_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/go_validate.rs
@@ -9,11 +9,14 @@ use std::fmt::Write as _;
 use super::super::helpers::{
     go_arg_literal, go_builder_option, is_streaming_endpoint, method_params, to_go_exported_name,
 };
-use super::super::model::GeneratedEndpoint;
+use super::super::model::{GeneratedEndpoint, TestFixtures};
 use super::super::modes::test_modes_for;
 
 /// Generate the Go SDK validator (one row per (endpoint, mode) pair).
-pub(super) fn render_go_validate(endpoints: &[GeneratedEndpoint]) -> String {
+pub(super) fn render_go_validate(
+    endpoints: &[GeneratedEndpoint],
+    fixtures: &TestFixtures,
+) -> String {
     let mut out = String::from(include_str!("templates/validate_go/preamble.go.tmpl"));
     for endpoint in endpoints
         .iter()
@@ -21,7 +24,7 @@ pub(super) fn render_go_validate(endpoints: &[GeneratedEndpoint]) -> String {
     {
         let go_name = to_go_exported_name(&endpoint.name);
         let mp = method_params(endpoint);
-        for mode in test_modes_for(endpoint) {
+        for mode in test_modes_for(endpoint, fixtures) {
             let mut args_parts: Vec<String> = mp
                 .iter()
                 .zip(mode.args.iter())

--- a/crates/thetadatadx/build_support/endpoints/render/python_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/python_validate.rs
@@ -10,18 +10,21 @@ use std::fmt::Write as _;
 use super::super::helpers::{
     is_streaming_endpoint, method_params, python_arg_literal, python_builder_kwarg,
 };
-use super::super::model::GeneratedEndpoint;
+use super::super::model::{GeneratedEndpoint, TestFixtures};
 use super::super::modes::test_modes_for;
 
 /// Generate the Python SDK validator (one row per (endpoint, mode) pair).
-pub(super) fn render_python_validate(endpoints: &[GeneratedEndpoint]) -> String {
+pub(super) fn render_python_validate(
+    endpoints: &[GeneratedEndpoint],
+    fixtures: &TestFixtures,
+) -> String {
     let mut out = String::from(include_str!("templates/validate_python/preamble.py.tmpl"));
     for endpoint in endpoints
         .iter()
         .filter(|endpoint| !is_streaming_endpoint(endpoint))
     {
         let mp = method_params(endpoint);
-        for mode in test_modes_for(endpoint) {
+        for mode in test_modes_for(endpoint, fixtures) {
             let mut args_parts: Vec<String> = mp
                 .iter()
                 .zip(mode.args.iter())

--- a/crates/thetadatadx/build_support/endpoints/render/sdk_files.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/sdk_files.rs
@@ -102,19 +102,19 @@ fn render_sdk_generated_files() -> Result<Vec<GeneratedSourceFile>, Box<dyn std:
         },
         GeneratedSourceFile {
             relative_path: "scripts/validate_cli.py",
-            contents: cli_validate::render_cli_validate(&parsed.endpoints),
+            contents: cli_validate::render_cli_validate(&parsed.endpoints, &parsed.fixtures),
         },
         GeneratedSourceFile {
             relative_path: "scripts/validate_python.py",
-            contents: python_validate::render_python_validate(&parsed.endpoints),
+            contents: python_validate::render_python_validate(&parsed.endpoints, &parsed.fixtures),
         },
         GeneratedSourceFile {
             relative_path: "sdks/go/validate.go",
-            contents: go_validate::render_go_validate(&parsed.endpoints),
+            contents: go_validate::render_go_validate(&parsed.endpoints, &parsed.fixtures),
         },
         GeneratedSourceFile {
             relative_path: "sdks/cpp/examples/validate.cpp",
-            contents: cpp_validate::render_cpp_validate(&parsed.endpoints),
+            contents: cpp_validate::render_cpp_validate(&parsed.endpoints, &parsed.fixtures),
         },
     ])
 }

--- a/crates/thetadatadx/build_support/endpoints/render/sdk_files.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/sdk_files.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 
 use super::super::helpers::collect_builder_params;
-use super::super::parser::load_endpoint_specs;
+use super::super::parser::{load_endpoint_specs, validate_test_fixtures};
 use super::{cli_validate, cpp, cpp_validate, ffi, go, go_validate, python, python_validate};
 
 struct GeneratedSourceFile {
@@ -49,6 +49,12 @@ pub fn check_sdk_generated_files(repo_root: &Path) -> Result<(), Box<dyn std::er
 
 fn render_sdk_generated_files() -> Result<Vec<GeneratedSourceFile>, Box<dyn std::error::Error>> {
     let parsed = load_endpoint_specs()?;
+    // Fixtures power the live-validator matrix only — kept out of the
+    // `load_endpoint_specs` path so `build.rs` doesn't pay the upstream
+    // OpenAPI snapshot dependency (not in the Python sdist). Every fixture
+    // consumer flows through here, so validating at this seam catches
+    // every drift case with full per-endpoint blast radius.
+    validate_test_fixtures(&parsed.fixtures, &parsed.endpoints)?;
     let builder_params = collect_builder_params(&parsed.endpoints);
 
     Ok(vec![

--- a/crates/thetadatadx/endpoint_surface.toml
+++ b/crates/thetadatadx/endpoint_surface.toml
@@ -1466,3 +1466,95 @@ wire_name = "option_history_quote"
 description = "Stream NBBO quotes for an option contract, chunk-by-chunk."
 rest_path = "/v3/option/history/quote"
 returns = "QuoteTicks"
+
+# ─────────────────────────── Live-validator fixtures ────────────────────────
+#
+# Representative values threaded into the (endpoint × mode) matrix that the
+# per-language live-validator renderers emit. Every mode in
+# `build_support/endpoints/modes.rs` reads its fixture values from this block
+# — there are no hardcoded fixture literals in Rust. Editing one row here
+# propagates to every generated validator (CLI, Python, Go, C++) the next
+# time `generate_sdk_surfaces` runs.
+#
+# `parser.rs::validate_test_fixtures` enforces fail-fast at build time:
+#   * every key in any fixture map must be in its expected vocabulary
+#     (real param name, real wire type, known mode/category). Typos like
+#     `expiratoin = "2025-03-21"` fail the build with the offending key.
+#   * every builder-bound optional param across all endpoints must have a
+#     row in `optional_defaults`. A missing row would otherwise silently
+#     drop the corresponding `with_<name>` cell from the matrix.
+
+[test_fixtures]
+# Anchor symbol per endpoint category. Picked to guarantee the representative
+# cell returns a non-empty response on the production server during a normal
+# session's trading window.
+category_symbol = { stock = "AAPL", option = "SPY", index = "SPX", rate = "SOFR" }
+
+# Default representative value per wire `param_type`. Used for every
+# method-call param except `Symbol`/`Symbols`, which route through
+# `category_symbol` above, and params listed in `concrete_overrides` below.
+# 20250303 is a Monday the pinned upstream snapshot confirms is a trading day
+# for every category we emit cells for.
+concrete_by_type = { Date = "20250303", Expiration = "20250321", Strike = "570", Right = "C", Interval = "60000", RequestType = "TRADE", Year = "2025", Str = "12:00:00.000" }
+
+# Per-param-name overrides that beat `concrete_by_type`. Used to compress
+# date ranges so bulk cells stack multiple 60s timeouts without blowing the
+# ~10-minute live-run budget (see issue #290). Widening this back to a
+# multi-day window is the first lever to pull if volume coverage matters
+# more than runtime for a specific cell.
+concrete_overrides = { end_date = "20250303" }
+
+[test_fixtures.optional_defaults]
+# Representative values for builder-bound optionals. Drive `with_<name>`
+# modes and the `all_optionals` combined cell. Every builder param across
+# every endpoint MUST have a row here (enforced by validate_test_fixtures);
+# without one, the corresponding `with_<name>` cell would silently drop
+# from the matrix.
+max_dte = "30"
+strike_range = "10"
+min_time = "09:45:00"
+venue = "nqb"
+start_time = "09:30:00"
+end_time = "10:00:00"
+start_date = "20250303"
+end_date = "20250303"
+exclusive = "true"
+annual_dividend = "0.015"
+rate_type = "sofr"
+rate_value = "0.05"
+stock_price = "150.0"
+version = "dg3"
+use_market_value = "true"
+underlyer_use_nbbo = "true"
+
+[test_fixtures.mode_overrides.concrete_iso]
+# ISO-dashed expiration acceptance is scoped to `Expiration` params (PR #284).
+expiration = "2025-03-21"
+
+[test_fixtures.mode_overrides.all_strikes_one_exp]
+# Concrete expiration, every strike across both rights. Emitted even for
+# endpoints that reject `expiration=*` because the expiration here is a real
+# date, not a wildcard.
+strike = "*"
+right = "both"
+
+[test_fixtures.mode_overrides.all_exps_one_strike]
+# Every expiration at one strike. Only emitted for endpoints upstream binds
+# to `expiration` (wildcard-accepting); skipped for those bound to
+# `expiration_no_star`.
+expiration = "*"
+right = "both"
+
+[test_fixtures.mode_overrides.bulk_chain]
+# Every expiration × every strike. Full option chain, skipped for
+# `expiration_no_star` endpoints.
+expiration = "*"
+strike = "*"
+right = "both"
+
+[test_fixtures.mode_overrides.legacy_zero_wildcard]
+# `0` sentinel is a v3 legacy wildcard form. Skipped for
+# `expiration_no_star` endpoints because they reject both `*` and `0`.
+expiration = "0"
+strike = "0"
+right = "both"


### PR DESCRIPTION
## Summary

`test_modes_for()` in `crates/thetadatadx/build_support/endpoints/modes.rs` previously hardcoded every representative live-validator fixture value — `max_dte=30`, `strike_range=10`, `min_time="09:45:00"`, fixture symbols (`AAPL`/`SPY`/`SPX`/`SOFR`), dates (`20250303`, `20250321`), wildcard sentinels (`*`, `0`, `both`), ISO overrides (`2025-03-21`), etc. Those literals were fixture *data* masquerading as *code* — a second source of truth outside `endpoint_surface.toml`, the file that already owns every other endpoint-surface detail.

This PR completes the migration: every fixture value now lives in a new `[test_fixtures]` block at the bottom of `endpoint_surface.toml`, `modes.rs` reads from it, and Rust contains zero hardcoded fixture literals.

## TOML shape

Added five sub-tables under `[test_fixtures]`:

- `category_symbol` — anchor `Symbol`/`Symbols` per category (`stock`/`option`/`index`/`rate`).
- `concrete_by_type` — default per-wire-`param_type` fixture (`Date`, `Expiration`, `Strike`, `Right`, `Interval`, `RequestType`, `Year`, `Str`).
- `concrete_overrides` — per-param-name overrides that beat `concrete_by_type` (compressed `end_date` keeping bulk cells under the 60s per-cell timeout — see #290).
- `mode_overrides.<mode>` — per-mode override sets for `concrete_iso`, `all_strikes_one_exp`, `all_exps_one_strike`, `bulk_chain`, `legacy_zero_wildcard`.
- `optional_defaults` — representative values for builder-bound optionals driving `with_<name>` and `all_optionals` modes.

## Byte-identity gate

Running `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check` produces identical `scripts/validate_cli.py`, `scripts/validate_python.py`, `sdks/go/validate.go`, and `sdks/cpp/examples/validate.cpp` vs. origin/main. `cargo run … generate_sdk_surfaces` (without `--check`) on `main` and on this branch yields a byte-identical tree — confirmed with `diff /tmp/baseline/*` after regenerating.

## LOC delta

- `build_support/endpoints/modes.rs`: 490 → 516 (+26) — the fixture *data* moves out but the plumbing to thread `&TestFixtures` through adds a few lines. Every representative value in Rust is gone; what remains is pure logic.
- `crates/thetadatadx/endpoint_surface.toml`: +82 LOC for the `[test_fixtures]` block.
- `build_support/endpoints/helpers.rs`: 801 → 789 (-12) — removed `validation_symbol` (its category→symbol table moved to `test_fixtures.category_symbol`).

Net: data moves from Rust constants to TOML rows; Rust now carries only the mode-selection *logic*.

## Scope beyond fixture migration

- Added `SurfaceTestFixtures` (TOML parse shape) + `TestFixtures` (resolved shape consumed by `modes.rs`) to `model.rs`.
- `parser.rs` parses the block and exposes it via `ParsedEndpoints.fixtures`.
- `proto_parser.rs`'s `ParsedEndpoints` constructor returns `TestFixtures::default()` (unused; just keeps the type total).
- All four `render_*_validate` renderers take `&TestFixtures` alongside `&[GeneratedEndpoint]`; `sdk_files.rs` threads `&parsed.fixtures` through.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — all green (109 + 178 + doc tests pass)
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check` — no drift
- [x] `python3 scripts/check_docs_consistency.py` — ok
- [x] `git diff` on `scripts/validate_cli.py`, `scripts/validate_python.py`, `sdks/go/validate.go`, `sdks/cpp/examples/validate.cpp`, `sdks/python/src/historical_methods.rs` — empty

Built on W2 (`885ac2e`) — the freshly-split module tree under `build_support/endpoints/`.

