### PR TITLE
fix(ci): unbreak main — timeout_ms TOML + CRLF-robust pin test

### DIFF
--- a/crates/thetadatadx/build_support/endpoints/model.rs
+++ b/crates/thetadatadx/build_support/endpoints/model.rs
@@ -23,6 +23,27 @@ pub(super) struct SurfaceSpec {
     pub(super) templates: HashMap<String, SurfaceTemplate>,
     pub(super) endpoints: Vec<SurfaceEndpoint>,
     pub(super) test_fixtures: SurfaceTestFixtures,
+    /// Global request-level options that appear on every endpoint via
+    /// `TdxEndpointRequestOptions`. Declared here so the FFI struct layout
+    /// stays in lock-step with the TOML (see scripts/check_docs_consistency.py).
+    /// Not consumed by the Rust generator today — only by the docs-consistency
+    /// drift check — but codified in the surface so future generator passes
+    /// can read from here rather than hardcoding timeout_ms.
+    #[serde(default)]
+    pub(super) request_options_global: Vec<SurfaceGlobalRequestOption>,
+}
+
+/// A cross-cutting request-level option (e.g. `timeout_ms`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct SurfaceGlobalRequestOption {
+    #[allow(dead_code)]
+    pub(super) name: String,
+    #[allow(dead_code)]
+    pub(super) description: String,
+    #[allow(dead_code)]
+    #[serde(rename = "type")]
+    pub(super) ty: String,
 }
 
 /// Representative fixture values feeding the live-validator parameter-mode

--- a/crates/thetadatadx/endpoint_surface.toml
+++ b/crates/thetadatadx/endpoint_surface.toml
@@ -8,6 +8,19 @@
 
 version = 2
 
+# Global request-level options attached to every endpoint via
+# `TdxEndpointRequestOptions` (FFI) / `EndpointOption` (Go) /
+# `with_timeout_ms` (Rust/Python/C++). These are NOT per-endpoint
+# builder params — they apply uniformly across the surface — but the
+# FFI struct layout still needs to mirror this list, so we declare
+# them here as the single source of truth. `scripts/check_docs_consistency.py`
+# enforces the drift check.
+
+[[request_options_global]]
+name = "timeout_ms"
+description = "Per-request deadline in milliseconds. 0 means no deadline."
+type = "u64"
+
 # Reusable parameter groups.
 
 [param_groups.request_type]

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -32,6 +32,15 @@ BUILDER_PARAMS = {
     if param.get("binding") == "builder"
 }
 
+# Global request-level options (not per-endpoint builder params, but still
+# required fields on `TdxEndpointRequestOptions` / `EndpointRequestOptions`
+# so the FFI struct layout must include them).
+GLOBAL_REQUEST_OPTIONS = {opt["name"] for opt in SURFACE.get("request_options_global", [])}
+
+# All fields the request-options structs must expose (per-endpoint builders +
+# cross-cutting globals). Drift in either direction is a bug.
+ALL_OPTION_FIELDS = BUILDER_PARAMS | GLOBAL_REQUEST_OPTIONS
+
 
 def endpoint_kind(endpoint: dict) -> str:
     kind = endpoint.get("kind")
@@ -304,9 +313,9 @@ def check_endpoint_option_surface() -> None:
     )
     # Exclude has_* sentinel flags (FFI implementation detail, not builder params)
     rust_fields = {f for f in rust_fields if not f.startswith("has_")}
-    if rust_fields != BUILDER_PARAMS:
-        missing = sorted(BUILDER_PARAMS - rust_fields)
-        extra = sorted(rust_fields - BUILDER_PARAMS)
+    if rust_fields != ALL_OPTION_FIELDS:
+        missing = sorted(ALL_OPTION_FIELDS - rust_fields)
+        extra = sorted(rust_fields - ALL_OPTION_FIELDS)
         fail(
             "ffi/src/endpoint_request_options.rs endpoint option fields drifted from endpoint_surface.toml. "
             f"missing={missing or '[]'} extra={extra or '[]'}"
@@ -319,13 +328,13 @@ def check_endpoint_option_surface() -> None:
         c_fields = extract_struct_fields(
             path,
             r"typedef struct \{(.*?)\n\}\s*TdxEndpointRequestOptions;",
-            r"^\s*(?:const char\*|int32_t|double)\s+([a-z_]+);",
+            r"^\s*(?:const char\*|int32_t|double|uint64_t)\s+([a-z_]+);",
         )
         # Exclude has_* sentinel flags (FFI implementation detail, not builder params)
         c_fields = {f for f in c_fields if not f.startswith("has_")}
-        if c_fields != BUILDER_PARAMS:
-            missing = sorted(BUILDER_PARAMS - c_fields)
-            extra = sorted(c_fields - BUILDER_PARAMS)
+        if c_fields != ALL_OPTION_FIELDS:
+            missing = sorted(ALL_OPTION_FIELDS - c_fields)
+            extra = sorted(c_fields - ALL_OPTION_FIELDS)
             fail(
                 f"{path.relative_to(ROOT)} endpoint option fields drifted from endpoint_surface.toml. "
                 f"missing={missing or '[]'} extra={extra or '[]'}"
@@ -336,7 +345,7 @@ def check_endpoint_option_surface() -> None:
         r"type EndpointRequestOptions struct \{(.*?)\n\}",
         r"^\s*([A-Z][A-Za-z0-9]+)\s+\*",
     )
-    expected_go_fields = {snake_to_go(name) for name in BUILDER_PARAMS}
+    expected_go_fields = {snake_to_go(name) for name in ALL_OPTION_FIELDS}
     if go_fields != expected_go_fields:
         missing = sorted(expected_go_fields - go_fields)
         extra = sorted(go_fields - expected_go_fields)
@@ -350,9 +359,9 @@ def check_endpoint_option_surface() -> None:
         r"struct EndpointRequestOptions \{(.*?)\n\};",
         r"^\s*std::optional<[^>]+>\s+([a-z_]+);",
     )
