### PR TITLE
refactor(test): per-cell rationale + redundancy audit (W6)

### DIFF
--- a/crates/thetadatadx/build_support/endpoints/modes.rs
+++ b/crates/thetadatadx/build_support/endpoints/modes.rs
@@ -32,6 +32,11 @@ pub(super) struct TestMode {
     /// Mode identifier (`concrete`, `bulk_chain`, `iso_date`, ...). Used in
     /// validator output so failures point at a specific cell.
     pub(super) name: String,
+    /// One-sentence description of what this cell proves. Emitted as a
+    /// comment in the generated validators, as a field in the per-cell JSON
+    /// artifact, and shown in `validate_agreement.py` disagreement output so
+    /// a reviewer reading a FAIL immediately sees which feature broke.
+    pub(super) rationale: &'static str,
     /// Method-call positional arguments, in declaration order. Each entry is
     /// the language-agnostic string value (e.g. `"SPY"`, `"20260417"`,
     /// `"*"`). `Symbols`-typed params are still rendered as a single string
@@ -52,6 +57,72 @@ pub(super) struct TestMode {
     /// `EndpointRequestOptions{}.with_xxx()`. CLI skips these (positional
     /// clap args don't support targeted optional injection); see PR #291.
     pub(super) builder_overrides: Vec<(String, String)>,
+}
+
+/// One-sentence rationale describing what each mode proves.
+///
+/// Surfaces in three places:
+/// * inline `# rationale:` comment in the generated validator scripts so a
+///   reader of `scripts/validate_python.py` sees per-cell intent;
+/// * `rationale` field in the per-cell JSON artifact; and
+/// * `validate_agreement.py` failure output, so a FAIL line carries the
+///   feature description not just the mode name.
+///
+/// Kept ≤100 chars so it fits on one line in failure tables. Per-optional
+/// `with_<name>` modes are produced from
+/// [`with_optional_rationale`] which builds a string at generator runtime.
+fn rationale_for_mode(name: &str) -> &'static str {
+    match name {
+        "basic" => "list/calendar/rate baseline call — no parameter variation",
+        "concrete" => "required params set, no optionals — baseline wire path",
+        "concrete_iso" => {
+            "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD"
+        }
+        "all_strikes_one_exp" => {
+            "strike=* on a supported endpoint — exercises strike wildcard wire-unset"
+        }
+        "all_exps_one_strike" => "expiration=* — exercises expiration wildcard wire-unset",
+        "bulk_chain" => "expiration=* + strike=* + right=both — tests full-chain server mode",
+        "legacy_zero_wildcard" => {
+            "expiration=0 + strike=0 → translated to * on wire — backward compat"
+        }
+        "with_intraday_window" => "start_time + end_time pair — intraday window optional wiring",
+        "with_date_range" => "start_date + end_date pair — date range optional wiring",
+        "all_optionals" => "every applicable optional set at once — proves multi-optional wiring",
+        _ => panic!(
+            "rationale_for_mode: unknown mode '{name}'; add a rationale to TestMode generation"
+        ),
+    }
+}
+
+/// Build a one-sentence rationale string for a `with_<param>` mode at
+/// generator runtime. Uses a small static table to keep entries succinct.
+fn with_optional_rationale(param_name: &str) -> &'static str {
+    match param_name {
+        "max_dte" => "max_dte=30 optional filter wiring",
+        "strike_range" => "strike_range=10 optional filter wiring",
+        "min_time" => "min_time=09:45:00 optional filter wiring",
+        "venue" => "venue=nqb optional venue selector wiring",
+        "exclusive" => "exclusive=true optional filter wiring",
+        "annual_dividend" => "annual_dividend=0.015 optional Greeks-input wiring",
+        "rate_type" => "rate_type=sofr optional Greeks-input wiring",
+        "rate_value" => "rate_value=0.05 optional Greeks-input wiring",
+        "stock_price" => "stock_price=150 optional Greeks-input wiring",
+        "version" => "version=dg3 optional Greeks-version selector wiring",
+        "use_market_value" => "use_market_value=true optional flag wiring",
+        "underlyer_use_nbbo" => "underlyer_use_nbbo=true optional flag wiring",
+        // start_time/end_time/start_date/end_date are exercised via the paired
+        // `with_intraday_window` / `with_date_range` modes; if a future
+        // endpoint accepts only one half they would fall through to here.
+        "start_time" => "start_time=09:30:00 optional filter wiring",
+        "end_time" => "end_time=10:00:00 optional filter wiring",
+        "start_date" => "start_date=20250303 optional filter wiring",
+        "end_date" => "end_date=20250303 optional filter wiring",
+        _ => panic!(
+            "with_optional_rationale: unknown optional param '{param_name}'; \
+             add a rationale before adding a new optional fixture"
+        ),
+    }
 }
 
 /// Minimum subscription tier each endpoint requires.
@@ -220,32 +291,34 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
 
     // ── List endpoints: one mode, no wildcard expiration (server rejects). ──
     if is_simple_list_endpoint(endpoint) {
-        return append_optional_modes(
+        return collapse_redundant_wires(append_optional_modes(
             endpoint,
             endpoint_tier,
             vec![TestMode {
                 name: "basic".to_string(),
+                rationale: rationale_for_mode("basic"),
                 args: concrete_args(endpoint),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
                 builder_overrides: Vec::new(),
             }],
-        );
+        ));
     }
 
     // ── Calendar / rate: one mode. ──────────────────────────────────────────
     if matches!(endpoint.category.as_str(), "calendar" | "rate") {
-        return append_optional_modes(
+        return collapse_redundant_wires(append_optional_modes(
             endpoint,
             endpoint_tier,
             vec![TestMode {
                 name: "basic".to_string(),
+                rationale: rationale_for_mode("basic"),
                 args: concrete_args(endpoint),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
                 builder_overrides: Vec::new(),
             }],
-        );
+        ));
     }
 
     // ── Option ContractSpec: full wildcard cross-product, except where the
@@ -259,6 +332,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
         let mut modes = vec![
             TestMode {
                 name: "concrete".to_string(),
+                rationale: rationale_for_mode("concrete"),
                 args: concrete_args(endpoint),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
@@ -266,6 +340,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             },
             TestMode {
                 name: "concrete_iso".to_string(),
+                rationale: rationale_for_mode("concrete_iso"),
                 args: args_with_overrides(endpoint, &[("expiration", "2025-03-21")]),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
@@ -273,6 +348,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             },
             TestMode {
                 name: "all_strikes_one_exp".to_string(),
+                rationale: rationale_for_mode("all_strikes_one_exp"),
                 args: args_with_overrides(endpoint, &[("strike", "*"), ("right", "both")]),
                 min_tier: endpoint_tier,
                 expect: "non_empty",
@@ -283,6 +359,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             modes.extend([
                 TestMode {
                     name: "all_exps_one_strike".to_string(),
+                    rationale: rationale_for_mode("all_exps_one_strike"),
                     args: args_with_overrides(endpoint, &[("expiration", "*"), ("right", "both")]),
                     min_tier: endpoint_tier,
                     expect: "non_empty",
@@ -290,6 +367,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
                 },
                 TestMode {
                     name: "bulk_chain".to_string(),
+                    rationale: rationale_for_mode("bulk_chain"),
                     args: args_with_overrides(
                         endpoint,
                         &[("expiration", "*"), ("strike", "*"), ("right", "both")],
@@ -300,6 +378,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
                 },
                 TestMode {
                     name: "legacy_zero_wildcard".to_string(),
+                    rationale: rationale_for_mode("legacy_zero_wildcard"),
                     args: args_with_overrides(
                         endpoint,
                         &[("expiration", "0"), ("strike", "0"), ("right", "both")],
@@ -311,7 +390,7 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             ]);
         }
         modes.dedup_by(|a, b| a.args == b.args && a.name == b.name);
-        return append_optional_modes(endpoint, endpoint_tier, modes);
+        return collapse_redundant_wires(append_optional_modes(endpoint, endpoint_tier, modes));
     }
 
     // ── Stock / index / non-ContractSpec endpoints. ─────────────────────────
@@ -322,17 +401,18 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
     // `YYYYMMDD` only — ISO-dashed acceptance is scoped to `Expiration`
     // (see PR #284). Adding an `iso_date` cell here would test behavior the
     // SDK contract intentionally does not support, so it would always fail.
-    append_optional_modes(
+    collapse_redundant_wires(append_optional_modes(
         endpoint,
         endpoint_tier,
         vec![TestMode {
             name: "concrete".to_string(),
+            rationale: rationale_for_mode("concrete"),
             args: concrete_args(endpoint),
             min_tier: endpoint_tier,
             expect: "non_empty",
             builder_overrides: Vec::new(),
         }],
-    )
+    ))
 }
 
 /// Representative value to feed each builder-bound (optional) parameter in
@@ -416,6 +496,7 @@ fn append_optional_modes(
         ];
         modes.push(TestMode {
             name: "with_intraday_window".to_string(),
+            rationale: rationale_for_mode("with_intraday_window"),
             args: concrete_args(endpoint),
             min_tier: endpoint_tier,
             expect: "non_empty",
@@ -441,6 +522,7 @@ fn append_optional_modes(
         ];
         modes.push(TestMode {
             name: "with_date_range".to_string(),
+            rationale: rationale_for_mode("with_date_range"),
             args: concrete_args(endpoint),
             min_tier: endpoint_tier,
             expect: "non_empty",
@@ -460,6 +542,7 @@ fn append_optional_modes(
         };
         modes.push(TestMode {
             name: format!("with_{param_name}"),
+            rationale: with_optional_rationale(param_name),
             args: concrete_args(endpoint),
             min_tier: endpoint_tier,
             expect: "non_empty",
@@ -479,6 +562,7 @@ fn append_optional_modes(
     if !all_overrides.is_empty() {
         modes.push(TestMode {
             name: "all_optionals".to_string(),
+            rationale: rationale_for_mode("all_optionals"),
             args: concrete_args(endpoint),
             min_tier: endpoint_tier,
             expect: "non_empty",
@@ -487,4 +571,71 @@ fn append_optional_modes(
     }
 
     modes
+}
+
+/// Collapse cells with identical wire shape down to a single canonical cell.
+///
+/// "Wire shape" here is `(args, sorted(builder_overrides))` — the tuple of
+/// values the SDK will marshal onto the proto request. Two cells that map to
+/// the same tuple will hit the server with byte-identical messages, so
+/// keeping both adds runtime cost (each ~60s timeout-bounded) without
+/// covering any new code path.
+///
+/// Collapsing rules:
+/// * Group modes by their wire-shape signature.
+/// * Within each group keep ONE representative (the lowest-index entry, so
+///   the canonical mode like `concrete`/`bulk_chain` wins over a later
+///   `with_<name>` whose override happened to match an existing fixture).
+/// * Append the names of the collapsed siblings into the kept cell's
+///   rationale as `(also covers: a, b)`. The downstream agreement output
+///   then makes it explicit that one cell is checking two named features.
+///
+/// This is the audit step from W6: the matrix used to silently include
+/// duplicate cells whenever an optional fixture happened to overlap a
+/// concrete value. Now no two emitted cells can share a wire shape; if they
+/// would, the duplicates roll up under the canonical mode's name.
+fn collapse_redundant_wires(modes: Vec<TestMode>) -> Vec<TestMode> {
+    use std::collections::BTreeMap;
+    // Wire-shape signature: positional args + sorted optional-override pairs.
+    // Two modes whose signatures are equal will marshal to byte-identical
+    // proto messages, so collapsing them removes only redundant runtime cost.
+    type WireSignature = (Vec<String>, Vec<(String, String)>);
+    let mut buckets: BTreeMap<WireSignature, Vec<usize>> = BTreeMap::new();
+    for (idx, mode) in modes.iter().enumerate() {
+        let mut sorted_overrides = mode.builder_overrides.clone();
+        sorted_overrides.sort();
+        buckets
+            .entry((mode.args.clone(), sorted_overrides))
+            .or_default()
+            .push(idx);
+    }
+    let mut keep_idx: Vec<(usize, Vec<String>)> = buckets
+        .values()
+        .map(|indices| {
+            let canonical = *indices.iter().min().unwrap();
+            let collapsed: Vec<String> = indices
+                .iter()
+                .filter(|&&i| i != canonical)
+                .map(|&i| modes[i].name.clone())
+                .collect();
+            (canonical, collapsed)
+        })
+        .collect();
+    keep_idx.sort_by_key(|(idx, _)| *idx);
+
+    let mut out = Vec::with_capacity(keep_idx.len());
+    for (idx, collapsed) in keep_idx {
+        let mut mode = modes[idx].clone();
+        if !collapsed.is_empty() {
+            // Build the appended rationale at generator runtime, then leak it
+            // to satisfy the `&'static str` field — generator runs once per
+            // build so the lifetime cost is one allocation per collapsed
+            // group, never freed across the build's lifetime. Kept under
+            // 200 chars to stay readable in the agreement table.
+            let extended = format!("{} (also covers: {})", mode.rationale, collapsed.join(", "));
+            mode.rationale = Box::leak(extended.into_boxed_str());
+        }
+        out.push(mode);
+    }
+    out
 }

--- a/crates/thetadatadx/build_support/endpoints/modes.rs
+++ b/crates/thetadatadx/build_support/endpoints/modes.rs
@@ -79,12 +79,12 @@ fn rationale_for_mode(name: &str) -> &'static str {
             "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD"
         }
         "all_strikes_one_exp" => {
-            "strike=* on a supported endpoint — exercises strike wildcard wire-unset"
+            "strike=* — collapses to proto-unset ContractSpec.strike (server default)"
         }
-        "all_exps_one_strike" => "expiration=* — exercises expiration wildcard wire-unset",
+        "all_exps_one_strike" => "expiration=* — sent as literal `*` on the wire (server fan-out)",
         "bulk_chain" => "expiration=* + strike=* + right=both — tests full-chain server mode",
         "legacy_zero_wildcard" => {
-            "expiration=0 + strike=0 → translated to * on wire — backward compat"
+            "expiration=0 → wire `*`; strike=0 + right=both → proto-unset — legacy-input compat"
         }
         "with_intraday_window" => "start_time + end_time pair — intraday window optional wiring",
         "with_date_range" => "start_date + end_date pair — date range optional wiring",
@@ -96,33 +96,24 @@ fn rationale_for_mode(name: &str) -> &'static str {
 }
 
 /// Build a one-sentence rationale string for a `with_<param>` mode at
-/// generator runtime. Uses a small static table to keep entries succinct.
-fn with_optional_rationale(param_name: &str) -> &'static str {
-    match param_name {
-        "max_dte" => "max_dte=30 optional filter wiring",
-        "strike_range" => "strike_range=10 optional filter wiring",
-        "min_time" => "min_time=09:45:00 optional filter wiring",
-        "venue" => "venue=nqb optional venue selector wiring",
-        "exclusive" => "exclusive=true optional filter wiring",
-        "annual_dividend" => "annual_dividend=0.015 optional Greeks-input wiring",
-        "rate_type" => "rate_type=sofr optional Greeks-input wiring",
-        "rate_value" => "rate_value=0.05 optional Greeks-input wiring",
-        "stock_price" => "stock_price=150 optional Greeks-input wiring",
-        "version" => "version=dg3 optional Greeks-version selector wiring",
-        "use_market_value" => "use_market_value=true optional flag wiring",
-        "underlyer_use_nbbo" => "underlyer_use_nbbo=true optional flag wiring",
-        // start_time/end_time/start_date/end_date are exercised via the paired
-        // `with_intraday_window` / `with_date_range` modes; if a future
-        // endpoint accepts only one half they would fall through to here.
-        "start_time" => "start_time=09:30:00 optional filter wiring",
-        "end_time" => "end_time=10:00:00 optional filter wiring",
-        "start_date" => "start_date=20250303 optional filter wiring",
-        "end_date" => "end_date=20250303 optional filter wiring",
+/// generator runtime. The literal value is threaded in from the
+/// [`optional_fixture_value`] table so the two can never drift.
+fn with_optional_rationale(param_name: &str, literal: &str) -> String {
+    let label = match param_name {
+        "max_dte" | "strike_range" | "min_time" | "exclusive" | "start_time" | "end_time"
+        | "start_date" | "end_date" => "optional filter wiring",
+        "venue" => "optional venue selector wiring",
+        "annual_dividend" | "rate_type" | "rate_value" | "stock_price" => {
+            "optional Greeks-input wiring"
+        }
+        "version" => "optional Greeks-version selector wiring",
+        "use_market_value" | "underlyer_use_nbbo" => "optional flag wiring",
         _ => panic!(
             "with_optional_rationale: unknown optional param '{param_name}'; \
-             add a rationale before adding a new optional fixture"
+             add a rationale class before adding a new optional fixture"
         ),
-    }
+    };
+    format!("{param_name}={literal} {label}")
 }
 
 /// Minimum subscription tier each endpoint requires.
@@ -291,34 +282,40 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
 
     // ── List endpoints: one mode, no wildcard expiration (server rejects). ──
     if is_simple_list_endpoint(endpoint) {
-        return collapse_redundant_wires(append_optional_modes(
+        return collapse_redundant_wires(
             endpoint,
-            endpoint_tier,
-            vec![TestMode {
-                name: "basic".to_string(),
-                rationale: rationale_for_mode("basic"),
-                args: concrete_args(endpoint),
-                min_tier: endpoint_tier,
-                expect: "non_empty",
-                builder_overrides: Vec::new(),
-            }],
-        ));
+            append_optional_modes(
+                endpoint,
+                endpoint_tier,
+                vec![TestMode {
+                    name: "basic".to_string(),
+                    rationale: rationale_for_mode("basic"),
+                    args: concrete_args(endpoint),
+                    min_tier: endpoint_tier,
+                    expect: "non_empty",
+                    builder_overrides: Vec::new(),
+                }],
+            ),
+        );
     }
 
     // ── Calendar / rate: one mode. ──────────────────────────────────────────
     if matches!(endpoint.category.as_str(), "calendar" | "rate") {
-        return collapse_redundant_wires(append_optional_modes(
+        return collapse_redundant_wires(
             endpoint,
-            endpoint_tier,
-            vec![TestMode {
-                name: "basic".to_string(),
-                rationale: rationale_for_mode("basic"),
-                args: concrete_args(endpoint),
-                min_tier: endpoint_tier,
-                expect: "non_empty",
-                builder_overrides: Vec::new(),
-            }],
-        ));
+            append_optional_modes(
+                endpoint,
+                endpoint_tier,
+                vec![TestMode {
+                    name: "basic".to_string(),
+                    rationale: rationale_for_mode("basic"),
+                    args: concrete_args(endpoint),
+                    min_tier: endpoint_tier,
+                    expect: "non_empty",
+                    builder_overrides: Vec::new(),
+                }],
+            ),
+        );
     }
 
     // ── Option ContractSpec: full wildcard cross-product, except where the
@@ -390,7 +387,10 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
             ]);
         }
         modes.dedup_by(|a, b| a.args == b.args && a.name == b.name);
-        return collapse_redundant_wires(append_optional_modes(endpoint, endpoint_tier, modes));
+        return collapse_redundant_wires(
+            endpoint,
+            append_optional_modes(endpoint, endpoint_tier, modes),
+        );
     }
 
     // ── Stock / index / non-ContractSpec endpoints. ─────────────────────────
@@ -401,18 +401,21 @@ pub(super) fn test_modes_for(endpoint: &GeneratedEndpoint) -> Vec<TestMode> {
     // `YYYYMMDD` only — ISO-dashed acceptance is scoped to `Expiration`
     // (see PR #284). Adding an `iso_date` cell here would test behavior the
     // SDK contract intentionally does not support, so it would always fail.
-    collapse_redundant_wires(append_optional_modes(
+    collapse_redundant_wires(
         endpoint,
-        endpoint_tier,
-        vec![TestMode {
-            name: "concrete".to_string(),
-            rationale: rationale_for_mode("concrete"),
-            args: concrete_args(endpoint),
-            min_tier: endpoint_tier,
-            expect: "non_empty",
-            builder_overrides: Vec::new(),
-        }],
-    ))
+        append_optional_modes(
+            endpoint,
+            endpoint_tier,
+            vec![TestMode {
+                name: "concrete".to_string(),
+                rationale: rationale_for_mode("concrete"),
+                args: concrete_args(endpoint),
+                min_tier: endpoint_tier,
+                expect: "non_empty",
+                builder_overrides: Vec::new(),
+            }],
+        ),
+    )
 }
 
 /// Representative value to feed each builder-bound (optional) parameter in
@@ -540,9 +543,15 @@ fn append_optional_modes(
         let Some(value) = optional_fixture_value(param_name) else {
             continue;
         };
+        // Rationale carries the exact fixture literal so the cell's text
+        // can never drift from `optional_fixture_value`. `String` is
+        // promoted to `&'static str` via `Box::leak` — generator runs once
+        // per build, so the allocation is effectively one-time.
+        let rationale: &'static str =
+            Box::leak(with_optional_rationale(param_name, value).into_boxed_str());
         modes.push(TestMode {
             name: format!("with_{param_name}"),
-            rationale: with_optional_rationale(param_name),
+            rationale,
             args: concrete_args(endpoint),
             min_tier: endpoint_tier,
             expect: "non_empty",
@@ -573,41 +582,144 @@ fn append_optional_modes(
     modes
 }
 
-/// Collapse cells with identical wire shape down to a single canonical cell.
+/// Approximate the wire-level canonicalization performed by the runtime
+/// client, so two modes whose proto messages differ only by SDK-level
+/// sentinel translation are detected as duplicates here.
 ///
-/// "Wire shape" here is `(args, sorted(builder_overrides))` — the tuple of
-/// values the SDK will marshal onto the proto request. Two cells that map to
-/// the same tuple will hit the server with byte-identical messages, so
-/// keeping both adds runtime cost (each ~60s timeout-bounded) without
-/// covering any new code path.
+/// Mirrors three runtime transformations:
+/// * `expiration`: `"0"` → `"*"`; ISO-dashed → compact `YYYYMMDD`.
+///   See `crates/thetadatadx/src/direct.rs:84` (`normalize_expiration`).
+/// * `strike`:     `""` / `"0"` / `"*"` → proto-unset.
+///   See `crates/thetadatadx/src/direct.rs:100` (`wire_strike_opt`).
+/// * `right`:      `"*"` / `"both"` (any case) → proto-unset.
+///   See `crates/thetadatadx/src/direct.rs:118` (`wire_right_opt`).
+///
+/// The canonical token is the string we expect the server to see. `None`
+/// means "proto field unset" — represented here as the sentinel
+/// `"<unset>"` so the grouping key stays a plain `String`. Any divergence
+/// between this pass and the runtime normalization is a bug (the audit
+/// stops being load-bearing); the runtime side has unit tests in
+/// `crates/thetadatadx/src/direct.rs`, the intent here is to stay in sync
+/// with those exact rules.
+fn canonicalize_wire_arg(param_name: &str, value: &str) -> String {
+    const UNSET: &str = "<unset>";
+    match param_name {
+        "expiration" => match value {
+            "0" => "*".to_string(),
+            v if is_build_time_iso_date(v) => v.replace('-', ""),
+            other => other.to_string(),
+        },
+        "strike" => {
+            if value.is_empty() || value == "*" || value == "0" {
+                UNSET.to_string()
+            } else {
+                value.to_string()
+            }
+        }
+        "right" => match value.to_ascii_lowercase().as_str() {
+            "*" | "both" => UNSET.to_string(),
+            "c" | "call" => "call".to_string(),
+            "p" | "put" => "put".to_string(),
+            other => other.to_string(),
+        },
+        _ => value.to_string(),
+    }
+}
+
+/// Build-time mirror of `crates/thetadatadx/src/validate.rs::is_iso_date`.
+/// Kept here to avoid taking a build dependency on the runtime crate.
+fn is_build_time_iso_date(value: &str) -> bool {
+    let mut parts = value.splitn(3, '-');
+    matches!(
+        (parts.next(), parts.next(), parts.next(), parts.next()),
+        (Some(y), Some(m), Some(d), None)
+            if y.len() == 4
+                && m.len() == 2
+                && d.len() == 2
+                && y.bytes().all(|b| b.is_ascii_digit())
+                && m.bytes().all(|b| b.is_ascii_digit())
+                && d.bytes().all(|b| b.is_ascii_digit())
+    )
+}
+
+/// Collapse cells whose post-canonicalization wire shape is identical down
+/// to a single canonical cell.
+///
+/// The signature combines:
+/// * positional args run through [`canonicalize_wire_arg`] per-param name,
+///   which mirrors the runtime's `expiration`/`strike`/`right` rewriting;
+/// * builder-override pairs, also canonicalized, sorted, **and** with stock
+///   endpoints' `"venue" → "nqb"` default synthesized in whenever the
+///   endpoint's `venue` param is absent from the mode's overrides.
+///   See `render/direct.rs:433` for the runtime default.
+///
+/// Two modes with equal signatures will marshal byte-identical proto
+/// messages, so collapsing them removes only redundant runtime cost.
 ///
 /// Collapsing rules:
-/// * Group modes by their wire-shape signature.
-/// * Within each group keep ONE representative (the lowest-index entry, so
-///   the canonical mode like `concrete`/`bulk_chain` wins over a later
-///   `with_<name>` whose override happened to match an existing fixture).
-/// * Append the names of the collapsed siblings into the kept cell's
-///   rationale as `(also covers: a, b)`. The downstream agreement output
-///   then makes it explicit that one cell is checking two named features.
+/// * Group modes by their canonicalized signature.
+/// * Within each group keep the lowest-index entry, so canonical modes like
+///   `concrete`/`bulk_chain` win over a later `with_<name>` whose override
+///   happened to match an existing fixture.
+/// * Append the names of collapsed siblings to the kept cell's rationale as
+///   `(also covers: a, b)` so the downstream agreement output makes the
+///   roll-up visible.
 ///
-/// This is the audit step from W6: the matrix used to silently include
-/// duplicate cells whenever an optional fixture happened to overlap a
-/// concrete value. Now no two emitted cells can share a wire shape; if they
-/// would, the duplicates roll up under the canonical mode's name.
-fn collapse_redundant_wires(modes: Vec<TestMode>) -> Vec<TestMode> {
+/// This is the audit step from W6: before it, cells with overlapping wire
+/// shapes co-existed silently. After it, no two emitted cells for a given
+/// endpoint share a wire shape; siblings are documented inline.
+fn collapse_redundant_wires(endpoint: &GeneratedEndpoint, modes: Vec<TestMode>) -> Vec<TestMode> {
     use std::collections::BTreeMap;
-    // Wire-shape signature: positional args + sorted optional-override pairs.
-    // Two modes whose signatures are equal will marshal to byte-identical
-    // proto messages, so collapsing them removes only redundant runtime cost.
+    // Canonicalized wire signature: positional args + sorted override pairs,
+    // with runtime-equivalent normalization applied to both sides.
     type WireSignature = (Vec<String>, Vec<(String, String)>);
+
+    let method_param_names: Vec<String> = method_params(endpoint)
+        .iter()
+        .map(|param| param.name.clone())
+        .collect();
+    let has_stock_venue_default = endpoint.category == "stock"
+        && builder_params(endpoint)
+            .iter()
+            .any(|param| param.name == "venue");
+
+    let canonical_overrides = |overrides: &[(String, String)]| -> Vec<(String, String)> {
+        let mut pairs: Vec<(String, String)> = overrides
+            .iter()
+            .map(|(k, v)| (k.clone(), canonicalize_wire_arg(k, v)))
+            .collect();
+        // Synthesize the stock-endpoint `venue=nqb` default when the mode
+        // doesn't override it: the runtime fills this in at request-build
+        // time (`render/direct.rs:433`), so omitting it here would make
+        // `concrete` and `with_venue` look like distinct wire shapes
+        // despite producing identical proto messages.
+        if has_stock_venue_default && !pairs.iter().any(|(k, _)| k == "venue") {
+            pairs.push(("venue".to_string(), "nqb".to_string()));
+        }
+        pairs.sort();
+        pairs
+    };
+
+    let canonical_args = |args: &[String]| -> Vec<String> {
+        args.iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let name = method_param_names
+                    .get(i)
+                    .map(String::as_str)
+                    .unwrap_or_default();
+                canonicalize_wire_arg(name, v)
+            })
+            .collect()
+    };
+
     let mut buckets: BTreeMap<WireSignature, Vec<usize>> = BTreeMap::new();
     for (idx, mode) in modes.iter().enumerate() {
-        let mut sorted_overrides = mode.builder_overrides.clone();
-        sorted_overrides.sort();
-        buckets
-            .entry((mode.args.clone(), sorted_overrides))
-            .or_default()
-            .push(idx);
+        let key = (
+            canonical_args(&mode.args),
+            canonical_overrides(&mode.builder_overrides),
+        );
+        buckets.entry(key).or_default().push(idx);
     }
     let mut keep_idx: Vec<(usize, Vec<String>)> = buckets
         .values()

--- a/crates/thetadatadx/build_support/endpoints/render/cli_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/cli_validate.rs
@@ -42,6 +42,7 @@ pub(super) fn render_cli_validate(endpoints: &[GeneratedEndpoint]) -> String {
                 endpoint = endpoint.name,
                 mode = mode.name,
                 min_tier = mode.min_tier,
+                rationale = mode.rationale,
                 args = tokens,
             )
             .unwrap();

--- a/crates/thetadatadx/build_support/endpoints/render/cpp_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/cpp_validate.rs
@@ -45,6 +45,7 @@ pub(super) fn render_cpp_validate(endpoints: &[GeneratedEndpoint]) -> String {
                 endpoint = endpoint.name,
                 mode = mode.name,
                 min_tier = mode.min_tier,
+                rationale = mode.rationale,
                 endpoint_name = endpoint.name,
                 args = args,
             )

--- a/crates/thetadatadx/build_support/endpoints/render/go_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/go_validate.rs
@@ -43,6 +43,7 @@ pub(super) fn render_go_validate(endpoints: &[GeneratedEndpoint]) -> String {
                 endpoint = endpoint.name,
                 mode = mode.name,
                 min_tier = mode.min_tier,
+                rationale = mode.rationale,
                 go_method_name = go_name,
                 args = args,
             )

--- a/crates/thetadatadx/build_support/endpoints/render/python_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/python_validate.rs
@@ -39,6 +39,7 @@ pub(super) fn render_python_validate(endpoints: &[GeneratedEndpoint]) -> String 
                 endpoint = endpoint.name,
                 mode = mode.name,
                 min_tier = mode.min_tier,
+                rationale = mode.rationale,
                 endpoint_name = endpoint.name,
                 args = args,
             )

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/cell.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/cell.py.tmpl
@@ -1,1 +1,3 @@
-    ({endpoint:?}, {mode:?}, {min_tier:?}, [{args}]),
+    # {endpoint}::{mode}
+    #   rationale: {rationale}
+    ({endpoint:?}, {mode:?}, {min_tier:?}, {rationale:?}, [{args}]),

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/postamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/postamble.py.tmpl
@@ -42,7 +42,7 @@ def _json_row_count(output: str) -> int:
             return 1
     return 0
 
-for endpoint, mode, min_tier, argv in CELLS:
+for endpoint, mode, min_tier, rationale, argv in CELLS:
     label = f"{endpoint}::{mode}"
     t0 = time.monotonic()
     try:
@@ -59,7 +59,8 @@ for endpoint, mode, min_tier, argv in CELLS:
         print(f"  {label:60s} FAIL  timeout after {PER_CELL_TIMEOUT_SECS}s")
         fail_count += 1
         records.append({
-            "endpoint": endpoint, "mode": mode, "status": "FAIL",
+            "endpoint": endpoint, "mode": mode, "rationale": rationale,
+            "status": "FAIL",
             "row_count": 0, "duration_ms": duration_ms, "detail": "timeout after 60s",
         })
         continue
@@ -86,11 +87,15 @@ for endpoint, mode, min_tier, argv in CELLS:
         pass_count += 1
     else:
         status = "FAIL"
-        detail = output.strip()[:200]
+        # CLI stdout can contain embedded newlines (panics, multi-line errors);
+        # keeping them in `detail` would wreck row alignment in
+        # validate_agreement.py's disagreement table. Escape at the producer.
+        detail = output.strip().replace("\n", "\\n").replace("\r", "\\r")[:200]
         print(f"  {label:60s} FAIL  {output.strip()}")
         fail_count += 1
     records.append({
-        "endpoint": endpoint, "mode": mode, "status": status,
+        "endpoint": endpoint, "mode": mode, "rationale": rationale,
+        "status": status,
         "row_count": row_count, "duration_ms": duration_ms, "detail": detail,
     })
 

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/preamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/preamble.py.tmpl
@@ -31,7 +31,9 @@ REPO = pathlib.Path(__file__).resolve().parents[1]
 TDX = REPO / "target" / "release" / ("tdx.exe" if os.name == "nt" else "tdx")
 ARTIFACT_PATH = REPO / "artifacts" / "validator_cli.json"
 
-# (endpoint, mode_name, declared_min_tier, [argv...])
+# (endpoint, mode_name, declared_min_tier, rationale, [argv...])
 # `declared_min_tier` is informational only (printed on tier-permission
-# skips so you can see which modes the server refused).
+# skips so you can see which modes the server refused). `rationale` is a
+# one-sentence description of what the cell proves; surfaces in the
+# per-cell JSON artifact and in scripts/validate_agreement.py output.
 CELLS = [

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cpp/cell.cpp.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cpp/cell.cpp.tmpl
@@ -1,1 +1,3 @@
-        cell({endpoint:?}, {mode:?}, {min_tier:?}, [&] {{ return client.{endpoint_name}({args}); }});
+        // {endpoint}::{mode}
+        //   rationale: {rationale}
+        cell({endpoint:?}, {mode:?}, {min_tier:?}, {rationale:?}, [&] {{ return client.{endpoint_name}({args}); }});

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cpp/postamble.cpp.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cpp/postamble.cpp.tmpl
@@ -14,6 +14,7 @@
             const auto& r = records[i];
             artifact << "    {\"endpoint\": \"" << json_escape(r.endpoint) << "\", ";
             artifact << "\"mode\": \"" << json_escape(r.mode) << "\", ";
+            artifact << "\"rationale\": \"" << json_escape(r.rationale) << "\", ";
             artifact << "\"status\": \"" << json_escape(r.status) << "\", ";
             artifact << "\"row_count\": " << r.row_count << ", ";
             artifact << "\"duration_ms\": " << r.duration_ms << ", ";

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cpp/preamble.cpp.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cpp/preamble.cpp.tmpl
@@ -42,6 +42,10 @@ std::string lower(std::string value) {
 struct CellRecord {
     std::string endpoint;
     std::string mode;
+    // rationale is the one-sentence cell description from the generator
+    // (rationale_for_mode in build_support/endpoints/modes.rs); surfaces
+    // in scripts/validate_agreement.py disagreement output.
+    std::string rationale;
     std::string status;
     int row_count = 0;
     long long duration_ms = 0;
@@ -89,9 +93,9 @@ int main(int argc, char** argv) {
         auto config = tdx::Config::production();
         auto client = tdx::Client::connect(creds, config);
 
-        auto cell = [&](const char* endpoint, const char* mode, const char* declared_min_tier, auto&& call) {
+        auto cell = [&](const char* endpoint, const char* mode, const char* declared_min_tier, const char* rationale, auto&& call) {
             const std::string label = std::string(endpoint) + "::" + mode;
-            CellRecord rec{endpoint, mode, std::string{}, 0, 0, std::string{}};
+            CellRecord rec{endpoint, mode, rationale, std::string{}, 0, 0, std::string{}};
             // If a prior cell timed out, its worker thread is still running
             // an FFI call against `client`. The FFI is not thread-safe on the
             // same handle (ffi/src/lib.rs:21), so we must NOT issue another
@@ -151,7 +155,12 @@ int main(int argc, char** argv) {
                     std::cout << "  " << std::left << std::setw(60) << label << " FAIL  " << e.what() << std::endl;
                     ++fail;
                     rec.status = "FAIL";
+                    // Runtime error messages can contain embedded newlines;
+                    // escape them so the agreement-table row stays on one
+                    // line (see scripts/validate_agreement.py).
                     std::string d = e.what();
+                    for (size_t pos = 0; (pos = d.find('\n', pos)) != std::string::npos; ) { d.replace(pos, 1, "\\n"); pos += 2; }
+                    for (size_t pos = 0; (pos = d.find('\r', pos)) != std::string::npos; ) { d.replace(pos, 1, "\\r"); pos += 2; }
                     if (d.size() > 200) { d = d.substr(0, 200); }
                     rec.detail = std::move(d);
                 }

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/cell.go.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/cell.go.tmpl
@@ -1,6 +1,8 @@
+	// {endpoint}::{mode}
+	//   rationale: {rationale}
 	if !hadTimeout {{
 		r = runWithTimeout(func() (int, error) {{ v, e := c.{go_method_name}({args}); return goRowCount(v), e }})
-		records = classify({endpoint:?}, {mode:?}, {min_tier:?}, r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify({endpoint:?}, {mode:?}, {min_tier:?}, {rationale:?}, r, &pass, &skip, &fail, &hadTimeout, records)
 	}} else {{
-		records = recordAborted({endpoint:?}, {mode:?}, &skip, records)
+		records = recordAborted({endpoint:?}, {mode:?}, {rationale:?}, &skip, records)
 	}}

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/postamble.go.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/postamble.go.tmpl
@@ -4,20 +4,20 @@
 // recordAborted adds a SKIP record for a cell that didn't run because an
 // earlier cell timed out. The ffi is not thread-safe on the same handle,
 // so we refuse to issue more calls once a worker has been leaked.
-func recordAborted(endpoint, mode string, skip *int, records []CellRecord) []CellRecord {
+func recordAborted(endpoint, mode, rationale string, skip *int, records []CellRecord) []CellRecord {
 	label := endpoint + "::" + mode
 	fmt.Printf("  %-60s SKIP: aborted-after-timeout\n", label)
 	*skip++
 	return append(records, CellRecord{
-		Endpoint: endpoint, Mode: mode, Status: "SKIP", Detail: "aborted-after-timeout",
+		Endpoint: endpoint, Mode: mode, Rationale: rationale, Status: "SKIP", Detail: "aborted-after-timeout",
 	})
 }
 
 // classify maps a live call outcome into PASS / SKIP / FAIL buckets and
 // appends a CellRecord for the agreement-check JSON artifact.
-func classify(endpoint, mode, declaredMinTier string, r cellResult, pass, skip, fail *int, hadTimeout *bool, records []CellRecord) []CellRecord {
+func classify(endpoint, mode, declaredMinTier, rationale string, r cellResult, pass, skip, fail *int, hadTimeout *bool, records []CellRecord) []CellRecord {
 	label := endpoint + "::" + mode
-	rec := CellRecord{Endpoint: endpoint, Mode: mode, RowCount: r.rowCount}
+	rec := CellRecord{Endpoint: endpoint, Mode: mode, Rationale: rationale, RowCount: r.rowCount}
 	if r.err == nil {
 		fmt.Printf("  %-60s PASS\n", label)
 		*pass++
@@ -50,7 +50,10 @@ func classify(endpoint, mode, declaredMinTier string, r cellResult, pass, skip, 
 	fmt.Printf("  %-60s FAIL  %v\n", label, r.err)
 	*fail++
 	rec.Status = "FAIL"
-	detail := r.err.Error()
+	// gRPC / transport errors can contain embedded newlines; escape them
+	// so the agreement-table row stays single-line.
+	detail := strings.ReplaceAll(r.err.Error(), "\n", "\\n")
+	detail = strings.ReplaceAll(detail, "\r", "\\r")
 	if len(detail) > 200 {
 		detail = detail[:200]
 	}

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/preamble.go.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/preamble.go.tmpl
@@ -20,9 +20,14 @@ var errCellTimeout = errors.New("cell timeout after 60s")
 
 // CellRecord is one row of the validator's per-cell JSON artifact used
 // by the cross-language agreement check. `Status` is PASS|SKIP|FAIL.
+// `Rationale` is the one-sentence description from the generator
+// (rationale_for_mode in build_support/endpoints/modes.rs); it surfaces
+// in scripts/validate_agreement.py disagreement output so a FAIL line
+// carries the feature description, not just the mode name.
 type CellRecord struct {
 	Endpoint   string `json:"endpoint"`
 	Mode       string `json:"mode"`
+	Rationale  string `json:"rationale"`
 	Status     string `json:"status"`
 	RowCount   int    `json:"row_count"`
 	DurationMS int64  `json:"duration_ms"`

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/cell.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/cell.py.tmpl
@@ -1,1 +1,3 @@
-    ({endpoint:?}, {mode:?}, {min_tier:?}, lambda: client.{endpoint_name}({args})),
+    # {endpoint}::{mode}
+    #   rationale: {rationale}
+    ({endpoint:?}, {mode:?}, {min_tier:?}, {rationale:?}, lambda: client.{endpoint_name}({args})),

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/postamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/postamble.py.tmpl
@@ -48,7 +48,7 @@ def _row_count(result):
     except TypeError:
         return 1
 
-for endpoint, mode, min_tier, call in CELLS:
+for endpoint, mode, min_tier, rationale, call in CELLS:
     label = f"{endpoint}::{mode}"
     # Once a cell has timed out, its daemon worker is still running the
     # blocking PyO3/FFI call on the shared client. The underlying FFI is
@@ -60,7 +60,8 @@ for endpoint, mode, min_tier, call in CELLS:
         print(f"  {label:60s} SKIP: aborted-after-timeout", flush=True)
         skip_count += 1
         records.append({
-            "endpoint": endpoint, "mode": mode, "status": "SKIP",
+            "endpoint": endpoint, "mode": mode, "rationale": rationale,
+            "status": "SKIP",
             "row_count": 0, "duration_ms": 0, "detail": "aborted-after-timeout",
         })
         continue
@@ -95,12 +96,16 @@ for endpoint, mode, min_tier, call in CELLS:
             pass_count += 1
         else:
             status = "FAIL"
-            detail = str(value)
+            # Exception messages can span multiple lines; escape them at the
+            # producer so the agreement-table row stays on one line. See
+            # scripts/validate_agreement.py disagreement output.
+            detail = str(value).replace("\n", "\\n").replace("\r", "\\r")[:200]
             print(f"  {label:60s} FAIL  {value}", flush=True)
             fail_count += 1
     records.append({
         "endpoint": endpoint,
         "mode": mode,
+        "rationale": rationale,
         "status": status,
         "row_count": row_count,
         "duration_ms": duration_ms,

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/preamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/preamble.py.tmpl
@@ -35,7 +35,10 @@ ARTIFACT_PATH = pathlib.Path(__file__).resolve().parents[1] / "artifacts" / "val
 
 client = ThetaDataDx(Credentials.from_file(sys.argv[1]), Config.production())
 
-# (endpoint, mode_name, declared_min_tier, callable)
+# (endpoint, mode_name, declared_min_tier, rationale, callable)
 # `declared_min_tier` is informational only (printed on tier-permission
-# skips so you can see which modes the server refused).
+# skips so you can see which modes the server refused). `rationale` is a
+# one-sentence description of what the cell proves; it surfaces in the
+# per-cell JSON artifact and in the cross-language agreement disagreement
+# output (see scripts/validate_agreement.py).
 CELLS = [

--- a/scripts/validate_agreement.py
+++ b/scripts/validate_agreement.py
@@ -164,14 +164,31 @@ def main() -> int:
     if disagreements:
         print("\nDISAGREEMENTS:", file=sys.stderr)
         for (endpoint, mode), present in disagreements[: args.max_cell_diff_rows]:
+            # Determine the disagreement kind so the header carries useful
+            # context (status mismatch vs. row-count mismatch on PASS).
+            statuses = {rec.get("status") for rec in present.values()}
+            kind = "status disagreement" if len(statuses) > 1 else "row-count disagreement"
             label = f"{endpoint}::{mode}"
-            print(f"  {label}", file=sys.stderr)
+            # All SDKs see the same generator output for a given cell, so
+            # rationale is identical across present[lang]; pick whichever is
+            # available. Fall back to "(missing)" if no SDK populated it
+            # (older artifacts written before this field landed).
+            rationale = next(
+                (rec.get("rationale") for rec in present.values() if rec.get("rationale")),
+                "(missing)",
+            )
+            print(f"  {label}  [{kind}]", file=sys.stderr)
+            print(f"    rationale: {rationale}", file=sys.stderr)
+            print(
+                f"    {'sdk':8s} | {'status':6s} | {'rows':5s} | detail",
+                file=sys.stderr,
+            )
             for lang in sorted(present):
                 rec = present[lang]
                 print(
-                    f"    {lang:8s} status={rec.get('status'):<4} "
-                    f"rows={rec.get('row_count'):<5} "
-                    f"detail={rec.get('detail', '')[:80]!r}",
+                    f"    {lang:8s} | {str(rec.get('status', '')):6s} | "
+                    f"{str(rec.get('row_count', '')):5s} | "
+                    f"{(rec.get('detail') or '')[:80]}",
                     file=sys.stderr,
                 )
         if len(disagreements) > args.max_cell_diff_rows:

--- a/scripts/validate_cli.py
+++ b/scripts/validate_cli.py
@@ -34,8 +34,8 @@ ARTIFACT_PATH = REPO / "artifacts" / "validator_cli.json"
 # (endpoint, mode_name, declared_min_tier, rationale, [argv...])
 # `declared_min_tier` is informational only (printed on tier-permission
 # skips so you can see which modes the server refused). `rationale` is a
-# one-sentence description of what the cell proves; it surfaces in the
-# per-cell JSON artifact and the cross-language agreement output.
+# one-sentence description of what the cell proves; surfaces in the
+# per-cell JSON artifact and in scripts/validate_agreement.py output.
 CELLS = [
     # stock_list_symbols::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
@@ -44,38 +44,38 @@ CELLS = [
     #   rationale: list/calendar/rate baseline call — no parameter variation
     ("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["stock", "list_dates", "TRADE", "AAPL"]),
     # stock_snapshot_ohlc::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "snapshot_ohlc", "AAPL"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "snapshot_ohlc", "AAPL"]),
     # stock_snapshot_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "snapshot_trade", "AAPL"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "snapshot_trade", "AAPL"]),
     # stock_snapshot_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "snapshot_quote", "AAPL"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "snapshot_quote", "AAPL"]),
     # stock_snapshot_market_value::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "snapshot_market_value", "AAPL"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "snapshot_market_value", "AAPL"]),
     # stock_history_eod::concrete
     #   rationale: required params set, no optionals — baseline wire path
     ("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["stock", "history_eod", "AAPL", "20250303", "20250303"]),
     # stock_history_ohlc::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_ohlc", "AAPL", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "history_ohlc", "AAPL", "20250303", "60000"]),
     # stock_history_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "history_trade", "AAPL", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "history_trade", "AAPL", "20250303"]),
     # stock_history_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_quote", "AAPL", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "history_quote", "AAPL", "20250303", "60000"]),
     # stock_history_trade_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "history_trade_quote", "AAPL", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "history_trade_quote", "AAPL", "20250303"]),
     # stock_at_time_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "at_time_trade", "AAPL", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)
+    ("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", ["stock", "at_time_trade", "AAPL", "20250303", "20250303", "12:00:00.000"]),
     # stock_at_time_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "at_time_quote", "AAPL", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)
+    ("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", ["stock", "at_time_quote", "AAPL", "20250303", "20250303", "12:00:00.000"]),
     # option_list_symbols::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
     ("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_symbols"]),
@@ -92,464 +92,311 @@ CELLS = [
     #   rationale: required params set, no optionals — baseline wire path
     ("option_list_contracts", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "list_contracts", "TRADE", "SPY", "20250303"]),
     # option_snapshot_ohlc::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_ohlc", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_ohlc::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_ohlc", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_ohlc", "SPY", "20250321", "570", "C"]),
     # option_snapshot_ohlc::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_ohlc", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_ohlc", "SPY", "20250321", "*", "both"]),
     # option_snapshot_ohlc::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_ohlc", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_ohlc", "SPY", "*", "570", "both"]),
     # option_snapshot_ohlc::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_ohlc", "SPY", "*", "*", "both"]),
-    # option_snapshot_ohlc::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_ohlc", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_ohlc", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_ohlc", "SPY", "*", "*", "both"]),
     # option_snapshot_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_trade", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_trade::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_trade", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_trade", "SPY", "20250321", "570", "C"]),
     # option_snapshot_trade::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_trade", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_trade", "SPY", "20250321", "*", "both"]),
     # option_snapshot_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_quote", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_quote::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_quote", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_quote", "SPY", "20250321", "570", "C"]),
     # option_snapshot_quote::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_quote", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_quote", "SPY", "20250321", "*", "both"]),
     # option_snapshot_quote::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_quote", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_quote", "SPY", "*", "570", "both"]),
     # option_snapshot_quote::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_quote", "SPY", "*", "*", "both"]),
-    # option_snapshot_quote::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_quote", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_quote", "SPY", "*", "*", "both"]),
     # option_snapshot_open_interest::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_open_interest", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_open_interest::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_open_interest", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_open_interest", "SPY", "20250321", "570", "C"]),
     # option_snapshot_open_interest::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_open_interest", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_open_interest", "SPY", "20250321", "*", "both"]),
     # option_snapshot_open_interest::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_open_interest", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_open_interest", "SPY", "*", "570", "both"]),
     # option_snapshot_open_interest::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_open_interest", "SPY", "*", "*", "both"]),
-    # option_snapshot_open_interest::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_open_interest", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_open_interest", "SPY", "*", "*", "both"]),
     # option_snapshot_market_value::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_market_value", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_market_value::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_market_value", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_market_value", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_market_value", "SPY", "20250321", "570", "C"]),
     # option_snapshot_market_value::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_market_value", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_market_value", "SPY", "20250321", "*", "both"]),
     # option_snapshot_market_value::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_market_value", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_market_value", "SPY", "*", "570", "both"]),
     # option_snapshot_market_value::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_market_value", "SPY", "*", "*", "both"]),
-    # option_snapshot_market_value::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_market_value", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_market_value", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_market_value", "SPY", "*", "*", "both"]),
     # option_snapshot_greeks_implied_volatility::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_greeks_implied_volatility::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "570", "C"]),
     # option_snapshot_greeks_implied_volatility::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "*", "both"]),
     # option_snapshot_greeks_implied_volatility::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "570", "both"]),
     # option_snapshot_greeks_implied_volatility::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "*", "both"]),
-    # option_snapshot_greeks_implied_volatility::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_implied_volatility", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "*", "both"]),
     # option_snapshot_greeks_all::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_all", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_greeks_all::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_all", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_greeks_all", "SPY", "20250321", "570", "C"]),
     # option_snapshot_greeks_all::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_all", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_all", "SPY", "20250321", "*", "both"]),
     # option_snapshot_greeks_all::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_all", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_all", "SPY", "*", "570", "both"]),
     # option_snapshot_greeks_all::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_all", "SPY", "*", "*", "both"]),
-    # option_snapshot_greeks_all::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_all", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_greeks_all", "SPY", "*", "*", "both"]),
     # option_snapshot_greeks_first_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_greeks_first_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_first_order", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "570", "C"]),
     # option_snapshot_greeks_first_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "*", "both"]),
     # option_snapshot_greeks_first_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_first_order", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_first_order", "SPY", "*", "570", "both"]),
     # option_snapshot_greeks_first_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_first_order", "SPY", "*", "*", "both"]),
-    # option_snapshot_greeks_first_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_first_order", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_greeks_first_order", "SPY", "*", "*", "both"]),
     # option_snapshot_greeks_second_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_greeks_second_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_second_order", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "570", "C"]),
     # option_snapshot_greeks_second_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "*", "both"]),
     # option_snapshot_greeks_second_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_second_order", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_second_order", "SPY", "*", "570", "both"]),
     # option_snapshot_greeks_second_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_second_order", "SPY", "*", "*", "both"]),
-    # option_snapshot_greeks_second_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_second_order", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_greeks_second_order", "SPY", "*", "*", "both"]),
     # option_snapshot_greeks_third_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "570", "C"]),
-    # option_snapshot_greeks_third_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_third_order", "SPY", "2025-03-21", "570", "C"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "570", "C"]),
     # option_snapshot_greeks_third_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "*", "both"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "*", "both"]),
     # option_snapshot_greeks_third_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_third_order", "SPY", "*", "570", "both"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_third_order", "SPY", "*", "570", "both"]),
     # option_snapshot_greeks_third_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_third_order", "SPY", "*", "*", "both"]),
-    # option_snapshot_greeks_third_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_third_order", "SPY", "0", "0", "both"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "snapshot_greeks_third_order", "SPY", "*", "*", "both"]),
     # option_history_eod::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["option", "history_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
-    # option_history_eod::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_eod", "concrete_iso", "free", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_eod", "SPY", "2025-03-21", "570", "C", "20250303", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
     # option_history_eod::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
     # option_history_eod::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
     # option_history_eod::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
-    # option_history_eod::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_eod", "legacy_zero_wildcard", "free", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_eod", "SPY", "0", "0", "both", "20250303", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
     # option_history_ohlc::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_ohlc", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    # option_history_ohlc::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_ohlc", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_ohlc", "SPY", "20250321", "570", "C", "20250303", "60000"]),
     # option_history_ohlc::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_ohlc", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_ohlc", "SPY", "20250321", "*", "both", "20250303", "60000"]),
     # option_history_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_trade", "SPY", "20250321", "570", "C", "20250303"]),
-    # option_history_trade::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_trade", "SPY", "20250321", "570", "C", "20250303"]),
     # option_history_trade::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade", "SPY", "20250321", "*", "both", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade", "SPY", "20250321", "*", "both", "20250303"]),
     # option_history_trade::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade", "SPY", "*", "570", "both", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade", "SPY", "*", "570", "both", "20250303"]),
     # option_history_trade::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade", "SPY", "*", "*", "both", "20250303"]),
-    # option_history_trade::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade", "SPY", "0", "0", "both", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_trade", "SPY", "*", "*", "both", "20250303"]),
     # option_history_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_quote", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    # option_history_quote::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_quote", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_quote", "SPY", "20250321", "570", "C", "20250303", "60000"]),
     # option_history_quote::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_quote", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_quote", "SPY", "20250321", "*", "both", "20250303", "60000"]),
     # option_history_quote::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_quote", "SPY", "*", "570", "both", "20250303", "60000"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_quote", "SPY", "*", "570", "both", "20250303", "60000"]),
     # option_history_quote::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_quote", "SPY", "*", "*", "both", "20250303", "60000"]),
-    # option_history_quote::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_quote", "SPY", "0", "0", "both", "20250303", "60000"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_quote", "SPY", "*", "*", "both", "20250303", "60000"]),
     # option_history_trade_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_trade_quote", "SPY", "20250321", "570", "C", "20250303"]),
-    # option_history_trade_quote::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_quote", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_quote", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_trade_quote", "SPY", "20250321", "570", "C", "20250303"]),
     # option_history_trade_quote::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_quote", "SPY", "20250321", "*", "both", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_quote", "SPY", "20250321", "*", "both", "20250303"]),
     # option_history_trade_quote::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_quote", "SPY", "*", "570", "both", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_quote", "SPY", "*", "570", "both", "20250303"]),
     # option_history_trade_quote::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_quote", "SPY", "*", "*", "both", "20250303"]),
-    # option_history_trade_quote::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_quote", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_quote", "SPY", "0", "0", "both", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_trade_quote", "SPY", "*", "*", "both", "20250303"]),
     # option_history_open_interest::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_open_interest", "SPY", "20250321", "570", "C", "20250303"]),
-    # option_history_open_interest::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_open_interest", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_open_interest", "SPY", "20250321", "570", "C", "20250303"]),
     # option_history_open_interest::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_open_interest", "SPY", "20250321", "*", "both", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_open_interest", "SPY", "20250321", "*", "both", "20250303"]),
     # option_history_open_interest::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_open_interest", "SPY", "*", "570", "both", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_open_interest", "SPY", "*", "570", "both", "20250303"]),
     # option_history_open_interest::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_open_interest", "SPY", "*", "*", "both", "20250303"]),
-    # option_history_open_interest::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_open_interest", "SPY", "0", "0", "both", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_open_interest", "SPY", "*", "*", "both", "20250303"]),
     # option_history_greeks_eod::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
-    # option_history_greeks_eod::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_eod", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_eod", "SPY", "2025-03-21", "570", "C", "20250303", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_greeks_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
     # option_history_greeks_eod::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
     # option_history_greeks_eod::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_greeks_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_greeks_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
     # option_history_greeks_eod::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_greeks_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
-    # option_history_greeks_eod::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_greeks_eod", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_greeks_eod", "SPY", "0", "0", "both", "20250303", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_greeks_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
     # option_history_greeks_all::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_all", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    # option_history_greeks_all::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_all", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_greeks_all", "SPY", "20250321", "570", "C", "20250303", "60000"]),
     # option_history_greeks_all::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_all", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_all", "SPY", "20250321", "*", "both", "20250303", "60000"]),
     # option_history_trade_greeks_all::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_all", "SPY", "20250321", "570", "C", "20250303"]),
-    # option_history_trade_greeks_all::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_all", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_trade_greeks_all", "SPY", "20250321", "570", "C", "20250303"]),
     # option_history_trade_greeks_all::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_all", "SPY", "20250321", "*", "both", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_all", "SPY", "20250321", "*", "both", "20250303"]),
     # option_history_trade_greeks_all::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_all", "SPY", "*", "570", "both", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_all", "SPY", "*", "570", "both", "20250303"]),
     # option_history_trade_greeks_all::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_all", "SPY", "*", "*", "both", "20250303"]),
-    # option_history_trade_greeks_all::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_all", "SPY", "0", "0", "both", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_trade_greeks_all", "SPY", "*", "*", "both", "20250303"]),
     # option_history_greeks_first_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_first_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    # option_history_greeks_first_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_first_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_greeks_first_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
     # option_history_greeks_first_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_first_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_first_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
     # option_history_trade_greeks_first_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "570", "C", "20250303"]),
-    # option_history_trade_greeks_first_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_first_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_first_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "570", "C", "20250303"]),
     # option_history_trade_greeks_first_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "*", "both", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "*", "both", "20250303"]),
     # option_history_trade_greeks_first_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_first_order", "SPY", "*", "570", "both", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_first_order", "SPY", "*", "570", "both", "20250303"]),
     # option_history_trade_greeks_first_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_first_order", "SPY", "*", "*", "both", "20250303"]),
-    # option_history_trade_greeks_first_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_first_order", "SPY", "0", "0", "both", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_trade_greeks_first_order", "SPY", "*", "*", "both", "20250303"]),
     # option_history_greeks_second_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_second_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    # option_history_greeks_second_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_second_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_greeks_second_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
     # option_history_greeks_second_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_second_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_second_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
     # option_history_trade_greeks_second_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "570", "C", "20250303"]),
-    # option_history_trade_greeks_second_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_second_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "570", "C", "20250303"]),
     # option_history_trade_greeks_second_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "*", "both", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "*", "both", "20250303"]),
     # option_history_trade_greeks_second_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_second_order", "SPY", "*", "570", "both", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_second_order", "SPY", "*", "570", "both", "20250303"]),
     # option_history_trade_greeks_second_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_second_order", "SPY", "*", "*", "both", "20250303"]),
-    # option_history_trade_greeks_second_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_second_order", "SPY", "0", "0", "both", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_trade_greeks_second_order", "SPY", "*", "*", "both", "20250303"]),
     # option_history_greeks_third_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_third_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    # option_history_greeks_third_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_third_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_greeks_third_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
     # option_history_greeks_third_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_third_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_third_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
     # option_history_trade_greeks_third_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "570", "C", "20250303"]),
-    # option_history_trade_greeks_third_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_third_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "570", "C", "20250303"]),
     # option_history_trade_greeks_third_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "*", "both", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "*", "both", "20250303"]),
     # option_history_trade_greeks_third_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_third_order", "SPY", "*", "570", "both", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_third_order", "SPY", "*", "570", "both", "20250303"]),
     # option_history_trade_greeks_third_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_third_order", "SPY", "*", "*", "both", "20250303"]),
-    # option_history_trade_greeks_third_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_third_order", "SPY", "0", "0", "both", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_trade_greeks_third_order", "SPY", "*", "*", "both", "20250303"]),
     # option_history_greeks_implied_volatility::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    # option_history_greeks_implied_volatility::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303", "60000"]),
     # option_history_greeks_implied_volatility::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303", "60000"]),
     # option_history_trade_greeks_implied_volatility::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303"]),
-    # option_history_trade_greeks_implied_volatility::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303"]),
     # option_history_trade_greeks_implied_volatility::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303"]),
     # option_history_trade_greeks_implied_volatility::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "570", "both", "20250303"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "570", "both", "20250303"]),
     # option_history_trade_greeks_implied_volatility::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "*", "both", "20250303"]),
-    # option_history_trade_greeks_implied_volatility::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_implied_volatility", "SPY", "0", "0", "both", "20250303"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "*", "both", "20250303"]),
     # option_at_time_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "at_time_trade", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
-    # option_at_time_trade::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_at_time_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "at_time_trade", "SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "at_time_trade", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
     # option_at_time_trade::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "at_time_trade", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "at_time_trade", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
     # option_at_time_trade::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "at_time_trade", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "at_time_trade", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
     # option_at_time_trade::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "at_time_trade", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
-    # option_at_time_trade::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_at_time_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "at_time_trade", "SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "at_time_trade", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
     # option_at_time_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "at_time_quote", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
-    # option_at_time_quote::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_at_time_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "at_time_quote", "SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", ["option", "at_time_quote", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
     # option_at_time_quote::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "at_time_quote", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "at_time_quote", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
     # option_at_time_quote::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "at_time_quote", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "at_time_quote", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
     # option_at_time_quote::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "at_time_quote", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
-    # option_at_time_quote::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_at_time_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "at_time_quote", "SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"]),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", ["option", "at_time_quote", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
     # index_list_symbols::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
     ("index_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["index", "list_symbols"]),
@@ -590,8 +437,8 @@ CELLS = [
     #   rationale: list/calendar/rate baseline call — no parameter variation
     ("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["rate", "history_eod", "SOFR", "20250303", "20250303"]),
     # stock_history_ohlc_range::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_ohlc_range", "AAPL", "20250303", "20250303", "60000"]),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", ["stock", "history_ohlc_range", "AAPL", "20250303", "20250303", "60000"]),
 ]
 
 if not TDX.exists():
@@ -681,7 +528,10 @@ for endpoint, mode, min_tier, rationale, argv in CELLS:
         pass_count += 1
     else:
         status = "FAIL"
-        detail = output.strip()[:200]
+        # CLI stdout can contain embedded newlines (panics, multi-line errors);
+        # keeping them in `detail` would wreck row alignment in
+        # validate_agreement.py's disagreement table. Escape at the producer.
+        detail = output.strip().replace("\n", "\\n").replace("\r", "\\r")[:200]
         print(f"  {label:60s} FAIL  {output.strip()}")
         fail_count += 1
     records.append({

--- a/scripts/validate_cli.py
+++ b/scripts/validate_cli.py
@@ -31,195 +31,567 @@ REPO = pathlib.Path(__file__).resolve().parents[1]
 TDX = REPO / "target" / "release" / ("tdx.exe" if os.name == "nt" else "tdx")
 ARTIFACT_PATH = REPO / "artifacts" / "validator_cli.json"
 
-# (endpoint, mode_name, declared_min_tier, [argv...])
+# (endpoint, mode_name, declared_min_tier, rationale, [argv...])
 # `declared_min_tier` is informational only (printed on tier-permission
-# skips so you can see which modes the server refused).
+# skips so you can see which modes the server refused). `rationale` is a
+# one-sentence description of what the cell proves; it surfaces in the
+# per-cell JSON artifact and the cross-language agreement output.
 CELLS = [
-    ("stock_list_symbols", "basic", "free", ["stock", "list_symbols"]),
-    ("stock_list_dates", "basic", "free", ["stock", "list_dates", "TRADE", "AAPL"]),
-    ("stock_snapshot_ohlc", "concrete", "value", ["stock", "snapshot_ohlc", "AAPL"]),
-    ("stock_snapshot_trade", "concrete", "standard", ["stock", "snapshot_trade", "AAPL"]),
-    ("stock_snapshot_quote", "concrete", "value", ["stock", "snapshot_quote", "AAPL"]),
-    ("stock_snapshot_market_value", "concrete", "standard", ["stock", "snapshot_market_value", "AAPL"]),
-    ("stock_history_eod", "concrete", "free", ["stock", "history_eod", "AAPL", "20250303", "20250303"]),
-    ("stock_history_ohlc", "concrete", "value", ["stock", "history_ohlc", "AAPL", "20250303", "60000"]),
-    ("stock_history_trade", "concrete", "standard", ["stock", "history_trade", "AAPL", "20250303"]),
-    ("stock_history_quote", "concrete", "value", ["stock", "history_quote", "AAPL", "20250303", "60000"]),
-    ("stock_history_trade_quote", "concrete", "standard", ["stock", "history_trade_quote", "AAPL", "20250303"]),
-    ("stock_at_time_trade", "concrete", "standard", ["stock", "at_time_trade", "AAPL", "20250303", "20250303", "12:00:00.000"]),
-    ("stock_at_time_quote", "concrete", "value", ["stock", "at_time_quote", "AAPL", "20250303", "20250303", "12:00:00.000"]),
-    ("option_list_symbols", "basic", "free", ["option", "list_symbols"]),
-    ("option_list_dates", "basic", "free", ["option", "list_dates", "TRADE", "SPY", "20250321", "570", "C"]),
-    ("option_list_expirations", "basic", "free", ["option", "list_expirations", "SPY"]),
-    ("option_list_strikes", "basic", "free", ["option", "list_strikes", "SPY", "20250321"]),
-    ("option_list_contracts", "concrete", "value", ["option", "list_contracts", "TRADE", "SPY", "20250303"]),
-    ("option_snapshot_ohlc", "concrete", "value", ["option", "snapshot_ohlc", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_ohlc", "concrete_iso", "value", ["option", "snapshot_ohlc", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", ["option", "snapshot_ohlc", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_ohlc", "all_exps_one_strike", "value", ["option", "snapshot_ohlc", "SPY", "*", "570", "both"]),
-    ("option_snapshot_ohlc", "bulk_chain", "value", ["option", "snapshot_ohlc", "SPY", "*", "*", "both"]),
-    ("option_snapshot_ohlc", "legacy_zero_wildcard", "value", ["option", "snapshot_ohlc", "SPY", "0", "0", "both"]),
-    ("option_snapshot_trade", "concrete", "standard", ["option", "snapshot_trade", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_trade", "concrete_iso", "standard", ["option", "snapshot_trade", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_trade", "all_strikes_one_exp", "standard", ["option", "snapshot_trade", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_quote", "concrete", "value", ["option", "snapshot_quote", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_quote", "concrete_iso", "value", ["option", "snapshot_quote", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_quote", "all_strikes_one_exp", "value", ["option", "snapshot_quote", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_quote", "all_exps_one_strike", "value", ["option", "snapshot_quote", "SPY", "*", "570", "both"]),
-    ("option_snapshot_quote", "bulk_chain", "value", ["option", "snapshot_quote", "SPY", "*", "*", "both"]),
-    ("option_snapshot_quote", "legacy_zero_wildcard", "value", ["option", "snapshot_quote", "SPY", "0", "0", "both"]),
-    ("option_snapshot_open_interest", "concrete", "value", ["option", "snapshot_open_interest", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_open_interest", "concrete_iso", "value", ["option", "snapshot_open_interest", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", ["option", "snapshot_open_interest", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_open_interest", "all_exps_one_strike", "value", ["option", "snapshot_open_interest", "SPY", "*", "570", "both"]),
-    ("option_snapshot_open_interest", "bulk_chain", "value", ["option", "snapshot_open_interest", "SPY", "*", "*", "both"]),
-    ("option_snapshot_open_interest", "legacy_zero_wildcard", "value", ["option", "snapshot_open_interest", "SPY", "0", "0", "both"]),
-    ("option_snapshot_market_value", "concrete", "standard", ["option", "snapshot_market_value", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_market_value", "concrete_iso", "standard", ["option", "snapshot_market_value", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", ["option", "snapshot_market_value", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_market_value", "all_exps_one_strike", "standard", ["option", "snapshot_market_value", "SPY", "*", "570", "both"]),
-    ("option_snapshot_market_value", "bulk_chain", "standard", ["option", "snapshot_market_value", "SPY", "*", "*", "both"]),
-    ("option_snapshot_market_value", "legacy_zero_wildcard", "standard", ["option", "snapshot_market_value", "SPY", "0", "0", "both"]),
-    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", ["option", "snapshot_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "570", "both"]),
-    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "*", "both"]),
-    ("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", ["option", "snapshot_greeks_implied_volatility", "SPY", "0", "0", "both"]),
-    ("option_snapshot_greeks_all", "concrete", "professional", ["option", "snapshot_greeks_all", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_greeks_all", "concrete_iso", "professional", ["option", "snapshot_greeks_all", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", ["option", "snapshot_greeks_all", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", ["option", "snapshot_greeks_all", "SPY", "*", "570", "both"]),
-    ("option_snapshot_greeks_all", "bulk_chain", "professional", ["option", "snapshot_greeks_all", "SPY", "*", "*", "both"]),
-    ("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", ["option", "snapshot_greeks_all", "SPY", "0", "0", "both"]),
-    ("option_snapshot_greeks_first_order", "concrete", "standard", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_greeks_first_order", "concrete_iso", "standard", ["option", "snapshot_greeks_first_order", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", ["option", "snapshot_greeks_first_order", "SPY", "*", "570", "both"]),
-    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", ["option", "snapshot_greeks_first_order", "SPY", "*", "*", "both"]),
-    ("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", ["option", "snapshot_greeks_first_order", "SPY", "0", "0", "both"]),
-    ("option_snapshot_greeks_second_order", "concrete", "professional", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_greeks_second_order", "concrete_iso", "professional", ["option", "snapshot_greeks_second_order", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", ["option", "snapshot_greeks_second_order", "SPY", "*", "570", "both"]),
-    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", ["option", "snapshot_greeks_second_order", "SPY", "*", "*", "both"]),
-    ("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", ["option", "snapshot_greeks_second_order", "SPY", "0", "0", "both"]),
-    ("option_snapshot_greeks_third_order", "concrete", "professional", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "570", "C"]),
-    ("option_snapshot_greeks_third_order", "concrete_iso", "professional", ["option", "snapshot_greeks_third_order", "SPY", "2025-03-21", "570", "C"]),
-    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "*", "both"]),
-    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", ["option", "snapshot_greeks_third_order", "SPY", "*", "570", "both"]),
-    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", ["option", "snapshot_greeks_third_order", "SPY", "*", "*", "both"]),
-    ("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", ["option", "snapshot_greeks_third_order", "SPY", "0", "0", "both"]),
-    ("option_history_eod", "concrete", "free", ["option", "history_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
-    ("option_history_eod", "concrete_iso", "free", ["option", "history_eod", "SPY", "2025-03-21", "570", "C", "20250303", "20250303"]),
-    ("option_history_eod", "all_strikes_one_exp", "free", ["option", "history_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
-    ("option_history_eod", "all_exps_one_strike", "free", ["option", "history_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
-    ("option_history_eod", "bulk_chain", "free", ["option", "history_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
-    ("option_history_eod", "legacy_zero_wildcard", "free", ["option", "history_eod", "SPY", "0", "0", "both", "20250303", "20250303"]),
-    ("option_history_ohlc", "concrete", "value", ["option", "history_ohlc", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    ("option_history_ohlc", "concrete_iso", "value", ["option", "history_ohlc", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
-    ("option_history_ohlc", "all_strikes_one_exp", "value", ["option", "history_ohlc", "SPY", "20250321", "*", "both", "20250303", "60000"]),
-    ("option_history_trade", "concrete", "standard", ["option", "history_trade", "SPY", "20250321", "570", "C", "20250303"]),
-    ("option_history_trade", "concrete_iso", "standard", ["option", "history_trade", "SPY", "2025-03-21", "570", "C", "20250303"]),
-    ("option_history_trade", "all_strikes_one_exp", "standard", ["option", "history_trade", "SPY", "20250321", "*", "both", "20250303"]),
-    ("option_history_trade", "all_exps_one_strike", "standard", ["option", "history_trade", "SPY", "*", "570", "both", "20250303"]),
-    ("option_history_trade", "bulk_chain", "standard", ["option", "history_trade", "SPY", "*", "*", "both", "20250303"]),
-    ("option_history_trade", "legacy_zero_wildcard", "standard", ["option", "history_trade", "SPY", "0", "0", "both", "20250303"]),
-    ("option_history_quote", "concrete", "value", ["option", "history_quote", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    ("option_history_quote", "concrete_iso", "value", ["option", "history_quote", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
-    ("option_history_quote", "all_strikes_one_exp", "value", ["option", "history_quote", "SPY", "20250321", "*", "both", "20250303", "60000"]),
-    ("option_history_quote", "all_exps_one_strike", "value", ["option", "history_quote", "SPY", "*", "570", "both", "20250303", "60000"]),
-    ("option_history_quote", "bulk_chain", "value", ["option", "history_quote", "SPY", "*", "*", "both", "20250303", "60000"]),
-    ("option_history_quote", "legacy_zero_wildcard", "value", ["option", "history_quote", "SPY", "0", "0", "both", "20250303", "60000"]),
-    ("option_history_trade_quote", "concrete", "standard", ["option", "history_trade_quote", "SPY", "20250321", "570", "C", "20250303"]),
-    ("option_history_trade_quote", "concrete_iso", "standard", ["option", "history_trade_quote", "SPY", "2025-03-21", "570", "C", "20250303"]),
-    ("option_history_trade_quote", "all_strikes_one_exp", "standard", ["option", "history_trade_quote", "SPY", "20250321", "*", "both", "20250303"]),
-    ("option_history_trade_quote", "all_exps_one_strike", "standard", ["option", "history_trade_quote", "SPY", "*", "570", "both", "20250303"]),
-    ("option_history_trade_quote", "bulk_chain", "standard", ["option", "history_trade_quote", "SPY", "*", "*", "both", "20250303"]),
-    ("option_history_trade_quote", "legacy_zero_wildcard", "standard", ["option", "history_trade_quote", "SPY", "0", "0", "both", "20250303"]),
-    ("option_history_open_interest", "concrete", "value", ["option", "history_open_interest", "SPY", "20250321", "570", "C", "20250303"]),
-    ("option_history_open_interest", "concrete_iso", "value", ["option", "history_open_interest", "SPY", "2025-03-21", "570", "C", "20250303"]),
-    ("option_history_open_interest", "all_strikes_one_exp", "value", ["option", "history_open_interest", "SPY", "20250321", "*", "both", "20250303"]),
-    ("option_history_open_interest", "all_exps_one_strike", "value", ["option", "history_open_interest", "SPY", "*", "570", "both", "20250303"]),
-    ("option_history_open_interest", "bulk_chain", "value", ["option", "history_open_interest", "SPY", "*", "*", "both", "20250303"]),
-    ("option_history_open_interest", "legacy_zero_wildcard", "value", ["option", "history_open_interest", "SPY", "0", "0", "both", "20250303"]),
-    ("option_history_greeks_eod", "concrete", "standard", ["option", "history_greeks_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
-    ("option_history_greeks_eod", "concrete_iso", "standard", ["option", "history_greeks_eod", "SPY", "2025-03-21", "570", "C", "20250303", "20250303"]),
-    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", ["option", "history_greeks_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
-    ("option_history_greeks_eod", "all_exps_one_strike", "standard", ["option", "history_greeks_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
-    ("option_history_greeks_eod", "bulk_chain", "standard", ["option", "history_greeks_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
-    ("option_history_greeks_eod", "legacy_zero_wildcard", "standard", ["option", "history_greeks_eod", "SPY", "0", "0", "both", "20250303", "20250303"]),
-    ("option_history_greeks_all", "concrete", "professional", ["option", "history_greeks_all", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_all", "concrete_iso", "professional", ["option", "history_greeks_all", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_all", "all_strikes_one_exp", "professional", ["option", "history_greeks_all", "SPY", "20250321", "*", "both", "20250303", "60000"]),
-    ("option_history_trade_greeks_all", "concrete", "professional", ["option", "history_trade_greeks_all", "SPY", "20250321", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_all", "concrete_iso", "professional", ["option", "history_trade_greeks_all", "SPY", "2025-03-21", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", ["option", "history_trade_greeks_all", "SPY", "20250321", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", ["option", "history_trade_greeks_all", "SPY", "*", "570", "both", "20250303"]),
-    ("option_history_trade_greeks_all", "bulk_chain", "professional", ["option", "history_trade_greeks_all", "SPY", "*", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", ["option", "history_trade_greeks_all", "SPY", "0", "0", "both", "20250303"]),
-    ("option_history_greeks_first_order", "concrete", "standard", ["option", "history_greeks_first_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_first_order", "concrete_iso", "standard", ["option", "history_greeks_first_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", ["option", "history_greeks_first_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
-    ("option_history_trade_greeks_first_order", "concrete", "professional", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_first_order", "concrete_iso", "professional", ["option", "history_trade_greeks_first_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", ["option", "history_trade_greeks_first_order", "SPY", "*", "570", "both", "20250303"]),
-    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", ["option", "history_trade_greeks_first_order", "SPY", "*", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", ["option", "history_trade_greeks_first_order", "SPY", "0", "0", "both", "20250303"]),
-    ("option_history_greeks_second_order", "concrete", "professional", ["option", "history_greeks_second_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_second_order", "concrete_iso", "professional", ["option", "history_greeks_second_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", ["option", "history_greeks_second_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
-    ("option_history_trade_greeks_second_order", "concrete", "professional", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_second_order", "concrete_iso", "professional", ["option", "history_trade_greeks_second_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", ["option", "history_trade_greeks_second_order", "SPY", "*", "570", "both", "20250303"]),
-    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", ["option", "history_trade_greeks_second_order", "SPY", "*", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", ["option", "history_trade_greeks_second_order", "SPY", "0", "0", "both", "20250303"]),
-    ("option_history_greeks_third_order", "concrete", "professional", ["option", "history_greeks_third_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_third_order", "concrete_iso", "professional", ["option", "history_greeks_third_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", ["option", "history_greeks_third_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
-    ("option_history_trade_greeks_third_order", "concrete", "professional", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_third_order", "concrete_iso", "professional", ["option", "history_trade_greeks_third_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", ["option", "history_trade_greeks_third_order", "SPY", "*", "570", "both", "20250303"]),
-    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", ["option", "history_trade_greeks_third_order", "SPY", "*", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", ["option", "history_trade_greeks_third_order", "SPY", "0", "0", "both", "20250303"]),
-    ("option_history_greeks_implied_volatility", "concrete", "standard", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_implied_volatility", "concrete_iso", "standard", ["option", "history_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
-    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303", "60000"]),
-    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", ["option", "history_trade_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C", "20250303"]),
-    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "570", "both", "20250303"]),
-    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "*", "both", "20250303"]),
-    ("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", ["option", "history_trade_greeks_implied_volatility", "SPY", "0", "0", "both", "20250303"]),
-    ("option_at_time_trade", "concrete", "standard", ["option", "at_time_trade", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_trade", "concrete_iso", "standard", ["option", "at_time_trade", "SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_trade", "all_strikes_one_exp", "standard", ["option", "at_time_trade", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_trade", "all_exps_one_strike", "standard", ["option", "at_time_trade", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_trade", "bulk_chain", "standard", ["option", "at_time_trade", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_trade", "legacy_zero_wildcard", "standard", ["option", "at_time_trade", "SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_quote", "concrete", "value", ["option", "at_time_quote", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_quote", "concrete_iso", "value", ["option", "at_time_quote", "SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_quote", "all_strikes_one_exp", "value", ["option", "at_time_quote", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_quote", "all_exps_one_strike", "value", ["option", "at_time_quote", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_quote", "bulk_chain", "value", ["option", "at_time_quote", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
-    ("option_at_time_quote", "legacy_zero_wildcard", "value", ["option", "at_time_quote", "SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"]),
-    ("index_list_symbols", "basic", "free", ["index", "list_symbols"]),
-    ("index_list_dates", "basic", "free", ["index", "list_dates", "SPX"]),
-    ("index_snapshot_ohlc", "concrete", "standard", ["index", "snapshot_ohlc", "SPX"]),
-    ("index_snapshot_price", "concrete", "standard", ["index", "snapshot_price", "SPX"]),
-    ("index_snapshot_market_value", "concrete", "standard", ["index", "snapshot_market_value", "SPX"]),
-    ("index_history_eod", "concrete", "free", ["index", "history_eod", "SPX", "20250303", "20250303"]),
-    ("index_history_ohlc", "concrete", "standard", ["index", "history_ohlc", "SPX", "20250303", "20250303", "60000"]),
-    ("index_history_price", "concrete", "value", ["index", "history_price", "SPX", "20250303", "60000"]),
-    ("index_at_time_price", "concrete", "value", ["index", "at_time_price", "SPX", "20250303", "20250303", "12:00:00.000"]),
-    ("calendar_open_today", "basic", "free", ["calendar", "open_today"]),
-    ("calendar_on_date", "basic", "value", ["calendar", "on_date", "20250303"]),
-    ("calendar_year", "basic", "value", ["calendar", "year", "2025"]),
-    ("interest_rate_history_eod", "basic", "free", ["rate", "history_eod", "SOFR", "20250303", "20250303"]),
-    ("stock_history_ohlc_range", "concrete", "value", ["stock", "history_ohlc_range", "AAPL", "20250303", "20250303", "60000"]),
+    # stock_list_symbols::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("stock_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["stock", "list_symbols"]),
+    # stock_list_dates::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["stock", "list_dates", "TRADE", "AAPL"]),
+    # stock_snapshot_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "snapshot_ohlc", "AAPL"]),
+    # stock_snapshot_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "snapshot_trade", "AAPL"]),
+    # stock_snapshot_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "snapshot_quote", "AAPL"]),
+    # stock_snapshot_market_value::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "snapshot_market_value", "AAPL"]),
+    # stock_history_eod::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["stock", "history_eod", "AAPL", "20250303", "20250303"]),
+    # stock_history_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_ohlc", "AAPL", "20250303", "60000"]),
+    # stock_history_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "history_trade", "AAPL", "20250303"]),
+    # stock_history_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_quote", "AAPL", "20250303", "60000"]),
+    # stock_history_trade_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "history_trade_quote", "AAPL", "20250303"]),
+    # stock_at_time_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "at_time_trade", "AAPL", "20250303", "20250303", "12:00:00.000"]),
+    # stock_at_time_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "at_time_quote", "AAPL", "20250303", "20250303", "12:00:00.000"]),
+    # option_list_symbols::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_symbols"]),
+    # option_list_dates::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("option_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_dates", "TRADE", "SPY", "20250321", "570", "C"]),
+    # option_list_expirations::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("option_list_expirations", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_expirations", "SPY"]),
+    # option_list_strikes::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("option_list_strikes", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_strikes", "SPY", "20250321"]),
+    # option_list_contracts::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_list_contracts", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "list_contracts", "TRADE", "SPY", "20250303"]),
+    # option_snapshot_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_ohlc", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_ohlc::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_ohlc", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_ohlc::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_ohlc", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_ohlc::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_ohlc", "SPY", "*", "570", "both"]),
+    # option_snapshot_ohlc::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_ohlc", "SPY", "*", "*", "both"]),
+    # option_snapshot_ohlc::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_ohlc", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_ohlc", "SPY", "0", "0", "both"]),
+    # option_snapshot_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_trade", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_trade::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_trade", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_trade::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_trade", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_quote", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_quote::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_quote", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_quote::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_quote", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_quote::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_quote", "SPY", "*", "570", "both"]),
+    # option_snapshot_quote::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_quote", "SPY", "*", "*", "both"]),
+    # option_snapshot_quote::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_quote", "SPY", "0", "0", "both"]),
+    # option_snapshot_open_interest::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_open_interest", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_open_interest::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_open_interest", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_open_interest::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_open_interest", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_open_interest::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_open_interest", "SPY", "*", "570", "both"]),
+    # option_snapshot_open_interest::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_open_interest", "SPY", "*", "*", "both"]),
+    # option_snapshot_open_interest::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_open_interest", "SPY", "0", "0", "both"]),
+    # option_snapshot_market_value::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_market_value", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_market_value::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_market_value", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_market_value", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_market_value::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_market_value", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_market_value::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_market_value", "SPY", "*", "570", "both"]),
+    # option_snapshot_market_value::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_market_value", "SPY", "*", "*", "both"]),
+    # option_snapshot_market_value::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_market_value", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_market_value", "SPY", "0", "0", "both"]),
+    # option_snapshot_greeks_implied_volatility::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_greeks_implied_volatility::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_greeks_implied_volatility::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_greeks_implied_volatility::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "570", "both"]),
+    # option_snapshot_greeks_implied_volatility::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "*", "both"]),
+    # option_snapshot_greeks_implied_volatility::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_implied_volatility", "SPY", "0", "0", "both"]),
+    # option_snapshot_greeks_all::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_all", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_greeks_all::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_all", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_greeks_all::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_all", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_greeks_all::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_all", "SPY", "*", "570", "both"]),
+    # option_snapshot_greeks_all::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_all", "SPY", "*", "*", "both"]),
+    # option_snapshot_greeks_all::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_all", "SPY", "0", "0", "both"]),
+    # option_snapshot_greeks_first_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_greeks_first_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_first_order", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_greeks_first_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_greeks_first_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_first_order", "SPY", "*", "570", "both"]),
+    # option_snapshot_greeks_first_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_first_order", "SPY", "*", "*", "both"]),
+    # option_snapshot_greeks_first_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_first_order", "SPY", "0", "0", "both"]),
+    # option_snapshot_greeks_second_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_greeks_second_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_second_order", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_greeks_second_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_greeks_second_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_second_order", "SPY", "*", "570", "both"]),
+    # option_snapshot_greeks_second_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_second_order", "SPY", "*", "*", "both"]),
+    # option_snapshot_greeks_second_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_second_order", "SPY", "0", "0", "both"]),
+    # option_snapshot_greeks_third_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "570", "C"]),
+    # option_snapshot_greeks_third_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "snapshot_greeks_third_order", "SPY", "2025-03-21", "570", "C"]),
+    # option_snapshot_greeks_third_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "*", "both"]),
+    # option_snapshot_greeks_third_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "snapshot_greeks_third_order", "SPY", "*", "570", "both"]),
+    # option_snapshot_greeks_third_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_third_order", "SPY", "*", "*", "both"]),
+    # option_snapshot_greeks_third_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "snapshot_greeks_third_order", "SPY", "0", "0", "both"]),
+    # option_history_eod::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["option", "history_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
+    # option_history_eod::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_eod", "concrete_iso", "free", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_eod", "SPY", "2025-03-21", "570", "C", "20250303", "20250303"]),
+    # option_history_eod::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
+    # option_history_eod::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
+    # option_history_eod::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
+    # option_history_eod::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_eod", "legacy_zero_wildcard", "free", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_eod", "SPY", "0", "0", "both", "20250303", "20250303"]),
+    # option_history_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_ohlc", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    # option_history_ohlc::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_ohlc", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    # option_history_ohlc::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_ohlc", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    # option_history_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_trade", "SPY", "20250321", "570", "C", "20250303"]),
+    # option_history_trade::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    # option_history_trade::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade", "SPY", "20250321", "*", "both", "20250303"]),
+    # option_history_trade::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade", "SPY", "*", "570", "both", "20250303"]),
+    # option_history_trade::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade", "SPY", "*", "*", "both", "20250303"]),
+    # option_history_trade::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade", "SPY", "0", "0", "both", "20250303"]),
+    # option_history_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_quote", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    # option_history_quote::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_quote", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    # option_history_quote::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_quote", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    # option_history_quote::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_quote", "SPY", "*", "570", "both", "20250303", "60000"]),
+    # option_history_quote::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_quote", "SPY", "*", "*", "both", "20250303", "60000"]),
+    # option_history_quote::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_quote", "SPY", "0", "0", "both", "20250303", "60000"]),
+    # option_history_trade_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_trade_quote", "SPY", "20250321", "570", "C", "20250303"]),
+    # option_history_trade_quote::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_quote", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_quote", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    # option_history_trade_quote::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_quote", "SPY", "20250321", "*", "both", "20250303"]),
+    # option_history_trade_quote::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_quote", "SPY", "*", "570", "both", "20250303"]),
+    # option_history_trade_quote::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_quote", "SPY", "*", "*", "both", "20250303"]),
+    # option_history_trade_quote::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_quote", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_quote", "SPY", "0", "0", "both", "20250303"]),
+    # option_history_open_interest::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_open_interest", "SPY", "20250321", "570", "C", "20250303"]),
+    # option_history_open_interest::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_open_interest", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    # option_history_open_interest::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_open_interest", "SPY", "20250321", "*", "both", "20250303"]),
+    # option_history_open_interest::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_open_interest", "SPY", "*", "570", "both", "20250303"]),
+    # option_history_open_interest::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_open_interest", "SPY", "*", "*", "both", "20250303"]),
+    # option_history_open_interest::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_open_interest", "SPY", "0", "0", "both", "20250303"]),
+    # option_history_greeks_eod::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
+    # option_history_greeks_eod::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_eod", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_eod", "SPY", "2025-03-21", "570", "C", "20250303", "20250303"]),
+    # option_history_greeks_eod::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
+    # option_history_greeks_eod::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_greeks_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
+    # option_history_greeks_eod::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_greeks_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
+    # option_history_greeks_eod::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_greeks_eod", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_greeks_eod", "SPY", "0", "0", "both", "20250303", "20250303"]),
+    # option_history_greeks_all::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_all", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_all::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_all", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_all::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_all", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    # option_history_trade_greeks_all::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_all", "SPY", "20250321", "570", "C", "20250303"]),
+    # option_history_trade_greeks_all::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_all", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    # option_history_trade_greeks_all::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_all", "SPY", "20250321", "*", "both", "20250303"]),
+    # option_history_trade_greeks_all::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_all", "SPY", "*", "570", "both", "20250303"]),
+    # option_history_trade_greeks_all::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_all", "SPY", "*", "*", "both", "20250303"]),
+    # option_history_trade_greeks_all::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_all", "SPY", "0", "0", "both", "20250303"]),
+    # option_history_greeks_first_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_first_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_first_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_first_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_first_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_first_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    # option_history_trade_greeks_first_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "570", "C", "20250303"]),
+    # option_history_trade_greeks_first_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_first_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_first_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    # option_history_trade_greeks_first_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "*", "both", "20250303"]),
+    # option_history_trade_greeks_first_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_first_order", "SPY", "*", "570", "both", "20250303"]),
+    # option_history_trade_greeks_first_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_first_order", "SPY", "*", "*", "both", "20250303"]),
+    # option_history_trade_greeks_first_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_first_order", "SPY", "0", "0", "both", "20250303"]),
+    # option_history_greeks_second_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_second_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_second_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_second_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_second_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_second_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    # option_history_trade_greeks_second_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "570", "C", "20250303"]),
+    # option_history_trade_greeks_second_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_second_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    # option_history_trade_greeks_second_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "*", "both", "20250303"]),
+    # option_history_trade_greeks_second_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_second_order", "SPY", "*", "570", "both", "20250303"]),
+    # option_history_trade_greeks_second_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_second_order", "SPY", "*", "*", "both", "20250303"]),
+    # option_history_trade_greeks_second_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_second_order", "SPY", "0", "0", "both", "20250303"]),
+    # option_history_greeks_third_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_third_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_third_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_third_order", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_third_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_third_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    # option_history_trade_greeks_third_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "570", "C", "20250303"]),
+    # option_history_trade_greeks_third_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_third_order", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    # option_history_trade_greeks_third_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "*", "both", "20250303"]),
+    # option_history_trade_greeks_third_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_third_order", "SPY", "*", "570", "both", "20250303"]),
+    # option_history_trade_greeks_third_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_third_order", "SPY", "*", "*", "both", "20250303"]),
+    # option_history_trade_greeks_third_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_third_order", "SPY", "0", "0", "both", "20250303"]),
+    # option_history_greeks_implied_volatility::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_implied_volatility::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C", "20250303", "60000"]),
+    # option_history_greeks_implied_volatility::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    # option_history_trade_greeks_implied_volatility::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303"]),
+    # option_history_trade_greeks_implied_volatility::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "history_trade_greeks_implied_volatility", "SPY", "2025-03-21", "570", "C", "20250303"]),
+    # option_history_trade_greeks_implied_volatility::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303"]),
+    # option_history_trade_greeks_implied_volatility::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "570", "both", "20250303"]),
+    # option_history_trade_greeks_implied_volatility::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "*", "both", "20250303"]),
+    # option_history_trade_greeks_implied_volatility::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "history_trade_greeks_implied_volatility", "SPY", "0", "0", "both", "20250303"]),
+    # option_at_time_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "at_time_trade", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_trade::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_at_time_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "at_time_trade", "SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_trade::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "at_time_trade", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_trade::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", ["option", "at_time_trade", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_trade::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "at_time_trade", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_trade::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_at_time_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "at_time_trade", "SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "at_time_quote", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_quote::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_at_time_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", ["option", "at_time_quote", "SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_quote::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", ["option", "at_time_quote", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_quote::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", ["option", "at_time_quote", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_quote::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "at_time_quote", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    # option_at_time_quote::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_at_time_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", ["option", "at_time_quote", "SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"]),
+    # index_list_symbols::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("index_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["index", "list_symbols"]),
+    # index_list_dates::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("index_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["index", "list_dates", "SPX"]),
+    # index_snapshot_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_snapshot_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_ohlc", "SPX"]),
+    # index_snapshot_price::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_snapshot_price", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_price", "SPX"]),
+    # index_snapshot_market_value::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_market_value", "SPX"]),
+    # index_history_eod::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["index", "history_eod", "SPX", "20250303", "20250303"]),
+    # index_history_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_history_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "history_ohlc", "SPX", "20250303", "20250303", "60000"]),
+    # index_history_price::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_history_price", "concrete", "value", "required params set, no optionals — baseline wire path", ["index", "history_price", "SPX", "20250303", "60000"]),
+    # index_at_time_price::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_at_time_price", "concrete", "value", "required params set, no optionals — baseline wire path", ["index", "at_time_price", "SPX", "20250303", "20250303", "12:00:00.000"]),
+    # calendar_open_today::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("calendar_open_today", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["calendar", "open_today"]),
+    # calendar_on_date::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("calendar_on_date", "basic", "value", "list/calendar/rate baseline call — no parameter variation", ["calendar", "on_date", "20250303"]),
+    # calendar_year::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("calendar_year", "basic", "value", "list/calendar/rate baseline call — no parameter variation", ["calendar", "year", "2025"]),
+    # interest_rate_history_eod::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["rate", "history_eod", "SOFR", "20250303", "20250303"]),
+    # stock_history_ohlc_range::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_ohlc_range", "AAPL", "20250303", "20250303", "60000"]),
 ]
 
 if not TDX.exists():
@@ -264,7 +636,7 @@ def _json_row_count(output: str) -> int:
             return 1
     return 0
 
-for endpoint, mode, min_tier, argv in CELLS:
+for endpoint, mode, min_tier, rationale, argv in CELLS:
     label = f"{endpoint}::{mode}"
     t0 = time.monotonic()
     try:
@@ -281,7 +653,8 @@ for endpoint, mode, min_tier, argv in CELLS:
         print(f"  {label:60s} FAIL  timeout after {PER_CELL_TIMEOUT_SECS}s")
         fail_count += 1
         records.append({
-            "endpoint": endpoint, "mode": mode, "status": "FAIL",
+            "endpoint": endpoint, "mode": mode, "rationale": rationale,
+            "status": "FAIL",
             "row_count": 0, "duration_ms": duration_ms, "detail": "timeout after 60s",
         })
         continue
@@ -312,7 +685,8 @@ for endpoint, mode, min_tier, argv in CELLS:
         print(f"  {label:60s} FAIL  {output.strip()}")
         fail_count += 1
     records.append({
-        "endpoint": endpoint, "mode": mode, "status": status,
+        "endpoint": endpoint, "mode": mode, "rationale": rationale,
+        "status": status,
         "row_count": row_count, "duration_ms": duration_ms, "detail": detail,
     })
 

--- a/scripts/validate_python.py
+++ b/scripts/validate_python.py
@@ -37,10 +37,10 @@ client = ThetaDataDx(Credentials.from_file(sys.argv[1]), Config.production())
 
 # (endpoint, mode_name, declared_min_tier, rationale, callable)
 # `declared_min_tier` is informational only (printed on tier-permission
-# skips so you can see which modes the server refused). `rationale`
-# is a one-sentence description of what the cell proves; it surfaces in
-# the per-cell JSON artifact and in the cross-language agreement
-# disagreement output (see scripts/validate_agreement.py).
+# skips so you can see which modes the server refused). `rationale` is a
+# one-sentence description of what the cell proves; it surfaces in the
+# per-cell JSON artifact and in the cross-language agreement disagreement
+# output (see scripts/validate_agreement.py).
 CELLS = [
     # stock_list_symbols::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
@@ -49,104 +49,71 @@ CELLS = [
     #   rationale: list/calendar/rate baseline call — no parameter variation
     ("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.stock_list_dates("TRADE", "AAPL")),
     # stock_snapshot_ohlc::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_snapshot_ohlc(["AAPL"])),
-    # stock_snapshot_ohlc::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_snapshot_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_snapshot_ohlc(["AAPL"], venue="nqb")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_snapshot_ohlc(["AAPL"])),
     # stock_snapshot_ohlc::with_min_time
-    #   rationale: min_time=09:45:00 optional filter wiring
-    ("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", lambda: client.stock_snapshot_ohlc(["AAPL"], min_time="09:45:00")),
-    # stock_snapshot_ohlc::all_optionals
-    #   rationale: every applicable optional set at once — proves multi-optional wiring
-    ("stock_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_snapshot_ohlc(["AAPL"], venue="nqb", min_time="09:45:00")),
+    #   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+    ("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", lambda: client.stock_snapshot_ohlc(["AAPL"], min_time="09:45:00")),
     # stock_snapshot_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_snapshot_trade(["AAPL"])),
-    # stock_snapshot_trade::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_snapshot_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", lambda: client.stock_snapshot_trade(["AAPL"], venue="nqb")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_snapshot_trade(["AAPL"])),
     # stock_snapshot_trade::with_min_time
-    #   rationale: min_time=09:45:00 optional filter wiring
-    ("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", lambda: client.stock_snapshot_trade(["AAPL"], min_time="09:45:00")),
-    # stock_snapshot_trade::all_optionals
-    #   rationale: every applicable optional set at once — proves multi-optional wiring
-    ("stock_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_snapshot_trade(["AAPL"], venue="nqb", min_time="09:45:00")),
+    #   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+    ("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", lambda: client.stock_snapshot_trade(["AAPL"], min_time="09:45:00")),
     # stock_snapshot_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_snapshot_quote(["AAPL"])),
-    # stock_snapshot_quote::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_snapshot_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_snapshot_quote(["AAPL"], venue="nqb")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_snapshot_quote(["AAPL"])),
     # stock_snapshot_quote::with_min_time
-    #   rationale: min_time=09:45:00 optional filter wiring
-    ("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", lambda: client.stock_snapshot_quote(["AAPL"], min_time="09:45:00")),
-    # stock_snapshot_quote::all_optionals
-    #   rationale: every applicable optional set at once — proves multi-optional wiring
-    ("stock_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_snapshot_quote(["AAPL"], venue="nqb", min_time="09:45:00")),
+    #   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+    ("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", lambda: client.stock_snapshot_quote(["AAPL"], min_time="09:45:00")),
     # stock_snapshot_market_value::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_snapshot_market_value(["AAPL"])),
-    # stock_snapshot_market_value::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_snapshot_market_value", "with_venue", "standard", "venue=nqb optional venue selector wiring", lambda: client.stock_snapshot_market_value(["AAPL"], venue="nqb")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_snapshot_market_value(["AAPL"])),
     # stock_snapshot_market_value::with_min_time
-    #   rationale: min_time=09:45:00 optional filter wiring
-    ("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", lambda: client.stock_snapshot_market_value(["AAPL"], min_time="09:45:00")),
-    # stock_snapshot_market_value::all_optionals
-    #   rationale: every applicable optional set at once — proves multi-optional wiring
-    ("stock_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_snapshot_market_value(["AAPL"], venue="nqb", min_time="09:45:00")),
+    #   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+    ("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", lambda: client.stock_snapshot_market_value(["AAPL"], min_time="09:45:00")),
     # stock_history_eod::concrete
     #   rationale: required params set, no optionals — baseline wire path
     ("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", lambda: client.stock_history_eod("AAPL", "20250303", "20250303")),
     # stock_history_ohlc::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000")),
     # stock_history_ohlc::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("stock_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
     # stock_history_ohlc::with_date_range
     #   rationale: start_date + end_date pair — date range optional wiring
     ("stock_history_ohlc", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    # stock_history_ohlc::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_history_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", venue="nqb")),
     # stock_history_ohlc::all_optionals
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("stock_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
     # stock_history_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_history_trade("AAPL", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_history_trade("AAPL", "20250303")),
     # stock_history_trade::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("stock_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_trade("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00")),
     # stock_history_trade::with_date_range
     #   rationale: start_date + end_date pair — date range optional wiring
     ("stock_history_trade", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", lambda: client.stock_history_trade("AAPL", "20250303", start_date="20250303", end_date="20250303")),
-    # stock_history_trade::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_history_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", lambda: client.stock_history_trade("AAPL", "20250303", venue="nqb")),
     # stock_history_trade::all_optionals
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("stock_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_trade("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
     # stock_history_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_history_quote("AAPL", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_history_quote("AAPL", "20250303", "60000")),
     # stock_history_quote::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("stock_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
     # stock_history_quote::with_date_range
     #   rationale: start_date + end_date pair — date range optional wiring
     ("stock_history_quote", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    # stock_history_quote::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_history_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_history_quote("AAPL", "20250303", "60000", venue="nqb")),
     # stock_history_quote::all_optionals
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("stock_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
     # stock_history_trade_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_history_trade_quote("AAPL", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_history_trade_quote("AAPL", "20250303")),
     # stock_history_trade_quote::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("stock_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00")),
@@ -156,24 +123,15 @@ CELLS = [
     # stock_history_trade_quote::with_exclusive
     #   rationale: exclusive=true optional filter wiring
     ("stock_history_trade_quote", "with_exclusive", "standard", "exclusive=true optional filter wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", exclusive=True)),
-    # stock_history_trade_quote::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_history_trade_quote", "with_venue", "standard", "venue=nqb optional venue selector wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", venue="nqb")),
     # stock_history_trade_quote::all_optionals
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("stock_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00", exclusive=True, venue="nqb", start_date="20250303", end_date="20250303")),
     # stock_at_time_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000")),
-    # stock_at_time_trade::with_venue
-    #   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
-    ("stock_at_time_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring (also covers: all_optionals)", lambda: client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000", venue="nqb")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)
+    ("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", lambda: client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000")),
     # stock_at_time_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000")),
-    # stock_at_time_quote::with_venue
-    #   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
-    ("stock_at_time_quote", "with_venue", "value", "venue=nqb optional venue selector wiring (also covers: all_optionals)", lambda: client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000", venue="nqb")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)
+    ("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", lambda: client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000")),
     # option_list_symbols::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
     ("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.option_list_symbols()),
@@ -193,23 +151,17 @@ CELLS = [
     #   rationale: max_dte=30 optional filter wiring (also covers: all_optionals)
     ("option_list_contracts", "with_max_dte", "value", "max_dte=30 optional filter wiring (also covers: all_optionals)", lambda: client.option_list_contracts("TRADE", "SPY", "20250303", max_dte=30)),
     # option_snapshot_ohlc::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C")),
-    # option_snapshot_ohlc::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_ohlc("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C")),
     # option_snapshot_ohlc::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_ohlc("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_ohlc("SPY", "20250321", "*", "both")),
     # option_snapshot_ohlc::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_ohlc("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_ohlc("SPY", "*", "570", "both")),
     # option_snapshot_ohlc::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_ohlc("SPY", "*", "*", "both")),
-    # option_snapshot_ohlc::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_ohlc", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_ohlc("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_ohlc("SPY", "*", "*", "both")),
     # option_snapshot_ohlc::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_snapshot_ohlc", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", max_dte=30)),
@@ -223,14 +175,11 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
     # option_snapshot_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C")),
-    # option_snapshot_trade::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_trade("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C")),
     # option_snapshot_trade::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_trade("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_trade("SPY", "20250321", "*", "both")),
     # option_snapshot_trade::with_strike_range
     #   rationale: strike_range=10 optional filter wiring
     ("option_snapshot_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", strike_range=10)),
@@ -241,23 +190,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", strike_range=10, min_time="09:45:00")),
     # option_snapshot_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C")),
-    # option_snapshot_quote::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_quote("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C")),
     # option_snapshot_quote::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_quote("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_quote("SPY", "20250321", "*", "both")),
     # option_snapshot_quote::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_quote("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_quote("SPY", "*", "570", "both")),
     # option_snapshot_quote::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_quote("SPY", "*", "*", "both")),
-    # option_snapshot_quote::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_quote("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_quote("SPY", "*", "*", "both")),
     # option_snapshot_quote::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_snapshot_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", max_dte=30)),
@@ -271,23 +214,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
     # option_snapshot_open_interest::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C")),
-    # option_snapshot_open_interest::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_open_interest("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C")),
     # option_snapshot_open_interest::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_open_interest("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_open_interest("SPY", "20250321", "*", "both")),
     # option_snapshot_open_interest::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_open_interest("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_open_interest("SPY", "*", "570", "both")),
     # option_snapshot_open_interest::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_open_interest("SPY", "*", "*", "both")),
-    # option_snapshot_open_interest::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_open_interest("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_open_interest("SPY", "*", "*", "both")),
     # option_snapshot_open_interest::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_snapshot_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", max_dte=30)),
@@ -301,23 +238,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
     # option_snapshot_market_value::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C")),
-    # option_snapshot_market_value::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_market_value", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_market_value("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C")),
     # option_snapshot_market_value::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_market_value("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_market_value("SPY", "20250321", "*", "both")),
     # option_snapshot_market_value::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_market_value("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_market_value("SPY", "*", "570", "both")),
     # option_snapshot_market_value::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_market_value("SPY", "*", "*", "both")),
-    # option_snapshot_market_value::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_market_value", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_market_value("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_market_value("SPY", "*", "*", "both")),
     # option_snapshot_market_value::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_snapshot_market_value", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", max_dte=30)),
@@ -331,23 +262,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
     # option_snapshot_greeks_implied_volatility::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C")),
-    # option_snapshot_greeks_implied_volatility::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C")),
     # option_snapshot_greeks_implied_volatility::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both")),
     # option_snapshot_greeks_implied_volatility::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both")),
     # option_snapshot_greeks_implied_volatility::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both")),
-    # option_snapshot_greeks_implied_volatility::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both")),
     # option_snapshot_greeks_implied_volatility::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", annual_dividend=0.015)),
@@ -358,8 +283,8 @@ CELLS = [
     #   rationale: rate_value=0.05 optional Greeks-input wiring
     ("option_snapshot_greeks_implied_volatility", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", rate_value=0.05)),
     # option_snapshot_greeks_implied_volatility::with_stock_price
-    #   rationale: stock_price=150 optional Greeks-input wiring
-    ("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", stock_price=150.0)),
+    #   rationale: stock_price=150.0 optional Greeks-input wiring
+    ("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150.0 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", stock_price=150.0)),
     # option_snapshot_greeks_implied_volatility::with_version
     #   rationale: version=dg3 optional Greeks-version selector wiring
     ("option_snapshot_greeks_implied_volatility", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", version="dg3")),
@@ -379,23 +304,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
     # option_snapshot_greeks_all::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C")),
-    # option_snapshot_greeks_all::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_all("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C")),
     # option_snapshot_greeks_all::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "*", "both")),
     # option_snapshot_greeks_all::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_all("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_all("SPY", "*", "570", "both")),
     # option_snapshot_greeks_all::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_all("SPY", "*", "*", "both")),
-    # option_snapshot_greeks_all::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_all("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_greeks_all("SPY", "*", "*", "both")),
     # option_snapshot_greeks_all::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", annual_dividend=0.015)),
@@ -406,8 +325,8 @@ CELLS = [
     #   rationale: rate_value=0.05 optional Greeks-input wiring
     ("option_snapshot_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", rate_value=0.05)),
     # option_snapshot_greeks_all::with_stock_price
-    #   rationale: stock_price=150 optional Greeks-input wiring
-    ("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", stock_price=150.0)),
+    #   rationale: stock_price=150.0 optional Greeks-input wiring
+    ("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", stock_price=150.0)),
     # option_snapshot_greeks_all::with_version
     #   rationale: version=dg3 optional Greeks-version selector wiring
     ("option_snapshot_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", version="dg3")),
@@ -427,23 +346,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
     # option_snapshot_greeks_first_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C")),
-    # option_snapshot_greeks_first_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_first_order("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C")),
     # option_snapshot_greeks_first_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both")),
     # option_snapshot_greeks_first_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "570", "both")),
     # option_snapshot_greeks_first_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "*", "both")),
-    # option_snapshot_greeks_first_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_first_order("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "*", "both")),
     # option_snapshot_greeks_first_order::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
@@ -454,8 +367,8 @@ CELLS = [
     #   rationale: rate_value=0.05 optional Greeks-input wiring
     ("option_snapshot_greeks_first_order", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", rate_value=0.05)),
     # option_snapshot_greeks_first_order::with_stock_price
-    #   rationale: stock_price=150 optional Greeks-input wiring
-    ("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", stock_price=150.0)),
+    #   rationale: stock_price=150.0 optional Greeks-input wiring
+    ("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150.0 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", stock_price=150.0)),
     # option_snapshot_greeks_first_order::with_version
     #   rationale: version=dg3 optional Greeks-version selector wiring
     ("option_snapshot_greeks_first_order", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", version="dg3")),
@@ -475,23 +388,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
     # option_snapshot_greeks_second_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C")),
-    # option_snapshot_greeks_second_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_second_order("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C")),
     # option_snapshot_greeks_second_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both")),
     # option_snapshot_greeks_second_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "570", "both")),
     # option_snapshot_greeks_second_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "*", "both")),
-    # option_snapshot_greeks_second_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_second_order("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "*", "both")),
     # option_snapshot_greeks_second_order::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
@@ -502,8 +409,8 @@ CELLS = [
     #   rationale: rate_value=0.05 optional Greeks-input wiring
     ("option_snapshot_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", rate_value=0.05)),
     # option_snapshot_greeks_second_order::with_stock_price
-    #   rationale: stock_price=150 optional Greeks-input wiring
-    ("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", stock_price=150.0)),
+    #   rationale: stock_price=150.0 optional Greeks-input wiring
+    ("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", stock_price=150.0)),
     # option_snapshot_greeks_second_order::with_version
     #   rationale: version=dg3 optional Greeks-version selector wiring
     ("option_snapshot_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", version="dg3")),
@@ -523,23 +430,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
     # option_snapshot_greeks_third_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C")),
-    # option_snapshot_greeks_third_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_snapshot_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_third_order("SPY", "2025-03-21", "570", "C")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C")),
     # option_snapshot_greeks_third_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both")),
     # option_snapshot_greeks_third_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "570", "both")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "570", "both")),
     # option_snapshot_greeks_third_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "*", "both")),
-    # option_snapshot_greeks_third_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_third_order("SPY", "0", "0", "both")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "*", "both")),
     # option_snapshot_greeks_third_order::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
@@ -550,8 +451,8 @@ CELLS = [
     #   rationale: rate_value=0.05 optional Greeks-input wiring
     ("option_snapshot_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", rate_value=0.05)),
     # option_snapshot_greeks_third_order::with_stock_price
-    #   rationale: stock_price=150 optional Greeks-input wiring
-    ("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", stock_price=150.0)),
+    #   rationale: stock_price=150.0 optional Greeks-input wiring
+    ("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", stock_price=150.0)),
     # option_snapshot_greeks_third_order::with_version
     #   rationale: version=dg3 optional Greeks-version selector wiring
     ("option_snapshot_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", version="dg3")),
@@ -571,23 +472,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_snapshot_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
     # option_history_eod::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303")),
-    # option_history_eod::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_eod", "concrete_iso", "free", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303")),
     # option_history_eod::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303")),
     # option_history_eod::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303")),
     # option_history_eod::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303")),
-    # option_history_eod::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_eod", "legacy_zero_wildcard", "free", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_eod("SPY", "0", "0", "both", "20250303", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303")),
     # option_history_eod::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_history_eod", "with_max_dte", "free", "max_dte=30 optional filter wiring", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30)),
@@ -598,14 +493,11 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_eod", "all_optionals", "free", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30, strike_range=10)),
     # option_history_ohlc::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000")),
-    # option_history_ohlc::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_ohlc("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000")),
     # option_history_ohlc::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000")),
     # option_history_ohlc::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
@@ -619,23 +511,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303")),
-    # option_history_trade::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade("SPY", "2025-03-21", "570", "C", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303")),
     # option_history_trade::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade("SPY", "20250321", "*", "both", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade("SPY", "20250321", "*", "both", "20250303")),
     # option_history_trade::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade("SPY", "*", "570", "both", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade("SPY", "*", "570", "both", "20250303")),
     # option_history_trade::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade("SPY", "*", "*", "both", "20250303")),
-    # option_history_trade::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade("SPY", "0", "0", "both", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_trade("SPY", "*", "*", "both", "20250303")),
     # option_history_trade::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
@@ -652,23 +538,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000")),
-    # option_history_quote::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_quote("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000")),
     # option_history_quote::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000")),
     # option_history_quote::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000")),
     # option_history_quote::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000")),
-    # option_history_quote::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_quote("SPY", "0", "0", "both", "20250303", "60000")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000")),
     # option_history_quote::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
@@ -685,23 +565,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_trade_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303")),
-    # option_history_trade_quote::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_quote", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_quote("SPY", "2025-03-21", "570", "C", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303")),
     # option_history_trade_quote::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303")),
     # option_history_trade_quote::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_quote("SPY", "*", "570", "both", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_quote("SPY", "*", "570", "both", "20250303")),
     # option_history_trade_quote::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_quote("SPY", "*", "*", "both", "20250303")),
-    # option_history_trade_quote::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_quote", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_quote("SPY", "0", "0", "both", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_trade_quote("SPY", "*", "*", "both", "20250303")),
     # option_history_trade_quote::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
@@ -721,23 +595,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", exclusive=True, max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_open_interest::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303")),
-    # option_history_open_interest::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_open_interest("SPY", "2025-03-21", "570", "C", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303")),
     # option_history_open_interest::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303")),
     # option_history_open_interest::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_open_interest("SPY", "*", "570", "both", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_open_interest("SPY", "*", "570", "both", "20250303")),
     # option_history_open_interest::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_open_interest("SPY", "*", "*", "both", "20250303")),
-    # option_history_open_interest::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_open_interest("SPY", "0", "0", "both", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_open_interest("SPY", "*", "*", "both", "20250303")),
     # option_history_open_interest::with_date_range
     #   rationale: start_date + end_date pair — date range optional wiring
     ("option_history_open_interest", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
@@ -751,23 +619,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_greeks_eod::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303")),
-    # option_history_greeks_eod::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_eod", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303")),
     # option_history_greeks_eod::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303")),
     # option_history_greeks_eod::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303")),
     # option_history_greeks_eod::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303")),
-    # option_history_greeks_eod::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_greeks_eod", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_greeks_eod("SPY", "0", "0", "both", "20250303", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303")),
     # option_history_greeks_eod::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_history_greeks_eod", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", annual_dividend=0.015)),
@@ -793,14 +655,11 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_greeks_eod", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", underlyer_use_nbbo=True, max_dte=30, strike_range=10)),
     # option_history_greeks_all::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000")),
-    # option_history_greeks_all::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_all("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000")),
     # option_history_greeks_all::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000")),
     # option_history_greeks_all::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
@@ -826,23 +685,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_trade_greeks_all::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303")),
-    # option_history_trade_greeks_all::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_all("SPY", "2025-03-21", "570", "C", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303")),
     # option_history_trade_greeks_all::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303")),
     # option_history_trade_greeks_all::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303")),
     # option_history_trade_greeks_all::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303")),
-    # option_history_trade_greeks_all::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_all("SPY", "0", "0", "both", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303")),
     # option_history_trade_greeks_all::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
@@ -871,14 +724,11 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_trade_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_greeks_first_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000")),
-    # option_history_greeks_first_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000")),
     # option_history_greeks_first_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000")),
     # option_history_greeks_first_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_first_order", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
@@ -904,23 +754,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_trade_greeks_first_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303")),
-    # option_history_trade_greeks_first_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_first_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303")),
     # option_history_trade_greeks_first_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303")),
     # option_history_trade_greeks_first_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303")),
     # option_history_trade_greeks_first_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303")),
-    # option_history_trade_greeks_first_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_first_order("SPY", "0", "0", "both", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303")),
     # option_history_trade_greeks_first_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_first_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
@@ -949,14 +793,11 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_trade_greeks_first_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_greeks_second_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000")),
-    # option_history_greeks_second_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000")),
     # option_history_greeks_second_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000")),
     # option_history_greeks_second_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
@@ -982,23 +823,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_trade_greeks_second_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303")),
-    # option_history_trade_greeks_second_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303")),
     # option_history_trade_greeks_second_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303")),
     # option_history_trade_greeks_second_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303")),
     # option_history_trade_greeks_second_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303")),
-    # option_history_trade_greeks_second_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_second_order("SPY", "0", "0", "both", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303")),
     # option_history_trade_greeks_second_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
@@ -1027,14 +862,11 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_trade_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_greeks_third_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000")),
-    # option_history_greeks_third_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000")),
     # option_history_greeks_third_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000")),
     # option_history_greeks_third_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
@@ -1060,23 +892,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_trade_greeks_third_order::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303")),
-    # option_history_trade_greeks_third_order::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303")),
     # option_history_trade_greeks_third_order::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303")),
     # option_history_trade_greeks_third_order::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303")),
     # option_history_trade_greeks_third_order::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303")),
-    # option_history_trade_greeks_third_order::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_third_order("SPY", "0", "0", "both", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303")),
     # option_history_trade_greeks_third_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
@@ -1105,14 +931,11 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_trade_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_greeks_implied_volatility::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000")),
-    # option_history_greeks_implied_volatility::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000")),
     # option_history_greeks_implied_volatility::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000")),
     # option_history_greeks_implied_volatility::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_implied_volatility", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
@@ -1138,23 +961,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
     # option_history_trade_greeks_implied_volatility::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303")),
-    # option_history_trade_greeks_implied_volatility::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303")),
     # option_history_trade_greeks_implied_volatility::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303")),
     # option_history_trade_greeks_implied_volatility::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303")),
     # option_history_trade_greeks_implied_volatility::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303")),
-    # option_history_trade_greeks_implied_volatility::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "0", "0", "both", "20250303")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303")),
     # option_history_trade_greeks_implied_volatility::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
@@ -1183,23 +1000,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_history_trade_greeks_implied_volatility", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
     # option_at_time_trade::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000")),
-    # option_at_time_trade::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_at_time_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_at_time_trade("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000")),
     # option_at_time_trade::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000")),
     # option_at_time_trade::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000")),
     # option_at_time_trade::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000")),
-    # option_at_time_trade::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_at_time_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_at_time_trade("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000")),
     # option_at_time_trade::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_at_time_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30)),
@@ -1210,23 +1021,17 @@ CELLS = [
     #   rationale: every applicable optional set at once — proves multi-optional wiring
     ("option_at_time_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30, strike_range=10)),
     # option_at_time_quote::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000")),
-    # option_at_time_quote::concrete_iso
-    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-    ("option_at_time_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_at_time_quote("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+    ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000")),
     # option_at_time_quote::all_strikes_one_exp
-    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000")),
+    #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000")),
     # option_at_time_quote::all_exps_one_strike
-    #   rationale: expiration=* — exercises expiration wildcard wire-unset
-    ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000")),
+    #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+    ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000")),
     # option_at_time_quote::bulk_chain
-    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000")),
-    # option_at_time_quote::legacy_zero_wildcard
-    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-    ("option_at_time_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_at_time_quote("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000")),
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000")),
     # option_at_time_quote::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_at_time_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30)),
@@ -1297,17 +1102,11 @@ CELLS = [
     #   rationale: list/calendar/rate baseline call — no parameter variation
     ("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.interest_rate_history_eod("SOFR", "20250303", "20250303")),
     # stock_history_ohlc_range::concrete
-    #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000")),
+    #   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+    ("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000")),
     # stock_history_ohlc_range::with_intraday_window
-    #   rationale: start_time + end_time pair — intraday window optional wiring
-    ("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    # stock_history_ohlc_range::with_venue
-    #   rationale: venue=nqb optional venue selector wiring
-    ("stock_history_ohlc_range", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", venue="nqb")),
-    # stock_history_ohlc_range::all_optionals
-    #   rationale: every applicable optional set at once — proves multi-optional wiring
-    ("stock_history_ohlc_range", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb")),
+    #   rationale: start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)
+    ("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
 ]
 
 pass_count = skip_count = fail_count = 0
@@ -1406,7 +1205,10 @@ for endpoint, mode, min_tier, rationale, call in CELLS:
             pass_count += 1
         else:
             status = "FAIL"
-            detail = str(value)
+            # Exception messages can span multiple lines; escape them at the
+            # producer so the agreement-table row stays on one line. See
+            # scripts/validate_agreement.py disagreement output.
+            detail = str(value).replace("\n", "\\n").replace("\r", "\\r")[:200]
             print(f"  {label:60s} FAIL  {value}", flush=True)
             fail_count += 1
     records.append({

--- a/scripts/validate_python.py
+++ b/scripts/validate_python.py
@@ -35,439 +35,1279 @@ ARTIFACT_PATH = pathlib.Path(__file__).resolve().parents[1] / "artifacts" / "val
 
 client = ThetaDataDx(Credentials.from_file(sys.argv[1]), Config.production())
 
-# (endpoint, mode_name, declared_min_tier, callable)
+# (endpoint, mode_name, declared_min_tier, rationale, callable)
 # `declared_min_tier` is informational only (printed on tier-permission
-# skips so you can see which modes the server refused).
+# skips so you can see which modes the server refused). `rationale`
+# is a one-sentence description of what the cell proves; it surfaces in
+# the per-cell JSON artifact and in the cross-language agreement
+# disagreement output (see scripts/validate_agreement.py).
 CELLS = [
-    ("stock_list_symbols", "basic", "free", lambda: client.stock_list_symbols()),
-    ("stock_list_dates", "basic", "free", lambda: client.stock_list_dates("TRADE", "AAPL")),
-    ("stock_snapshot_ohlc", "concrete", "value", lambda: client.stock_snapshot_ohlc(["AAPL"])),
-    ("stock_snapshot_ohlc", "with_venue", "value", lambda: client.stock_snapshot_ohlc(["AAPL"], venue="nqb")),
-    ("stock_snapshot_ohlc", "with_min_time", "value", lambda: client.stock_snapshot_ohlc(["AAPL"], min_time="09:45:00")),
-    ("stock_snapshot_ohlc", "all_optionals", "value", lambda: client.stock_snapshot_ohlc(["AAPL"], venue="nqb", min_time="09:45:00")),
-    ("stock_snapshot_trade", "concrete", "standard", lambda: client.stock_snapshot_trade(["AAPL"])),
-    ("stock_snapshot_trade", "with_venue", "standard", lambda: client.stock_snapshot_trade(["AAPL"], venue="nqb")),
-    ("stock_snapshot_trade", "with_min_time", "standard", lambda: client.stock_snapshot_trade(["AAPL"], min_time="09:45:00")),
-    ("stock_snapshot_trade", "all_optionals", "standard", lambda: client.stock_snapshot_trade(["AAPL"], venue="nqb", min_time="09:45:00")),
-    ("stock_snapshot_quote", "concrete", "value", lambda: client.stock_snapshot_quote(["AAPL"])),
-    ("stock_snapshot_quote", "with_venue", "value", lambda: client.stock_snapshot_quote(["AAPL"], venue="nqb")),
-    ("stock_snapshot_quote", "with_min_time", "value", lambda: client.stock_snapshot_quote(["AAPL"], min_time="09:45:00")),
-    ("stock_snapshot_quote", "all_optionals", "value", lambda: client.stock_snapshot_quote(["AAPL"], venue="nqb", min_time="09:45:00")),
-    ("stock_snapshot_market_value", "concrete", "standard", lambda: client.stock_snapshot_market_value(["AAPL"])),
-    ("stock_snapshot_market_value", "with_venue", "standard", lambda: client.stock_snapshot_market_value(["AAPL"], venue="nqb")),
-    ("stock_snapshot_market_value", "with_min_time", "standard", lambda: client.stock_snapshot_market_value(["AAPL"], min_time="09:45:00")),
-    ("stock_snapshot_market_value", "all_optionals", "standard", lambda: client.stock_snapshot_market_value(["AAPL"], venue="nqb", min_time="09:45:00")),
-    ("stock_history_eod", "concrete", "free", lambda: client.stock_history_eod("AAPL", "20250303", "20250303")),
-    ("stock_history_ohlc", "concrete", "value", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000")),
-    ("stock_history_ohlc", "with_intraday_window", "value", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("stock_history_ohlc", "with_date_range", "value", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("stock_history_ohlc", "with_venue", "value", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", venue="nqb")),
-    ("stock_history_ohlc", "all_optionals", "value", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
-    ("stock_history_trade", "concrete", "standard", lambda: client.stock_history_trade("AAPL", "20250303")),
-    ("stock_history_trade", "with_intraday_window", "standard", lambda: client.stock_history_trade("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("stock_history_trade", "with_date_range", "standard", lambda: client.stock_history_trade("AAPL", "20250303", start_date="20250303", end_date="20250303")),
-    ("stock_history_trade", "with_venue", "standard", lambda: client.stock_history_trade("AAPL", "20250303", venue="nqb")),
-    ("stock_history_trade", "all_optionals", "standard", lambda: client.stock_history_trade("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
-    ("stock_history_quote", "concrete", "value", lambda: client.stock_history_quote("AAPL", "20250303", "60000")),
-    ("stock_history_quote", "with_intraday_window", "value", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("stock_history_quote", "with_date_range", "value", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("stock_history_quote", "with_venue", "value", lambda: client.stock_history_quote("AAPL", "20250303", "60000", venue="nqb")),
-    ("stock_history_quote", "all_optionals", "value", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
-    ("stock_history_trade_quote", "concrete", "standard", lambda: client.stock_history_trade_quote("AAPL", "20250303")),
-    ("stock_history_trade_quote", "with_intraday_window", "standard", lambda: client.stock_history_trade_quote("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("stock_history_trade_quote", "with_date_range", "standard", lambda: client.stock_history_trade_quote("AAPL", "20250303", start_date="20250303", end_date="20250303")),
-    ("stock_history_trade_quote", "with_exclusive", "standard", lambda: client.stock_history_trade_quote("AAPL", "20250303", exclusive=True)),
-    ("stock_history_trade_quote", "with_venue", "standard", lambda: client.stock_history_trade_quote("AAPL", "20250303", venue="nqb")),
-    ("stock_history_trade_quote", "all_optionals", "standard", lambda: client.stock_history_trade_quote("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00", exclusive=True, venue="nqb", start_date="20250303", end_date="20250303")),
-    ("stock_at_time_trade", "concrete", "standard", lambda: client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000")),
-    ("stock_at_time_trade", "with_venue", "standard", lambda: client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000", venue="nqb")),
-    ("stock_at_time_trade", "all_optionals", "standard", lambda: client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000", venue="nqb")),
-    ("stock_at_time_quote", "concrete", "value", lambda: client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000")),
-    ("stock_at_time_quote", "with_venue", "value", lambda: client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000", venue="nqb")),
-    ("stock_at_time_quote", "all_optionals", "value", lambda: client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000", venue="nqb")),
-    ("option_list_symbols", "basic", "free", lambda: client.option_list_symbols()),
-    ("option_list_dates", "basic", "free", lambda: client.option_list_dates("TRADE", "SPY", "20250321", "570", "C")),
-    ("option_list_expirations", "basic", "free", lambda: client.option_list_expirations("SPY")),
-    ("option_list_strikes", "basic", "free", lambda: client.option_list_strikes("SPY", "20250321")),
-    ("option_list_contracts", "concrete", "value", lambda: client.option_list_contracts("TRADE", "SPY", "20250303")),
-    ("option_list_contracts", "with_max_dte", "value", lambda: client.option_list_contracts("TRADE", "SPY", "20250303", max_dte=30)),
-    ("option_list_contracts", "all_optionals", "value", lambda: client.option_list_contracts("TRADE", "SPY", "20250303", max_dte=30)),
-    ("option_snapshot_ohlc", "concrete", "value", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C")),
-    ("option_snapshot_ohlc", "concrete_iso", "value", lambda: client.option_snapshot_ohlc("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", lambda: client.option_snapshot_ohlc("SPY", "20250321", "*", "both")),
-    ("option_snapshot_ohlc", "all_exps_one_strike", "value", lambda: client.option_snapshot_ohlc("SPY", "*", "570", "both")),
-    ("option_snapshot_ohlc", "bulk_chain", "value", lambda: client.option_snapshot_ohlc("SPY", "*", "*", "both")),
-    ("option_snapshot_ohlc", "legacy_zero_wildcard", "value", lambda: client.option_snapshot_ohlc("SPY", "0", "0", "both")),
-    ("option_snapshot_ohlc", "with_max_dte", "value", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_ohlc", "with_strike_range", "value", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_ohlc", "with_min_time", "value", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_ohlc", "all_optionals", "value", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
-    ("option_snapshot_trade", "concrete", "standard", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C")),
-    ("option_snapshot_trade", "concrete_iso", "standard", lambda: client.option_snapshot_trade("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_trade", "all_strikes_one_exp", "standard", lambda: client.option_snapshot_trade("SPY", "20250321", "*", "both")),
-    ("option_snapshot_trade", "with_strike_range", "standard", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_trade", "with_min_time", "standard", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_trade", "all_optionals", "standard", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", strike_range=10, min_time="09:45:00")),
-    ("option_snapshot_quote", "concrete", "value", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C")),
-    ("option_snapshot_quote", "concrete_iso", "value", lambda: client.option_snapshot_quote("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_quote", "all_strikes_one_exp", "value", lambda: client.option_snapshot_quote("SPY", "20250321", "*", "both")),
-    ("option_snapshot_quote", "all_exps_one_strike", "value", lambda: client.option_snapshot_quote("SPY", "*", "570", "both")),
-    ("option_snapshot_quote", "bulk_chain", "value", lambda: client.option_snapshot_quote("SPY", "*", "*", "both")),
-    ("option_snapshot_quote", "legacy_zero_wildcard", "value", lambda: client.option_snapshot_quote("SPY", "0", "0", "both")),
-    ("option_snapshot_quote", "with_max_dte", "value", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_quote", "with_strike_range", "value", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_quote", "with_min_time", "value", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_quote", "all_optionals", "value", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
-    ("option_snapshot_open_interest", "concrete", "value", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C")),
-    ("option_snapshot_open_interest", "concrete_iso", "value", lambda: client.option_snapshot_open_interest("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", lambda: client.option_snapshot_open_interest("SPY", "20250321", "*", "both")),
-    ("option_snapshot_open_interest", "all_exps_one_strike", "value", lambda: client.option_snapshot_open_interest("SPY", "*", "570", "both")),
-    ("option_snapshot_open_interest", "bulk_chain", "value", lambda: client.option_snapshot_open_interest("SPY", "*", "*", "both")),
-    ("option_snapshot_open_interest", "legacy_zero_wildcard", "value", lambda: client.option_snapshot_open_interest("SPY", "0", "0", "both")),
-    ("option_snapshot_open_interest", "with_max_dte", "value", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_open_interest", "with_strike_range", "value", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_open_interest", "with_min_time", "value", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_open_interest", "all_optionals", "value", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
-    ("option_snapshot_market_value", "concrete", "standard", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C")),
-    ("option_snapshot_market_value", "concrete_iso", "standard", lambda: client.option_snapshot_market_value("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", lambda: client.option_snapshot_market_value("SPY", "20250321", "*", "both")),
-    ("option_snapshot_market_value", "all_exps_one_strike", "standard", lambda: client.option_snapshot_market_value("SPY", "*", "570", "both")),
-    ("option_snapshot_market_value", "bulk_chain", "standard", lambda: client.option_snapshot_market_value("SPY", "*", "*", "both")),
-    ("option_snapshot_market_value", "legacy_zero_wildcard", "standard", lambda: client.option_snapshot_market_value("SPY", "0", "0", "both")),
-    ("option_snapshot_market_value", "with_max_dte", "standard", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_market_value", "with_strike_range", "standard", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_market_value", "with_min_time", "standard", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_market_value", "all_optionals", "standard", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
-    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C")),
-    ("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both")),
-    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both")),
-    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both")),
-    ("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "0", "0", "both")),
-    ("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", annual_dividend=0.015)),
-    ("option_snapshot_greeks_implied_volatility", "with_rate_type", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", rate_type="sofr")),
-    ("option_snapshot_greeks_implied_volatility", "with_rate_value", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", rate_value=0.05)),
-    ("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", stock_price=150.0)),
-    ("option_snapshot_greeks_implied_volatility", "with_version", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", version="dg3")),
-    ("option_snapshot_greeks_implied_volatility", "with_max_dte", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_greeks_implied_volatility", "with_strike_range", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_greeks_implied_volatility", "with_min_time", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_greeks_implied_volatility", "with_use_market_value", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", use_market_value=True)),
-    ("option_snapshot_greeks_implied_volatility", "all_optionals", "standard", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
-    ("option_snapshot_greeks_all", "concrete", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C")),
-    ("option_snapshot_greeks_all", "concrete_iso", "professional", lambda: client.option_snapshot_greeks_all("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "*", "both")),
-    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", lambda: client.option_snapshot_greeks_all("SPY", "*", "570", "both")),
-    ("option_snapshot_greeks_all", "bulk_chain", "professional", lambda: client.option_snapshot_greeks_all("SPY", "*", "*", "both")),
-    ("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", lambda: client.option_snapshot_greeks_all("SPY", "0", "0", "both")),
-    ("option_snapshot_greeks_all", "with_annual_dividend", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", annual_dividend=0.015)),
-    ("option_snapshot_greeks_all", "with_rate_type", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", rate_type="sofr")),
-    ("option_snapshot_greeks_all", "with_rate_value", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", rate_value=0.05)),
-    ("option_snapshot_greeks_all", "with_stock_price", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", stock_price=150.0)),
-    ("option_snapshot_greeks_all", "with_version", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", version="dg3")),
-    ("option_snapshot_greeks_all", "with_max_dte", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_greeks_all", "with_strike_range", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_greeks_all", "with_min_time", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_greeks_all", "with_use_market_value", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", use_market_value=True)),
-    ("option_snapshot_greeks_all", "all_optionals", "professional", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
-    ("option_snapshot_greeks_first_order", "concrete", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C")),
-    ("option_snapshot_greeks_first_order", "concrete_iso", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both")),
-    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "570", "both")),
-    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "*", "both")),
-    ("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "0", "0", "both")),
-    ("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
-    ("option_snapshot_greeks_first_order", "with_rate_type", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", rate_type="sofr")),
-    ("option_snapshot_greeks_first_order", "with_rate_value", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", rate_value=0.05)),
-    ("option_snapshot_greeks_first_order", "with_stock_price", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", stock_price=150.0)),
-    ("option_snapshot_greeks_first_order", "with_version", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", version="dg3")),
-    ("option_snapshot_greeks_first_order", "with_max_dte", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_greeks_first_order", "with_strike_range", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_greeks_first_order", "with_min_time", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_greeks_first_order", "with_use_market_value", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", use_market_value=True)),
-    ("option_snapshot_greeks_first_order", "all_optionals", "standard", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
-    ("option_snapshot_greeks_second_order", "concrete", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C")),
-    ("option_snapshot_greeks_second_order", "concrete_iso", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both")),
-    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "570", "both")),
-    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "*", "both")),
-    ("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "0", "0", "both")),
-    ("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
-    ("option_snapshot_greeks_second_order", "with_rate_type", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", rate_type="sofr")),
-    ("option_snapshot_greeks_second_order", "with_rate_value", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", rate_value=0.05)),
-    ("option_snapshot_greeks_second_order", "with_stock_price", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", stock_price=150.0)),
-    ("option_snapshot_greeks_second_order", "with_version", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", version="dg3")),
-    ("option_snapshot_greeks_second_order", "with_max_dte", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_greeks_second_order", "with_strike_range", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_greeks_second_order", "with_min_time", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_greeks_second_order", "with_use_market_value", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", use_market_value=True)),
-    ("option_snapshot_greeks_second_order", "all_optionals", "professional", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
-    ("option_snapshot_greeks_third_order", "concrete", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C")),
-    ("option_snapshot_greeks_third_order", "concrete_iso", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "2025-03-21", "570", "C")),
-    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both")),
-    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "570", "both")),
-    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "*", "both")),
-    ("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "0", "0", "both")),
-    ("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
-    ("option_snapshot_greeks_third_order", "with_rate_type", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", rate_type="sofr")),
-    ("option_snapshot_greeks_third_order", "with_rate_value", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", rate_value=0.05)),
-    ("option_snapshot_greeks_third_order", "with_stock_price", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", stock_price=150.0)),
-    ("option_snapshot_greeks_third_order", "with_version", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", version="dg3")),
-    ("option_snapshot_greeks_third_order", "with_max_dte", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", max_dte=30)),
-    ("option_snapshot_greeks_third_order", "with_strike_range", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", strike_range=10)),
-    ("option_snapshot_greeks_third_order", "with_min_time", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", min_time="09:45:00")),
-    ("option_snapshot_greeks_third_order", "with_use_market_value", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", use_market_value=True)),
-    ("option_snapshot_greeks_third_order", "all_optionals", "professional", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
-    ("option_history_eod", "concrete", "free", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303")),
-    ("option_history_eod", "concrete_iso", "free", lambda: client.option_history_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303")),
-    ("option_history_eod", "all_strikes_one_exp", "free", lambda: client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303")),
-    ("option_history_eod", "all_exps_one_strike", "free", lambda: client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303")),
-    ("option_history_eod", "bulk_chain", "free", lambda: client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303")),
-    ("option_history_eod", "legacy_zero_wildcard", "free", lambda: client.option_history_eod("SPY", "0", "0", "both", "20250303", "20250303")),
-    ("option_history_eod", "with_max_dte", "free", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30)),
-    ("option_history_eod", "with_strike_range", "free", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", strike_range=10)),
-    ("option_history_eod", "all_optionals", "free", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30, strike_range=10)),
-    ("option_history_ohlc", "concrete", "value", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000")),
-    ("option_history_ohlc", "concrete_iso", "value", lambda: client.option_history_ohlc("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
-    ("option_history_ohlc", "all_strikes_one_exp", "value", lambda: client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000")),
-    ("option_history_ohlc", "with_intraday_window", "value", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_ohlc", "with_date_range", "value", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("option_history_ohlc", "with_strike_range", "value", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
-    ("option_history_ohlc", "all_optionals", "value", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_trade", "concrete", "standard", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303")),
-    ("option_history_trade", "concrete_iso", "standard", lambda: client.option_history_trade("SPY", "2025-03-21", "570", "C", "20250303")),
-    ("option_history_trade", "all_strikes_one_exp", "standard", lambda: client.option_history_trade("SPY", "20250321", "*", "both", "20250303")),
-    ("option_history_trade", "all_exps_one_strike", "standard", lambda: client.option_history_trade("SPY", "*", "570", "both", "20250303")),
-    ("option_history_trade", "bulk_chain", "standard", lambda: client.option_history_trade("SPY", "*", "*", "both", "20250303")),
-    ("option_history_trade", "legacy_zero_wildcard", "standard", lambda: client.option_history_trade("SPY", "0", "0", "both", "20250303")),
-    ("option_history_trade", "with_intraday_window", "standard", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_trade", "with_date_range", "standard", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
-    ("option_history_trade", "with_max_dte", "standard", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
-    ("option_history_trade", "with_strike_range", "standard", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
-    ("option_history_trade", "all_optionals", "standard", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_quote", "concrete", "value", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000")),
-    ("option_history_quote", "concrete_iso", "value", lambda: client.option_history_quote("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
-    ("option_history_quote", "all_strikes_one_exp", "value", lambda: client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000")),
-    ("option_history_quote", "all_exps_one_strike", "value", lambda: client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000")),
-    ("option_history_quote", "bulk_chain", "value", lambda: client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000")),
-    ("option_history_quote", "legacy_zero_wildcard", "value", lambda: client.option_history_quote("SPY", "0", "0", "both", "20250303", "60000")),
-    ("option_history_quote", "with_intraday_window", "value", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_quote", "with_date_range", "value", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("option_history_quote", "with_max_dte", "value", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", max_dte=30)),
-    ("option_history_quote", "with_strike_range", "value", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
-    ("option_history_quote", "all_optionals", "value", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_trade_quote", "concrete", "standard", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303")),
-    ("option_history_trade_quote", "concrete_iso", "standard", lambda: client.option_history_trade_quote("SPY", "2025-03-21", "570", "C", "20250303")),
-    ("option_history_trade_quote", "all_strikes_one_exp", "standard", lambda: client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303")),
-    ("option_history_trade_quote", "all_exps_one_strike", "standard", lambda: client.option_history_trade_quote("SPY", "*", "570", "both", "20250303")),
-    ("option_history_trade_quote", "bulk_chain", "standard", lambda: client.option_history_trade_quote("SPY", "*", "*", "both", "20250303")),
-    ("option_history_trade_quote", "legacy_zero_wildcard", "standard", lambda: client.option_history_trade_quote("SPY", "0", "0", "both", "20250303")),
-    ("option_history_trade_quote", "with_intraday_window", "standard", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_trade_quote", "with_date_range", "standard", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
-    ("option_history_trade_quote", "with_exclusive", "standard", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", exclusive=True)),
-    ("option_history_trade_quote", "with_max_dte", "standard", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
-    ("option_history_trade_quote", "with_strike_range", "standard", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
-    ("option_history_trade_quote", "all_optionals", "standard", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", exclusive=True, max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_open_interest", "concrete", "value", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303")),
-    ("option_history_open_interest", "concrete_iso", "value", lambda: client.option_history_open_interest("SPY", "2025-03-21", "570", "C", "20250303")),
-    ("option_history_open_interest", "all_strikes_one_exp", "value", lambda: client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303")),
-    ("option_history_open_interest", "all_exps_one_strike", "value", lambda: client.option_history_open_interest("SPY", "*", "570", "both", "20250303")),
-    ("option_history_open_interest", "bulk_chain", "value", lambda: client.option_history_open_interest("SPY", "*", "*", "both", "20250303")),
-    ("option_history_open_interest", "legacy_zero_wildcard", "value", lambda: client.option_history_open_interest("SPY", "0", "0", "both", "20250303")),
-    ("option_history_open_interest", "with_date_range", "value", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
-    ("option_history_open_interest", "with_max_dte", "value", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
-    ("option_history_open_interest", "with_strike_range", "value", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
-    ("option_history_open_interest", "all_optionals", "value", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_eod", "concrete", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303")),
-    ("option_history_greeks_eod", "concrete_iso", "standard", lambda: client.option_history_greeks_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303")),
-    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303")),
-    ("option_history_greeks_eod", "all_exps_one_strike", "standard", lambda: client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303")),
-    ("option_history_greeks_eod", "bulk_chain", "standard", lambda: client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303")),
-    ("option_history_greeks_eod", "legacy_zero_wildcard", "standard", lambda: client.option_history_greeks_eod("SPY", "0", "0", "both", "20250303", "20250303")),
-    ("option_history_greeks_eod", "with_annual_dividend", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", annual_dividend=0.015)),
-    ("option_history_greeks_eod", "with_rate_type", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", rate_type="sofr")),
-    ("option_history_greeks_eod", "with_rate_value", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", rate_value=0.05)),
-    ("option_history_greeks_eod", "with_version", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", version="dg3")),
-    ("option_history_greeks_eod", "with_underlyer_use_nbbo", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", underlyer_use_nbbo=True)),
-    ("option_history_greeks_eod", "with_max_dte", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30)),
-    ("option_history_greeks_eod", "with_strike_range", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", strike_range=10)),
-    ("option_history_greeks_eod", "all_optionals", "standard", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", underlyer_use_nbbo=True, max_dte=30, strike_range=10)),
-    ("option_history_greeks_all", "concrete", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_all", "concrete_iso", "professional", lambda: client.option_history_greeks_all("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_all", "all_strikes_one_exp", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000")),
-    ("option_history_greeks_all", "with_intraday_window", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_greeks_all", "with_date_range", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_all", "with_annual_dividend", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
-    ("option_history_greeks_all", "with_rate_type", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
-    ("option_history_greeks_all", "with_rate_value", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
-    ("option_history_greeks_all", "with_version", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
-    ("option_history_greeks_all", "with_strike_range", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
-    ("option_history_greeks_all", "all_optionals", "professional", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_all", "concrete", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303")),
-    ("option_history_trade_greeks_all", "concrete_iso", "professional", lambda: client.option_history_trade_greeks_all("SPY", "2025-03-21", "570", "C", "20250303")),
-    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303")),
-    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", lambda: client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303")),
-    ("option_history_trade_greeks_all", "bulk_chain", "professional", lambda: client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303")),
-    ("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", lambda: client.option_history_trade_greeks_all("SPY", "0", "0", "both", "20250303")),
-    ("option_history_trade_greeks_all", "with_intraday_window", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_trade_greeks_all", "with_date_range", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_all", "with_annual_dividend", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
-    ("option_history_trade_greeks_all", "with_rate_type", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
-    ("option_history_trade_greeks_all", "with_rate_value", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
-    ("option_history_trade_greeks_all", "with_version", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", version="dg3")),
-    ("option_history_trade_greeks_all", "with_max_dte", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
-    ("option_history_trade_greeks_all", "with_strike_range", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
-    ("option_history_trade_greeks_all", "all_optionals", "professional", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_first_order", "concrete", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_first_order", "concrete_iso", "standard", lambda: client.option_history_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000")),
-    ("option_history_greeks_first_order", "with_intraday_window", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_greeks_first_order", "with_date_range", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_first_order", "with_annual_dividend", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
-    ("option_history_greeks_first_order", "with_rate_type", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
-    ("option_history_greeks_first_order", "with_rate_value", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
-    ("option_history_greeks_first_order", "with_version", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
-    ("option_history_greeks_first_order", "with_strike_range", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
-    ("option_history_greeks_first_order", "all_optionals", "standard", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_first_order", "concrete", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303")),
-    ("option_history_trade_greeks_first_order", "concrete_iso", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303")),
-    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303")),
-    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303")),
-    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303")),
-    ("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "0", "0", "both", "20250303")),
-    ("option_history_trade_greeks_first_order", "with_intraday_window", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_trade_greeks_first_order", "with_date_range", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_first_order", "with_annual_dividend", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
-    ("option_history_trade_greeks_first_order", "with_rate_type", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
-    ("option_history_trade_greeks_first_order", "with_rate_value", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
-    ("option_history_trade_greeks_first_order", "with_version", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", version="dg3")),
-    ("option_history_trade_greeks_first_order", "with_max_dte", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
-    ("option_history_trade_greeks_first_order", "with_strike_range", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
-    ("option_history_trade_greeks_first_order", "all_optionals", "professional", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_second_order", "concrete", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_second_order", "concrete_iso", "professional", lambda: client.option_history_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000")),
-    ("option_history_greeks_second_order", "with_intraday_window", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_greeks_second_order", "with_date_range", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_second_order", "with_annual_dividend", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
-    ("option_history_greeks_second_order", "with_rate_type", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
-    ("option_history_greeks_second_order", "with_rate_value", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
-    ("option_history_greeks_second_order", "with_version", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
-    ("option_history_greeks_second_order", "with_strike_range", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
-    ("option_history_greeks_second_order", "all_optionals", "professional", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_second_order", "concrete", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303")),
-    ("option_history_trade_greeks_second_order", "concrete_iso", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303")),
-    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303")),
-    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303")),
-    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303")),
-    ("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "0", "0", "both", "20250303")),
-    ("option_history_trade_greeks_second_order", "with_intraday_window", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_trade_greeks_second_order", "with_date_range", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_second_order", "with_annual_dividend", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
-    ("option_history_trade_greeks_second_order", "with_rate_type", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
-    ("option_history_trade_greeks_second_order", "with_rate_value", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
-    ("option_history_trade_greeks_second_order", "with_version", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", version="dg3")),
-    ("option_history_trade_greeks_second_order", "with_max_dte", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
-    ("option_history_trade_greeks_second_order", "with_strike_range", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
-    ("option_history_trade_greeks_second_order", "all_optionals", "professional", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_third_order", "concrete", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_third_order", "concrete_iso", "professional", lambda: client.option_history_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000")),
-    ("option_history_greeks_third_order", "with_intraday_window", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_greeks_third_order", "with_date_range", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_third_order", "with_annual_dividend", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
-    ("option_history_greeks_third_order", "with_rate_type", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
-    ("option_history_greeks_third_order", "with_rate_value", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
-    ("option_history_greeks_third_order", "with_version", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
-    ("option_history_greeks_third_order", "with_strike_range", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
-    ("option_history_greeks_third_order", "all_optionals", "professional", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_third_order", "concrete", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303")),
-    ("option_history_trade_greeks_third_order", "concrete_iso", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303")),
-    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303")),
-    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303")),
-    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303")),
-    ("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "0", "0", "both", "20250303")),
-    ("option_history_trade_greeks_third_order", "with_intraday_window", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_trade_greeks_third_order", "with_date_range", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_third_order", "with_annual_dividend", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
-    ("option_history_trade_greeks_third_order", "with_rate_type", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
-    ("option_history_trade_greeks_third_order", "with_rate_value", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
-    ("option_history_trade_greeks_third_order", "with_version", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", version="dg3")),
-    ("option_history_trade_greeks_third_order", "with_max_dte", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
-    ("option_history_trade_greeks_third_order", "with_strike_range", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
-    ("option_history_trade_greeks_third_order", "all_optionals", "professional", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_implied_volatility", "concrete", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_implied_volatility", "concrete_iso", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
-    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000")),
-    ("option_history_greeks_implied_volatility", "with_intraday_window", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_greeks_implied_volatility", "with_date_range", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("option_history_greeks_implied_volatility", "with_annual_dividend", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
-    ("option_history_greeks_implied_volatility", "with_rate_type", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
-    ("option_history_greeks_implied_volatility", "with_rate_value", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
-    ("option_history_greeks_implied_volatility", "with_version", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
-    ("option_history_greeks_implied_volatility", "with_strike_range", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
-    ("option_history_greeks_implied_volatility", "all_optionals", "standard", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303")),
-    ("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303")),
-    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303")),
-    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303")),
-    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303")),
-    ("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "0", "0", "both", "20250303")),
-    ("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
-    ("option_history_trade_greeks_implied_volatility", "with_date_range", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
-    ("option_history_trade_greeks_implied_volatility", "with_annual_dividend", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
-    ("option_history_trade_greeks_implied_volatility", "with_rate_type", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
-    ("option_history_trade_greeks_implied_volatility", "with_rate_value", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
-    ("option_history_trade_greeks_implied_volatility", "with_version", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", version="dg3")),
-    ("option_history_trade_greeks_implied_volatility", "with_max_dte", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
-    ("option_history_trade_greeks_implied_volatility", "with_strike_range", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
-    ("option_history_trade_greeks_implied_volatility", "all_optionals", "professional", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
-    ("option_at_time_trade", "concrete", "standard", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_trade", "concrete_iso", "standard", lambda: client.option_at_time_trade("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_trade", "all_strikes_one_exp", "standard", lambda: client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_trade", "all_exps_one_strike", "standard", lambda: client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_trade", "bulk_chain", "standard", lambda: client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_trade", "legacy_zero_wildcard", "standard", lambda: client.option_at_time_trade("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_trade", "with_max_dte", "standard", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30)),
-    ("option_at_time_trade", "with_strike_range", "standard", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", strike_range=10)),
-    ("option_at_time_trade", "all_optionals", "standard", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30, strike_range=10)),
-    ("option_at_time_quote", "concrete", "value", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_quote", "concrete_iso", "value", lambda: client.option_at_time_quote("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_quote", "all_strikes_one_exp", "value", lambda: client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_quote", "all_exps_one_strike", "value", lambda: client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_quote", "bulk_chain", "value", lambda: client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_quote", "legacy_zero_wildcard", "value", lambda: client.option_at_time_quote("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000")),
-    ("option_at_time_quote", "with_max_dte", "value", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30)),
-    ("option_at_time_quote", "with_strike_range", "value", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", strike_range=10)),
-    ("option_at_time_quote", "all_optionals", "value", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30, strike_range=10)),
-    ("index_list_symbols", "basic", "free", lambda: client.index_list_symbols()),
-    ("index_list_dates", "basic", "free", lambda: client.index_list_dates("SPX")),
-    ("index_snapshot_ohlc", "concrete", "standard", lambda: client.index_snapshot_ohlc(["SPX"])),
-    ("index_snapshot_ohlc", "with_min_time", "standard", lambda: client.index_snapshot_ohlc(["SPX"], min_time="09:45:00")),
-    ("index_snapshot_ohlc", "all_optionals", "standard", lambda: client.index_snapshot_ohlc(["SPX"], min_time="09:45:00")),
-    ("index_snapshot_price", "concrete", "standard", lambda: client.index_snapshot_price(["SPX"])),
-    ("index_snapshot_price", "with_min_time", "standard", lambda: client.index_snapshot_price(["SPX"], min_time="09:45:00")),
-    ("index_snapshot_price", "all_optionals", "standard", lambda: client.index_snapshot_price(["SPX"], min_time="09:45:00")),
-    ("index_snapshot_market_value", "concrete", "standard", lambda: client.index_snapshot_market_value(["SPX"])),
-    ("index_snapshot_market_value", "with_min_time", "standard", lambda: client.index_snapshot_market_value(["SPX"], min_time="09:45:00")),
-    ("index_snapshot_market_value", "all_optionals", "standard", lambda: client.index_snapshot_market_value(["SPX"], min_time="09:45:00")),
-    ("index_history_eod", "concrete", "free", lambda: client.index_history_eod("SPX", "20250303", "20250303")),
-    ("index_history_ohlc", "concrete", "standard", lambda: client.index_history_ohlc("SPX", "20250303", "20250303", "60000")),
-    ("index_history_ohlc", "with_intraday_window", "standard", lambda: client.index_history_ohlc("SPX", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("index_history_ohlc", "all_optionals", "standard", lambda: client.index_history_ohlc("SPX", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("index_history_price", "concrete", "value", lambda: client.index_history_price("SPX", "20250303", "60000")),
-    ("index_history_price", "with_intraday_window", "value", lambda: client.index_history_price("SPX", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("index_history_price", "with_date_range", "value", lambda: client.index_history_price("SPX", "20250303", "60000", start_date="20250303", end_date="20250303")),
-    ("index_history_price", "all_optionals", "value", lambda: client.index_history_price("SPX", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", start_date="20250303", end_date="20250303")),
-    ("index_at_time_price", "concrete", "value", lambda: client.index_at_time_price("SPX", "20250303", "20250303", "12:00:00.000")),
-    ("calendar_open_today", "basic", "free", lambda: client.calendar_open_today()),
-    ("calendar_on_date", "basic", "value", lambda: client.calendar_on_date("20250303")),
-    ("calendar_year", "basic", "value", lambda: client.calendar_year("2025")),
-    ("interest_rate_history_eod", "basic", "free", lambda: client.interest_rate_history_eod("SOFR", "20250303", "20250303")),
-    ("stock_history_ohlc_range", "concrete", "value", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000")),
-    ("stock_history_ohlc_range", "with_intraday_window", "value", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
-    ("stock_history_ohlc_range", "with_venue", "value", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", venue="nqb")),
-    ("stock_history_ohlc_range", "all_optionals", "value", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb")),
+    # stock_list_symbols::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("stock_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.stock_list_symbols()),
+    # stock_list_dates::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.stock_list_dates("TRADE", "AAPL")),
+    # stock_snapshot_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_snapshot_ohlc(["AAPL"])),
+    # stock_snapshot_ohlc::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_snapshot_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_snapshot_ohlc(["AAPL"], venue="nqb")),
+    # stock_snapshot_ohlc::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", lambda: client.stock_snapshot_ohlc(["AAPL"], min_time="09:45:00")),
+    # stock_snapshot_ohlc::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_snapshot_ohlc(["AAPL"], venue="nqb", min_time="09:45:00")),
+    # stock_snapshot_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_snapshot_trade(["AAPL"])),
+    # stock_snapshot_trade::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_snapshot_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", lambda: client.stock_snapshot_trade(["AAPL"], venue="nqb")),
+    # stock_snapshot_trade::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", lambda: client.stock_snapshot_trade(["AAPL"], min_time="09:45:00")),
+    # stock_snapshot_trade::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_snapshot_trade(["AAPL"], venue="nqb", min_time="09:45:00")),
+    # stock_snapshot_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_snapshot_quote(["AAPL"])),
+    # stock_snapshot_quote::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_snapshot_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_snapshot_quote(["AAPL"], venue="nqb")),
+    # stock_snapshot_quote::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", lambda: client.stock_snapshot_quote(["AAPL"], min_time="09:45:00")),
+    # stock_snapshot_quote::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_snapshot_quote(["AAPL"], venue="nqb", min_time="09:45:00")),
+    # stock_snapshot_market_value::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_snapshot_market_value(["AAPL"])),
+    # stock_snapshot_market_value::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_snapshot_market_value", "with_venue", "standard", "venue=nqb optional venue selector wiring", lambda: client.stock_snapshot_market_value(["AAPL"], venue="nqb")),
+    # stock_snapshot_market_value::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", lambda: client.stock_snapshot_market_value(["AAPL"], min_time="09:45:00")),
+    # stock_snapshot_market_value::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_snapshot_market_value(["AAPL"], venue="nqb", min_time="09:45:00")),
+    # stock_history_eod::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", lambda: client.stock_history_eod("AAPL", "20250303", "20250303")),
+    # stock_history_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000")),
+    # stock_history_ohlc::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("stock_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # stock_history_ohlc::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("stock_history_ohlc", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # stock_history_ohlc::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_history_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", venue="nqb")),
+    # stock_history_ohlc::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_ohlc("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
+    # stock_history_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_history_trade("AAPL", "20250303")),
+    # stock_history_trade::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("stock_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_trade("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # stock_history_trade::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("stock_history_trade", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", lambda: client.stock_history_trade("AAPL", "20250303", start_date="20250303", end_date="20250303")),
+    # stock_history_trade::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_history_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", lambda: client.stock_history_trade("AAPL", "20250303", venue="nqb")),
+    # stock_history_trade::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_trade("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
+    # stock_history_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_history_quote("AAPL", "20250303", "60000")),
+    # stock_history_quote::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("stock_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # stock_history_quote::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("stock_history_quote", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # stock_history_quote::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_history_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_history_quote("AAPL", "20250303", "60000", venue="nqb")),
+    # stock_history_quote::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_quote("AAPL", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb", start_date="20250303", end_date="20250303")),
+    # stock_history_trade_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_history_trade_quote("AAPL", "20250303")),
+    # stock_history_trade_quote::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("stock_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # stock_history_trade_quote::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("stock_history_trade_quote", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", start_date="20250303", end_date="20250303")),
+    # stock_history_trade_quote::with_exclusive
+    #   rationale: exclusive=true optional filter wiring
+    ("stock_history_trade_quote", "with_exclusive", "standard", "exclusive=true optional filter wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", exclusive=True)),
+    # stock_history_trade_quote::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_history_trade_quote", "with_venue", "standard", "venue=nqb optional venue selector wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", venue="nqb")),
+    # stock_history_trade_quote::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_trade_quote("AAPL", "20250303", start_time="09:30:00", end_time="10:00:00", exclusive=True, venue="nqb", start_date="20250303", end_date="20250303")),
+    # stock_at_time_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000")),
+    # stock_at_time_trade::with_venue
+    #   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
+    ("stock_at_time_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring (also covers: all_optionals)", lambda: client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000", venue="nqb")),
+    # stock_at_time_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000")),
+    # stock_at_time_quote::with_venue
+    #   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
+    ("stock_at_time_quote", "with_venue", "value", "venue=nqb optional venue selector wiring (also covers: all_optionals)", lambda: client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000", venue="nqb")),
+    # option_list_symbols::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.option_list_symbols()),
+    # option_list_dates::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("option_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.option_list_dates("TRADE", "SPY", "20250321", "570", "C")),
+    # option_list_expirations::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("option_list_expirations", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.option_list_expirations("SPY")),
+    # option_list_strikes::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("option_list_strikes", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.option_list_strikes("SPY", "20250321")),
+    # option_list_contracts::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_list_contracts", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_list_contracts("TRADE", "SPY", "20250303")),
+    # option_list_contracts::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring (also covers: all_optionals)
+    ("option_list_contracts", "with_max_dte", "value", "max_dte=30 optional filter wiring (also covers: all_optionals)", lambda: client.option_list_contracts("TRADE", "SPY", "20250303", max_dte=30)),
+    # option_snapshot_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C")),
+    # option_snapshot_ohlc::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_ohlc("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_ohlc::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_ohlc("SPY", "20250321", "*", "both")),
+    # option_snapshot_ohlc::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_ohlc("SPY", "*", "570", "both")),
+    # option_snapshot_ohlc::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_ohlc("SPY", "*", "*", "both")),
+    # option_snapshot_ohlc::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_ohlc", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_ohlc("SPY", "0", "0", "both")),
+    # option_snapshot_ohlc::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_ohlc", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_ohlc::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_ohlc", "with_strike_range", "value", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_ohlc::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_ohlc::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
+    # option_snapshot_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C")),
+    # option_snapshot_trade::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_trade("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_trade::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_trade("SPY", "20250321", "*", "both")),
+    # option_snapshot_trade::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_trade::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_trade::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", strike_range=10, min_time="09:45:00")),
+    # option_snapshot_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C")),
+    # option_snapshot_quote::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_quote("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_quote::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_quote("SPY", "20250321", "*", "both")),
+    # option_snapshot_quote::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_quote("SPY", "*", "570", "both")),
+    # option_snapshot_quote::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_quote("SPY", "*", "*", "both")),
+    # option_snapshot_quote::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_quote("SPY", "0", "0", "both")),
+    # option_snapshot_quote::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_quote::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_quote::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_quote::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
+    # option_snapshot_open_interest::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C")),
+    # option_snapshot_open_interest::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_open_interest("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_open_interest::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_open_interest("SPY", "20250321", "*", "both")),
+    # option_snapshot_open_interest::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_open_interest("SPY", "*", "570", "both")),
+    # option_snapshot_open_interest::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_open_interest("SPY", "*", "*", "both")),
+    # option_snapshot_open_interest::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_open_interest("SPY", "0", "0", "both")),
+    # option_snapshot_open_interest::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_open_interest::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_open_interest", "with_strike_range", "value", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_open_interest::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_open_interest", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_open_interest::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
+    # option_snapshot_market_value::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C")),
+    # option_snapshot_market_value::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_market_value", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_market_value("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_market_value::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_market_value("SPY", "20250321", "*", "both")),
+    # option_snapshot_market_value::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_market_value("SPY", "*", "570", "both")),
+    # option_snapshot_market_value::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_market_value("SPY", "*", "*", "both")),
+    # option_snapshot_market_value::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_market_value", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_market_value("SPY", "0", "0", "both")),
+    # option_snapshot_market_value::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_market_value", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_market_value::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_market_value", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_market_value::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_market_value::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", max_dte=30, strike_range=10, min_time="09:45:00")),
+    # option_snapshot_greeks_implied_volatility::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C")),
+    # option_snapshot_greeks_implied_volatility::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_greeks_implied_volatility::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both")),
+    # option_snapshot_greeks_implied_volatility::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both")),
+    # option_snapshot_greeks_implied_volatility::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both")),
+    # option_snapshot_greeks_implied_volatility::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "0", "0", "both")),
+    # option_snapshot_greeks_implied_volatility::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", annual_dividend=0.015)),
+    # option_snapshot_greeks_implied_volatility::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_snapshot_greeks_implied_volatility", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", rate_type="sofr")),
+    # option_snapshot_greeks_implied_volatility::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_snapshot_greeks_implied_volatility", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", rate_value=0.05)),
+    # option_snapshot_greeks_implied_volatility::with_stock_price
+    #   rationale: stock_price=150 optional Greeks-input wiring
+    ("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", stock_price=150.0)),
+    # option_snapshot_greeks_implied_volatility::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_snapshot_greeks_implied_volatility", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", version="dg3")),
+    # option_snapshot_greeks_implied_volatility::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_greeks_implied_volatility", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_greeks_implied_volatility::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_greeks_implied_volatility", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_greeks_implied_volatility::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_greeks_implied_volatility", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_greeks_implied_volatility::with_use_market_value
+    #   rationale: use_market_value=true optional flag wiring
+    ("option_snapshot_greeks_implied_volatility", "with_use_market_value", "standard", "use_market_value=true optional flag wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", use_market_value=True)),
+    # option_snapshot_greeks_implied_volatility::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
+    # option_snapshot_greeks_all::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C")),
+    # option_snapshot_greeks_all::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_all("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_greeks_all::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "*", "both")),
+    # option_snapshot_greeks_all::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_all("SPY", "*", "570", "both")),
+    # option_snapshot_greeks_all::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_all("SPY", "*", "*", "both")),
+    # option_snapshot_greeks_all::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_all("SPY", "0", "0", "both")),
+    # option_snapshot_greeks_all::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_snapshot_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", annual_dividend=0.015)),
+    # option_snapshot_greeks_all::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_snapshot_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", rate_type="sofr")),
+    # option_snapshot_greeks_all::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_snapshot_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", rate_value=0.05)),
+    # option_snapshot_greeks_all::with_stock_price
+    #   rationale: stock_price=150 optional Greeks-input wiring
+    ("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", stock_price=150.0)),
+    # option_snapshot_greeks_all::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_snapshot_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", version="dg3")),
+    # option_snapshot_greeks_all::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_greeks_all", "with_max_dte", "professional", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_greeks_all::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_greeks_all::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_greeks_all", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_greeks_all::with_use_market_value
+    #   rationale: use_market_value=true optional flag wiring
+    ("option_snapshot_greeks_all", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", use_market_value=True)),
+    # option_snapshot_greeks_all::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
+    # option_snapshot_greeks_first_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C")),
+    # option_snapshot_greeks_first_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_first_order("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_greeks_first_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both")),
+    # option_snapshot_greeks_first_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "570", "both")),
+    # option_snapshot_greeks_first_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "*", "both")),
+    # option_snapshot_greeks_first_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_first_order("SPY", "0", "0", "both")),
+    # option_snapshot_greeks_first_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
+    # option_snapshot_greeks_first_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_snapshot_greeks_first_order", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", rate_type="sofr")),
+    # option_snapshot_greeks_first_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_snapshot_greeks_first_order", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", rate_value=0.05)),
+    # option_snapshot_greeks_first_order::with_stock_price
+    #   rationale: stock_price=150 optional Greeks-input wiring
+    ("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", stock_price=150.0)),
+    # option_snapshot_greeks_first_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_snapshot_greeks_first_order", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", version="dg3")),
+    # option_snapshot_greeks_first_order::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_greeks_first_order", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_greeks_first_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_greeks_first_order", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_greeks_first_order::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_greeks_first_order", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_greeks_first_order::with_use_market_value
+    #   rationale: use_market_value=true optional flag wiring
+    ("option_snapshot_greeks_first_order", "with_use_market_value", "standard", "use_market_value=true optional flag wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", use_market_value=True)),
+    # option_snapshot_greeks_first_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
+    # option_snapshot_greeks_second_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C")),
+    # option_snapshot_greeks_second_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_second_order("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_greeks_second_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both")),
+    # option_snapshot_greeks_second_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "570", "both")),
+    # option_snapshot_greeks_second_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "*", "both")),
+    # option_snapshot_greeks_second_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_second_order("SPY", "0", "0", "both")),
+    # option_snapshot_greeks_second_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
+    # option_snapshot_greeks_second_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_snapshot_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", rate_type="sofr")),
+    # option_snapshot_greeks_second_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_snapshot_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", rate_value=0.05)),
+    # option_snapshot_greeks_second_order::with_stock_price
+    #   rationale: stock_price=150 optional Greeks-input wiring
+    ("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", stock_price=150.0)),
+    # option_snapshot_greeks_second_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_snapshot_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", version="dg3")),
+    # option_snapshot_greeks_second_order::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_greeks_second_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_greeks_second_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_greeks_second_order::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_greeks_second_order", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_greeks_second_order::with_use_market_value
+    #   rationale: use_market_value=true optional flag wiring
+    ("option_snapshot_greeks_second_order", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", use_market_value=True)),
+    # option_snapshot_greeks_second_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
+    # option_snapshot_greeks_third_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C")),
+    # option_snapshot_greeks_third_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_snapshot_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_snapshot_greeks_third_order("SPY", "2025-03-21", "570", "C")),
+    # option_snapshot_greeks_third_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both")),
+    # option_snapshot_greeks_third_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "570", "both")),
+    # option_snapshot_greeks_third_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "*", "both")),
+    # option_snapshot_greeks_third_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_snapshot_greeks_third_order("SPY", "0", "0", "both")),
+    # option_snapshot_greeks_third_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", annual_dividend=0.015)),
+    # option_snapshot_greeks_third_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_snapshot_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", rate_type="sofr")),
+    # option_snapshot_greeks_third_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_snapshot_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", rate_value=0.05)),
+    # option_snapshot_greeks_third_order::with_stock_price
+    #   rationale: stock_price=150 optional Greeks-input wiring
+    ("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", stock_price=150.0)),
+    # option_snapshot_greeks_third_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_snapshot_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", version="dg3")),
+    # option_snapshot_greeks_third_order::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_snapshot_greeks_third_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", max_dte=30)),
+    # option_snapshot_greeks_third_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_snapshot_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", strike_range=10)),
+    # option_snapshot_greeks_third_order::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring
+    ("option_snapshot_greeks_third_order", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", min_time="09:45:00")),
+    # option_snapshot_greeks_third_order::with_use_market_value
+    #   rationale: use_market_value=true optional flag wiring
+    ("option_snapshot_greeks_third_order", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", use_market_value=True)),
+    # option_snapshot_greeks_third_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_snapshot_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, stock_price=150.0, version="dg3", max_dte=30, strike_range=10, min_time="09:45:00", use_market_value=True)),
+    # option_history_eod::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303")),
+    # option_history_eod::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_eod", "concrete_iso", "free", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303")),
+    # option_history_eod::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303")),
+    # option_history_eod::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303")),
+    # option_history_eod::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303")),
+    # option_history_eod::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_eod", "legacy_zero_wildcard", "free", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_eod("SPY", "0", "0", "both", "20250303", "20250303")),
+    # option_history_eod::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_eod", "with_max_dte", "free", "max_dte=30 optional filter wiring", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30)),
+    # option_history_eod::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_eod", "with_strike_range", "free", "strike_range=10 optional filter wiring", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", strike_range=10)),
+    # option_history_eod::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_eod", "all_optionals", "free", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30, strike_range=10)),
+    # option_history_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000")),
+    # option_history_ohlc::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_ohlc("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    # option_history_ohlc::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000")),
+    # option_history_ohlc::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_ohlc::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_ohlc", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # option_history_ohlc::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_ohlc", "with_strike_range", "value", "strike_range=10 optional filter wiring", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
+    # option_history_ohlc::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303")),
+    # option_history_trade::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade("SPY", "2025-03-21", "570", "C", "20250303")),
+    # option_history_trade::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade("SPY", "20250321", "*", "both", "20250303")),
+    # option_history_trade::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade("SPY", "*", "570", "both", "20250303")),
+    # option_history_trade::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade("SPY", "*", "*", "both", "20250303")),
+    # option_history_trade::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade("SPY", "0", "0", "both", "20250303")),
+    # option_history_trade::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_trade::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_trade", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
+    # option_history_trade::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
+    # option_history_trade::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
+    # option_history_trade::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000")),
+    # option_history_quote::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_quote("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    # option_history_quote::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000")),
+    # option_history_quote::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000")),
+    # option_history_quote::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000")),
+    # option_history_quote::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_quote("SPY", "0", "0", "both", "20250303", "60000")),
+    # option_history_quote::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_quote::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_quote", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # option_history_quote::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", max_dte=30)),
+    # option_history_quote::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
+    # option_history_quote::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_trade_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303")),
+    # option_history_trade_quote::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_quote", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_quote("SPY", "2025-03-21", "570", "C", "20250303")),
+    # option_history_trade_quote::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303")),
+    # option_history_trade_quote::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_quote("SPY", "*", "570", "both", "20250303")),
+    # option_history_trade_quote::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_quote("SPY", "*", "*", "both", "20250303")),
+    # option_history_trade_quote::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_quote", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_quote("SPY", "0", "0", "both", "20250303")),
+    # option_history_trade_quote::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_trade_quote::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_trade_quote", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
+    # option_history_trade_quote::with_exclusive
+    #   rationale: exclusive=true optional filter wiring
+    ("option_history_trade_quote", "with_exclusive", "standard", "exclusive=true optional filter wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", exclusive=True)),
+    # option_history_trade_quote::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_trade_quote", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
+    # option_history_trade_quote::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_trade_quote", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
+    # option_history_trade_quote::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", exclusive=True, max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_open_interest::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303")),
+    # option_history_open_interest::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_open_interest("SPY", "2025-03-21", "570", "C", "20250303")),
+    # option_history_open_interest::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303")),
+    # option_history_open_interest::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_open_interest("SPY", "*", "570", "both", "20250303")),
+    # option_history_open_interest::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_open_interest("SPY", "*", "*", "both", "20250303")),
+    # option_history_open_interest::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_open_interest("SPY", "0", "0", "both", "20250303")),
+    # option_history_open_interest::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_open_interest", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
+    # option_history_open_interest::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
+    # option_history_open_interest::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_open_interest", "with_strike_range", "value", "strike_range=10 optional filter wiring", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
+    # option_history_open_interest::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_greeks_eod::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303")),
+    # option_history_greeks_eod::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_eod", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303")),
+    # option_history_greeks_eod::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303")),
+    # option_history_greeks_eod::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303")),
+    # option_history_greeks_eod::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303")),
+    # option_history_greeks_eod::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_greeks_eod", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_greeks_eod("SPY", "0", "0", "both", "20250303", "20250303")),
+    # option_history_greeks_eod::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_greeks_eod", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", annual_dividend=0.015)),
+    # option_history_greeks_eod::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_greeks_eod", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", rate_type="sofr")),
+    # option_history_greeks_eod::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_greeks_eod", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", rate_value=0.05)),
+    # option_history_greeks_eod::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_greeks_eod", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", version="dg3")),
+    # option_history_greeks_eod::with_underlyer_use_nbbo
+    #   rationale: underlyer_use_nbbo=true optional flag wiring
+    ("option_history_greeks_eod", "with_underlyer_use_nbbo", "standard", "underlyer_use_nbbo=true optional flag wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", underlyer_use_nbbo=True)),
+    # option_history_greeks_eod::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_greeks_eod", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30)),
+    # option_history_greeks_eod::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_greeks_eod", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", strike_range=10)),
+    # option_history_greeks_eod::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_greeks_eod", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", underlyer_use_nbbo=True, max_dte=30, strike_range=10)),
+    # option_history_greeks_all::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000")),
+    # option_history_greeks_all::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_all("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    # option_history_greeks_all::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000")),
+    # option_history_greeks_all::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_greeks_all::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_greeks_all", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # option_history_greeks_all::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
+    # option_history_greeks_all::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
+    # option_history_greeks_all::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
+    # option_history_greeks_all::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
+    # option_history_greeks_all::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
+    # option_history_greeks_all::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_all::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303")),
+    # option_history_trade_greeks_all::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_all("SPY", "2025-03-21", "570", "C", "20250303")),
+    # option_history_trade_greeks_all::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303")),
+    # option_history_trade_greeks_all::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303")),
+    # option_history_trade_greeks_all::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303")),
+    # option_history_trade_greeks_all::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_all("SPY", "0", "0", "both", "20250303")),
+    # option_history_trade_greeks_all::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_trade_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_trade_greeks_all::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_trade_greeks_all", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_all::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_trade_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
+    # option_history_trade_greeks_all::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_trade_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
+    # option_history_trade_greeks_all::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_trade_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
+    # option_history_trade_greeks_all::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_trade_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", version="dg3")),
+    # option_history_trade_greeks_all::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_trade_greeks_all", "with_max_dte", "professional", "max_dte=30 optional filter wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
+    # option_history_trade_greeks_all::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_trade_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
+    # option_history_trade_greeks_all::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_trade_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_greeks_first_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000")),
+    # option_history_greeks_first_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    # option_history_greeks_first_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000")),
+    # option_history_greeks_first_order::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_greeks_first_order", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_greeks_first_order::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_greeks_first_order", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # option_history_greeks_first_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
+    # option_history_greeks_first_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_greeks_first_order", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
+    # option_history_greeks_first_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_greeks_first_order", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
+    # option_history_greeks_first_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_greeks_first_order", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
+    # option_history_greeks_first_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_greeks_first_order", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
+    # option_history_greeks_first_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_first_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303")),
+    # option_history_trade_greeks_first_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_first_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303")),
+    # option_history_trade_greeks_first_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303")),
+    # option_history_trade_greeks_first_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303")),
+    # option_history_trade_greeks_first_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303")),
+    # option_history_trade_greeks_first_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_first_order("SPY", "0", "0", "both", "20250303")),
+    # option_history_trade_greeks_first_order::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_trade_greeks_first_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_trade_greeks_first_order::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_trade_greeks_first_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_first_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_trade_greeks_first_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
+    # option_history_trade_greeks_first_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_trade_greeks_first_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
+    # option_history_trade_greeks_first_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_trade_greeks_first_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
+    # option_history_trade_greeks_first_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_trade_greeks_first_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", version="dg3")),
+    # option_history_trade_greeks_first_order::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_trade_greeks_first_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
+    # option_history_trade_greeks_first_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_trade_greeks_first_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
+    # option_history_trade_greeks_first_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_trade_greeks_first_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_greeks_second_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000")),
+    # option_history_greeks_second_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    # option_history_greeks_second_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000")),
+    # option_history_greeks_second_order::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_greeks_second_order::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_greeks_second_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # option_history_greeks_second_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
+    # option_history_greeks_second_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
+    # option_history_greeks_second_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
+    # option_history_greeks_second_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
+    # option_history_greeks_second_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
+    # option_history_greeks_second_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_second_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303")),
+    # option_history_trade_greeks_second_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303")),
+    # option_history_trade_greeks_second_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303")),
+    # option_history_trade_greeks_second_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303")),
+    # option_history_trade_greeks_second_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303")),
+    # option_history_trade_greeks_second_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_second_order("SPY", "0", "0", "both", "20250303")),
+    # option_history_trade_greeks_second_order::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_trade_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_trade_greeks_second_order::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_trade_greeks_second_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_second_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_trade_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
+    # option_history_trade_greeks_second_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_trade_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
+    # option_history_trade_greeks_second_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_trade_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
+    # option_history_trade_greeks_second_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_trade_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", version="dg3")),
+    # option_history_trade_greeks_second_order::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_trade_greeks_second_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
+    # option_history_trade_greeks_second_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_trade_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
+    # option_history_trade_greeks_second_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_trade_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_greeks_third_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000")),
+    # option_history_greeks_third_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    # option_history_greeks_third_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000")),
+    # option_history_greeks_third_order::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_greeks_third_order::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_greeks_third_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # option_history_greeks_third_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
+    # option_history_greeks_third_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
+    # option_history_greeks_third_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
+    # option_history_greeks_third_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
+    # option_history_greeks_third_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
+    # option_history_greeks_third_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_third_order::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303")),
+    # option_history_trade_greeks_third_order::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303")),
+    # option_history_trade_greeks_third_order::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303")),
+    # option_history_trade_greeks_third_order::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303")),
+    # option_history_trade_greeks_third_order::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303")),
+    # option_history_trade_greeks_third_order::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_third_order("SPY", "0", "0", "both", "20250303")),
+    # option_history_trade_greeks_third_order::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_trade_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_trade_greeks_third_order::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_trade_greeks_third_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_third_order::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_trade_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
+    # option_history_trade_greeks_third_order::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_trade_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
+    # option_history_trade_greeks_third_order::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_trade_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
+    # option_history_trade_greeks_third_order::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_trade_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", version="dg3")),
+    # option_history_trade_greeks_third_order::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_trade_greeks_third_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
+    # option_history_trade_greeks_third_order::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_trade_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
+    # option_history_trade_greeks_third_order::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_trade_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_greeks_implied_volatility::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000")),
+    # option_history_greeks_implied_volatility::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303", "60000")),
+    # option_history_greeks_implied_volatility::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000")),
+    # option_history_greeks_implied_volatility::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_greeks_implied_volatility", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_greeks_implied_volatility::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_greeks_implied_volatility", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # option_history_greeks_implied_volatility::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", annual_dividend=0.015)),
+    # option_history_greeks_implied_volatility::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_greeks_implied_volatility", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", rate_type="sofr")),
+    # option_history_greeks_implied_volatility::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_greeks_implied_volatility", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", rate_value=0.05)),
+    # option_history_greeks_implied_volatility::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_greeks_implied_volatility", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", version="dg3")),
+    # option_history_greeks_implied_volatility::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_greeks_implied_volatility", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", strike_range=10)),
+    # option_history_greeks_implied_volatility::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_implied_volatility::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303")),
+    # option_history_trade_greeks_implied_volatility::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303")),
+    # option_history_trade_greeks_implied_volatility::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303")),
+    # option_history_trade_greeks_implied_volatility::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303")),
+    # option_history_trade_greeks_implied_volatility::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303")),
+    # option_history_trade_greeks_implied_volatility::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "0", "0", "both", "20250303")),
+    # option_history_trade_greeks_implied_volatility::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00")),
+    # option_history_trade_greeks_implied_volatility::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("option_history_trade_greeks_implied_volatility", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303")),
+    # option_history_trade_greeks_implied_volatility::with_annual_dividend
+    #   rationale: annual_dividend=0.015 optional Greeks-input wiring
+    ("option_history_trade_greeks_implied_volatility", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", annual_dividend=0.015)),
+    # option_history_trade_greeks_implied_volatility::with_rate_type
+    #   rationale: rate_type=sofr optional Greeks-input wiring
+    ("option_history_trade_greeks_implied_volatility", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", rate_type="sofr")),
+    # option_history_trade_greeks_implied_volatility::with_rate_value
+    #   rationale: rate_value=0.05 optional Greeks-input wiring
+    ("option_history_trade_greeks_implied_volatility", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", rate_value=0.05)),
+    # option_history_trade_greeks_implied_volatility::with_version
+    #   rationale: version=dg3 optional Greeks-version selector wiring
+    ("option_history_trade_greeks_implied_volatility", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", version="dg3")),
+    # option_history_trade_greeks_implied_volatility::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_history_trade_greeks_implied_volatility", "with_max_dte", "professional", "max_dte=30 optional filter wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", max_dte=30)),
+    # option_history_trade_greeks_implied_volatility::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_history_trade_greeks_implied_volatility", "with_strike_range", "professional", "strike_range=10 optional filter wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", strike_range=10)),
+    # option_history_trade_greeks_implied_volatility::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_history_trade_greeks_implied_volatility", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", annual_dividend=0.015, rate_type="sofr", rate_value=0.05, version="dg3", max_dte=30, strike_range=10, start_date="20250303", end_date="20250303")),
+    # option_at_time_trade::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_trade::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_at_time_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_at_time_trade("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_trade::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_trade::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_trade::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_trade::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_at_time_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_at_time_trade("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_trade::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_at_time_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30)),
+    # option_at_time_trade::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_at_time_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", strike_range=10)),
+    # option_at_time_trade::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_at_time_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30, strike_range=10)),
+    # option_at_time_quote::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_quote::concrete_iso
+    #   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+    ("option_at_time_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", lambda: client.option_at_time_quote("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_quote::all_strikes_one_exp
+    #   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", lambda: client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_quote::all_exps_one_strike
+    #   rationale: expiration=* — exercises expiration wildcard wire-unset
+    ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", lambda: client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_quote::bulk_chain
+    #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_quote::legacy_zero_wildcard
+    #   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+    ("option_at_time_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", lambda: client.option_at_time_quote("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000")),
+    # option_at_time_quote::with_max_dte
+    #   rationale: max_dte=30 optional filter wiring
+    ("option_at_time_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30)),
+    # option_at_time_quote::with_strike_range
+    #   rationale: strike_range=10 optional filter wiring
+    ("option_at_time_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", strike_range=10)),
+    # option_at_time_quote::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("option_at_time_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30, strike_range=10)),
+    # index_list_symbols::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("index_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.index_list_symbols()),
+    # index_list_dates::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("index_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.index_list_dates("SPX")),
+    # index_snapshot_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_snapshot_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.index_snapshot_ohlc(["SPX"])),
+    # index_snapshot_ohlc::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+    ("index_snapshot_ohlc", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", lambda: client.index_snapshot_ohlc(["SPX"], min_time="09:45:00")),
+    # index_snapshot_price::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_snapshot_price", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.index_snapshot_price(["SPX"])),
+    # index_snapshot_price::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+    ("index_snapshot_price", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", lambda: client.index_snapshot_price(["SPX"], min_time="09:45:00")),
+    # index_snapshot_market_value::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.index_snapshot_market_value(["SPX"])),
+    # index_snapshot_market_value::with_min_time
+    #   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+    ("index_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", lambda: client.index_snapshot_market_value(["SPX"], min_time="09:45:00")),
+    # index_history_eod::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", lambda: client.index_history_eod("SPX", "20250303", "20250303")),
+    # index_history_ohlc::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_history_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.index_history_ohlc("SPX", "20250303", "20250303", "60000")),
+    # index_history_ohlc::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)
+    ("index_history_ohlc", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)", lambda: client.index_history_ohlc("SPX", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # index_history_price::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_history_price", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.index_history_price("SPX", "20250303", "60000")),
+    # index_history_price::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("index_history_price", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.index_history_price("SPX", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # index_history_price::with_date_range
+    #   rationale: start_date + end_date pair — date range optional wiring
+    ("index_history_price", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.index_history_price("SPX", "20250303", "60000", start_date="20250303", end_date="20250303")),
+    # index_history_price::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("index_history_price", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.index_history_price("SPX", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", start_date="20250303", end_date="20250303")),
+    # index_at_time_price::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("index_at_time_price", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.index_at_time_price("SPX", "20250303", "20250303", "12:00:00.000")),
+    # calendar_open_today::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("calendar_open_today", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.calendar_open_today()),
+    # calendar_on_date::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("calendar_on_date", "basic", "value", "list/calendar/rate baseline call — no parameter variation", lambda: client.calendar_on_date("20250303")),
+    # calendar_year::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("calendar_year", "basic", "value", "list/calendar/rate baseline call — no parameter variation", lambda: client.calendar_year("2025")),
+    # interest_rate_history_eod::basic
+    #   rationale: list/calendar/rate baseline call — no parameter variation
+    ("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", lambda: client.interest_rate_history_eod("SOFR", "20250303", "20250303")),
+    # stock_history_ohlc_range::concrete
+    #   rationale: required params set, no optionals — baseline wire path
+    ("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000")),
+    # stock_history_ohlc_range::with_intraday_window
+    #   rationale: start_time + end_time pair — intraday window optional wiring
+    ("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00")),
+    # stock_history_ohlc_range::with_venue
+    #   rationale: venue=nqb optional venue selector wiring
+    ("stock_history_ohlc_range", "with_venue", "value", "venue=nqb optional venue selector wiring", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", venue="nqb")),
+    # stock_history_ohlc_range::all_optionals
+    #   rationale: every applicable optional set at once — proves multi-optional wiring
+    ("stock_history_ohlc_range", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", lambda: client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", venue="nqb")),
 ]
 
 pass_count = skip_count = fail_count = 0
@@ -518,7 +1358,7 @@ def _row_count(result):
     except TypeError:
         return 1
 
-for endpoint, mode, min_tier, call in CELLS:
+for endpoint, mode, min_tier, rationale, call in CELLS:
     label = f"{endpoint}::{mode}"
     # Once a cell has timed out, its daemon worker is still running the
     # blocking PyO3/FFI call on the shared client. The underlying FFI is
@@ -530,7 +1370,8 @@ for endpoint, mode, min_tier, call in CELLS:
         print(f"  {label:60s} SKIP: aborted-after-timeout", flush=True)
         skip_count += 1
         records.append({
-            "endpoint": endpoint, "mode": mode, "status": "SKIP",
+            "endpoint": endpoint, "mode": mode, "rationale": rationale,
+            "status": "SKIP",
             "row_count": 0, "duration_ms": 0, "detail": "aborted-after-timeout",
         })
         continue
@@ -571,6 +1412,7 @@ for endpoint, mode, min_tier, call in CELLS:
     records.append({
         "endpoint": endpoint,
         "mode": mode,
+        "rationale": rationale,
         "status": status,
         "row_count": row_count,
         "duration_ms": duration_ms,

--- a/sdks/cpp/examples/validate.cpp
+++ b/sdks/cpp/examples/validate.cpp
@@ -42,6 +42,10 @@ std::string lower(std::string value) {
 struct CellRecord {
     std::string endpoint;
     std::string mode;
+    // rationale is the one-sentence cell description from the generator
+    // (rationale_for_mode in build_support/endpoints/modes.rs); surfaces in
+    // scripts/validate_agreement.py disagreement output.
+    std::string rationale;
     std::string status;
     int row_count = 0;
     long long duration_ms = 0;
@@ -89,9 +93,9 @@ int main(int argc, char** argv) {
         auto config = tdx::Config::production();
         auto client = tdx::Client::connect(creds, config);
 
-        auto cell = [&](const char* endpoint, const char* mode, const char* declared_min_tier, auto&& call) {
+        auto cell = [&](const char* endpoint, const char* mode, const char* declared_min_tier, const char* rationale, auto&& call) {
             const std::string label = std::string(endpoint) + "::" + mode;
-            CellRecord rec{endpoint, mode, std::string{}, 0, 0, std::string{}};
+            CellRecord rec{endpoint, mode, rationale, std::string{}, 0, 0, std::string{}};
             // If a prior cell timed out, its worker thread is still running
             // an FFI call against `client`. The FFI is not thread-safe on the
             // same handle (ffi/src/lib.rs:21), so we must NOT issue another
@@ -160,435 +164,1272 @@ int main(int argc, char** argv) {
             records.push_back(rec);
         };
 
-        cell("stock_list_symbols", "basic", "free", [&] { return client.stock_list_symbols(); });
-        cell("stock_list_dates", "basic", "free", [&] { return client.stock_list_dates("TRADE", "AAPL"); });
-        cell("stock_snapshot_ohlc", "concrete", "value", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}); });
-        cell("stock_snapshot_ohlc", "with_venue", "value", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_snapshot_ohlc", "with_min_time", "value", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("stock_snapshot_ohlc", "all_optionals", "value", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
-        cell("stock_snapshot_trade", "concrete", "standard", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}); });
-        cell("stock_snapshot_trade", "with_venue", "standard", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_snapshot_trade", "with_min_time", "standard", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("stock_snapshot_trade", "all_optionals", "standard", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
-        cell("stock_snapshot_quote", "concrete", "value", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}); });
-        cell("stock_snapshot_quote", "with_venue", "value", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_snapshot_quote", "with_min_time", "value", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("stock_snapshot_quote", "all_optionals", "value", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
-        cell("stock_snapshot_market_value", "concrete", "standard", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}); });
-        cell("stock_snapshot_market_value", "with_venue", "standard", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_snapshot_market_value", "with_min_time", "standard", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("stock_snapshot_market_value", "all_optionals", "standard", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
-        cell("stock_history_eod", "concrete", "free", [&] { return client.stock_history_eod("AAPL", "20250303", "20250303"); });
-        cell("stock_history_ohlc", "concrete", "value", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000"); });
-        cell("stock_history_ohlc", "with_intraday_window", "value", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("stock_history_ohlc", "with_date_range", "value", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("stock_history_ohlc", "with_venue", "value", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_history_ohlc", "all_optionals", "value", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
-        cell("stock_history_trade", "concrete", "standard", [&] { return client.stock_history_trade("AAPL", "20250303"); });
-        cell("stock_history_trade", "with_intraday_window", "standard", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("stock_history_trade", "with_date_range", "standard", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("stock_history_trade", "with_venue", "standard", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_history_trade", "all_optionals", "standard", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
-        cell("stock_history_quote", "concrete", "value", [&] { return client.stock_history_quote("AAPL", "20250303", "60000"); });
-        cell("stock_history_quote", "with_intraday_window", "value", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("stock_history_quote", "with_date_range", "value", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("stock_history_quote", "with_venue", "value", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_history_quote", "all_optionals", "value", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
-        cell("stock_history_trade_quote", "concrete", "standard", [&] { return client.stock_history_trade_quote("AAPL", "20250303"); });
-        cell("stock_history_trade_quote", "with_intraday_window", "standard", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("stock_history_trade_quote", "with_date_range", "standard", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("stock_history_trade_quote", "with_exclusive", "standard", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_exclusive(true)); });
-        cell("stock_history_trade_quote", "with_venue", "standard", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_history_trade_quote", "all_optionals", "standard", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_exclusive(true).with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
-        cell("stock_at_time_trade", "concrete", "standard", [&] { return client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000"); });
-        cell("stock_at_time_trade", "with_venue", "standard", [&] { return client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_at_time_trade", "all_optionals", "standard", [&] { return client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_at_time_quote", "concrete", "value", [&] { return client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000"); });
-        cell("stock_at_time_quote", "with_venue", "value", [&] { return client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_at_time_quote", "all_optionals", "value", [&] { return client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("option_list_symbols", "basic", "free", [&] { return client.option_list_symbols(); });
-        cell("option_list_dates", "basic", "free", [&] { return client.option_list_dates("TRADE", "SPY", "20250321", "570", "C"); });
-        cell("option_list_expirations", "basic", "free", [&] { return client.option_list_expirations("SPY"); });
-        cell("option_list_strikes", "basic", "free", [&] { return client.option_list_strikes("SPY", "20250321"); });
-        cell("option_list_contracts", "concrete", "value", [&] { return client.option_list_contracts("TRADE", "SPY", "20250303"); });
-        cell("option_list_contracts", "with_max_dte", "value", [&] { return client.option_list_contracts("TRADE", "SPY", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_list_contracts", "all_optionals", "value", [&] { return client.option_list_contracts("TRADE", "SPY", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_ohlc", "concrete", "value", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_ohlc", "concrete_iso", "value", [&] { return client.option_snapshot_ohlc("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_ohlc", "all_strikes_one_exp", "value", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_ohlc", "all_exps_one_strike", "value", [&] { return client.option_snapshot_ohlc("SPY", "*", "570", "both"); });
-        cell("option_snapshot_ohlc", "bulk_chain", "value", [&] { return client.option_snapshot_ohlc("SPY", "*", "*", "both"); });
-        cell("option_snapshot_ohlc", "legacy_zero_wildcard", "value", [&] { return client.option_snapshot_ohlc("SPY", "0", "0", "both"); });
-        cell("option_snapshot_ohlc", "with_max_dte", "value", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_ohlc", "with_strike_range", "value", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_ohlc", "with_min_time", "value", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_ohlc", "all_optionals", "value", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
-        cell("option_snapshot_trade", "concrete", "standard", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_trade", "concrete_iso", "standard", [&] { return client.option_snapshot_trade("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_trade", "all_strikes_one_exp", "standard", [&] { return client.option_snapshot_trade("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_trade", "with_strike_range", "standard", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_trade", "with_min_time", "standard", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_trade", "all_optionals", "standard", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10).with_min_time("09:45:00")); });
-        cell("option_snapshot_quote", "concrete", "value", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_quote", "concrete_iso", "value", [&] { return client.option_snapshot_quote("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_quote", "all_strikes_one_exp", "value", [&] { return client.option_snapshot_quote("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_quote", "all_exps_one_strike", "value", [&] { return client.option_snapshot_quote("SPY", "*", "570", "both"); });
-        cell("option_snapshot_quote", "bulk_chain", "value", [&] { return client.option_snapshot_quote("SPY", "*", "*", "both"); });
-        cell("option_snapshot_quote", "legacy_zero_wildcard", "value", [&] { return client.option_snapshot_quote("SPY", "0", "0", "both"); });
-        cell("option_snapshot_quote", "with_max_dte", "value", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_quote", "with_strike_range", "value", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_quote", "with_min_time", "value", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_quote", "all_optionals", "value", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
-        cell("option_snapshot_open_interest", "concrete", "value", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_open_interest", "concrete_iso", "value", [&] { return client.option_snapshot_open_interest("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_open_interest", "all_strikes_one_exp", "value", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_open_interest", "all_exps_one_strike", "value", [&] { return client.option_snapshot_open_interest("SPY", "*", "570", "both"); });
-        cell("option_snapshot_open_interest", "bulk_chain", "value", [&] { return client.option_snapshot_open_interest("SPY", "*", "*", "both"); });
-        cell("option_snapshot_open_interest", "legacy_zero_wildcard", "value", [&] { return client.option_snapshot_open_interest("SPY", "0", "0", "both"); });
-        cell("option_snapshot_open_interest", "with_max_dte", "value", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_open_interest", "with_strike_range", "value", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_open_interest", "with_min_time", "value", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_open_interest", "all_optionals", "value", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
-        cell("option_snapshot_market_value", "concrete", "standard", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_market_value", "concrete_iso", "standard", [&] { return client.option_snapshot_market_value("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_market_value", "all_strikes_one_exp", "standard", [&] { return client.option_snapshot_market_value("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_market_value", "all_exps_one_strike", "standard", [&] { return client.option_snapshot_market_value("SPY", "*", "570", "both"); });
-        cell("option_snapshot_market_value", "bulk_chain", "standard", [&] { return client.option_snapshot_market_value("SPY", "*", "*", "both"); });
-        cell("option_snapshot_market_value", "legacy_zero_wildcard", "standard", [&] { return client.option_snapshot_market_value("SPY", "0", "0", "both"); });
-        cell("option_snapshot_market_value", "with_max_dte", "standard", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_market_value", "with_strike_range", "standard", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_market_value", "with_min_time", "standard", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_market_value", "all_optionals", "standard", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
-        cell("option_snapshot_greeks_implied_volatility", "concrete", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both"); });
-        cell("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both"); });
-        cell("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "0", "0", "both"); });
-        cell("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_snapshot_greeks_implied_volatility", "with_rate_type", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_snapshot_greeks_implied_volatility", "with_rate_value", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
-        cell("option_snapshot_greeks_implied_volatility", "with_version", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_snapshot_greeks_implied_volatility", "with_max_dte", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_greeks_implied_volatility", "with_strike_range", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_greeks_implied_volatility", "with_min_time", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_greeks_implied_volatility", "with_use_market_value", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
-        cell("option_snapshot_greeks_implied_volatility", "all_optionals", "standard", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
-        cell("option_snapshot_greeks_all", "concrete", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_greeks_all", "concrete_iso", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_greeks_all", "all_exps_one_strike", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "*", "570", "both"); });
-        cell("option_snapshot_greeks_all", "bulk_chain", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "*", "*", "both"); });
-        cell("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "0", "0", "both"); });
-        cell("option_snapshot_greeks_all", "with_annual_dividend", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_snapshot_greeks_all", "with_rate_type", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_snapshot_greeks_all", "with_rate_value", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_snapshot_greeks_all", "with_stock_price", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
-        cell("option_snapshot_greeks_all", "with_version", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_snapshot_greeks_all", "with_max_dte", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_greeks_all", "with_strike_range", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_greeks_all", "with_min_time", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_greeks_all", "with_use_market_value", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
-        cell("option_snapshot_greeks_all", "all_optionals", "professional", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
-        cell("option_snapshot_greeks_first_order", "concrete", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_greeks_first_order", "concrete_iso", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "570", "both"); });
-        cell("option_snapshot_greeks_first_order", "bulk_chain", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "*", "both"); });
-        cell("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "0", "0", "both"); });
-        cell("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_snapshot_greeks_first_order", "with_rate_type", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_snapshot_greeks_first_order", "with_rate_value", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_snapshot_greeks_first_order", "with_stock_price", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
-        cell("option_snapshot_greeks_first_order", "with_version", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_snapshot_greeks_first_order", "with_max_dte", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_greeks_first_order", "with_strike_range", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_greeks_first_order", "with_min_time", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_greeks_first_order", "with_use_market_value", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
-        cell("option_snapshot_greeks_first_order", "all_optionals", "standard", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
-        cell("option_snapshot_greeks_second_order", "concrete", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_greeks_second_order", "concrete_iso", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "570", "both"); });
-        cell("option_snapshot_greeks_second_order", "bulk_chain", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "*", "both"); });
-        cell("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "0", "0", "both"); });
-        cell("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_snapshot_greeks_second_order", "with_rate_type", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_snapshot_greeks_second_order", "with_rate_value", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_snapshot_greeks_second_order", "with_stock_price", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
-        cell("option_snapshot_greeks_second_order", "with_version", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_snapshot_greeks_second_order", "with_max_dte", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_greeks_second_order", "with_strike_range", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_greeks_second_order", "with_min_time", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_greeks_second_order", "with_use_market_value", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
-        cell("option_snapshot_greeks_second_order", "all_optionals", "professional", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
-        cell("option_snapshot_greeks_third_order", "concrete", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C"); });
-        cell("option_snapshot_greeks_third_order", "concrete_iso", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "2025-03-21", "570", "C"); });
-        cell("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both"); });
-        cell("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "570", "both"); });
-        cell("option_snapshot_greeks_third_order", "bulk_chain", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "*", "both"); });
-        cell("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "0", "0", "both"); });
-        cell("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_snapshot_greeks_third_order", "with_rate_type", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_snapshot_greeks_third_order", "with_rate_value", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_snapshot_greeks_third_order", "with_stock_price", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
-        cell("option_snapshot_greeks_third_order", "with_version", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_snapshot_greeks_third_order", "with_max_dte", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_snapshot_greeks_third_order", "with_strike_range", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_snapshot_greeks_third_order", "with_min_time", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("option_snapshot_greeks_third_order", "with_use_market_value", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
-        cell("option_snapshot_greeks_third_order", "all_optionals", "professional", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
-        cell("option_history_eod", "concrete", "free", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303"); });
-        cell("option_history_eod", "concrete_iso", "free", [&] { return client.option_history_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); });
-        cell("option_history_eod", "all_strikes_one_exp", "free", [&] { return client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303"); });
-        cell("option_history_eod", "all_exps_one_strike", "free", [&] { return client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303"); });
-        cell("option_history_eod", "bulk_chain", "free", [&] { return client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303"); });
-        cell("option_history_eod", "legacy_zero_wildcard", "free", [&] { return client.option_history_eod("SPY", "0", "0", "both", "20250303", "20250303"); });
-        cell("option_history_eod", "with_max_dte", "free", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_eod", "with_strike_range", "free", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_eod", "all_optionals", "free", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10)); });
-        cell("option_history_ohlc", "concrete", "value", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        cell("option_history_ohlc", "concrete_iso", "value", [&] { return client.option_history_ohlc("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
-        cell("option_history_ohlc", "all_strikes_one_exp", "value", [&] { return client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000"); });
-        cell("option_history_ohlc", "with_intraday_window", "value", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_ohlc", "with_date_range", "value", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_ohlc", "with_strike_range", "value", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_ohlc", "all_optionals", "value", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade", "concrete", "standard", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303"); });
-        cell("option_history_trade", "concrete_iso", "standard", [&] { return client.option_history_trade("SPY", "2025-03-21", "570", "C", "20250303"); });
-        cell("option_history_trade", "all_strikes_one_exp", "standard", [&] { return client.option_history_trade("SPY", "20250321", "*", "both", "20250303"); });
-        cell("option_history_trade", "all_exps_one_strike", "standard", [&] { return client.option_history_trade("SPY", "*", "570", "both", "20250303"); });
-        cell("option_history_trade", "bulk_chain", "standard", [&] { return client.option_history_trade("SPY", "*", "*", "both", "20250303"); });
-        cell("option_history_trade", "legacy_zero_wildcard", "standard", [&] { return client.option_history_trade("SPY", "0", "0", "both", "20250303"); });
-        cell("option_history_trade", "with_intraday_window", "standard", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_trade", "with_date_range", "standard", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade", "with_max_dte", "standard", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_trade", "with_strike_range", "standard", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_trade", "all_optionals", "standard", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_quote", "concrete", "value", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        cell("option_history_quote", "concrete_iso", "value", [&] { return client.option_history_quote("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
-        cell("option_history_quote", "all_strikes_one_exp", "value", [&] { return client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000"); });
-        cell("option_history_quote", "all_exps_one_strike", "value", [&] { return client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000"); });
-        cell("option_history_quote", "bulk_chain", "value", [&] { return client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000"); });
-        cell("option_history_quote", "legacy_zero_wildcard", "value", [&] { return client.option_history_quote("SPY", "0", "0", "both", "20250303", "60000"); });
-        cell("option_history_quote", "with_intraday_window", "value", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_quote", "with_date_range", "value", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_quote", "with_max_dte", "value", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_quote", "with_strike_range", "value", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_quote", "all_optionals", "value", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_quote", "concrete", "standard", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303"); });
-        cell("option_history_trade_quote", "concrete_iso", "standard", [&] { return client.option_history_trade_quote("SPY", "2025-03-21", "570", "C", "20250303"); });
-        cell("option_history_trade_quote", "all_strikes_one_exp", "standard", [&] { return client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303"); });
-        cell("option_history_trade_quote", "all_exps_one_strike", "standard", [&] { return client.option_history_trade_quote("SPY", "*", "570", "both", "20250303"); });
-        cell("option_history_trade_quote", "bulk_chain", "standard", [&] { return client.option_history_trade_quote("SPY", "*", "*", "both", "20250303"); });
-        cell("option_history_trade_quote", "legacy_zero_wildcard", "standard", [&] { return client.option_history_trade_quote("SPY", "0", "0", "both", "20250303"); });
-        cell("option_history_trade_quote", "with_intraday_window", "standard", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_trade_quote", "with_date_range", "standard", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_quote", "with_exclusive", "standard", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_exclusive(true)); });
-        cell("option_history_trade_quote", "with_max_dte", "standard", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_trade_quote", "with_strike_range", "standard", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_trade_quote", "all_optionals", "standard", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_exclusive(true).with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_open_interest", "concrete", "value", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303"); });
-        cell("option_history_open_interest", "concrete_iso", "value", [&] { return client.option_history_open_interest("SPY", "2025-03-21", "570", "C", "20250303"); });
-        cell("option_history_open_interest", "all_strikes_one_exp", "value", [&] { return client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303"); });
-        cell("option_history_open_interest", "all_exps_one_strike", "value", [&] { return client.option_history_open_interest("SPY", "*", "570", "both", "20250303"); });
-        cell("option_history_open_interest", "bulk_chain", "value", [&] { return client.option_history_open_interest("SPY", "*", "*", "both", "20250303"); });
-        cell("option_history_open_interest", "legacy_zero_wildcard", "value", [&] { return client.option_history_open_interest("SPY", "0", "0", "both", "20250303"); });
-        cell("option_history_open_interest", "with_date_range", "value", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_open_interest", "with_max_dte", "value", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_open_interest", "with_strike_range", "value", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_open_interest", "all_optionals", "value", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_eod", "concrete", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303"); });
-        cell("option_history_greeks_eod", "concrete_iso", "standard", [&] { return client.option_history_greeks_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); });
-        cell("option_history_greeks_eod", "all_strikes_one_exp", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303"); });
-        cell("option_history_greeks_eod", "all_exps_one_strike", "standard", [&] { return client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303"); });
-        cell("option_history_greeks_eod", "bulk_chain", "standard", [&] { return client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303"); });
-        cell("option_history_greeks_eod", "legacy_zero_wildcard", "standard", [&] { return client.option_history_greeks_eod("SPY", "0", "0", "both", "20250303", "20250303"); });
-        cell("option_history_greeks_eod", "with_annual_dividend", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_greeks_eod", "with_rate_type", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_greeks_eod", "with_rate_value", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_greeks_eod", "with_version", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_greeks_eod", "with_underlyer_use_nbbo", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_underlyer_use_nbbo(true)); });
-        cell("option_history_greeks_eod", "with_max_dte", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_greeks_eod", "with_strike_range", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_greeks_eod", "all_optionals", "standard", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_underlyer_use_nbbo(true).with_max_dte(30).with_strike_range(10)); });
-        cell("option_history_greeks_all", "concrete", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_all", "concrete_iso", "professional", [&] { return client.option_history_greeks_all("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_all", "all_strikes_one_exp", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000"); });
-        cell("option_history_greeks_all", "with_intraday_window", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_greeks_all", "with_date_range", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_all", "with_annual_dividend", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_greeks_all", "with_rate_type", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_greeks_all", "with_rate_value", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_greeks_all", "with_version", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_greeks_all", "with_strike_range", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_greeks_all", "all_optionals", "professional", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_all", "concrete", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_all", "concrete_iso", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "2025-03-21", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_all", "all_exps_one_strike", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303"); });
-        cell("option_history_trade_greeks_all", "bulk_chain", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "0", "0", "both", "20250303"); });
-        cell("option_history_trade_greeks_all", "with_intraday_window", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_trade_greeks_all", "with_date_range", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_all", "with_annual_dividend", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_trade_greeks_all", "with_rate_type", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_trade_greeks_all", "with_rate_value", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_trade_greeks_all", "with_version", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_trade_greeks_all", "with_max_dte", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_trade_greeks_all", "with_strike_range", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_trade_greeks_all", "all_optionals", "professional", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_first_order", "concrete", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_first_order", "concrete_iso", "standard", [&] { return client.option_history_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_first_order", "all_strikes_one_exp", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
-        cell("option_history_greeks_first_order", "with_intraday_window", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_greeks_first_order", "with_date_range", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_first_order", "with_annual_dividend", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_greeks_first_order", "with_rate_type", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_greeks_first_order", "with_rate_value", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_greeks_first_order", "with_version", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_greeks_first_order", "with_strike_range", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_greeks_first_order", "all_optionals", "standard", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_first_order", "concrete", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_first_order", "concrete_iso", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303"); });
-        cell("option_history_trade_greeks_first_order", "bulk_chain", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "0", "0", "both", "20250303"); });
-        cell("option_history_trade_greeks_first_order", "with_intraday_window", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_trade_greeks_first_order", "with_date_range", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_first_order", "with_annual_dividend", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_trade_greeks_first_order", "with_rate_type", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_trade_greeks_first_order", "with_rate_value", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_trade_greeks_first_order", "with_version", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_trade_greeks_first_order", "with_max_dte", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_trade_greeks_first_order", "with_strike_range", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_trade_greeks_first_order", "all_optionals", "professional", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_second_order", "concrete", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_second_order", "concrete_iso", "professional", [&] { return client.option_history_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_second_order", "all_strikes_one_exp", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
-        cell("option_history_greeks_second_order", "with_intraday_window", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_greeks_second_order", "with_date_range", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_second_order", "with_annual_dividend", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_greeks_second_order", "with_rate_type", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_greeks_second_order", "with_rate_value", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_greeks_second_order", "with_version", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_greeks_second_order", "with_strike_range", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_greeks_second_order", "all_optionals", "professional", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_second_order", "concrete", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_second_order", "concrete_iso", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303"); });
-        cell("option_history_trade_greeks_second_order", "bulk_chain", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "0", "0", "both", "20250303"); });
-        cell("option_history_trade_greeks_second_order", "with_intraday_window", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_trade_greeks_second_order", "with_date_range", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_second_order", "with_annual_dividend", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_trade_greeks_second_order", "with_rate_type", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_trade_greeks_second_order", "with_rate_value", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_trade_greeks_second_order", "with_version", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_trade_greeks_second_order", "with_max_dte", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_trade_greeks_second_order", "with_strike_range", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_trade_greeks_second_order", "all_optionals", "professional", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_third_order", "concrete", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_third_order", "concrete_iso", "professional", [&] { return client.option_history_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_third_order", "all_strikes_one_exp", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
-        cell("option_history_greeks_third_order", "with_intraday_window", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_greeks_third_order", "with_date_range", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_third_order", "with_annual_dividend", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_greeks_third_order", "with_rate_type", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_greeks_third_order", "with_rate_value", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_greeks_third_order", "with_version", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_greeks_third_order", "with_strike_range", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_greeks_third_order", "all_optionals", "professional", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_third_order", "concrete", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_third_order", "concrete_iso", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303"); });
-        cell("option_history_trade_greeks_third_order", "bulk_chain", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "0", "0", "both", "20250303"); });
-        cell("option_history_trade_greeks_third_order", "with_intraday_window", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_trade_greeks_third_order", "with_date_range", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_third_order", "with_annual_dividend", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_trade_greeks_third_order", "with_rate_type", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_trade_greeks_third_order", "with_rate_value", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_trade_greeks_third_order", "with_version", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_trade_greeks_third_order", "with_max_dte", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_trade_greeks_third_order", "with_strike_range", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_trade_greeks_third_order", "all_optionals", "professional", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_implied_volatility", "concrete", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_implied_volatility", "concrete_iso", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
-        cell("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000"); });
-        cell("option_history_greeks_implied_volatility", "with_intraday_window", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_greeks_implied_volatility", "with_date_range", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_greeks_implied_volatility", "with_annual_dividend", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_greeks_implied_volatility", "with_rate_type", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_greeks_implied_volatility", "with_rate_value", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_greeks_implied_volatility", "with_version", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_greeks_implied_volatility", "with_strike_range", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_greeks_implied_volatility", "all_optionals", "standard", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_implied_volatility", "concrete", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303"); });
-        cell("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303"); });
-        cell("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303"); });
-        cell("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "0", "0", "both", "20250303"); });
-        cell("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("option_history_trade_greeks_implied_volatility", "with_date_range", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_history_trade_greeks_implied_volatility", "with_annual_dividend", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
-        cell("option_history_trade_greeks_implied_volatility", "with_rate_type", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
-        cell("option_history_trade_greeks_implied_volatility", "with_rate_value", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
-        cell("option_history_trade_greeks_implied_volatility", "with_version", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
-        cell("option_history_trade_greeks_implied_volatility", "with_max_dte", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_history_trade_greeks_implied_volatility", "with_strike_range", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_history_trade_greeks_implied_volatility", "all_optionals", "professional", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
-        cell("option_at_time_trade", "concrete", "standard", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_trade", "concrete_iso", "standard", [&] { return client.option_at_time_trade("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_trade", "all_strikes_one_exp", "standard", [&] { return client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_trade", "all_exps_one_strike", "standard", [&] { return client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_trade", "bulk_chain", "standard", [&] { return client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_trade", "legacy_zero_wildcard", "standard", [&] { return client.option_at_time_trade("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_trade", "with_max_dte", "standard", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_at_time_trade", "with_strike_range", "standard", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_at_time_trade", "all_optionals", "standard", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10)); });
-        cell("option_at_time_quote", "concrete", "value", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_quote", "concrete_iso", "value", [&] { return client.option_at_time_quote("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_quote", "all_strikes_one_exp", "value", [&] { return client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_quote", "all_exps_one_strike", "value", [&] { return client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_quote", "bulk_chain", "value", [&] { return client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_quote", "legacy_zero_wildcard", "value", [&] { return client.option_at_time_quote("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); });
-        cell("option_at_time_quote", "with_max_dte", "value", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
-        cell("option_at_time_quote", "with_strike_range", "value", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
-        cell("option_at_time_quote", "all_optionals", "value", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10)); });
-        cell("index_list_symbols", "basic", "free", [&] { return client.index_list_symbols(); });
-        cell("index_list_dates", "basic", "free", [&] { return client.index_list_dates("SPX"); });
-        cell("index_snapshot_ohlc", "concrete", "standard", [&] { return client.index_snapshot_ohlc(std::vector<std::string>{"SPX"}); });
-        cell("index_snapshot_ohlc", "with_min_time", "standard", [&] { return client.index_snapshot_ohlc(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("index_snapshot_ohlc", "all_optionals", "standard", [&] { return client.index_snapshot_ohlc(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("index_snapshot_price", "concrete", "standard", [&] { return client.index_snapshot_price(std::vector<std::string>{"SPX"}); });
-        cell("index_snapshot_price", "with_min_time", "standard", [&] { return client.index_snapshot_price(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("index_snapshot_price", "all_optionals", "standard", [&] { return client.index_snapshot_price(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("index_snapshot_market_value", "concrete", "standard", [&] { return client.index_snapshot_market_value(std::vector<std::string>{"SPX"}); });
-        cell("index_snapshot_market_value", "with_min_time", "standard", [&] { return client.index_snapshot_market_value(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("index_snapshot_market_value", "all_optionals", "standard", [&] { return client.index_snapshot_market_value(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        cell("index_history_eod", "concrete", "free", [&] { return client.index_history_eod("SPX", "20250303", "20250303"); });
-        cell("index_history_ohlc", "concrete", "standard", [&] { return client.index_history_ohlc("SPX", "20250303", "20250303", "60000"); });
-        cell("index_history_ohlc", "with_intraday_window", "standard", [&] { return client.index_history_ohlc("SPX", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("index_history_ohlc", "all_optionals", "standard", [&] { return client.index_history_ohlc("SPX", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("index_history_price", "concrete", "value", [&] { return client.index_history_price("SPX", "20250303", "60000"); });
-        cell("index_history_price", "with_intraday_window", "value", [&] { return client.index_history_price("SPX", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("index_history_price", "with_date_range", "value", [&] { return client.index_history_price("SPX", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        cell("index_history_price", "all_optionals", "value", [&] { return client.index_history_price("SPX", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_start_date("20250303").with_end_date("20250303")); });
-        cell("index_at_time_price", "concrete", "value", [&] { return client.index_at_time_price("SPX", "20250303", "20250303", "12:00:00.000"); });
-        cell("calendar_open_today", "basic", "free", [&] { return client.calendar_open_today(); });
-        cell("calendar_on_date", "basic", "value", [&] { return client.calendar_on_date("20250303"); });
-        cell("calendar_year", "basic", "value", [&] { return client.calendar_year("2025"); });
-        cell("interest_rate_history_eod", "basic", "free", [&] { return client.interest_rate_history_eod("SOFR", "20250303", "20250303"); });
-        cell("stock_history_ohlc_range", "concrete", "value", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000"); });
-        cell("stock_history_ohlc_range", "with_intraday_window", "value", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        cell("stock_history_ohlc_range", "with_venue", "value", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        cell("stock_history_ohlc_range", "all_optionals", "value", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb")); });
+        // stock_list_symbols::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("stock_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.stock_list_symbols(); });
+        // stock_list_dates::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.stock_list_dates("TRADE", "AAPL"); });
+        // stock_snapshot_ohlc::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}); });
+        // stock_snapshot_ohlc::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_snapshot_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_snapshot_ohlc::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // stock_snapshot_ohlc::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
+        // stock_snapshot_trade::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}); });
+        // stock_snapshot_trade::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_snapshot_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_snapshot_trade::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // stock_snapshot_trade::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
+        // stock_snapshot_quote::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}); });
+        // stock_snapshot_quote::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_snapshot_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_snapshot_quote::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // stock_snapshot_quote::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
+        // stock_snapshot_market_value::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}); });
+        // stock_snapshot_market_value::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_snapshot_market_value", "with_venue", "standard", "venue=nqb optional venue selector wiring", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_snapshot_market_value::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // stock_snapshot_market_value::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
+        // stock_history_eod::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_eod("AAPL", "20250303", "20250303"); });
+        // stock_history_ohlc::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000"); });
+        // stock_history_ohlc::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("stock_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // stock_history_ohlc::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("stock_history_ohlc", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // stock_history_ohlc::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_history_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_history_ohlc::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
+        // stock_history_trade::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_trade("AAPL", "20250303"); });
+        // stock_history_trade::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("stock_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // stock_history_trade::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("stock_history_trade", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // stock_history_trade::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_history_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_history_trade::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
+        // stock_history_quote::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_quote("AAPL", "20250303", "60000"); });
+        // stock_history_quote::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("stock_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // stock_history_quote::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("stock_history_quote", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // stock_history_quote::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_history_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_history_quote::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
+        // stock_history_trade_quote::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_trade_quote("AAPL", "20250303"); });
+        // stock_history_trade_quote::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("stock_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // stock_history_trade_quote::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("stock_history_trade_quote", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // stock_history_trade_quote::with_exclusive
+        //   rationale: exclusive=true optional filter wiring
+        cell("stock_history_trade_quote", "with_exclusive", "standard", "exclusive=true optional filter wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_exclusive(true)); });
+        // stock_history_trade_quote::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_history_trade_quote", "with_venue", "standard", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_history_trade_quote::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_exclusive(true).with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
+        // stock_at_time_trade::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000"); });
+        // stock_at_time_trade::with_venue
+        //   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
+        cell("stock_at_time_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring (also covers: all_optionals)", [&] { return client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_at_time_quote::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000"); });
+        // stock_at_time_quote::with_venue
+        //   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
+        cell("stock_at_time_quote", "with_venue", "value", "venue=nqb optional venue selector wiring (also covers: all_optionals)", [&] { return client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // option_list_symbols::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.option_list_symbols(); });
+        // option_list_dates::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("option_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.option_list_dates("TRADE", "SPY", "20250321", "570", "C"); });
+        // option_list_expirations::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("option_list_expirations", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.option_list_expirations("SPY"); });
+        // option_list_strikes::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("option_list_strikes", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.option_list_strikes("SPY", "20250321"); });
+        // option_list_contracts::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_list_contracts", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_list_contracts("TRADE", "SPY", "20250303"); });
+        // option_list_contracts::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring (also covers: all_optionals)
+        cell("option_list_contracts", "with_max_dte", "value", "max_dte=30 optional filter wiring (also covers: all_optionals)", [&] { return client.option_list_contracts("TRADE", "SPY", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_ohlc::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C"); });
+        // option_snapshot_ohlc::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_ohlc("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_ohlc::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "*", "both"); });
+        // option_snapshot_ohlc::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_ohlc("SPY", "*", "570", "both"); });
+        // option_snapshot_ohlc::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_ohlc("SPY", "*", "*", "both"); });
+        // option_snapshot_ohlc::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_ohlc", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_ohlc("SPY", "0", "0", "both"); });
+        // option_snapshot_ohlc::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_ohlc", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_ohlc::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_ohlc", "with_strike_range", "value", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_ohlc::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_ohlc::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
+        // option_snapshot_trade::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C"); });
+        // option_snapshot_trade::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_trade("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_trade::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_trade("SPY", "20250321", "*", "both"); });
+        // option_snapshot_trade::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_trade::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_trade::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10).with_min_time("09:45:00")); });
+        // option_snapshot_quote::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C"); });
+        // option_snapshot_quote::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_quote("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_quote::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_quote("SPY", "20250321", "*", "both"); });
+        // option_snapshot_quote::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_quote("SPY", "*", "570", "both"); });
+        // option_snapshot_quote::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_quote("SPY", "*", "*", "both"); });
+        // option_snapshot_quote::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_quote("SPY", "0", "0", "both"); });
+        // option_snapshot_quote::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_quote::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_quote::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_quote::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
+        // option_snapshot_open_interest::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C"); });
+        // option_snapshot_open_interest::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_open_interest("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_open_interest::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "*", "both"); });
+        // option_snapshot_open_interest::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_open_interest("SPY", "*", "570", "both"); });
+        // option_snapshot_open_interest::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_open_interest("SPY", "*", "*", "both"); });
+        // option_snapshot_open_interest::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_open_interest("SPY", "0", "0", "both"); });
+        // option_snapshot_open_interest::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_open_interest::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_open_interest", "with_strike_range", "value", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_open_interest::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_open_interest", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_open_interest::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
+        // option_snapshot_market_value::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C"); });
+        // option_snapshot_market_value::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_market_value", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_market_value("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_market_value::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_market_value("SPY", "20250321", "*", "both"); });
+        // option_snapshot_market_value::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_market_value("SPY", "*", "570", "both"); });
+        // option_snapshot_market_value::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_market_value("SPY", "*", "*", "both"); });
+        // option_snapshot_market_value::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_market_value", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_market_value("SPY", "0", "0", "both"); });
+        // option_snapshot_market_value::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_market_value", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_market_value::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_market_value", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_market_value::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_market_value::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
+        // option_snapshot_greeks_implied_volatility::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C"); });
+        // option_snapshot_greeks_implied_volatility::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_greeks_implied_volatility::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both"); });
+        // option_snapshot_greeks_implied_volatility::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both"); });
+        // option_snapshot_greeks_implied_volatility::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both"); });
+        // option_snapshot_greeks_implied_volatility::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "0", "0", "both"); });
+        // option_snapshot_greeks_implied_volatility::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_snapshot_greeks_implied_volatility::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_snapshot_greeks_implied_volatility::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_snapshot_greeks_implied_volatility::with_stock_price
+        //   rationale: stock_price=150 optional Greeks-input wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        // option_snapshot_greeks_implied_volatility::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_snapshot_greeks_implied_volatility::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_greeks_implied_volatility::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_greeks_implied_volatility::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_greeks_implied_volatility::with_use_market_value
+        //   rationale: use_market_value=true optional flag wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_use_market_value", "standard", "use_market_value=true optional flag wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
+        // option_snapshot_greeks_implied_volatility::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
+        // option_snapshot_greeks_all::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C"); });
+        // option_snapshot_greeks_all::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_all("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_greeks_all::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "*", "both"); });
+        // option_snapshot_greeks_all::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_all("SPY", "*", "570", "both"); });
+        // option_snapshot_greeks_all::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_all("SPY", "*", "*", "both"); });
+        // option_snapshot_greeks_all::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_all("SPY", "0", "0", "both"); });
+        // option_snapshot_greeks_all::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_snapshot_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_snapshot_greeks_all::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_snapshot_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_snapshot_greeks_all::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_snapshot_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_snapshot_greeks_all::with_stock_price
+        //   rationale: stock_price=150 optional Greeks-input wiring
+        cell("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        // option_snapshot_greeks_all::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_snapshot_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_snapshot_greeks_all::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_greeks_all", "with_max_dte", "professional", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_greeks_all::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_greeks_all::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_greeks_all", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_greeks_all::with_use_market_value
+        //   rationale: use_market_value=true optional flag wiring
+        cell("option_snapshot_greeks_all", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
+        // option_snapshot_greeks_all::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
+        // option_snapshot_greeks_first_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C"); });
+        // option_snapshot_greeks_first_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_first_order("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_greeks_first_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both"); });
+        // option_snapshot_greeks_first_order::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "570", "both"); });
+        // option_snapshot_greeks_first_order::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "*", "both"); });
+        // option_snapshot_greeks_first_order::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_first_order("SPY", "0", "0", "both"); });
+        // option_snapshot_greeks_first_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_snapshot_greeks_first_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_snapshot_greeks_first_order", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_snapshot_greeks_first_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_snapshot_greeks_first_order", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_snapshot_greeks_first_order::with_stock_price
+        //   rationale: stock_price=150 optional Greeks-input wiring
+        cell("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        // option_snapshot_greeks_first_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_snapshot_greeks_first_order", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_snapshot_greeks_first_order::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_greeks_first_order", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_greeks_first_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_greeks_first_order", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_greeks_first_order::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_greeks_first_order", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_greeks_first_order::with_use_market_value
+        //   rationale: use_market_value=true optional flag wiring
+        cell("option_snapshot_greeks_first_order", "with_use_market_value", "standard", "use_market_value=true optional flag wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
+        // option_snapshot_greeks_first_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
+        // option_snapshot_greeks_second_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C"); });
+        // option_snapshot_greeks_second_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_second_order("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_greeks_second_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both"); });
+        // option_snapshot_greeks_second_order::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "570", "both"); });
+        // option_snapshot_greeks_second_order::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "*", "both"); });
+        // option_snapshot_greeks_second_order::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_second_order("SPY", "0", "0", "both"); });
+        // option_snapshot_greeks_second_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_snapshot_greeks_second_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_snapshot_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_snapshot_greeks_second_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_snapshot_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_snapshot_greeks_second_order::with_stock_price
+        //   rationale: stock_price=150 optional Greeks-input wiring
+        cell("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        // option_snapshot_greeks_second_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_snapshot_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_snapshot_greeks_second_order::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_greeks_second_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_greeks_second_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_greeks_second_order::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_greeks_second_order", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_greeks_second_order::with_use_market_value
+        //   rationale: use_market_value=true optional flag wiring
+        cell("option_snapshot_greeks_second_order", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
+        // option_snapshot_greeks_second_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
+        // option_snapshot_greeks_third_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C"); });
+        // option_snapshot_greeks_third_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_snapshot_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_third_order("SPY", "2025-03-21", "570", "C"); });
+        // option_snapshot_greeks_third_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both"); });
+        // option_snapshot_greeks_third_order::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "570", "both"); });
+        // option_snapshot_greeks_third_order::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "*", "both"); });
+        // option_snapshot_greeks_third_order::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_third_order("SPY", "0", "0", "both"); });
+        // option_snapshot_greeks_third_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_snapshot_greeks_third_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_snapshot_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_snapshot_greeks_third_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_snapshot_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_snapshot_greeks_third_order::with_stock_price
+        //   rationale: stock_price=150 optional Greeks-input wiring
+        cell("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        // option_snapshot_greeks_third_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_snapshot_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_snapshot_greeks_third_order::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_snapshot_greeks_third_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_snapshot_greeks_third_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_snapshot_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_snapshot_greeks_third_order::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring
+        cell("option_snapshot_greeks_third_order", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // option_snapshot_greeks_third_order::with_use_market_value
+        //   rationale: use_market_value=true optional flag wiring
+        cell("option_snapshot_greeks_third_order", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_use_market_value(true)); });
+        // option_snapshot_greeks_third_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_snapshot_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
+        // option_history_eod::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303"); });
+        // option_history_eod::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_eod", "concrete_iso", "free", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); });
+        // option_history_eod::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_eod", "all_strikes_one_exp", "free", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303"); });
+        // option_history_eod::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_eod", "all_exps_one_strike", "free", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303"); });
+        // option_history_eod::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303"); });
+        // option_history_eod::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_eod", "legacy_zero_wildcard", "free", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_eod("SPY", "0", "0", "both", "20250303", "20250303"); });
+        // option_history_eod::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_eod", "with_max_dte", "free", "max_dte=30 optional filter wiring", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_eod::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_eod", "with_strike_range", "free", "strike_range=10 optional filter wiring", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_eod::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_eod", "all_optionals", "free", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10)); });
+        // option_history_ohlc::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000"); });
+        // option_history_ohlc::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_ohlc("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        // option_history_ohlc::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        // option_history_ohlc::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_ohlc::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_ohlc", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_ohlc::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_ohlc", "with_strike_range", "value", "strike_range=10 optional filter wiring", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_ohlc::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303"); });
+        // option_history_trade::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade("SPY", "2025-03-21", "570", "C", "20250303"); });
+        // option_history_trade::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade("SPY", "20250321", "*", "both", "20250303"); });
+        // option_history_trade::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade("SPY", "*", "570", "both", "20250303"); });
+        // option_history_trade::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade("SPY", "*", "*", "both", "20250303"); });
+        // option_history_trade::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade("SPY", "0", "0", "both", "20250303"); });
+        // option_history_trade::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_trade::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_trade", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_trade::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_trade::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_quote::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000"); });
+        // option_history_quote::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_quote("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        // option_history_quote::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        // option_history_quote::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000"); });
+        // option_history_quote::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000"); });
+        // option_history_quote::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_quote("SPY", "0", "0", "both", "20250303", "60000"); });
+        // option_history_quote::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_quote::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_quote", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_quote::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_quote::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_quote::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_quote::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303"); });
+        // option_history_trade_quote::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_trade_quote", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_quote("SPY", "2025-03-21", "570", "C", "20250303"); });
+        // option_history_trade_quote::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303"); });
+        // option_history_trade_quote::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_quote("SPY", "*", "570", "both", "20250303"); });
+        // option_history_trade_quote::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_quote("SPY", "*", "*", "both", "20250303"); });
+        // option_history_trade_quote::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_trade_quote", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_quote("SPY", "0", "0", "both", "20250303"); });
+        // option_history_trade_quote::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_trade_quote::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_trade_quote", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_quote::with_exclusive
+        //   rationale: exclusive=true optional filter wiring
+        cell("option_history_trade_quote", "with_exclusive", "standard", "exclusive=true optional filter wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_exclusive(true)); });
+        // option_history_trade_quote::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_trade_quote", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_trade_quote::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_trade_quote", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_trade_quote::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_exclusive(true).with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_open_interest::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303"); });
+        // option_history_open_interest::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_open_interest("SPY", "2025-03-21", "570", "C", "20250303"); });
+        // option_history_open_interest::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303"); });
+        // option_history_open_interest::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_open_interest("SPY", "*", "570", "both", "20250303"); });
+        // option_history_open_interest::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_open_interest("SPY", "*", "*", "both", "20250303"); });
+        // option_history_open_interest::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_open_interest("SPY", "0", "0", "both", "20250303"); });
+        // option_history_open_interest::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_open_interest", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_open_interest::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_open_interest::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_open_interest", "with_strike_range", "value", "strike_range=10 optional filter wiring", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_open_interest::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_eod::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303"); });
+        // option_history_greeks_eod::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_greeks_eod", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); });
+        // option_history_greeks_eod::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303"); });
+        // option_history_greeks_eod::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303"); });
+        // option_history_greeks_eod::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303"); });
+        // option_history_greeks_eod::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_greeks_eod", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_greeks_eod("SPY", "0", "0", "both", "20250303", "20250303"); });
+        // option_history_greeks_eod::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_greeks_eod", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_greeks_eod::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_greeks_eod", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_greeks_eod::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_greeks_eod", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_greeks_eod::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_greeks_eod", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_greeks_eod::with_underlyer_use_nbbo
+        //   rationale: underlyer_use_nbbo=true optional flag wiring
+        cell("option_history_greeks_eod", "with_underlyer_use_nbbo", "standard", "underlyer_use_nbbo=true optional flag wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_underlyer_use_nbbo(true)); });
+        // option_history_greeks_eod::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_greeks_eod", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_greeks_eod::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_greeks_eod", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_greeks_eod::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_greeks_eod", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_underlyer_use_nbbo(true).with_max_dte(30).with_strike_range(10)); });
+        // option_history_greeks_all::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_all::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_all("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_all::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        // option_history_greeks_all::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_greeks_all::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_greeks_all", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_all::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_greeks_all::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_greeks_all::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_greeks_all::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_greeks_all::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_greeks_all::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_all::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303"); });
+        // option_history_trade_greeks_all::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_trade_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_all("SPY", "2025-03-21", "570", "C", "20250303"); });
+        // option_history_trade_greeks_all::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303"); });
+        // option_history_trade_greeks_all::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303"); });
+        // option_history_trade_greeks_all::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303"); });
+        // option_history_trade_greeks_all::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_all("SPY", "0", "0", "both", "20250303"); });
+        // option_history_trade_greeks_all::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_trade_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_trade_greeks_all::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_trade_greeks_all", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_all::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_trade_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_trade_greeks_all::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_trade_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_trade_greeks_all::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_trade_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_trade_greeks_all::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_trade_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_trade_greeks_all::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_trade_greeks_all", "with_max_dte", "professional", "max_dte=30 optional filter wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_trade_greeks_all::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_trade_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_trade_greeks_all::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_trade_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_first_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_first_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_first_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        // option_history_greeks_first_order::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_greeks_first_order", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_greeks_first_order::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_greeks_first_order", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_first_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_greeks_first_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_greeks_first_order", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_greeks_first_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_greeks_first_order", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_greeks_first_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_greeks_first_order", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_greeks_first_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_greeks_first_order", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_greeks_first_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_first_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303"); });
+        // option_history_trade_greeks_first_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_trade_greeks_first_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303"); });
+        // option_history_trade_greeks_first_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303"); });
+        // option_history_trade_greeks_first_order::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303"); });
+        // option_history_trade_greeks_first_order::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303"); });
+        // option_history_trade_greeks_first_order::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_first_order("SPY", "0", "0", "both", "20250303"); });
+        // option_history_trade_greeks_first_order::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_trade_greeks_first_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_trade_greeks_first_order::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_trade_greeks_first_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_first_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_trade_greeks_first_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_trade_greeks_first_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_trade_greeks_first_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_trade_greeks_first_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_trade_greeks_first_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_trade_greeks_first_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_trade_greeks_first_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_trade_greeks_first_order::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_trade_greeks_first_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_trade_greeks_first_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_trade_greeks_first_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_trade_greeks_first_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_trade_greeks_first_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_second_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_second_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_second_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        // option_history_greeks_second_order::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_greeks_second_order::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_greeks_second_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_second_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_greeks_second_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_greeks_second_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_greeks_second_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_greeks_second_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_greeks_second_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_second_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303"); });
+        // option_history_trade_greeks_second_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_trade_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303"); });
+        // option_history_trade_greeks_second_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303"); });
+        // option_history_trade_greeks_second_order::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303"); });
+        // option_history_trade_greeks_second_order::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303"); });
+        // option_history_trade_greeks_second_order::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_second_order("SPY", "0", "0", "both", "20250303"); });
+        // option_history_trade_greeks_second_order::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_trade_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_trade_greeks_second_order::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_trade_greeks_second_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_second_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_trade_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_trade_greeks_second_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_trade_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_trade_greeks_second_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_trade_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_trade_greeks_second_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_trade_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_trade_greeks_second_order::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_trade_greeks_second_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_trade_greeks_second_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_trade_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_trade_greeks_second_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_trade_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_third_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_third_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_third_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        // option_history_greeks_third_order::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_greeks_third_order::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_greeks_third_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_third_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_greeks_third_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_greeks_third_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_greeks_third_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_greeks_third_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_greeks_third_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_third_order::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303"); });
+        // option_history_trade_greeks_third_order::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_trade_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303"); });
+        // option_history_trade_greeks_third_order::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303"); });
+        // option_history_trade_greeks_third_order::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303"); });
+        // option_history_trade_greeks_third_order::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303"); });
+        // option_history_trade_greeks_third_order::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_third_order("SPY", "0", "0", "both", "20250303"); });
+        // option_history_trade_greeks_third_order::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_trade_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_trade_greeks_third_order::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_trade_greeks_third_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_third_order::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_trade_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_trade_greeks_third_order::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_trade_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_trade_greeks_third_order::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_trade_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_trade_greeks_third_order::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_trade_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_trade_greeks_third_order::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_trade_greeks_third_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_trade_greeks_third_order::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_trade_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_trade_greeks_third_order::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_trade_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_implied_volatility::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_implied_volatility::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        // option_history_greeks_implied_volatility::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        // option_history_greeks_implied_volatility::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_greeks_implied_volatility", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_greeks_implied_volatility::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_greeks_implied_volatility", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_greeks_implied_volatility::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_greeks_implied_volatility::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_greeks_implied_volatility", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_greeks_implied_volatility::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_greeks_implied_volatility", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_greeks_implied_volatility::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_greeks_implied_volatility", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_greeks_implied_volatility::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_greeks_implied_volatility", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_greeks_implied_volatility::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_implied_volatility::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303"); });
+        // option_history_trade_greeks_implied_volatility::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303"); });
+        // option_history_trade_greeks_implied_volatility::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303"); });
+        // option_history_trade_greeks_implied_volatility::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303"); });
+        // option_history_trade_greeks_implied_volatility::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303"); });
+        // option_history_trade_greeks_implied_volatility::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "0", "0", "both", "20250303"); });
+        // option_history_trade_greeks_implied_volatility::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // option_history_trade_greeks_implied_volatility::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("option_history_trade_greeks_implied_volatility", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // option_history_trade_greeks_implied_volatility::with_annual_dividend
+        //   rationale: annual_dividend=0.015 optional Greeks-input wiring
+        cell("option_history_trade_greeks_implied_volatility", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
+        // option_history_trade_greeks_implied_volatility::with_rate_type
+        //   rationale: rate_type=sofr optional Greeks-input wiring
+        cell("option_history_trade_greeks_implied_volatility", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_type("sofr")); });
+        // option_history_trade_greeks_implied_volatility::with_rate_value
+        //   rationale: rate_value=0.05 optional Greeks-input wiring
+        cell("option_history_trade_greeks_implied_volatility", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
+        // option_history_trade_greeks_implied_volatility::with_version
+        //   rationale: version=dg3 optional Greeks-version selector wiring
+        cell("option_history_trade_greeks_implied_volatility", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_version("dg3")); });
+        // option_history_trade_greeks_implied_volatility::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_history_trade_greeks_implied_volatility", "with_max_dte", "professional", "max_dte=30 optional filter wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_history_trade_greeks_implied_volatility::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_history_trade_greeks_implied_volatility", "with_strike_range", "professional", "strike_range=10 optional filter wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_history_trade_greeks_implied_volatility::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_history_trade_greeks_implied_volatility", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
+        // option_at_time_trade::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_trade::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_at_time_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_at_time_trade("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_trade::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_trade::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_trade::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_trade::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_at_time_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_at_time_trade("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_trade::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_at_time_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_at_time_trade::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_at_time_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_at_time_trade::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_at_time_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10)); });
+        // option_at_time_quote::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_quote::concrete_iso
+        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
+        cell("option_at_time_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_at_time_quote("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_quote::all_strikes_one_exp
+        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+        cell("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_quote::all_exps_one_strike
+        //   rationale: expiration=* — exercises expiration wildcard wire-unset
+        cell("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_quote::bulk_chain
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+        cell("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_quote::legacy_zero_wildcard
+        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
+        cell("option_at_time_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_at_time_quote("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); });
+        // option_at_time_quote::with_max_dte
+        //   rationale: max_dte=30 optional filter wiring
+        cell("option_at_time_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
+        // option_at_time_quote::with_strike_range
+        //   rationale: strike_range=10 optional filter wiring
+        cell("option_at_time_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
+        // option_at_time_quote::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("option_at_time_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10)); });
+        // index_list_symbols::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("index_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.index_list_symbols(); });
+        // index_list_dates::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("index_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.index_list_dates("SPX"); });
+        // index_snapshot_ohlc::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("index_snapshot_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.index_snapshot_ohlc(std::vector<std::string>{"SPX"}); });
+        // index_snapshot_ohlc::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+        cell("index_snapshot_ohlc", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", [&] { return client.index_snapshot_ohlc(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // index_snapshot_price::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("index_snapshot_price", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.index_snapshot_price(std::vector<std::string>{"SPX"}); });
+        // index_snapshot_price::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+        cell("index_snapshot_price", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", [&] { return client.index_snapshot_price(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // index_snapshot_market_value::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("index_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.index_snapshot_market_value(std::vector<std::string>{"SPX"}); });
+        // index_snapshot_market_value::with_min_time
+        //   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+        cell("index_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", [&] { return client.index_snapshot_market_value(std::vector<std::string>{"SPX"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
+        // index_history_eod::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("index_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", [&] { return client.index_history_eod("SPX", "20250303", "20250303"); });
+        // index_history_ohlc::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("index_history_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.index_history_ohlc("SPX", "20250303", "20250303", "60000"); });
+        // index_history_ohlc::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)
+        cell("index_history_ohlc", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)", [&] { return client.index_history_ohlc("SPX", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // index_history_price::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("index_history_price", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.index_history_price("SPX", "20250303", "60000"); });
+        // index_history_price::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("index_history_price", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.index_history_price("SPX", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // index_history_price::with_date_range
+        //   rationale: start_date + end_date pair — date range optional wiring
+        cell("index_history_price", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.index_history_price("SPX", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
+        // index_history_price::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("index_history_price", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.index_history_price("SPX", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_start_date("20250303").with_end_date("20250303")); });
+        // index_at_time_price::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("index_at_time_price", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.index_at_time_price("SPX", "20250303", "20250303", "12:00:00.000"); });
+        // calendar_open_today::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("calendar_open_today", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.calendar_open_today(); });
+        // calendar_on_date::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("calendar_on_date", "basic", "value", "list/calendar/rate baseline call — no parameter variation", [&] { return client.calendar_on_date("20250303"); });
+        // calendar_year::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("calendar_year", "basic", "value", "list/calendar/rate baseline call — no parameter variation", [&] { return client.calendar_year("2025"); });
+        // interest_rate_history_eod::basic
+        //   rationale: list/calendar/rate baseline call — no parameter variation
+        cell("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.interest_rate_history_eod("SOFR", "20250303", "20250303"); });
+        // stock_history_ohlc_range::concrete
+        //   rationale: required params set, no optionals — baseline wire path
+        cell("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000"); });
+        // stock_history_ohlc_range::with_intraday_window
+        //   rationale: start_time + end_time pair — intraday window optional wiring
+        cell("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
+        // stock_history_ohlc_range::with_venue
+        //   rationale: venue=nqb optional venue selector wiring
+        cell("stock_history_ohlc_range", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        // stock_history_ohlc_range::all_optionals
+        //   rationale: every applicable optional set at once — proves multi-optional wiring
+        cell("stock_history_ohlc_range", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb")); });
     } catch (const std::exception& e) {
         std::cerr << "validator bootstrap failure: " << e.what() << std::endl;
         return 1;
@@ -605,6 +1446,7 @@ int main(int argc, char** argv) {
             const auto& r = records[i];
             artifact << "    {\"endpoint\": \"" << json_escape(r.endpoint) << "\", ";
             artifact << "\"mode\": \"" << json_escape(r.mode) << "\", ";
+            artifact << "\"rationale\": \"" << json_escape(r.rationale) << "\", ";
             artifact << "\"status\": \"" << json_escape(r.status) << "\", ";
             artifact << "\"row_count\": " << r.row_count << ", ";
             artifact << "\"duration_ms\": " << r.duration_ms << ", ";

--- a/sdks/cpp/examples/validate.cpp
+++ b/sdks/cpp/examples/validate.cpp
@@ -43,8 +43,8 @@ struct CellRecord {
     std::string endpoint;
     std::string mode;
     // rationale is the one-sentence cell description from the generator
-    // (rationale_for_mode in build_support/endpoints/modes.rs); surfaces in
-    // scripts/validate_agreement.py disagreement output.
+    // (rationale_for_mode in build_support/endpoints/modes.rs); surfaces
+    // in scripts/validate_agreement.py disagreement output.
     std::string rationale;
     std::string status;
     int row_count = 0;
@@ -155,7 +155,12 @@ int main(int argc, char** argv) {
                     std::cout << "  " << std::left << std::setw(60) << label << " FAIL  " << e.what() << std::endl;
                     ++fail;
                     rec.status = "FAIL";
+                    // Runtime error messages can contain embedded newlines;
+                    // escape them so the agreement-table row stays on one
+                    // line (see scripts/validate_agreement.py).
                     std::string d = e.what();
+                    for (size_t pos = 0; (pos = d.find('\n', pos)) != std::string::npos; ) { d.replace(pos, 1, "\\n"); pos += 2; }
+                    for (size_t pos = 0; (pos = d.find('\r', pos)) != std::string::npos; ) { d.replace(pos, 1, "\\r"); pos += 2; }
                     if (d.size() > 200) { d = d.substr(0, 200); }
                     rec.detail = std::move(d);
                 }
@@ -171,104 +176,71 @@ int main(int argc, char** argv) {
         //   rationale: list/calendar/rate baseline call — no parameter variation
         cell("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.stock_list_dates("TRADE", "AAPL"); });
         // stock_snapshot_ohlc::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}); });
-        // stock_snapshot_ohlc::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_snapshot_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}); });
         // stock_snapshot_ohlc::with_min_time
-        //   rationale: min_time=09:45:00 optional filter wiring
-        cell("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        // stock_snapshot_ohlc::all_optionals
-        //   rationale: every applicable optional set at once — proves multi-optional wiring
-        cell("stock_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
+        //   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+        cell("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", [&] { return client.stock_snapshot_ohlc(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
         // stock_snapshot_trade::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}); });
-        // stock_snapshot_trade::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_snapshot_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}); });
         // stock_snapshot_trade::with_min_time
-        //   rationale: min_time=09:45:00 optional filter wiring
-        cell("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        // stock_snapshot_trade::all_optionals
-        //   rationale: every applicable optional set at once — proves multi-optional wiring
-        cell("stock_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
+        //   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+        cell("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", [&] { return client.stock_snapshot_trade(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
         // stock_snapshot_quote::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}); });
-        // stock_snapshot_quote::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_snapshot_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}); });
         // stock_snapshot_quote::with_min_time
-        //   rationale: min_time=09:45:00 optional filter wiring
-        cell("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        // stock_snapshot_quote::all_optionals
-        //   rationale: every applicable optional set at once — proves multi-optional wiring
-        cell("stock_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
+        //   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+        cell("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", [&] { return client.stock_snapshot_quote(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
         // stock_snapshot_market_value::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}); });
-        // stock_snapshot_market_value::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_snapshot_market_value", "with_venue", "standard", "venue=nqb optional venue selector wiring", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}); });
         // stock_snapshot_market_value::with_min_time
-        //   rationale: min_time=09:45:00 optional filter wiring
-        cell("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
-        // stock_snapshot_market_value::all_optionals
-        //   rationale: every applicable optional set at once — proves multi-optional wiring
-        cell("stock_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_venue("nqb").with_min_time("09:45:00")); });
+        //   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
+        cell("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", [&] { return client.stock_snapshot_market_value(std::vector<std::string>{"AAPL"}, tdx::EndpointRequestOptions{}.with_min_time("09:45:00")); });
         // stock_history_eod::concrete
         //   rationale: required params set, no optionals — baseline wire path
         cell("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_eod("AAPL", "20250303", "20250303"); });
         // stock_history_ohlc::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000"); });
         // stock_history_ohlc::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("stock_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
         // stock_history_ohlc::with_date_range
         //   rationale: start_date + end_date pair — date range optional wiring
         cell("stock_history_ohlc", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        // stock_history_ohlc::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_history_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
         // stock_history_ohlc::all_optionals
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("stock_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_ohlc("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
         // stock_history_trade::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_trade("AAPL", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_history_trade("AAPL", "20250303"); });
         // stock_history_trade::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("stock_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
         // stock_history_trade::with_date_range
         //   rationale: start_date + end_date pair — date range optional wiring
         cell("stock_history_trade", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        // stock_history_trade::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_history_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
         // stock_history_trade::all_optionals
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("stock_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_trade("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
         // stock_history_quote::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_quote("AAPL", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_history_quote("AAPL", "20250303", "60000"); });
         // stock_history_quote::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("stock_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
         // stock_history_quote::with_date_range
         //   rationale: start_date + end_date pair — date range optional wiring
         cell("stock_history_quote", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
-        // stock_history_quote::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_history_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
         // stock_history_quote::all_optionals
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("stock_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_quote("AAPL", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
         // stock_history_trade_quote::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_trade_quote("AAPL", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_history_trade_quote("AAPL", "20250303"); });
         // stock_history_trade_quote::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("stock_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -278,24 +250,15 @@ int main(int argc, char** argv) {
         // stock_history_trade_quote::with_exclusive
         //   rationale: exclusive=true optional filter wiring
         cell("stock_history_trade_quote", "with_exclusive", "standard", "exclusive=true optional filter wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_exclusive(true)); });
-        // stock_history_trade_quote::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_history_trade_quote", "with_venue", "standard", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
         // stock_history_trade_quote::all_optionals
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("stock_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_trade_quote("AAPL", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_exclusive(true).with_venue("nqb").with_start_date("20250303").with_end_date("20250303")); });
         // stock_at_time_trade::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000"); });
-        // stock_at_time_trade::with_venue
-        //   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
-        cell("stock_at_time_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring (also covers: all_optionals)", [&] { return client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)
+        cell("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", [&] { return client.stock_at_time_trade("AAPL", "20250303", "20250303", "12:00:00.000"); });
         // stock_at_time_quote::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000"); });
-        // stock_at_time_quote::with_venue
-        //   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
-        cell("stock_at_time_quote", "with_venue", "value", "venue=nqb optional venue selector wiring (also covers: all_optionals)", [&] { return client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)
+        cell("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", [&] { return client.stock_at_time_quote("AAPL", "20250303", "20250303", "12:00:00.000"); });
         // option_list_symbols::basic
         //   rationale: list/calendar/rate baseline call — no parameter variation
         cell("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.option_list_symbols(); });
@@ -315,23 +278,17 @@ int main(int argc, char** argv) {
         //   rationale: max_dte=30 optional filter wiring (also covers: all_optionals)
         cell("option_list_contracts", "with_max_dte", "value", "max_dte=30 optional filter wiring (also covers: all_optionals)", [&] { return client.option_list_contracts("TRADE", "SPY", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
         // option_snapshot_ohlc::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C"); });
-        // option_snapshot_ohlc::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_ohlc("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C"); });
         // option_snapshot_ohlc::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "*", "both"); });
         // option_snapshot_ohlc::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_ohlc("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_ohlc("SPY", "*", "570", "both"); });
         // option_snapshot_ohlc::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_ohlc("SPY", "*", "*", "both"); });
-        // option_snapshot_ohlc::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_ohlc", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_ohlc("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_ohlc("SPY", "*", "*", "both"); });
         // option_snapshot_ohlc::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_snapshot_ohlc", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
@@ -345,14 +302,11 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
         // option_snapshot_trade::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C"); });
-        // option_snapshot_trade::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_trade("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C"); });
         // option_snapshot_trade::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_trade("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_trade("SPY", "20250321", "*", "both"); });
         // option_snapshot_trade::with_strike_range
         //   rationale: strike_range=10 optional filter wiring
         cell("option_snapshot_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10)); });
@@ -363,23 +317,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10).with_min_time("09:45:00")); });
         // option_snapshot_quote::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C"); });
-        // option_snapshot_quote::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_quote("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C"); });
         // option_snapshot_quote::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_quote("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_quote("SPY", "20250321", "*", "both"); });
         // option_snapshot_quote::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_quote("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_quote("SPY", "*", "570", "both"); });
         // option_snapshot_quote::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_quote("SPY", "*", "*", "both"); });
-        // option_snapshot_quote::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_quote("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_quote("SPY", "*", "*", "both"); });
         // option_snapshot_quote::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_snapshot_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
@@ -393,23 +341,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
         // option_snapshot_open_interest::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C"); });
-        // option_snapshot_open_interest::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_open_interest("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C"); });
         // option_snapshot_open_interest::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "*", "both"); });
         // option_snapshot_open_interest::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_open_interest("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_open_interest("SPY", "*", "570", "both"); });
         // option_snapshot_open_interest::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_open_interest("SPY", "*", "*", "both"); });
-        // option_snapshot_open_interest::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_open_interest("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_open_interest("SPY", "*", "*", "both"); });
         // option_snapshot_open_interest::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_snapshot_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
@@ -423,23 +365,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
         // option_snapshot_market_value::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C"); });
-        // option_snapshot_market_value::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_market_value", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_market_value("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C"); });
         // option_snapshot_market_value::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_market_value("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_market_value("SPY", "20250321", "*", "both"); });
         // option_snapshot_market_value::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_market_value("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_market_value("SPY", "*", "570", "both"); });
         // option_snapshot_market_value::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_market_value("SPY", "*", "*", "both"); });
-        // option_snapshot_market_value::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_market_value", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_market_value("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_market_value("SPY", "*", "*", "both"); });
         // option_snapshot_market_value::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_snapshot_market_value", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
@@ -453,23 +389,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_min_time("09:45:00")); });
         // option_snapshot_greeks_implied_volatility::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C"); });
-        // option_snapshot_greeks_implied_volatility::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C"); });
         // option_snapshot_greeks_implied_volatility::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both"); });
         // option_snapshot_greeks_implied_volatility::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both"); });
         // option_snapshot_greeks_implied_volatility::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both"); });
-        // option_snapshot_greeks_implied_volatility::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both"); });
         // option_snapshot_greeks_implied_volatility::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
@@ -480,8 +410,8 @@ int main(int argc, char** argv) {
         //   rationale: rate_value=0.05 optional Greeks-input wiring
         cell("option_snapshot_greeks_implied_volatility", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
         // option_snapshot_greeks_implied_volatility::with_stock_price
-        //   rationale: stock_price=150 optional Greeks-input wiring
-        cell("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        //   rationale: stock_price=150.0 optional Greeks-input wiring
+        cell("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150.0 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
         // option_snapshot_greeks_implied_volatility::with_version
         //   rationale: version=dg3 optional Greeks-version selector wiring
         cell("option_snapshot_greeks_implied_volatility", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
@@ -501,23 +431,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
         // option_snapshot_greeks_all::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C"); });
-        // option_snapshot_greeks_all::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_all("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C"); });
         // option_snapshot_greeks_all::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "*", "both"); });
         // option_snapshot_greeks_all::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_all("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_all("SPY", "*", "570", "both"); });
         // option_snapshot_greeks_all::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_all("SPY", "*", "*", "both"); });
-        // option_snapshot_greeks_all::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_all("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_greeks_all("SPY", "*", "*", "both"); });
         // option_snapshot_greeks_all::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
@@ -528,8 +452,8 @@ int main(int argc, char** argv) {
         //   rationale: rate_value=0.05 optional Greeks-input wiring
         cell("option_snapshot_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
         // option_snapshot_greeks_all::with_stock_price
-        //   rationale: stock_price=150 optional Greeks-input wiring
-        cell("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        //   rationale: stock_price=150.0 optional Greeks-input wiring
+        cell("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
         // option_snapshot_greeks_all::with_version
         //   rationale: version=dg3 optional Greeks-version selector wiring
         cell("option_snapshot_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
@@ -549,23 +473,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
         // option_snapshot_greeks_first_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C"); });
-        // option_snapshot_greeks_first_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_first_order("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C"); });
         // option_snapshot_greeks_first_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both"); });
         // option_snapshot_greeks_first_order::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "570", "both"); });
         // option_snapshot_greeks_first_order::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "*", "both"); });
-        // option_snapshot_greeks_first_order::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_first_order("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "*", "both"); });
         // option_snapshot_greeks_first_order::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
@@ -576,8 +494,8 @@ int main(int argc, char** argv) {
         //   rationale: rate_value=0.05 optional Greeks-input wiring
         cell("option_snapshot_greeks_first_order", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
         // option_snapshot_greeks_first_order::with_stock_price
-        //   rationale: stock_price=150 optional Greeks-input wiring
-        cell("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        //   rationale: stock_price=150.0 optional Greeks-input wiring
+        cell("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150.0 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
         // option_snapshot_greeks_first_order::with_version
         //   rationale: version=dg3 optional Greeks-version selector wiring
         cell("option_snapshot_greeks_first_order", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
@@ -597,23 +515,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
         // option_snapshot_greeks_second_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C"); });
-        // option_snapshot_greeks_second_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_second_order("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C"); });
         // option_snapshot_greeks_second_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both"); });
         // option_snapshot_greeks_second_order::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "570", "both"); });
         // option_snapshot_greeks_second_order::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "*", "both"); });
-        // option_snapshot_greeks_second_order::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_second_order("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "*", "both"); });
         // option_snapshot_greeks_second_order::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
@@ -624,8 +536,8 @@ int main(int argc, char** argv) {
         //   rationale: rate_value=0.05 optional Greeks-input wiring
         cell("option_snapshot_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
         // option_snapshot_greeks_second_order::with_stock_price
-        //   rationale: stock_price=150 optional Greeks-input wiring
-        cell("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        //   rationale: stock_price=150.0 optional Greeks-input wiring
+        cell("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
         // option_snapshot_greeks_second_order::with_version
         //   rationale: version=dg3 optional Greeks-version selector wiring
         cell("option_snapshot_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
@@ -645,23 +557,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
         // option_snapshot_greeks_third_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C"); });
-        // option_snapshot_greeks_third_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_snapshot_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_snapshot_greeks_third_order("SPY", "2025-03-21", "570", "C"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C"); });
         // option_snapshot_greeks_third_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both"); });
         // option_snapshot_greeks_third_order::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "570", "both"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "570", "both"); });
         // option_snapshot_greeks_third_order::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "*", "both"); });
-        // option_snapshot_greeks_third_order::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_snapshot_greeks_third_order("SPY", "0", "0", "both"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "*", "both"); });
         // option_snapshot_greeks_third_order::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
@@ -672,8 +578,8 @@ int main(int argc, char** argv) {
         //   rationale: rate_value=0.05 optional Greeks-input wiring
         cell("option_snapshot_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_rate_value(0.05)); });
         // option_snapshot_greeks_third_order::with_stock_price
-        //   rationale: stock_price=150 optional Greeks-input wiring
-        cell("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
+        //   rationale: stock_price=150.0 optional Greeks-input wiring
+        cell("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_stock_price(150.0)); });
         // option_snapshot_greeks_third_order::with_version
         //   rationale: version=dg3 optional Greeks-version selector wiring
         cell("option_snapshot_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_version("dg3")); });
@@ -693,23 +599,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_snapshot_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_stock_price(150.0).with_version("dg3").with_max_dte(30).with_strike_range(10).with_min_time("09:45:00").with_use_market_value(true)); });
         // option_history_eod::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303"); });
-        // option_history_eod::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_eod", "concrete_iso", "free", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303"); });
         // option_history_eod::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_eod", "all_strikes_one_exp", "free", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303"); });
         // option_history_eod::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_eod", "all_exps_one_strike", "free", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_eod", "all_exps_one_strike", "free", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303"); });
         // option_history_eod::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303"); });
-        // option_history_eod::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_eod", "legacy_zero_wildcard", "free", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_eod("SPY", "0", "0", "both", "20250303", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303"); });
         // option_history_eod::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_history_eod", "with_max_dte", "free", "max_dte=30 optional filter wiring", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
@@ -720,14 +620,11 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_eod", "all_optionals", "free", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10)); });
         // option_history_ohlc::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        // option_history_ohlc::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_ohlc("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000"); });
         // option_history_ohlc::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000"); });
         // option_history_ohlc::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -741,23 +638,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_trade::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303"); });
-        // option_history_trade::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade("SPY", "2025-03-21", "570", "C", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303"); });
         // option_history_trade::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade("SPY", "20250321", "*", "both", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade("SPY", "20250321", "*", "both", "20250303"); });
         // option_history_trade::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade("SPY", "*", "570", "both", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade("SPY", "*", "570", "both", "20250303"); });
         // option_history_trade::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade("SPY", "*", "*", "both", "20250303"); });
-        // option_history_trade::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade("SPY", "0", "0", "both", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_trade("SPY", "*", "*", "both", "20250303"); });
         // option_history_trade::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -774,23 +665,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_quote::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        // option_history_quote::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_quote("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000"); });
         // option_history_quote::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000"); });
         // option_history_quote::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000"); });
         // option_history_quote::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000"); });
-        // option_history_quote::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_quote("SPY", "0", "0", "both", "20250303", "60000"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000"); });
         // option_history_quote::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -807,23 +692,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_trade_quote::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303"); });
-        // option_history_trade_quote::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_trade_quote", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_quote("SPY", "2025-03-21", "570", "C", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303"); });
         // option_history_trade_quote::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303"); });
         // option_history_trade_quote::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_quote("SPY", "*", "570", "both", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_quote("SPY", "*", "570", "both", "20250303"); });
         // option_history_trade_quote::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_quote("SPY", "*", "*", "both", "20250303"); });
-        // option_history_trade_quote::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_trade_quote", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_quote("SPY", "0", "0", "both", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_trade_quote("SPY", "*", "*", "both", "20250303"); });
         // option_history_trade_quote::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -843,23 +722,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_exclusive(true).with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_open_interest::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303"); });
-        // option_history_open_interest::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_open_interest("SPY", "2025-03-21", "570", "C", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303"); });
         // option_history_open_interest::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303"); });
         // option_history_open_interest::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_open_interest("SPY", "*", "570", "both", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_open_interest("SPY", "*", "570", "both", "20250303"); });
         // option_history_open_interest::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_open_interest("SPY", "*", "*", "both", "20250303"); });
-        // option_history_open_interest::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_open_interest("SPY", "0", "0", "both", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_open_interest("SPY", "*", "*", "both", "20250303"); });
         // option_history_open_interest::with_date_range
         //   rationale: start_date + end_date pair — date range optional wiring
         cell("option_history_open_interest", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303")); });
@@ -873,23 +746,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_greeks_eod::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303"); });
-        // option_history_greeks_eod::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_greeks_eod", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_eod("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303"); });
         // option_history_greeks_eod::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303"); });
         // option_history_greeks_eod::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303"); });
         // option_history_greeks_eod::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303"); });
-        // option_history_greeks_eod::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_greeks_eod", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_greeks_eod("SPY", "0", "0", "both", "20250303", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303"); });
         // option_history_greeks_eod::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_history_greeks_eod", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015)); });
@@ -915,14 +782,11 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_greeks_eod", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_underlyer_use_nbbo(true).with_max_dte(30).with_strike_range(10)); });
         // option_history_greeks_all::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        // option_history_greeks_all::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_all("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000"); });
         // option_history_greeks_all::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000"); });
         // option_history_greeks_all::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -948,23 +812,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_trade_greeks_all::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303"); });
-        // option_history_trade_greeks_all::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_trade_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_all("SPY", "2025-03-21", "570", "C", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303"); });
         // option_history_trade_greeks_all::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303"); });
         // option_history_trade_greeks_all::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303"); });
         // option_history_trade_greeks_all::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303"); });
-        // option_history_trade_greeks_all::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_all("SPY", "0", "0", "both", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303"); });
         // option_history_trade_greeks_all::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -993,14 +851,11 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_trade_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_greeks_first_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        // option_history_greeks_first_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
         // option_history_greeks_first_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
         // option_history_greeks_first_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_first_order", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -1026,23 +881,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_trade_greeks_first_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303"); });
-        // option_history_trade_greeks_first_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_trade_greeks_first_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_first_order("SPY", "2025-03-21", "570", "C", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303"); });
         // option_history_trade_greeks_first_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303"); });
         // option_history_trade_greeks_first_order::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303"); });
         // option_history_trade_greeks_first_order::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303"); });
-        // option_history_trade_greeks_first_order::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_first_order("SPY", "0", "0", "both", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303"); });
         // option_history_trade_greeks_first_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_first_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -1071,14 +920,11 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_trade_greeks_first_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_greeks_second_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        // option_history_greeks_second_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
         // option_history_greeks_second_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
         // option_history_greeks_second_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -1104,23 +950,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_trade_greeks_second_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303"); });
-        // option_history_trade_greeks_second_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_trade_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_second_order("SPY", "2025-03-21", "570", "C", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303"); });
         // option_history_trade_greeks_second_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303"); });
         // option_history_trade_greeks_second_order::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303"); });
         // option_history_trade_greeks_second_order::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303"); });
-        // option_history_trade_greeks_second_order::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_second_order("SPY", "0", "0", "both", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303"); });
         // option_history_trade_greeks_second_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -1149,14 +989,11 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_trade_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_greeks_third_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        // option_history_greeks_third_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000"); });
         // option_history_greeks_third_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000"); });
         // option_history_greeks_third_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -1182,23 +1019,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_trade_greeks_third_order::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303"); });
-        // option_history_trade_greeks_third_order::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_trade_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_third_order("SPY", "2025-03-21", "570", "C", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303"); });
         // option_history_trade_greeks_third_order::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303"); });
         // option_history_trade_greeks_third_order::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303"); });
         // option_history_trade_greeks_third_order::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303"); });
-        // option_history_trade_greeks_third_order::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_third_order("SPY", "0", "0", "both", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303"); });
         // option_history_trade_greeks_third_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -1227,14 +1058,11 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_trade_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_greeks_implied_volatility::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000"); });
-        // option_history_greeks_implied_volatility::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000"); });
         // option_history_greeks_implied_volatility::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000"); });
         // option_history_greeks_implied_volatility::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_implied_volatility", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -1260,23 +1088,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_history_trade_greeks_implied_volatility::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303"); });
-        // option_history_trade_greeks_implied_volatility::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "2025-03-21", "570", "C", "20250303"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303"); });
         // option_history_trade_greeks_implied_volatility::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303"); });
         // option_history_trade_greeks_implied_volatility::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303"); });
         // option_history_trade_greeks_implied_volatility::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303"); });
-        // option_history_trade_greeks_implied_volatility::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "0", "0", "both", "20250303"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303"); });
         // option_history_trade_greeks_implied_volatility::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
@@ -1305,23 +1127,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_history_trade_greeks_implied_volatility", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_annual_dividend(0.015).with_rate_type("sofr").with_rate_value(0.05).with_version("dg3").with_max_dte(30).with_strike_range(10).with_start_date("20250303").with_end_date("20250303")); });
         // option_at_time_trade::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); });
-        // option_at_time_trade::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_at_time_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_at_time_trade("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); });
         // option_at_time_trade::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); });
         // option_at_time_trade::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); });
         // option_at_time_trade::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); });
-        // option_at_time_trade::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_at_time_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_at_time_trade("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); });
         // option_at_time_trade::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_at_time_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
@@ -1332,23 +1148,17 @@ int main(int argc, char** argv) {
         //   rationale: every applicable optional set at once — proves multi-optional wiring
         cell("option_at_time_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30).with_strike_range(10)); });
         // option_at_time_quote::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); });
-        // option_at_time_quote::concrete_iso
-        //   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-        cell("option_at_time_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", [&] { return client.option_at_time_quote("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
+        cell("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); });
         // option_at_time_quote::all_strikes_one_exp
-        //   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
-        cell("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", [&] { return client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); });
+        //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
+        cell("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); });
         // option_at_time_quote::all_exps_one_strike
-        //   rationale: expiration=* — exercises expiration wildcard wire-unset
-        cell("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", [&] { return client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); });
+        //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
+        cell("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); });
         // option_at_time_quote::bulk_chain
-        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); });
-        // option_at_time_quote::legacy_zero_wildcard
-        //   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-        cell("option_at_time_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", [&] { return client.option_at_time_quote("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); });
+        //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
+        cell("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", [&] { return client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); });
         // option_at_time_quote::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_at_time_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30)); });
@@ -1419,17 +1229,11 @@ int main(int argc, char** argv) {
         //   rationale: list/calendar/rate baseline call — no parameter variation
         cell("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", [&] { return client.interest_rate_history_eod("SOFR", "20250303", "20250303"); });
         // stock_history_ohlc_range::concrete
-        //   rationale: required params set, no optionals — baseline wire path
-        cell("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000"); });
+        //   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
+        cell("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000"); });
         // stock_history_ohlc_range::with_intraday_window
-        //   rationale: start_time + end_time pair — intraday window optional wiring
-        cell("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
-        // stock_history_ohlc_range::with_venue
-        //   rationale: venue=nqb optional venue selector wiring
-        cell("stock_history_ohlc_range", "with_venue", "value", "venue=nqb optional venue selector wiring", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_venue("nqb")); });
-        // stock_history_ohlc_range::all_optionals
-        //   rationale: every applicable optional set at once — proves multi-optional wiring
-        cell("stock_history_ohlc_range", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_venue("nqb")); });
+        //   rationale: start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)
+        cell("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)", [&] { return client.stock_history_ohlc_range("AAPL", "20250303", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00")); });
     } catch (const std::exception& e) {
         std::cerr << "validator bootstrap failure: " << e.what() << std::endl;
         return 1;

--- a/sdks/go/validate.go
+++ b/sdks/go/validate.go
@@ -20,9 +20,14 @@ var errCellTimeout = errors.New("cell timeout after 60s")
 
 // CellRecord is one row of the validator's per-cell JSON artifact used
 // by the cross-language agreement check. `Status` is PASS|SKIP|FAIL.
+// `Rationale` is the one-sentence description from the generator (see
+// rationale_for_mode in build_support/endpoints/modes.rs); it surfaces
+// in scripts/validate_agreement.py disagreement output so a FAIL line
+// carries the feature description, not just the mode name.
 type CellRecord struct {
 	Endpoint   string `json:"endpoint"`
 	Mode       string `json:"mode"`
+	Rationale  string `json:"rationale"`
 	Status     string `json:"status"`
 	RowCount   int    `json:"row_count"`
 	DurationMS int64  `json:"duration_ms"`
@@ -89,2639 +94,3441 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	records := make([]CellRecord, 0)
 	var r cellResult
 
+	// stock_list_symbols::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockListSymbols(); return goRowCount(v), e })
-		records = classify("stock_list_symbols", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_list_symbols", "basic", &skip, records)
+		records = recordAborted("stock_list_symbols", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// stock_list_dates::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockListDates("TRADE", "AAPL"); return goRowCount(v), e })
-		records = classify("stock_list_dates", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_list_dates", "basic", &skip, records)
+		records = recordAborted("stock_list_dates", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// stock_snapshot_ohlc::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotOHLC([]string{"AAPL"}); return goRowCount(v), e })
-		records = classify("stock_snapshot_ohlc", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_ohlc", "concrete", &skip, records)
+		records = recordAborted("stock_snapshot_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_snapshot_ohlc::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotOHLC([]string{"AAPL"}, WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_snapshot_ohlc", "with_venue", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_ohlc", "with_venue", &skip, records)
+		records = recordAborted("stock_snapshot_ohlc", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_snapshot_ohlc::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotOHLC([]string{"AAPL"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_ohlc", "with_min_time", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_ohlc", "with_min_time", &skip, records)
+		records = recordAborted("stock_snapshot_ohlc", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// stock_snapshot_ohlc::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotOHLC([]string{"AAPL"}, WithVenue("nqb"), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_ohlc", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_ohlc", "all_optionals", &skip, records)
+		records = recordAborted("stock_snapshot_ohlc", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// stock_snapshot_trade::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotTrade([]string{"AAPL"}); return goRowCount(v), e })
-		records = classify("stock_snapshot_trade", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_trade", "concrete", &skip, records)
+		records = recordAborted("stock_snapshot_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_snapshot_trade::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotTrade([]string{"AAPL"}, WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_snapshot_trade", "with_venue", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_trade", "with_venue", &skip, records)
+		records = recordAborted("stock_snapshot_trade", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_snapshot_trade::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotTrade([]string{"AAPL"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_trade", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_trade", "with_min_time", &skip, records)
+		records = recordAborted("stock_snapshot_trade", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// stock_snapshot_trade::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotTrade([]string{"AAPL"}, WithVenue("nqb"), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_trade", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_trade", "all_optionals", &skip, records)
+		records = recordAborted("stock_snapshot_trade", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// stock_snapshot_quote::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotQuote([]string{"AAPL"}); return goRowCount(v), e })
-		records = classify("stock_snapshot_quote", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_quote", "concrete", &skip, records)
+		records = recordAborted("stock_snapshot_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_snapshot_quote::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotQuote([]string{"AAPL"}, WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_snapshot_quote", "with_venue", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_quote", "with_venue", &skip, records)
+		records = recordAborted("stock_snapshot_quote", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_snapshot_quote::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotQuote([]string{"AAPL"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_quote", "with_min_time", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_quote", "with_min_time", &skip, records)
+		records = recordAborted("stock_snapshot_quote", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// stock_snapshot_quote::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotQuote([]string{"AAPL"}, WithVenue("nqb"), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_quote", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_quote", "all_optionals", &skip, records)
+		records = recordAborted("stock_snapshot_quote", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// stock_snapshot_market_value::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotMarketValue([]string{"AAPL"}); return goRowCount(v), e })
-		records = classify("stock_snapshot_market_value", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_market_value", "concrete", &skip, records)
+		records = recordAborted("stock_snapshot_market_value", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_snapshot_market_value::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotMarketValue([]string{"AAPL"}, WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_snapshot_market_value", "with_venue", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_market_value", "with_venue", "standard", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_market_value", "with_venue", &skip, records)
+		records = recordAborted("stock_snapshot_market_value", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_snapshot_market_value::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotMarketValue([]string{"AAPL"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_market_value", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_market_value", "with_min_time", &skip, records)
+		records = recordAborted("stock_snapshot_market_value", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// stock_snapshot_market_value::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotMarketValue([]string{"AAPL"}, WithVenue("nqb"), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_market_value", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_market_value", "all_optionals", &skip, records)
+		records = recordAborted("stock_snapshot_market_value", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// stock_history_eod::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryEOD("AAPL", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("stock_history_eod", "concrete", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_eod", "concrete", &skip, records)
+		records = recordAborted("stock_history_eod", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
 
+	// stock_history_ohlc::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLC("AAPL", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("stock_history_ohlc", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc", "concrete", &skip, records)
+		records = recordAborted("stock_history_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_history_ohlc::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLC("AAPL", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc", "with_intraday_window", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc", "with_intraday_window", &skip, records)
+		records = recordAborted("stock_history_ohlc", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// stock_history_ohlc::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLC("AAPL", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc", "with_date_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc", "with_date_range", &skip, records)
+		records = recordAborted("stock_history_ohlc", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// stock_history_ohlc::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLC("AAPL", "20250303", "60000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc", "with_venue", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc", "with_venue", &skip, records)
+		records = recordAborted("stock_history_ohlc", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_history_ohlc::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLC("AAPL", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithVenue("nqb"), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc", "all_optionals", &skip, records)
+		records = recordAborted("stock_history_ohlc", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// stock_history_trade::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTrade("AAPL", "20250303"); return goRowCount(v), e })
-		records = classify("stock_history_trade", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade", "concrete", &skip, records)
+		records = recordAborted("stock_history_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_history_trade::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTrade("AAPL", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("stock_history_trade", "with_intraday_window", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade", "with_intraday_window", &skip, records)
+		records = recordAborted("stock_history_trade", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// stock_history_trade::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTrade("AAPL", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("stock_history_trade", "with_date_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade", "with_date_range", &skip, records)
+		records = recordAborted("stock_history_trade", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// stock_history_trade::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTrade("AAPL", "20250303", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_trade", "with_venue", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade", "with_venue", &skip, records)
+		records = recordAborted("stock_history_trade", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_history_trade::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTrade("AAPL", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithVenue("nqb"), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("stock_history_trade", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade", "all_optionals", &skip, records)
+		records = recordAborted("stock_history_trade", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// stock_history_quote::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryQuote("AAPL", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("stock_history_quote", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_quote", "concrete", &skip, records)
+		records = recordAborted("stock_history_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_history_quote::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryQuote("AAPL", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("stock_history_quote", "with_intraday_window", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_quote", "with_intraday_window", &skip, records)
+		records = recordAborted("stock_history_quote", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// stock_history_quote::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryQuote("AAPL", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("stock_history_quote", "with_date_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_quote", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_quote", "with_date_range", &skip, records)
+		records = recordAborted("stock_history_quote", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// stock_history_quote::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryQuote("AAPL", "20250303", "60000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_quote", "with_venue", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_quote", "with_venue", &skip, records)
+		records = recordAborted("stock_history_quote", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_history_quote::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryQuote("AAPL", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithVenue("nqb"), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("stock_history_quote", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_quote", "all_optionals", &skip, records)
+		records = recordAborted("stock_history_quote", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// stock_history_trade_quote::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTradeQuote("AAPL", "20250303"); return goRowCount(v), e })
-		records = classify("stock_history_trade_quote", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade_quote", "concrete", &skip, records)
+		records = recordAborted("stock_history_trade_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_history_trade_quote::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTradeQuote("AAPL", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("stock_history_trade_quote", "with_intraday_window", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade_quote", "with_intraday_window", &skip, records)
+		records = recordAborted("stock_history_trade_quote", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// stock_history_trade_quote::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTradeQuote("AAPL", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("stock_history_trade_quote", "with_date_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade_quote", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade_quote", "with_date_range", &skip, records)
+		records = recordAborted("stock_history_trade_quote", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// stock_history_trade_quote::with_exclusive
+	//   rationale: exclusive=true optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTradeQuote("AAPL", "20250303", WithExclusive(true)); return goRowCount(v), e })
-		records = classify("stock_history_trade_quote", "with_exclusive", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade_quote", "with_exclusive", "standard", "exclusive=true optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade_quote", "with_exclusive", &skip, records)
+		records = recordAborted("stock_history_trade_quote", "with_exclusive", "exclusive=true optional filter wiring", &skip, records)
 	}
+	// stock_history_trade_quote::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTradeQuote("AAPL", "20250303", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_trade_quote", "with_venue", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade_quote", "with_venue", "standard", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade_quote", "with_venue", &skip, records)
+		records = recordAborted("stock_history_trade_quote", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_history_trade_quote::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTradeQuote("AAPL", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithExclusive(true), WithVenue("nqb"), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("stock_history_trade_quote", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade_quote", "all_optionals", &skip, records)
+		records = recordAborted("stock_history_trade_quote", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// stock_at_time_trade::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeTrade("AAPL", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("stock_at_time_trade", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_at_time_trade", "concrete", &skip, records)
+		records = recordAborted("stock_at_time_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_at_time_trade::with_venue
+	//   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeTrade("AAPL", "20250303", "20250303", "12:00:00.000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_at_time_trade", "with_venue", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_at_time_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_at_time_trade", "with_venue", &skip, records)
-	}
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeTrade("AAPL", "20250303", "20250303", "12:00:00.000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_at_time_trade", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_at_time_trade", "all_optionals", &skip, records)
+		records = recordAborted("stock_at_time_trade", "with_venue", "venue=nqb optional venue selector wiring (also covers: all_optionals)", &skip, records)
 	}
 
+	// stock_at_time_quote::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeQuote("AAPL", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("stock_at_time_quote", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_at_time_quote", "concrete", &skip, records)
+		records = recordAborted("stock_at_time_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_at_time_quote::with_venue
+	//   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeQuote("AAPL", "20250303", "20250303", "12:00:00.000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_at_time_quote", "with_venue", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_at_time_quote", "with_venue", "value", "venue=nqb optional venue selector wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_at_time_quote", "with_venue", &skip, records)
-	}
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeQuote("AAPL", "20250303", "20250303", "12:00:00.000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_at_time_quote", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_at_time_quote", "all_optionals", &skip, records)
+		records = recordAborted("stock_at_time_quote", "with_venue", "venue=nqb optional venue selector wiring (also covers: all_optionals)", &skip, records)
 	}
 
+	// option_list_symbols::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionListSymbols(); return goRowCount(v), e })
-		records = classify("option_list_symbols", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_list_symbols", "basic", &skip, records)
+		records = recordAborted("option_list_symbols", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// option_list_dates::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionListDates("TRADE", "SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_list_dates", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_list_dates", "basic", &skip, records)
+		records = recordAborted("option_list_dates", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// option_list_expirations::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionListExpirations("SPY"); return goRowCount(v), e })
-		records = classify("option_list_expirations", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_list_expirations", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_list_expirations", "basic", &skip, records)
+		records = recordAborted("option_list_expirations", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// option_list_strikes::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionListStrikes("SPY", "20250321"); return goRowCount(v), e })
-		records = classify("option_list_strikes", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_list_strikes", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_list_strikes", "basic", &skip, records)
+		records = recordAborted("option_list_strikes", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// option_list_contracts::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionListContracts("TRADE", "SPY", "20250303"); return goRowCount(v), e })
-		records = classify("option_list_contracts", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_list_contracts", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_list_contracts", "concrete", &skip, records)
+		records = recordAborted("option_list_contracts", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_list_contracts::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionListContracts("TRADE", "SPY", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_list_contracts", "with_max_dte", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_list_contracts", "with_max_dte", "value", "max_dte=30 optional filter wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_list_contracts", "with_max_dte", &skip, records)
-	}
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionListContracts("TRADE", "SPY", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_list_contracts", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_list_contracts", "all_optionals", &skip, records)
+		records = recordAborted("option_list_contracts", "with_max_dte", "max_dte=30 optional filter wiring (also covers: all_optionals)", &skip, records)
 	}
 
+	// option_snapshot_ohlc::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_ohlc::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "concrete_iso", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_ohlc::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "all_strikes_one_exp", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_ohlc::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "all_exps_one_strike", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_ohlc::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "bulk_chain", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_ohlc::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "legacy_zero_wildcard", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_ohlc::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "with_max_dte", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "with_max_dte", "value", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_ohlc::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "with_strike_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "with_strike_range", "value", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_ohlc::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "with_min_time", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_ohlc::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "20250321", "570", "C", WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_trade::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_trade", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_trade::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_trade", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_trade", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_trade::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_trade", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_trade", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_trade::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_trade", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_trade", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_trade::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_trade", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_trade", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_trade::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "20250321", "570", "C", WithStrikeRange(int32(10)), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_trade", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_trade", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_quote::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_quote::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "concrete_iso", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_quote", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_quote::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "all_strikes_one_exp", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_quote", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_quote::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "all_exps_one_strike", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_quote", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_quote::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "bulk_chain", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_quote::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "legacy_zero_wildcard", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_quote", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_quote::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "with_max_dte", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_quote", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_quote::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "with_strike_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_quote", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_quote::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "with_min_time", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_quote", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_quote::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "20250321", "570", "C", WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_quote", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_open_interest::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_open_interest::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "concrete_iso", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_open_interest::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "all_strikes_one_exp", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_open_interest::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "all_exps_one_strike", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_open_interest::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "bulk_chain", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_open_interest::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "legacy_zero_wildcard", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_open_interest::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "with_max_dte", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_open_interest::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "with_strike_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "with_strike_range", "value", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_open_interest::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "with_min_time", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_open_interest::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "570", "C", WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_market_value::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_market_value::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_market_value::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_market_value::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "all_exps_one_strike", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_market_value::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "bulk_chain", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_market_value::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "legacy_zero_wildcard", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_market_value::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "with_max_dte", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "with_max_dte", "standard", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_market_value::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_market_value::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_market_value::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "570", "C", WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_greeks_implied_volatility::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_rate_type", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_rate_type", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_rate_value", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_rate_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_stock_price
+	//   rationale: stock_price=150 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_stock_price", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_version", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_version", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_max_dte", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_max_dte", "standard", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::with_use_market_value
+	//   rationale: use_market_value=true optional flag wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_use_market_value", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_use_market_value", "standard", "use_market_value=true optional flag wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_use_market_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_use_market_value", "use_market_value=true optional flag wiring", &skip, records)
 	}
+	// option_snapshot_greeks_implied_volatility::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithStockPrice(150.0), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00"), WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_greeks_all::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_greeks_all::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_greeks_all::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_all::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "all_exps_one_strike", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_all::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "bulk_chain", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_greeks_all::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_rate_type", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_rate_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_stock_price
+	//   rationale: stock_price=150 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_stock_price", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_stock_price", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_version", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_max_dte", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_max_dte", "professional", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_min_time", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::with_use_market_value
+	//   rationale: use_market_value=true optional flag wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_use_market_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_use_market_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_use_market_value", "use_market_value=true optional flag wiring", &skip, records)
 	}
+	// option_snapshot_greeks_all::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithStockPrice(150.0), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00"), WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_greeks_first_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "bulk_chain", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_rate_type", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_rate_value", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_stock_price
+	//   rationale: stock_price=150 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_stock_price", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_stock_price", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_version", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_version", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_max_dte", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_max_dte", "standard", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::with_use_market_value
+	//   rationale: use_market_value=true optional flag wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_use_market_value", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_use_market_value", "standard", "use_market_value=true optional flag wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_use_market_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_use_market_value", "use_market_value=true optional flag wiring", &skip, records)
 	}
+	// option_snapshot_greeks_first_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithStockPrice(150.0), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00"), WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_greeks_second_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "bulk_chain", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_stock_price
+	//   rationale: stock_price=150 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_stock_price", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_stock_price", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_version", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_max_dte", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_min_time", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::with_use_market_value
+	//   rationale: use_market_value=true optional flag wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_use_market_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_use_market_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_use_market_value", "use_market_value=true optional flag wiring", &skip, records)
 	}
+	// option_snapshot_greeks_second_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithStockPrice(150.0), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00"), WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_snapshot_greeks_third_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "concrete", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "bulk_chain", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "bulk_chain", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_stock_price
+	//   rationale: stock_price=150 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_stock_price", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_stock_price", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_version", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_max_dte", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_max_dte", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_min_time", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_min_time", "professional", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_min_time", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::with_use_market_value
+	//   rationale: use_market_value=true optional flag wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_use_market_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_use_market_value", "professional", "use_market_value=true optional flag wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_use_market_value", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_use_market_value", "use_market_value=true optional flag wiring", &skip, records)
 	}
+	// option_snapshot_greeks_third_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithStockPrice(150.0), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithMinTime("09:45:00"), WithUseMarketValue(true)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "all_optionals", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_eod::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "20250321", "570", "C", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "concrete", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "concrete", &skip, records)
+		records = recordAborted("option_history_eod", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_eod::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "concrete_iso", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "concrete_iso", "free", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_eod", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_eod::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "20250321", "*", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "all_strikes_one_exp", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "all_strikes_one_exp", "free", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_eod", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_eod::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "*", "570", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "all_exps_one_strike", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "all_exps_one_strike", "free", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_eod", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_eod::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "*", "*", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "bulk_chain", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_eod", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_eod::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "0", "0", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "legacy_zero_wildcard", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "legacy_zero_wildcard", "free", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_eod", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_eod::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_eod", "with_max_dte", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "with_max_dte", "free", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_eod", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_eod::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_eod", "with_strike_range", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "with_strike_range", "free", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_eod", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_eod::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithMaxDTE(int32(30)), WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_eod", "all_optionals", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "all_optionals", "free", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "all_optionals", &skip, records)
+		records = recordAborted("option_history_eod", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_ohlc::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "concrete", &skip, records)
+		records = recordAborted("option_history_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_ohlc::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "concrete_iso", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_ohlc", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_ohlc::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "all_strikes_one_exp", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_ohlc", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_ohlc::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "with_intraday_window", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_ohlc", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_ohlc::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "20250321", "570", "C", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "with_date_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "with_date_range", &skip, records)
+		records = recordAborted("option_history_ohlc", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_ohlc::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "20250321", "570", "C", "20250303", "60000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "with_strike_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "with_strike_range", "value", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_ohlc", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_ohlc::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "all_optionals", &skip, records)
+		records = recordAborted("option_history_ohlc", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_trade::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "concrete", &skip, records)
+		records = recordAborted("option_history_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_trade::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_trade", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_trade::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_trade", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "all_exps_one_strike", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_trade", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "bulk_chain", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_trade", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_trade::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "legacy_zero_wildcard", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_trade", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_trade::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_trade", "with_intraday_window", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_trade", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_trade::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "570", "C", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade", "with_date_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "with_date_range", &skip, records)
+		records = recordAborted("option_history_trade", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_trade::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_trade", "with_max_dte", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_trade", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_trade::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "570", "C", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_trade", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_trade", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_trade::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "all_optionals", &skip, records)
+		records = recordAborted("option_history_trade", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_quote::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "concrete", &skip, records)
+		records = recordAborted("option_history_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_quote::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "concrete_iso", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_quote", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_quote::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "all_strikes_one_exp", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_quote", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_quote::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "*", "570", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "all_exps_one_strike", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_quote", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_quote::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "*", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "bulk_chain", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_quote::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "0", "0", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "legacy_zero_wildcard", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_quote", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_quote::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_quote", "with_intraday_window", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_quote", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_quote::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "570", "C", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_quote", "with_date_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "with_date_range", &skip, records)
+		records = recordAborted("option_history_quote", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_quote::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "570", "C", "20250303", "60000", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_quote", "with_max_dte", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_quote", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_quote::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "570", "C", "20250303", "60000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_quote", "with_strike_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_quote", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_quote::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_quote", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "all_optionals", &skip, records)
+		records = recordAborted("option_history_quote", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_trade_quote::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "concrete", &skip, records)
+		records = recordAborted("option_history_trade_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_trade_quote::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_trade_quote", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_trade_quote::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_trade_quote", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_quote::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "all_exps_one_strike", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_trade_quote", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_quote::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "bulk_chain", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_trade_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_trade_quote::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "legacy_zero_wildcard", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_trade_quote", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_trade_quote::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "with_intraday_window", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_trade_quote", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_trade_quote::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "570", "C", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "with_date_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "with_date_range", &skip, records)
+		records = recordAborted("option_history_trade_quote", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_trade_quote::with_exclusive
+	//   rationale: exclusive=true optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "570", "C", "20250303", WithExclusive(true)); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "with_exclusive", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "with_exclusive", "standard", "exclusive=true optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "with_exclusive", &skip, records)
+		records = recordAborted("option_history_trade_quote", "with_exclusive", "exclusive=true optional filter wiring", &skip, records)
 	}
+	// option_history_trade_quote::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "with_max_dte", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "with_max_dte", "standard", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_trade_quote", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_quote::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "570", "C", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_trade_quote", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_quote::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithExclusive(true), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "all_optionals", &skip, records)
+		records = recordAborted("option_history_trade_quote", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_open_interest::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "concrete", &skip, records)
+		records = recordAborted("option_history_open_interest", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_open_interest::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "concrete_iso", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_open_interest", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_open_interest::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "all_strikes_one_exp", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_open_interest", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_open_interest::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "all_exps_one_strike", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_open_interest", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_open_interest::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "bulk_chain", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_open_interest", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_open_interest::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "legacy_zero_wildcard", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_open_interest", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_open_interest::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "570", "C", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "with_date_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "with_date_range", &skip, records)
+		records = recordAborted("option_history_open_interest", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_open_interest::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "with_max_dte", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_open_interest", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_open_interest::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "570", "C", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "with_strike_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "with_strike_range", "value", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_open_interest", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_open_interest::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "all_optionals", &skip, records)
+		records = recordAborted("option_history_open_interest", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_greeks_eod::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "concrete", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_greeks_eod::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_greeks_eod::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "*", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_greeks_eod::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "*", "570", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "all_exps_one_strike", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_greeks_eod::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "*", "*", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "bulk_chain", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_greeks_eod::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "0", "0", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "legacy_zero_wildcard", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_greeks_eod::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "with_annual_dividend", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_eod::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "with_rate_type", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_eod::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "with_rate_value", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_eod::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "with_version", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "with_version", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_greeks_eod::with_underlyer_use_nbbo
+	//   rationale: underlyer_use_nbbo=true optional flag wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithUnderlyerUseNBBO(true)); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "with_underlyer_use_nbbo", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "with_underlyer_use_nbbo", "standard", "underlyer_use_nbbo=true optional flag wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "with_underlyer_use_nbbo", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "with_underlyer_use_nbbo", "underlyer_use_nbbo=true optional flag wiring", &skip, records)
 	}
+	// option_history_greeks_eod::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "with_max_dte", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "with_max_dte", "standard", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_greeks_eod::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_greeks_eod::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303", WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithUnderlyerUseNBBO(true), WithMaxDTE(int32(30)), WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "all_optionals", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_greeks_all::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "concrete", &skip, records)
+		records = recordAborted("option_history_greeks_all", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_greeks_all::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_greeks_all", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_greeks_all::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_greeks_all", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_greeks_all::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "with_intraday_window", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_greeks_all", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_greeks_all::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "with_date_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "with_date_range", &skip, records)
+		records = recordAborted("option_history_greeks_all", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_greeks_all::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_greeks_all", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_all::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_greeks_all", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_all::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_greeks_all", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_all::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "with_version", &skip, records)
+		records = recordAborted("option_history_greeks_all", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_greeks_all::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_greeks_all", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_greeks_all::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "all_optionals", &skip, records)
+		records = recordAborted("option_history_greeks_all", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_trade_greeks_all::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "concrete", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_trade_greeks_all::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_trade_greeks_all::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_all::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "all_exps_one_strike", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_all::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "bulk_chain", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_trade_greeks_all::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_trade_greeks_all::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "with_intraday_window", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_all::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "with_date_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "with_date_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_all::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_all::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_all::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_all::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "with_version", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_trade_greeks_all::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "with_max_dte", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "with_max_dte", "professional", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_all::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_all::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "all_optionals", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_greeks_first_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "concrete", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_greeks_first_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_greeks_first_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_greeks_first_order::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "with_intraday_window", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_greeks_first_order::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "with_date_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "with_date_range", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_greeks_first_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "with_annual_dividend", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_first_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "with_rate_type", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_first_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "with_rate_value", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_first_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "with_version", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "with_version", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_greeks_first_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_greeks_first_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "all_optionals", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_trade_greeks_first_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "concrete", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "bulk_chain", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "with_intraday_window", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "with_date_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "with_date_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "with_version", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "with_max_dte", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_first_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "all_optionals", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_greeks_second_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "concrete", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_greeks_second_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_greeks_second_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_greeks_second_order::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "with_intraday_window", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_greeks_second_order::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "with_date_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "with_date_range", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_greeks_second_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_second_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_second_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_second_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "with_version", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_greeks_second_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_greeks_second_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "all_optionals", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_trade_greeks_second_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "concrete", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "bulk_chain", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "with_intraday_window", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "with_date_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "with_date_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "with_version", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "with_max_dte", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_second_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "all_optionals", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_greeks_third_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "concrete", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_greeks_third_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_greeks_third_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_greeks_third_order::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "with_intraday_window", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_greeks_third_order::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "with_date_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "with_date_range", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_greeks_third_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_third_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_third_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_third_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "with_version", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_greeks_third_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_greeks_third_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "all_optionals", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_trade_greeks_third_order::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "concrete", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "bulk_chain", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "with_intraday_window", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "with_date_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "with_date_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "with_version", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "with_max_dte", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "with_max_dte", "professional", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_third_order::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "all_optionals", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_greeks_implied_volatility::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "concrete", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "with_intraday_window", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "with_date_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "with_date_range", "standard", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "with_date_range", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "with_annual_dividend", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "with_rate_type", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "with_rate_type", "standard", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "with_rate_value", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "with_rate_value", "standard", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "with_version", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "with_version", "standard", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "with_version", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_greeks_implied_volatility::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "all_optionals", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_history_trade_greeks_implied_volatility::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "concrete", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "concrete", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "concrete_iso", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "bulk_chain", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_intraday_window", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "with_date_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "with_date_range", "professional", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_date_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::with_annual_dividend
+	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithAnnualDividend(0.015)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "with_annual_dividend", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_annual_dividend", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_annual_dividend", "annual_dividend=0.015 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::with_rate_type
+	//   rationale: rate_type=sofr optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithRateType("sofr")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "with_rate_type", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "with_rate_type", "professional", "rate_type=sofr optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_rate_type", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_rate_type", "rate_type=sofr optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::with_rate_value
+	//   rationale: rate_value=0.05 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithRateValue(0.05)); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "with_rate_value", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "with_rate_value", "professional", "rate_value=0.05 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_rate_value", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::with_version
+	//   rationale: version=dg3 optional Greeks-version selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithVersion("dg3")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "with_version", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "with_version", "professional", "version=dg3 optional Greeks-version selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_version", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_version", "version=dg3 optional Greeks-version selector wiring", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "with_max_dte", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "with_max_dte", "professional", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_max_dte", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "with_strike_range", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "with_strike_range", "professional", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_strike_range", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_history_trade_greeks_implied_volatility::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithAnnualDividend(0.015), WithRateType("sofr"), WithRateValue(0.05), WithVersion("dg3"), WithMaxDTE(int32(30)), WithStrikeRange(int32(10)), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "all_optionals", "professional", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "all_optionals", "professional", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_optionals", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_at_time_trade::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "concrete", &skip, records)
+		records = recordAborted("option_at_time_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_at_time_trade::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "concrete_iso", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "concrete_iso", &skip, records)
+		records = recordAborted("option_at_time_trade", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_at_time_trade::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "all_strikes_one_exp", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_at_time_trade", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_at_time_trade::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "all_exps_one_strike", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_at_time_trade", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_at_time_trade::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "bulk_chain", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "bulk_chain", &skip, records)
+		records = recordAborted("option_at_time_trade", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_at_time_trade::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "legacy_zero_wildcard", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_at_time_trade", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_at_time_trade::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "with_max_dte", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "with_max_dte", &skip, records)
+		records = recordAborted("option_at_time_trade", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_at_time_trade::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "with_strike_range", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "with_strike_range", &skip, records)
+		records = recordAborted("option_at_time_trade", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_at_time_trade::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", WithMaxDTE(int32(30)), WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "all_optionals", &skip, records)
+		records = recordAborted("option_at_time_trade", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// option_at_time_quote::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "concrete", &skip, records)
+		records = recordAborted("option_at_time_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// option_at_time_quote::concrete_iso
+	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "concrete_iso", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "concrete_iso", &skip, records)
+		records = recordAborted("option_at_time_quote", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
 	}
+	// option_at_time_quote::all_strikes_one_exp
+	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "all_strikes_one_exp", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "all_strikes_one_exp", &skip, records)
+		records = recordAborted("option_at_time_quote", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
 	}
+	// option_at_time_quote::all_exps_one_strike
+	//   rationale: expiration=* — exercises expiration wildcard wire-unset
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "all_exps_one_strike", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "all_exps_one_strike", &skip, records)
+		records = recordAborted("option_at_time_quote", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
 	}
+	// option_at_time_quote::bulk_chain
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "bulk_chain", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "bulk_chain", &skip, records)
+		records = recordAborted("option_at_time_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
 	}
+	// option_at_time_quote::legacy_zero_wildcard
+	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "legacy_zero_wildcard", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "legacy_zero_wildcard", &skip, records)
+		records = recordAborted("option_at_time_quote", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
 	}
+	// option_at_time_quote::with_max_dte
+	//   rationale: max_dte=30 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", WithMaxDTE(int32(30))); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "with_max_dte", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "with_max_dte", &skip, records)
+		records = recordAborted("option_at_time_quote", "with_max_dte", "max_dte=30 optional filter wiring", &skip, records)
 	}
+	// option_at_time_quote::with_strike_range
+	//   rationale: strike_range=10 optional filter wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "with_strike_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "with_strike_range", "value", "strike_range=10 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "with_strike_range", &skip, records)
+		records = recordAborted("option_at_time_quote", "with_strike_range", "strike_range=10 optional filter wiring", &skip, records)
 	}
+	// option_at_time_quote::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", WithMaxDTE(int32(30)), WithStrikeRange(int32(10))); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "all_optionals", &skip, records)
+		records = recordAborted("option_at_time_quote", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// index_list_symbols::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexListSymbols(); return goRowCount(v), e })
-		records = classify("index_list_symbols", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_list_symbols", "basic", &skip, records)
+		records = recordAborted("index_list_symbols", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// index_list_dates::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexListDates("SPX"); return goRowCount(v), e })
-		records = classify("index_list_dates", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_list_dates", "basic", &skip, records)
+		records = recordAborted("index_list_dates", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// index_snapshot_ohlc::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotOHLC([]string{"SPX"}); return goRowCount(v), e })
-		records = classify("index_snapshot_ohlc", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_snapshot_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_snapshot_ohlc", "concrete", &skip, records)
+		records = recordAborted("index_snapshot_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// index_snapshot_ohlc::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotOHLC([]string{"SPX"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("index_snapshot_ohlc", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_snapshot_ohlc", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_snapshot_ohlc", "with_min_time", &skip, records)
-	}
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotOHLC([]string{"SPX"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("index_snapshot_ohlc", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("index_snapshot_ohlc", "all_optionals", &skip, records)
+		records = recordAborted("index_snapshot_ohlc", "with_min_time", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", &skip, records)
 	}
 
+	// index_snapshot_price::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotPrice([]string{"SPX"}); return goRowCount(v), e })
-		records = classify("index_snapshot_price", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_snapshot_price", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_snapshot_price", "concrete", &skip, records)
+		records = recordAborted("index_snapshot_price", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// index_snapshot_price::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotPrice([]string{"SPX"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("index_snapshot_price", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_snapshot_price", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_snapshot_price", "with_min_time", &skip, records)
-	}
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotPrice([]string{"SPX"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("index_snapshot_price", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("index_snapshot_price", "all_optionals", &skip, records)
+		records = recordAborted("index_snapshot_price", "with_min_time", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", &skip, records)
 	}
 
+	// index_snapshot_market_value::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotMarketValue([]string{"SPX"}); return goRowCount(v), e })
-		records = classify("index_snapshot_market_value", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_snapshot_market_value", "concrete", &skip, records)
+		records = recordAborted("index_snapshot_market_value", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// index_snapshot_market_value::with_min_time
+	//   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotMarketValue([]string{"SPX"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("index_snapshot_market_value", "with_min_time", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_snapshot_market_value", "with_min_time", &skip, records)
-	}
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.IndexSnapshotMarketValue([]string{"SPX"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("index_snapshot_market_value", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("index_snapshot_market_value", "all_optionals", &skip, records)
+		records = recordAborted("index_snapshot_market_value", "with_min_time", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", &skip, records)
 	}
 
+	// index_history_eod::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexHistoryEOD("SPX", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("index_history_eod", "concrete", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_history_eod", "concrete", &skip, records)
+		records = recordAborted("index_history_eod", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
 
+	// index_history_ohlc::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexHistoryOHLC("SPX", "20250303", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("index_history_ohlc", "concrete", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_history_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_history_ohlc", "concrete", &skip, records)
+		records = recordAborted("index_history_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// index_history_ohlc::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexHistoryOHLC("SPX", "20250303", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("index_history_ohlc", "with_intraday_window", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_history_ohlc", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_history_ohlc", "with_intraday_window", &skip, records)
-	}
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.IndexHistoryOHLC("SPX", "20250303", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("index_history_ohlc", "all_optionals", "standard", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("index_history_ohlc", "all_optionals", &skip, records)
+		records = recordAborted("index_history_ohlc", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)", &skip, records)
 	}
 
+	// index_history_price::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexHistoryPrice("SPX", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("index_history_price", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_history_price", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_history_price", "concrete", &skip, records)
+		records = recordAborted("index_history_price", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// index_history_price::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexHistoryPrice("SPX", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("index_history_price", "with_intraday_window", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_history_price", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_history_price", "with_intraday_window", &skip, records)
+		records = recordAborted("index_history_price", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// index_history_price::with_date_range
+	//   rationale: start_date + end_date pair — date range optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexHistoryPrice("SPX", "20250303", "60000", WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("index_history_price", "with_date_range", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_history_price", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_history_price", "with_date_range", &skip, records)
+		records = recordAborted("index_history_price", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
+	// index_history_price::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexHistoryPrice("SPX", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithStartDate("20250303"), WithEndDate("20250303")); return goRowCount(v), e })
-		records = classify("index_history_price", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_history_price", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_history_price", "all_optionals", &skip, records)
+		records = recordAborted("index_history_price", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
+	// index_at_time_price::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.IndexAtTimePrice("SPX", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("index_at_time_price", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("index_at_time_price", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("index_at_time_price", "concrete", &skip, records)
+		records = recordAborted("index_at_time_price", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
 
+	// calendar_open_today::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.CalendarOpenToday(); return goRowCount(v), e })
-		records = classify("calendar_open_today", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("calendar_open_today", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("calendar_open_today", "basic", &skip, records)
+		records = recordAborted("calendar_open_today", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// calendar_on_date::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.CalendarOnDate("20250303"); return goRowCount(v), e })
-		records = classify("calendar_on_date", "basic", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("calendar_on_date", "basic", "value", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("calendar_on_date", "basic", &skip, records)
+		records = recordAborted("calendar_on_date", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// calendar_year::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.CalendarYear("2025"); return goRowCount(v), e })
-		records = classify("calendar_year", "basic", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("calendar_year", "basic", "value", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("calendar_year", "basic", &skip, records)
+		records = recordAborted("calendar_year", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// interest_rate_history_eod::basic
+	//   rationale: list/calendar/rate baseline call — no parameter variation
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.InterestRateHistoryEOD("SOFR", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("interest_rate_history_eod", "basic", "free", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("interest_rate_history_eod", "basic", &skip, records)
+		records = recordAborted("interest_rate_history_eod", "basic", "list/calendar/rate baseline call — no parameter variation", &skip, records)
 	}
 
+	// stock_history_ohlc_range::concrete
+	//   rationale: required params set, no optionals — baseline wire path
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLCRange("AAPL", "20250303", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("stock_history_ohlc_range", "concrete", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc_range", "concrete", &skip, records)
+		records = recordAborted("stock_history_ohlc_range", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
 	}
+	// stock_history_ohlc_range::with_intraday_window
+	//   rationale: start_time + end_time pair — intraday window optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLCRange("AAPL", "20250303", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc_range", "with_intraday_window", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc_range", "with_intraday_window", &skip, records)
+		records = recordAborted("stock_history_ohlc_range", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
 	}
+	// stock_history_ohlc_range::with_venue
+	//   rationale: venue=nqb optional venue selector wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLCRange("AAPL", "20250303", "20250303", "60000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc_range", "with_venue", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc_range", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc_range", "with_venue", &skip, records)
+		records = recordAborted("stock_history_ohlc_range", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
 	}
+	// stock_history_ohlc_range::all_optionals
+	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLCRange("AAPL", "20250303", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc_range", "all_optionals", "value", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc_range", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc_range", "all_optionals", &skip, records)
+		records = recordAborted("stock_history_ohlc_range", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
 	}
 
 	return pass, skip, fail, hadTimeout, records
@@ -2730,20 +3537,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 // recordAborted adds a SKIP record for a cell that didn't run because an
 // earlier cell timed out. The ffi is not thread-safe on the same handle,
 // so we refuse to issue more calls once a worker has been leaked.
-func recordAborted(endpoint, mode string, skip *int, records []CellRecord) []CellRecord {
+func recordAborted(endpoint, mode, rationale string, skip *int, records []CellRecord) []CellRecord {
 	label := endpoint + "::" + mode
 	fmt.Printf("  %-60s SKIP: aborted-after-timeout\n", label)
 	*skip++
 	return append(records, CellRecord{
-		Endpoint: endpoint, Mode: mode, Status: "SKIP", Detail: "aborted-after-timeout",
+		Endpoint: endpoint, Mode: mode, Rationale: rationale, Status: "SKIP", Detail: "aborted-after-timeout",
 	})
 }
 
 // classify maps a live call outcome into PASS / SKIP / FAIL buckets and
 // appends a CellRecord for the agreement-check JSON artifact.
-func classify(endpoint, mode, declaredMinTier string, r cellResult, pass, skip, fail *int, hadTimeout *bool, records []CellRecord) []CellRecord {
+func classify(endpoint, mode, declaredMinTier, rationale string, r cellResult, pass, skip, fail *int, hadTimeout *bool, records []CellRecord) []CellRecord {
 	label := endpoint + "::" + mode
-	rec := CellRecord{Endpoint: endpoint, Mode: mode, RowCount: r.rowCount}
+	rec := CellRecord{Endpoint: endpoint, Mode: mode, Rationale: rationale, RowCount: r.rowCount}
 	if r.err == nil {
 		fmt.Printf("  %-60s PASS\n", label)
 		*pass++

--- a/sdks/go/validate.go
+++ b/sdks/go/validate.go
@@ -20,8 +20,8 @@ var errCellTimeout = errors.New("cell timeout after 60s")
 
 // CellRecord is one row of the validator's per-cell JSON artifact used
 // by the cross-language agreement check. `Status` is PASS|SKIP|FAIL.
-// `Rationale` is the one-sentence description from the generator (see
-// rationale_for_mode in build_support/endpoints/modes.rs); it surfaces
+// `Rationale` is the one-sentence description from the generator
+// (rationale_for_mode in build_support/endpoints/modes.rs); it surfaces
 // in scripts/validate_agreement.py disagreement output so a FAIL line
 // carries the feature description, not just the mode name.
 type CellRecord struct {
@@ -113,135 +113,71 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// stock_snapshot_ohlc::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotOHLC([]string{"AAPL"}); return goRowCount(v), e })
-		records = classify("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// stock_snapshot_ohlc::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotOHLC([]string{"AAPL"}, WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_snapshot_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_snapshot_ohlc", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
+		records = recordAborted("stock_snapshot_ohlc", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_snapshot_ohlc::with_min_time
-	//   rationale: min_time=09:45:00 optional filter wiring
+	//   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotOHLC([]string{"AAPL"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_ohlc", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
-	}
-	// stock_snapshot_ohlc::all_optionals
-	//   rationale: every applicable optional set at once — proves multi-optional wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotOHLC([]string{"AAPL"}, WithVenue("nqb"), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_ohlc", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_snapshot_ohlc", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
+		records = recordAborted("stock_snapshot_ohlc", "with_min_time", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", &skip, records)
 	}
 
 	// stock_snapshot_trade::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotTrade([]string{"AAPL"}); return goRowCount(v), e })
-		records = classify("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// stock_snapshot_trade::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotTrade([]string{"AAPL"}, WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_snapshot_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_snapshot_trade", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
+		records = recordAborted("stock_snapshot_trade", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_snapshot_trade::with_min_time
-	//   rationale: min_time=09:45:00 optional filter wiring
+	//   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotTrade([]string{"AAPL"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_trade", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
-	}
-	// stock_snapshot_trade::all_optionals
-	//   rationale: every applicable optional set at once — proves multi-optional wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotTrade([]string{"AAPL"}, WithVenue("nqb"), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_trade", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_snapshot_trade", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
+		records = recordAborted("stock_snapshot_trade", "with_min_time", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", &skip, records)
 	}
 
 	// stock_snapshot_quote::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotQuote([]string{"AAPL"}); return goRowCount(v), e })
-		records = classify("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// stock_snapshot_quote::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotQuote([]string{"AAPL"}, WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_snapshot_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_snapshot_quote", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
+		records = recordAborted("stock_snapshot_quote", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_snapshot_quote::with_min_time
-	//   rationale: min_time=09:45:00 optional filter wiring
+	//   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotQuote([]string{"AAPL"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_quote", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
-	}
-	// stock_snapshot_quote::all_optionals
-	//   rationale: every applicable optional set at once — proves multi-optional wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotQuote([]string{"AAPL"}, WithVenue("nqb"), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_quote", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_snapshot_quote", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
+		records = recordAborted("stock_snapshot_quote", "with_min_time", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", &skip, records)
 	}
 
 	// stock_snapshot_market_value::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotMarketValue([]string{"AAPL"}); return goRowCount(v), e })
-		records = classify("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_market_value", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// stock_snapshot_market_value::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotMarketValue([]string{"AAPL"}, WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_snapshot_market_value", "with_venue", "standard", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_snapshot_market_value", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
+		records = recordAborted("stock_snapshot_market_value", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_snapshot_market_value::with_min_time
-	//   rationale: min_time=09:45:00 optional filter wiring
+	//   rationale: min_time=09:45:00 optional filter wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotMarketValue([]string{"AAPL"}, WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_snapshot_market_value", "with_min_time", "min_time=09:45:00 optional filter wiring", &skip, records)
-	}
-	// stock_snapshot_market_value::all_optionals
-	//   rationale: every applicable optional set at once — proves multi-optional wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockSnapshotMarketValue([]string{"AAPL"}, WithVenue("nqb"), WithMinTime("09:45:00")); return goRowCount(v), e })
-		records = classify("stock_snapshot_market_value", "all_optionals", "standard", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_snapshot_market_value", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
+		records = recordAborted("stock_snapshot_market_value", "with_min_time", "min_time=09:45:00 optional filter wiring (also covers: all_optionals)", &skip, records)
 	}
 
 	// stock_history_eod::concrete
@@ -254,12 +190,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// stock_history_ohlc::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLC("AAPL", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
+		records = recordAborted("stock_history_ohlc", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_history_ohlc::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -277,14 +213,6 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	} else {
 		records = recordAborted("stock_history_ohlc", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
-	// stock_history_ohlc::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLC("AAPL", "20250303", "60000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_history_ohlc", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
-	}
 	// stock_history_ohlc::all_optionals
 	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
@@ -295,12 +223,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// stock_history_trade::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTrade("AAPL", "20250303"); return goRowCount(v), e })
-		records = classify("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
+		records = recordAborted("stock_history_trade", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_history_trade::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -318,14 +246,6 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	} else {
 		records = recordAborted("stock_history_trade", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
-	// stock_history_trade::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTrade("AAPL", "20250303", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_history_trade", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
-	}
 	// stock_history_trade::all_optionals
 	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
@@ -336,12 +256,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// stock_history_quote::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryQuote("AAPL", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
+		records = recordAborted("stock_history_quote", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_history_quote::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -359,14 +279,6 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	} else {
 		records = recordAborted("stock_history_quote", "with_date_range", "start_date + end_date pair — date range optional wiring", &skip, records)
 	}
-	// stock_history_quote::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryQuote("AAPL", "20250303", "60000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_quote", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_history_quote", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
-	}
 	// stock_history_quote::all_optionals
 	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
@@ -377,12 +289,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// stock_history_trade_quote::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTradeQuote("AAPL", "20250303"); return goRowCount(v), e })
-		records = classify("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_trade_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
+		records = recordAborted("stock_history_trade_quote", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_history_trade_quote::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -408,14 +320,6 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	} else {
 		records = recordAborted("stock_history_trade_quote", "with_exclusive", "exclusive=true optional filter wiring", &skip, records)
 	}
-	// stock_history_trade_quote::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryTradeQuote("AAPL", "20250303", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_trade_quote", "with_venue", "standard", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_history_trade_quote", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
-	}
 	// stock_history_trade_quote::all_optionals
 	//   rationale: every applicable optional set at once — proves multi-optional wiring
 	if !hadTimeout {
@@ -426,37 +330,21 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// stock_at_time_trade::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeTrade("AAPL", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_at_time_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// stock_at_time_trade::with_venue
-	//   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeTrade("AAPL", "20250303", "20250303", "12:00:00.000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_at_time_trade", "with_venue", "standard", "venue=nqb optional venue selector wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_at_time_trade", "with_venue", "venue=nqb optional venue selector wiring (also covers: all_optionals)", &skip, records)
+		records = recordAborted("stock_at_time_trade", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", &skip, records)
 	}
 
 	// stock_at_time_quote::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeQuote("AAPL", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_at_time_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// stock_at_time_quote::with_venue
-	//   rationale: venue=nqb optional venue selector wiring (also covers: all_optionals)
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockAtTimeQuote("AAPL", "20250303", "20250303", "12:00:00.000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_at_time_quote", "with_venue", "value", "venue=nqb optional venue selector wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_at_time_quote", "with_venue", "venue=nqb optional venue selector wiring (also covers: all_optionals)", &skip, records)
+		records = recordAborted("stock_at_time_quote", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue, all_optionals)", &skip, records)
 	}
 
 	// option_list_symbols::basic
@@ -513,52 +401,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_ohlc::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_ohlc::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_ohlc", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_ohlc::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_ohlc::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_ohlc::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_ohlc", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_ohlc::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOHLC("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_ohlc", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_ohlc", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_ohlc", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_ohlc::with_max_dte
 	//   rationale: max_dte=30 optional filter wiring
@@ -594,28 +466,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_trade::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_trade::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_trade", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_trade", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_trade::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotTrade("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_trade", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_trade", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_trade::with_strike_range
 	//   rationale: strike_range=10 optional filter wiring
@@ -643,52 +507,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_quote::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_quote::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_quote", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_quote", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_quote::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_quote", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_quote::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_quote", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_quote::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_quote::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotQuote("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_quote", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_quote::with_max_dte
 	//   rationale: max_dte=30 optional filter wiring
@@ -724,52 +572,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_open_interest::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_open_interest::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_open_interest", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_open_interest::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_open_interest::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_open_interest::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_open_interest", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_open_interest::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotOpenInterest("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_open_interest", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_open_interest", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_open_interest::with_max_dte
 	//   rationale: max_dte=30 optional filter wiring
@@ -805,52 +637,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_market_value::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_market_value::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_market_value", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_market_value::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_market_value::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_market_value::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_market_value", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_market_value::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotMarketValue("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_market_value", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_market_value", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_market_value", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_market_value::with_max_dte
 	//   rationale: max_dte=30 optional filter wiring
@@ -886,52 +702,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_greeks_implied_volatility::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_greeks_implied_volatility::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_greeks_implied_volatility::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_greeks_implied_volatility::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_greeks_implied_volatility::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_greeks_implied_volatility::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_greeks_implied_volatility::with_annual_dividend
 	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
@@ -958,12 +758,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_implied_volatility::with_stock_price
-	//   rationale: stock_price=150 optional Greeks-input wiring
+	//   rationale: stock_price=150.0 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_implied_volatility", "with_stock_price", "standard", "stock_price=150.0 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
+		records = recordAborted("option_snapshot_greeks_implied_volatility", "with_stock_price", "stock_price=150.0 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_implied_volatility::with_version
 	//   rationale: version=dg3 optional Greeks-version selector wiring
@@ -1015,52 +815,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_greeks_all::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_greeks_all::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_all", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_greeks_all::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_greeks_all::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_greeks_all::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_greeks_all::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_all", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_greeks_all::with_annual_dividend
 	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
@@ -1087,12 +871,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 		records = recordAborted("option_snapshot_greeks_all", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_all::with_stock_price
-	//   rationale: stock_price=150 optional Greeks-input wiring
+	//   rationale: stock_price=150.0 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_all", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_all", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
+		records = recordAborted("option_snapshot_greeks_all", "with_stock_price", "stock_price=150.0 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_all::with_version
 	//   rationale: version=dg3 optional Greeks-version selector wiring
@@ -1144,52 +928,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_greeks_first_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_greeks_first_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_greeks_first_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_greeks_first_order::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_greeks_first_order::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_greeks_first_order::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_greeks_first_order::with_annual_dividend
 	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
@@ -1216,12 +984,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 		records = recordAborted("option_snapshot_greeks_first_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_first_order::with_stock_price
-	//   rationale: stock_price=150 optional Greeks-input wiring
+	//   rationale: stock_price=150.0 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_first_order", "with_stock_price", "standard", "stock_price=150.0 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_first_order", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
+		records = recordAborted("option_snapshot_greeks_first_order", "with_stock_price", "stock_price=150.0 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_first_order::with_version
 	//   rationale: version=dg3 optional Greeks-version selector wiring
@@ -1273,52 +1041,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_greeks_second_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_greeks_second_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_greeks_second_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_greeks_second_order::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_greeks_second_order::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_greeks_second_order::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_greeks_second_order::with_annual_dividend
 	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
@@ -1345,12 +1097,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 		records = recordAborted("option_snapshot_greeks_second_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_second_order::with_stock_price
-	//   rationale: stock_price=150 optional Greeks-input wiring
+	//   rationale: stock_price=150.0 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_second_order", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_second_order", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
+		records = recordAborted("option_snapshot_greeks_second_order", "with_stock_price", "stock_price=150.0 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_second_order::with_version
 	//   rationale: version=dg3 optional Greeks-version selector wiring
@@ -1402,52 +1154,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_snapshot_greeks_third_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_snapshot_greeks_third_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "2025-03-21", "570", "C"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_snapshot_greeks_third_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_snapshot_greeks_third_order::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "*", "570", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_snapshot_greeks_third_order::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "*", "*", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_snapshot_greeks_third_order::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "0", "0", "both"); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_snapshot_greeks_third_order::with_annual_dividend
 	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
@@ -1474,12 +1210,12 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 		records = recordAborted("option_snapshot_greeks_third_order", "with_rate_value", "rate_value=0.05 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_third_order::with_stock_price
-	//   rationale: stock_price=150 optional Greeks-input wiring
+	//   rationale: stock_price=150.0 optional Greeks-input wiring
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "570", "C", WithStockPrice(150.0)); return goRowCount(v), e })
-		records = classify("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_snapshot_greeks_third_order", "with_stock_price", "professional", "stock_price=150.0 optional Greeks-input wiring", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_snapshot_greeks_third_order", "with_stock_price", "stock_price=150 optional Greeks-input wiring", &skip, records)
+		records = recordAborted("option_snapshot_greeks_third_order", "with_stock_price", "stock_price=150.0 optional Greeks-input wiring", &skip, records)
 	}
 	// option_snapshot_greeks_third_order::with_version
 	//   rationale: version=dg3 optional Greeks-version selector wiring
@@ -1531,52 +1267,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_eod::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "20250321", "570", "C", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_eod::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "concrete_iso", "free", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_eod", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_eod", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_eod::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "20250321", "*", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "all_strikes_one_exp", "free", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_eod", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_eod::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "*", "570", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "all_exps_one_strike", "free", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "all_exps_one_strike", "free", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_eod", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_eod::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "*", "*", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_eod", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_eod::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryEOD("SPY", "0", "0", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_eod", "legacy_zero_wildcard", "free", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_eod", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_eod", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_eod::with_max_dte
 	//   rationale: max_dte=30 optional filter wiring
@@ -1604,28 +1324,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_ohlc::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_ohlc::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_ohlc", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_ohlc", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_ohlc::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOHLC("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_ohlc", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_ohlc", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_ohlc::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -1661,52 +1373,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_trade::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_trade::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_trade", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_trade::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_trade::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_trade::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_trade::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTrade("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_trade", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_trade::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -1750,52 +1446,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_quote::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_quote::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_quote", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_quote", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_quote::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_quote", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_quote::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "*", "570", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_quote", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_quote::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "*", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_quote::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryQuote("SPY", "0", "0", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_quote", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_quote::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -1839,52 +1519,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_trade_quote::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_trade_quote::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_quote", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_trade_quote", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_trade_quote::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_quote", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_trade_quote::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_quote", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_trade_quote::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_trade_quote::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeQuote("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_quote", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_quote", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_trade_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_trade_quote::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -1936,52 +1600,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_open_interest::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_open_interest::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_open_interest", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_open_interest", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_open_interest::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_open_interest", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_open_interest::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_open_interest", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_open_interest::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_open_interest", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_open_interest::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryOpenInterest("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_open_interest", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_open_interest", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_open_interest", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_open_interest::with_date_range
 	//   rationale: start_date + end_date pair — date range optional wiring
@@ -2017,52 +1665,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_greeks_eod::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "570", "C", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_greeks_eod::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "2025-03-21", "570", "C", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_greeks_eod", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_greeks_eod::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "*", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_greeks_eod::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "*", "570", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_greeks_eod::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "*", "*", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_eod", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_greeks_eod::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksEOD("SPY", "0", "0", "both", "20250303", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_greeks_eod", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_greeks_eod", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_greeks_eod", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_greeks_eod::with_annual_dividend
 	//   rationale: annual_dividend=0.015 optional Greeks-input wiring
@@ -2130,28 +1762,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_greeks_all::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_greeks_all::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_greeks_all", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_greeks_all", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_greeks_all::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_all", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_greeks_all", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_greeks_all::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -2219,52 +1843,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_trade_greeks_all::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_trade_greeks_all::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_all", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_trade_greeks_all::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_trade_greeks_all::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_trade_greeks_all::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_all", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_trade_greeks_all::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksAll("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_all", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_all", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_trade_greeks_all", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_trade_greeks_all::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -2340,28 +1948,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_greeks_first_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_greeks_first_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_greeks_first_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_greeks_first_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_first_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_greeks_first_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_greeks_first_order::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -2429,52 +2029,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_trade_greeks_first_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_trade_greeks_first_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_trade_greeks_first_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_trade_greeks_first_order::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_trade_greeks_first_order::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_trade_greeks_first_order::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_first_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_trade_greeks_first_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_trade_greeks_first_order::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -2550,28 +2134,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_greeks_second_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_greeks_second_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_greeks_second_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_greeks_second_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_second_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_greeks_second_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_greeks_second_order::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -2639,52 +2215,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_trade_greeks_second_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_trade_greeks_second_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_trade_greeks_second_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_trade_greeks_second_order::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_trade_greeks_second_order::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_trade_greeks_second_order::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_second_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_trade_greeks_second_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_trade_greeks_second_order::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -2760,28 +2320,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_greeks_third_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_greeks_third_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_greeks_third_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_greeks_third_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_third_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_greeks_third_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_greeks_third_order::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -2849,52 +2401,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_trade_greeks_third_order::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_trade_greeks_third_order::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_trade_greeks_third_order::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_trade_greeks_third_order::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_trade_greeks_third_order::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_trade_greeks_third_order::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_third_order", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_trade_greeks_third_order", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_trade_greeks_third_order::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -2970,28 +2506,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_greeks_implied_volatility::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_greeks_implied_volatility::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "2025-03-21", "570", "C", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_greeks_implied_volatility::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "*", "both", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_greeks_implied_volatility", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_greeks_implied_volatility", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_greeks_implied_volatility::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -3059,52 +2587,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_history_trade_greeks_implied_volatility::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_history_trade_greeks_implied_volatility::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "2025-03-21", "570", "C", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "concrete_iso", "professional", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_history_trade_greeks_implied_volatility::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_history_trade_greeks_implied_volatility::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "*", "570", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_history_trade_greeks_implied_volatility::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "*", "*", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_history_trade_greeks_implied_volatility::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "0", "0", "both", "20250303"); return goRowCount(v), e })
-		records = classify("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "professional", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_history_trade_greeks_implied_volatility", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_history_trade_greeks_implied_volatility", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_history_trade_greeks_implied_volatility::with_intraday_window
 	//   rationale: start_time + end_time pair — intraday window optional wiring
@@ -3180,52 +2692,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_at_time_trade::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_at_time_trade::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "concrete_iso", "standard", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_at_time_trade", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_at_time_trade", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_at_time_trade::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_at_time_trade", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_at_time_trade::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_at_time_trade", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_at_time_trade::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_trade", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_at_time_trade::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeTrade("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_trade", "legacy_zero_wildcard", "standard", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_at_time_trade", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_at_time_trade", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_at_time_trade::with_max_dte
 	//   rationale: max_dte=30 optional filter wiring
@@ -3253,52 +2749,36 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// option_at_time_quote::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: concrete_iso)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
-	}
-	// option_at_time_quote::concrete_iso
-	//   rationale: expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "2025-03-21", "570", "C", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "concrete_iso", "value", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_at_time_quote", "concrete_iso", "expiration in YYYY-MM-DD form — tests ISO-date canonicalization to YYYYMMDD", &skip, records)
+		records = recordAborted("option_at_time_quote", "concrete", "required params set, no optionals — baseline wire path (also covers: concrete_iso)", &skip, records)
 	}
 	// option_at_time_quote::all_strikes_one_exp
-	//   rationale: strike=* on a supported endpoint — exercises strike wildcard wire-unset
+	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "all_strikes_one_exp", "strike=* on a supported endpoint — exercises strike wildcard wire-unset", &skip, records)
+		records = recordAborted("option_at_time_quote", "all_strikes_one_exp", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", &skip, records)
 	}
 	// option_at_time_quote::all_exps_one_strike
-	//   rationale: expiration=* — exercises expiration wildcard wire-unset
+	//   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — exercises expiration wildcard wire-unset", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "all_exps_one_strike", "expiration=* — exercises expiration wildcard wire-unset", &skip, records)
+		records = recordAborted("option_at_time_quote", "all_exps_one_strike", "expiration=* — sent as literal `*` on the wire (server fan-out)", &skip, records)
 	}
 	// option_at_time_quote::bulk_chain
-	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
+	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("option_at_time_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode", &skip, records)
-	}
-	// option_at_time_quote::legacy_zero_wildcard
-	//   rationale: expiration=0 + strike=0 → translated to * on wire — backward compat
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.OptionAtTimeQuote("SPY", "0", "0", "both", "20250303", "20250303", "12:00:00.000"); return goRowCount(v), e })
-		records = classify("option_at_time_quote", "legacy_zero_wildcard", "value", "expiration=0 + strike=0 → translated to * on wire — backward compat", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("option_at_time_quote", "legacy_zero_wildcard", "expiration=0 + strike=0 → translated to * on wire — backward compat", &skip, records)
+		records = recordAborted("option_at_time_quote", "bulk_chain", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", &skip, records)
 	}
 	// option_at_time_quote::with_max_dte
 	//   rationale: max_dte=30 optional filter wiring
@@ -3499,36 +2979,20 @@ func ValidateAllEndpoints(c *Client) (int, int, int, bool, []CellRecord) {
 	}
 
 	// stock_history_ohlc_range::concrete
-	//   rationale: required params set, no optionals — baseline wire path
+	//   rationale: required params set, no optionals — baseline wire path (also covers: with_venue)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLCRange("AAPL", "20250303", "20250303", "60000"); return goRowCount(v), e })
-		records = classify("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path (also covers: with_venue)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc_range", "concrete", "required params set, no optionals — baseline wire path", &skip, records)
+		records = recordAborted("stock_history_ohlc_range", "concrete", "required params set, no optionals — baseline wire path (also covers: with_venue)", &skip, records)
 	}
 	// stock_history_ohlc_range::with_intraday_window
-	//   rationale: start_time + end_time pair — intraday window optional wiring
+	//   rationale: start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)
 	if !hadTimeout {
 		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLCRange("AAPL", "20250303", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
+		records = classify("stock_history_ohlc_range", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)", r, &pass, &skip, &fail, &hadTimeout, records)
 	} else {
-		records = recordAborted("stock_history_ohlc_range", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring", &skip, records)
-	}
-	// stock_history_ohlc_range::with_venue
-	//   rationale: venue=nqb optional venue selector wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLCRange("AAPL", "20250303", "20250303", "60000", WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc_range", "with_venue", "value", "venue=nqb optional venue selector wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_history_ohlc_range", "with_venue", "venue=nqb optional venue selector wiring", &skip, records)
-	}
-	// stock_history_ohlc_range::all_optionals
-	//   rationale: every applicable optional set at once — proves multi-optional wiring
-	if !hadTimeout {
-		r = runWithTimeout(func() (int, error) { v, e := c.StockHistoryOHLCRange("AAPL", "20250303", "20250303", "60000", WithStartTime("09:30:00"), WithEndTime("10:00:00"), WithVenue("nqb")); return goRowCount(v), e })
-		records = classify("stock_history_ohlc_range", "all_optionals", "value", "every applicable optional set at once — proves multi-optional wiring", r, &pass, &skip, &fail, &hadTimeout, records)
-	} else {
-		records = recordAborted("stock_history_ohlc_range", "all_optionals", "every applicable optional set at once — proves multi-optional wiring", &skip, records)
+		records = recordAborted("stock_history_ohlc_range", "with_intraday_window", "start_time + end_time pair — intraday window optional wiring (also covers: all_optionals)", &skip, records)
 	}
 
 	return pass, skip, fail, hadTimeout, records
@@ -3583,7 +3047,10 @@ func classify(endpoint, mode, declaredMinTier, rationale string, r cellResult, p
 	fmt.Printf("  %-60s FAIL  %v\n", label, r.err)
 	*fail++
 	rec.Status = "FAIL"
-	detail := r.err.Error()
+	// gRPC / transport errors can contain embedded newlines; escape them
+	// so the agreement-table row stays single-line.
+	detail := strings.ReplaceAll(r.err.Error(), "\n", "\\n")
+	detail = strings.ReplaceAll(detail, "\r", "\\r")
 	if len(detail) > 200 {
 		detail = detail[:200]
 	}


### PR DESCRIPTION
## Summary

Adds a `rationale: &'static str` field to `TestMode` so every live-validator cell carries a one-sentence description of what it proves. The rationale surfaces in three places:

- inline `# rationale: …` comment in each generated validator (Python / CLI / Go / C++)
- `rationale` field on every record in the per-cell JSON artifact
- header line in `scripts/validate_agreement.py` disagreement output

Also performs a **post-canonicalization** wire-shape redundancy audit: `collapse_redundant_wires` mirrors the runtime's three rewrite rules (`expiration: 0 → *` / ISO-dashed → compact; `strike: 0/*/"" → proto-unset`; `right: */both → proto-unset` — see `crates/thetadatadx/src/direct.rs:84/100/118`) and synthesizes the stock-endpoint `venue=nqb` default from `render/direct.rs:433`. Two cells with equal canonical signatures marshal byte-identical proto bytes, so keeping both adds only redundant runtime cost.

Cells whose proto wire genuinely differs are still preserved even when their rationale overlaps conceptually. Siblings collapsed by the audit are folded into the kept cell's rationale as `(also covers: …)` — no silent deletion.

## Cell counts (Python/Go/C++, before → after)

| Category | Baseline (main) | Post-audit |
| --- | --- | --- |
| `option_history_*` | 204 | 176 |
| `option_snapshot_*` | 126 | 107 |
| `stock_history_*` | 26 | 20 |
| `option_at_time_*` | 18 | 14 |
| `stock_snapshot_*` | 16 | 8 |
| `index_history_*` | 8 | 7 |
| `option_list_*` | 7 | 6 |
| `index_snapshot_*` | 9 | 6 |
| `stock_at_time_*` | 6 | 2 |
| lists + `calendar_*` + `interest_rate_*` + `index_at_*` | 9 | 9 |
| **Total (Python / Go / C++)** | **429** | **355** |
| **Total (CLI, no builder overrides)** | **185** | **134** |

Representative collapses:
- `bulk_chain` absorbs `legacy_zero_wildcard` on every option_snapshot/history endpoint (`0`/`*` both normalize to the same wire).
- `concrete` absorbs `with_venue` + `all_optionals` on every stock_at_time endpoint (runtime defaults `venue=nqb`).
- `all_strikes_one_exp` absorbs `with_strike_range` on many option endpoints whose strike_range fixture coincides with a proto-unset strike.

## Sample rationale emission (`scripts/validate_python.py`)

```python
# option_snapshot_trade::bulk_chain
#   rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
("option_snapshot_trade", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)", lambda: client.option_snapshot_trade("SPY", "*", "*", "both")),

# option_snapshot_ohlc::all_exps_one_strike
#   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_ohlc("SPY", "*", "570", "both")),
```

## Sample agreement-script failure output (synthetic)

```
DISAGREEMENTS:
  option_snapshot_trade::bulk_chain  [row-count disagreement]
    rationale: expiration=* + strike=* + right=both — tests full-chain server mode (also covers: legacy_zero_wildcard)
    sdk      | status | rows  | detail
    go       | PASS   | 1999  |
    python   | PASS   | 2000  |
  option_snapshot_trade::with_max_dte  [status disagreement]
    rationale: max_dte=30 optional filter wiring
    sdk      | status | rows  | detail
    go       | FAIL   | 0     | unknown field max_dte
    python   | PASS   | 42    |
```

## Round-2 fixes (in response to round-1)

- **[important]** wire-signature was raw call-site before; now post-canonicalization (matches `direct.rs:84/100/118` + `render/direct.rs:433`). Collapse count grew 7 → 67.
- **[minor]** rationale strings corrected to match wire semantics (`all_exps_one_strike` = literal `*`; `legacy_zero_wildcard` = proto-unset fold; `all_strikes_one_exp` = proto-unset).
- **[minor]** `with_<name>` rationale now takes the literal directly from `optional_fixture_value` so `stock_price=150.0` / `max_dte=30` / etc. can never drift from the fixture table.
- **[minor]** `detail` field is single-line by construction — producers in all four SDKs escape embedded `\n` / `\r`. Template CI now hosts these as regular template Python/Go/C++.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check` (regenerated artifacts match)
- [x] `python3 -c "import ast; ast.parse(open('scripts/validate_python.py').read())"` (and `validate_cli.py`, `validate_agreement.py`)
- [x] `go build ./...` + `go test ./...` in `sdks/go`
- [x] C++ `thetadatadx_validate` builds cleanly via cmake (clean build)
- [x] Synthetic agreement run with injected multi-line `\n`-embedded `detail` preserves row alignment (escapes work end-to-end)