-    if cpp_fields != BUILDER_PARAMS:
-        missing = sorted(BUILDER_PARAMS - cpp_fields)
-        extra = sorted(cpp_fields - BUILDER_PARAMS)
+    if cpp_fields != ALL_OPTION_FIELDS:
+        missing = sorted(ALL_OPTION_FIELDS - cpp_fields)
+        extra = sorted(cpp_fields - ALL_OPTION_FIELDS)
         fail(
             "sdks/cpp/include/endpoint_options.hpp.inc EndpointRequestOptions fields drifted from endpoint_surface.toml. "
             f"missing={missing or '[]'} extra={extra or '[]'}"

--- a/sdks/go/timeout_pin_test.go
+++ b/sdks/go/timeout_pin_test.go
@@ -108,7 +108,15 @@ func TestEveryFFIErrorReaderPinsOSThread(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", fname, err)
 		}
-		lines := strings.Split(string(data), "\n")
+		// Strip trailing CR so the HasSuffix check works on Windows
+		// checkouts that use CRLF line endings. Handwritten .go files
+		// without an `eol=lf` rule in .gitattributes land with \r\n on
+		// Windows CI runners, which silently broke the count before.
+		rawLines := strings.Split(string(data), "\n")
+		lines := make([]string, len(rawLines))
+		for idx, l := range rawLines {
+			lines[idx] = strings.TrimRight(l, "\r")
+		}
 		for i, line := range lines {
 			if !strings.HasPrefix(line, "func ") || !strings.HasSuffix(line, "{") {
 				continue


### PR DESCRIPTION
## Summary

Two CI failures landed on main after #298 was merged. Hotfix for both, preserving SSOT direction.

### Failure 1: Extended Surfaces (Linux)
```
docs consistency error: ffi/src/endpoint_request_options.rs endpoint option fields drifted from endpoint_surface.toml. missing=[] extra=['timeout_ms']
```
W3 added `timeout_ms` to the FFI struct but not to `endpoint_surface.toml`. The drift check compared FFI struct fields against `BUILDER_PARAMS` only.

**Fix**: new `[[request_options_global]]` TOML section. `check_docs_consistency.py` combines `BUILDER_PARAMS | GLOBAL_REQUEST_OPTIONS`. `SurfaceSpec` parses the new section so `deny_unknown_fields` passes. Generator doesn't consume the new field yet — future W7 pass will wire it.

### Failure 2: SDK Bindings (windows-latest)
```
TLS-pinned-method count changed: got 83, want exactly 88
```
Handwritten `client.go`, `thetadx.go`, `fpss.go` lack `eol=lf` in `.gitattributes`. Windows CI checks out CRLF. The test used `strings.HasSuffix(line, "{")` against lines ending in `\r`, silently skipping 5 pinned methods (1 in client.go, 3 in thetadx.go, 1 in fpss.go). 88−5=83.

**Fix**: strip trailing `\r` before the prefix/suffix checks. Test is now line-ending agnostic.

## Test plan
- [x] `cargo fmt --all -- --check` green
- [x] `cargo clippy --workspace --locked -- -D warnings` green
- [x] `cargo test --workspace --locked` green
- [x] `generate_sdk_surfaces --check` no drift
- [x] `TestEveryFFIErrorReaderPinsOSThread` passes on Linux (88 methods)
- [ ] Windows CI verifies the CRLF fix
- [ ] Extended Surfaces verifies the TOML drift fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)