### PR TITLE
fix: correctness + SSOT cleanups (grpc status parse, FFI null, Go error-check unification)

### DIFF
--- a/crates/tdbe/src/errors.rs
+++ b/crates/tdbe/src/errors.rs
@@ -92,27 +92,8 @@ pub fn error_from_http_code(code: u16) -> Option<&'static ThetaDataError> {
     ERRORS.iter().find(|e| e.http_code == code)
 }
 
-/// Extract an `http_status_code` from gRPC metadata text and look it up.
-///
-/// The metadata string is expected to contain `http_status_code=NNN` or just
-/// the numeric code itself. Returns `None` if no valid code is found or the
-/// code is not in the known error table.
-#[must_use]
-pub fn error_from_grpc_metadata(metadata: &str) -> Option<&'static ThetaDataError> {
-    // Try "http_status_code=NNN" first.
-    if let Some(pos) = metadata.find("http_status_code=") {
-        let after = &metadata[pos + "http_status_code=".len()..];
-        let num_str: String = after.chars().take_while(char::is_ascii_digit).collect();
-        if let Ok(code) = num_str.parse::<u16>() {
-            return error_from_http_code(code);
-        }
-    }
-    // Fallback: try parsing the whole string as a number.
-    if let Ok(code) = metadata.trim().parse::<u16>() {
-        return error_from_http_code(code);
-    }
-    None
-}
+/// Metadata key carrying the ThetaData HTTP status in gRPC responses.
+pub const HTTP_STATUS_CODE_KEY: &str = "http_status_code";
 
 /// Human-readable error name for an HTTP status code, or `"UNKNOWN"`.
 #[inline]
@@ -137,32 +118,6 @@ mod tests {
     fn unknown_code() {
         assert!(error_from_http_code(999).is_none());
         assert!(error_from_http_code(500).is_none());
-    }
-
-    #[test]
-    fn grpc_metadata_key_value() {
-        let meta = "http_status_code=473";
-        let err = error_from_grpc_metadata(meta).unwrap();
-        assert_eq!(err.name, "INVALID_PARAMS");
-    }
-
-    #[test]
-    fn grpc_metadata_embedded() {
-        let meta = "some_prefix http_status_code=476 some_suffix";
-        let err = error_from_grpc_metadata(meta).unwrap();
-        assert_eq!(err.name, "WRONG_IP");
-    }
-
-    #[test]
-    fn grpc_metadata_bare_number() {
-        let err = error_from_grpc_metadata("471").unwrap();
-        assert_eq!(err.name, "PERMISSION");
-    }
-
-    #[test]
-    fn grpc_metadata_unknown() {
-        assert!(error_from_grpc_metadata("garbage").is_none());
-        assert!(error_from_grpc_metadata("http_status_code=999").is_none());
     }
 
     #[test]

--- a/crates/tdbe/src/types/price.rs
+++ b/crates/tdbe/src/types/price.rs
@@ -56,10 +56,6 @@ impl Price {
     #[inline]
     #[must_use]
     pub fn new(value: i32, price_type: i32) -> Self {
-        debug_assert!(
-            (0..20).contains(&price_type),
-            "price_type must be 0..20, got {price_type}"
-        );
         Self {
             value,
             price_type: price_type.clamp(0, 19),

--- a/crates/thetadatadx/build_support/endpoints/helpers.rs
+++ b/crates/thetadatadx/build_support/endpoints/helpers.rs
@@ -424,22 +424,26 @@ pub(super) fn ffi_output_variant(return_type: &str) -> &'static str {
     }
 }
 
-pub(super) fn ffi_from_vec_expr(return_type: &str) -> &'static str {
+/// Returns the `#[repr(C)]` array type name for the given `EndpointOutput`
+/// variant (e.g. `TdxEodTickArray`). The emitter wraps `<type>::from_vec(...)`
+/// — which returns `Result<Self, NulError>` — in an inline match that routes
+/// interior-NUL failures through the FFI error slot.
+pub(super) fn ffi_from_vec_array_type(return_type: &str) -> &'static str {
     match return_type {
-        "StringList" => "TdxStringArray::from_vec(values)",
-        "EodTicks" => "TdxEodTickArray::from_vec(values)",
-        "OhlcTicks" => "TdxOhlcTickArray::from_vec(values)",
-        "TradeTicks" => "TdxTradeTickArray::from_vec(values)",
-        "QuoteTicks" => "TdxQuoteTickArray::from_vec(values)",
-        "TradeQuoteTicks" => "TdxTradeQuoteTickArray::from_vec(values)",
-        "OpenInterestTicks" => "TdxOpenInterestTickArray::from_vec(values)",
-        "MarketValueTicks" => "TdxMarketValueTickArray::from_vec(values)",
-        "GreeksTicks" => "TdxGreeksTickArray::from_vec(values)",
-        "IvTicks" => "TdxIvTickArray::from_vec(values)",
-        "PriceTicks" => "TdxPriceTickArray::from_vec(values)",
-        "CalendarDays" => "TdxCalendarDayArray::from_vec(values)",
-        "InterestRateTicks" => "TdxInterestRateTickArray::from_vec(values)",
-        "OptionContracts" => "TdxOptionContractArray::from_vec(values)",
+        "StringList" => "TdxStringArray",
+        "OptionContracts" => "TdxOptionContractArray",
+        "EodTicks" => "TdxEodTickArray",
+        "OhlcTicks" => "TdxOhlcTickArray",
+        "TradeTicks" => "TdxTradeTickArray",
+        "QuoteTicks" => "TdxQuoteTickArray",
+        "TradeQuoteTicks" => "TdxTradeQuoteTickArray",
+        "OpenInterestTicks" => "TdxOpenInterestTickArray",
+        "MarketValueTicks" => "TdxMarketValueTickArray",
+        "GreeksTicks" => "TdxGreeksTickArray",
+        "IvTicks" => "TdxIvTickArray",
+        "PriceTicks" => "TdxPriceTickArray",
+        "CalendarDays" => "TdxCalendarDayArray",
+        "InterestRateTicks" => "TdxInterestRateTickArray",
         other => panic!("unsupported FFI from_vec return type: {other}"),
     }
 }

--- a/crates/thetadatadx/build_support/endpoints/model.rs
+++ b/crates/thetadatadx/build_support/endpoints/model.rs
@@ -34,14 +34,16 @@ pub(super) struct SurfaceSpec {
 }
 
 /// A cross-cutting request-level option (e.g. `timeout_ms`).
+///
+/// Schema-validation-only: fields exist to enforce the TOML shape via serde
+/// (`deny_unknown_fields` + required keys) but are not read by the Rust
+/// generator today. The docs-consistency drift check uses the raw TOML.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[allow(dead_code)]
 pub(super) struct SurfaceGlobalRequestOption {
-    #[allow(dead_code)]
     pub(super) name: String,
-    #[allow(dead_code)]
     pub(super) description: String,
-    #[allow(dead_code)]
     #[serde(rename = "type")]
     pub(super) ty: String,
 }

--- a/crates/thetadatadx/build_support/endpoints/render/ffi.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/ffi.rs
@@ -10,7 +10,7 @@
 use std::fmt::Write as _;
 
 use super::super::helpers::{
-    c_option_value_type, ffi_array_type, ffi_from_vec_expr, ffi_option_has_flag,
+    c_option_value_type, ffi_array_type, ffi_from_vec_array_type, ffi_option_has_flag,
     ffi_option_insert_expr, ffi_option_value_type, ffi_output_variant, is_streaming_endpoint,
     method_params,
 };
@@ -118,7 +118,7 @@ fn render_ffi_with_options_endpoint(endpoint: &GeneratedEndpoint) -> String {
     let method_params = method_params(endpoint);
     let array_type = ffi_array_type(&endpoint.return_type);
     let output_variant = ffi_output_variant(&endpoint.return_type);
-    let from_vec_expr = ffi_from_vec_expr(&endpoint.return_type);
+    let from_vec_type = ffi_from_vec_array_type(&endpoint.return_type);
     let mut out = String::new();
 
     writeln!(
@@ -183,10 +183,16 @@ fn render_ffi_with_options_endpoint(endpoint: &GeneratedEndpoint) -> String {
     out.push_str("    }) {\n");
     writeln!(
         out,
-        "        Ok(thetadatadx::EndpointOutput::{}(values)) => {},",
-        output_variant, from_vec_expr
+        "        Ok(thetadatadx::EndpointOutput::{}(values)) => match {}::from_vec(values) {{",
+        output_variant, from_vec_type
     )
     .unwrap();
+    out.push_str("            Ok(arr) => arr,\n");
+    out.push_str("            Err(e) => {\n");
+    out.push_str("                set_error(&format!(\"interior NUL in server string: {e}\"));\n");
+    out.push_str("                empty\n");
+    out.push_str("            }\n");
+    out.push_str("        },\n");
     out.push_str("        Ok(other) => {\n");
     writeln!(
         out,

--- a/crates/thetadatadx/build_support/endpoints/render/go.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/go.rs
@@ -274,7 +274,7 @@ fn render_go_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
     // or a failure (e.g. timeout). Consult the error slot directly.
     writeln!(
         out,
-        "\tif e := lastErrorRaw(); e != \"\" {{\n\t\t{}(arr)\n\t\treturn nil, fmt.Errorf(\"thetadatadx: %s\", e)\n\t}}",
+        "\tif e := lastError(); e != \"\" {{\n\t\t{}(arr)\n\t\treturn nil, fmt.Errorf(\"thetadatadx: %s\", e)\n\t}}",
         ffi_free_fn(&endpoint.return_type)
     )
     .unwrap();

--- a/crates/thetadatadx/src/auth/mod.rs
+++ b/crates/thetadatadx/src/auth/mod.rs
@@ -8,7 +8,7 @@
 //! # Auth flow (from decompiled Java — `AuthenticationManager`)
 //!
 //! ```text
-//! creds.txt --> Credentials --> nexus::authenticate() --> SessionToken
+//! creds.txt --> Credentials --> nexus::authenticate() --> AuthResponse.session_id
 //!                                                           |
 //!                         +---------------------------------+
 //!                         |
@@ -20,4 +20,4 @@ pub mod creds;
 pub mod nexus;
 
 pub use creds::Credentials;
-pub use nexus::{authenticate, AuthResponse, AuthUser, SessionToken};
+pub use nexus::{authenticate, AuthResponse, AuthUser};

--- a/crates/thetadatadx/src/auth/nexus.rs
+++ b/crates/thetadatadx/src/auth/nexus.rs
@@ -286,32 +286,6 @@ pub async fn authenticate(creds: &Credentials) -> Result<AuthResponse, Error> {
     Ok(auth)
 }
 
-/// The session UUID parsed from an `AuthResponse`.
-///
-/// Thin wrapper to ensure the UUID was validated at parse time.
-#[derive(Debug, Clone)]
-pub struct SessionToken {
-    /// The raw UUID string, as returned by the Nexus API.
-    pub session_uuid: String,
-}
-
-impl SessionToken {
-    /// Extract and validate the session token from an auth response.
-    /// # Errors
-    ///
-    /// Returns an error on network, authentication, or parsing failure.
-    pub fn from_response(resp: &AuthResponse) -> Result<Self, Error> {
-        let _uuid = Uuid::parse_str(&resp.session_id).map_err(|e| Error::Auth {
-            kind: crate::error::AuthErrorKind::ServerError,
-            message: format!("invalid session UUID '{}': {e}", resp.session_id),
-        })?;
-
-        Ok(Self {
-            session_uuid: resp.session_id.clone(),
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -320,27 +294,5 @@ mod tests {
     fn terminal_key_is_valid_uuid() {
         // Sanity check: the hardcoded terminal key should be a valid UUID.
         Uuid::parse_str(TERMINAL_KEY).expect("TERMINAL_KEY must be a valid UUID");
-    }
-
-    #[test]
-    fn session_token_from_valid_response() {
-        let resp = AuthResponse {
-            session_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
-            user: None,
-            session_created: None,
-        };
-        let token = SessionToken::from_response(&resp).unwrap();
-        assert_eq!(token.session_uuid, resp.session_id);
-    }
-
-    #[test]
-    fn session_token_rejects_garbage() {
-        let resp = AuthResponse {
-            session_id: "not-a-uuid".to_string(),
-            user: None,
-            session_created: None,
-        };
-        let err = SessionToken::from_response(&resp).unwrap_err();
-        assert!(err.to_string().contains("invalid session UUID"));
     }
 }

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -9,13 +9,13 @@
 //! # Architecture
 //!
 //! ```text
-//! Credentials --> nexus::authenticate() --> SessionToken
+//! Credentials --> nexus::authenticate() --> AuthResponse.session_id
 //!                                              |
 //!              +-------------------------------+
 //!              |
 //!       DirectClient
 //!        |-- mdds_stub: BetaThetaTerminalClient  (gRPC, historical data)
-//!        \-- session: SessionToken               (UUID in every QueryInfo)
+//!        \-- session_uuid: String                (UUID in every QueryInfo)
 //! ```
 //!
 //! Every MDDS request wraps parameters in a `QueryInfo` that carries the session
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use tokio_stream::StreamExt;
 
-use crate::auth::{self, Credentials, SessionToken};
+use crate::auth::{self, Credentials};
 use crate::config::DirectConfig;
 use crate::decode;
 use crate::error::Error;
@@ -132,8 +132,8 @@ macro_rules! contract_spec {
 /// # }
 /// ```
 pub struct DirectClient {
-    /// Session token from Nexus auth (UUID embedded in every request).
-    session: SessionToken,
+    /// Session UUID from Nexus auth (embedded in every request).
+    session_uuid: String,
     /// gRPC channel to MDDS server.
     channel: tonic::transport::Channel,
     /// Configuration snapshot (retained for diagnostics/reconnect).
@@ -169,10 +169,10 @@ impl DirectClient {
         // Step 1: Authenticate against Nexus API.
         tracing::info!(mdds = %config.mdds_uri(), "authenticating with Nexus API");
         let auth_resp = auth::authenticate(creds).await?;
-        let session = SessionToken::from_response(&auth_resp)?;
+        let session_uuid = auth_resp.session_id.clone();
 
         tracing::debug!(
-            session_id_prefix = %&session.session_uuid[..8.min(session.session_uuid.len())],
+            session_id_prefix = %&session_uuid[..8.min(session_uuid.len())],
             stock_tier = ?auth_resp.user.as_ref().and_then(|u| u.stock_subscription),
             "session established (session_id redacted)"
         );
@@ -209,7 +209,7 @@ impl DirectClient {
 
         let query_info_template = proto::QueryInfo {
             auth_token: Some(proto::AuthToken {
-                session_uuid: session.session_uuid.clone(),
+                session_uuid: session_uuid.clone(),
             }),
             query_parameters,
             client_type: CLIENT_TYPE.to_string(),
@@ -244,7 +244,7 @@ impl DirectClient {
         let options_tier = auth_resp.user.as_ref().and_then(|u| u.options_subscription);
 
         Ok(Self {
-            session,
+            session_uuid,
             channel,
             config,
             query_info_template,
@@ -378,7 +378,7 @@ impl DirectClient {
     /// Return the session UUID string.
     #[must_use]
     pub fn session_uuid(&self) -> &str {
-        &self.session.session_uuid
+        &self.session_uuid
     }
 
     /// Stock subscription tier from Nexus auth response (0=Free, 1=Value, 2=Standard, 3=Pro).

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -132,22 +132,22 @@ impl From<tonic::Status> for Error {
     fn from(s: tonic::Status) -> Self {
         // Extract http_status_code from gRPC metadata and enrich the error
         // message with the ThetaData error name when available.
-        let metadata_str = format!("{:?}", s.metadata());
-        if let Some(td_err) = tdbe::errors::error_from_grpc_metadata(&metadata_str) {
-            Self::Grpc {
-                status: format!("{:?}", s.code()),
-                message: format!(
-                    "{} (ThetaData: {} -- {})",
-                    s.message(),
-                    td_err.name,
-                    td_err.description
-                ),
-            }
-        } else {
-            Self::Grpc {
-                status: format!("{:?}", s.code()),
-                message: s.message().to_string(),
-            }
-        }
+        let td_err = s
+            .metadata()
+            .get(tdbe::errors::HTTP_STATUS_CODE_KEY)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u16>().ok())
+            .and_then(tdbe::errors::error_from_http_code);
+        let status = format!("{:?}", s.code());
+        let message = match td_err {
+            Some(td) => format!(
+                "{} (ThetaData: {} -- {})",
+                s.message(),
+                td.name,
+                td.description
+            ),
+            None => s.message().to_string(),
+        };
+        Self::Grpc { status, message }
     }
 }

--- a/ffi/src/endpoint_with_options.rs
+++ b/ffi/src/endpoint_with_options.rs
@@ -23,7 +23,13 @@ pub unsafe extern "C" fn tdx_stock_list_symbols_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_list_symbols", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::StringList(values)) => TdxStringArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::StringList(values)) => match TdxStringArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_list_symbols: {other:?}"));
             empty
@@ -84,7 +90,13 @@ pub unsafe extern "C" fn tdx_stock_list_dates_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_list_dates", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::StringList(values)) => TdxStringArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::StringList(values)) => match TdxStringArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_list_dates: {other:?}"));
             empty
@@ -129,7 +141,13 @@ pub unsafe extern "C" fn tdx_stock_snapshot_ohlc_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_snapshot_ohlc", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => TdxOhlcTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => match TdxOhlcTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_snapshot_ohlc: {other:?}"));
             empty
@@ -174,7 +192,13 @@ pub unsafe extern "C" fn tdx_stock_snapshot_trade_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_snapshot_trade", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => TdxTradeTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => match TdxTradeTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_snapshot_trade: {other:?}"));
             empty
@@ -219,7 +243,13 @@ pub unsafe extern "C" fn tdx_stock_snapshot_quote_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_snapshot_quote", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => TdxQuoteTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => match TdxQuoteTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_snapshot_quote: {other:?}"));
             empty
@@ -264,7 +294,13 @@ pub unsafe extern "C" fn tdx_stock_snapshot_market_value_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_snapshot_market_value", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::MarketValueTicks(values)) => TdxMarketValueTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::MarketValueTicks(values)) => match TdxMarketValueTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_snapshot_market_value: {other:?}"));
             empty
@@ -338,7 +374,13 @@ pub unsafe extern "C" fn tdx_stock_history_eod_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_history_eod", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::EodTicks(values)) => TdxEodTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::EodTicks(values)) => match TdxEodTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_history_eod: {other:?}"));
             empty
@@ -412,7 +454,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_history_ohlc", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => TdxOhlcTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => match TdxOhlcTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_history_ohlc: {other:?}"));
             empty
@@ -473,7 +521,13 @@ pub unsafe extern "C" fn tdx_stock_history_trade_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_history_trade", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => TdxTradeTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => match TdxTradeTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_history_trade: {other:?}"));
             empty
@@ -547,7 +601,13 @@ pub unsafe extern "C" fn tdx_stock_history_quote_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_history_quote", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => TdxQuoteTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => match TdxQuoteTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_history_quote: {other:?}"));
             empty
@@ -608,7 +668,13 @@ pub unsafe extern "C" fn tdx_stock_history_trade_quote_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_history_trade_quote", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::TradeQuoteTicks(values)) => TdxTradeQuoteTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::TradeQuoteTicks(values)) => match TdxTradeQuoteTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_history_trade_quote: {other:?}"));
             empty
@@ -695,7 +761,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_trade_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_at_time_trade", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => TdxTradeTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => match TdxTradeTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_at_time_trade: {other:?}"));
             empty
@@ -782,7 +854,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_quote_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_at_time_quote", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => TdxQuoteTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => match TdxQuoteTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_at_time_quote: {other:?}"));
             empty
@@ -817,7 +895,13 @@ pub unsafe extern "C" fn tdx_option_list_symbols_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_list_symbols", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::StringList(values)) => TdxStringArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::StringList(values)) => match TdxStringArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_list_symbols: {other:?}"));
             empty
@@ -917,7 +1001,13 @@ pub unsafe extern "C" fn tdx_option_list_dates_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_list_dates", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::StringList(values)) => TdxStringArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::StringList(values)) => match TdxStringArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_list_dates: {other:?}"));
             empty
@@ -965,7 +1055,13 @@ pub unsafe extern "C" fn tdx_option_list_expirations_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_list_expirations", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::StringList(values)) => TdxStringArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::StringList(values)) => match TdxStringArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_list_expirations: {other:?}"));
             empty
@@ -1026,7 +1122,13 @@ pub unsafe extern "C" fn tdx_option_list_strikes_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_list_strikes", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::StringList(values)) => TdxStringArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::StringList(values)) => match TdxStringArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_list_strikes: {other:?}"));
             empty
@@ -1100,7 +1202,13 @@ pub unsafe extern "C" fn tdx_option_list_contracts_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_list_contracts", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OptionContracts(values)) => TdxOptionContractArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OptionContracts(values)) => match TdxOptionContractArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_list_contracts: {other:?}"));
             empty
@@ -1187,7 +1295,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_ohlc_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_ohlc", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => TdxOhlcTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => match TdxOhlcTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_ohlc: {other:?}"));
             empty
@@ -1274,7 +1388,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_trade_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_trade", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => TdxTradeTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => match TdxTradeTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_trade: {other:?}"));
             empty
@@ -1361,7 +1481,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_quote_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_quote", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => TdxQuoteTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => match TdxQuoteTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_quote: {other:?}"));
             empty
@@ -1448,7 +1574,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_open_interest_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_open_interest", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OpenInterestTicks(values)) => TdxOpenInterestTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OpenInterestTicks(values)) => match TdxOpenInterestTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_open_interest: {other:?}"));
             empty
@@ -1535,7 +1667,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_market_value_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_market_value", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::MarketValueTicks(values)) => TdxMarketValueTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::MarketValueTicks(values)) => match TdxMarketValueTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_market_value: {other:?}"));
             empty
@@ -1622,7 +1760,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_implied_volatility_with_opti
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_greeks_implied_volatility", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::IvTicks(values)) => TdxIvTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::IvTicks(values)) => match TdxIvTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_greeks_implied_volatility: {other:?}"));
             empty
@@ -1709,7 +1853,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_all_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_greeks_all", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_greeks_all: {other:?}"));
             empty
@@ -1796,7 +1946,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_first_order_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_greeks_first_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_greeks_first_order: {other:?}"));
             empty
@@ -1883,7 +2039,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_second_order_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_greeks_second_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_greeks_second_order: {other:?}"));
             empty
@@ -1970,7 +2132,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_third_order_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_snapshot_greeks_third_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_snapshot_greeks_third_order: {other:?}"));
             empty
@@ -2083,7 +2251,13 @@ pub unsafe extern "C" fn tdx_option_history_eod_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_eod", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::EodTicks(values)) => TdxEodTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::EodTicks(values)) => match TdxEodTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_eod: {other:?}"));
             empty
@@ -2196,7 +2370,13 @@ pub unsafe extern "C" fn tdx_option_history_ohlc_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_ohlc", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => TdxOhlcTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => match TdxOhlcTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_ohlc: {other:?}"));
             empty
@@ -2296,7 +2476,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_trade", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => TdxTradeTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => match TdxTradeTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_trade: {other:?}"));
             empty
@@ -2409,7 +2595,13 @@ pub unsafe extern "C" fn tdx_option_history_quote_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_quote", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => TdxQuoteTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => match TdxQuoteTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_quote: {other:?}"));
             empty
@@ -2509,7 +2701,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_quote_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_trade_quote", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::TradeQuoteTicks(values)) => TdxTradeQuoteTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::TradeQuoteTicks(values)) => match TdxTradeQuoteTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_trade_quote: {other:?}"));
             empty
@@ -2609,7 +2807,13 @@ pub unsafe extern "C" fn tdx_option_history_open_interest_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_open_interest", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OpenInterestTicks(values)) => TdxOpenInterestTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OpenInterestTicks(values)) => match TdxOpenInterestTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_open_interest: {other:?}"));
             empty
@@ -2722,7 +2926,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_eod_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_greeks_eod", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_greeks_eod: {other:?}"));
             empty
@@ -2835,7 +3045,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_all_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_greeks_all", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_greeks_all: {other:?}"));
             empty
@@ -2935,7 +3151,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_all_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_trade_greeks_all", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_trade_greeks_all: {other:?}"));
             empty
@@ -3048,7 +3270,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_first_order_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_greeks_first_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_greeks_first_order: {other:?}"));
             empty
@@ -3148,7 +3376,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_first_order_with_option
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_trade_greeks_first_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_trade_greeks_first_order: {other:?}"));
             empty
@@ -3261,7 +3495,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_second_order_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_greeks_second_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_greeks_second_order: {other:?}"));
             empty
@@ -3361,7 +3601,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_second_order_with_optio
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_trade_greeks_second_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_trade_greeks_second_order: {other:?}"));
             empty
@@ -3474,7 +3720,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_third_order_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_greeks_third_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_greeks_third_order: {other:?}"));
             empty
@@ -3574,7 +3826,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_third_order_with_option
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_trade_greeks_third_order", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => TdxGreeksTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::GreeksTicks(values)) => match TdxGreeksTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_trade_greeks_third_order: {other:?}"));
             empty
@@ -3687,7 +3945,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_implied_volatility_with_optio
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_greeks_implied_volatility", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::IvTicks(values)) => TdxIvTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::IvTicks(values)) => match TdxIvTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_greeks_implied_volatility: {other:?}"));
             empty
@@ -3787,7 +4051,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_implied_volatility_with
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_history_trade_greeks_implied_volatility", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::IvTicks(values)) => TdxIvTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::IvTicks(values)) => match TdxIvTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_history_trade_greeks_implied_volatility: {other:?}"));
             empty
@@ -3913,7 +4183,13 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_at_time_trade", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => TdxTradeTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::TradeTicks(values)) => match TdxTradeTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_at_time_trade: {other:?}"));
             empty
@@ -4039,7 +4315,13 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "option_at_time_quote", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => TdxQuoteTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::QuoteTicks(values)) => match TdxQuoteTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for option_at_time_quote: {other:?}"));
             empty
@@ -4074,7 +4356,13 @@ pub unsafe extern "C" fn tdx_index_list_symbols_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_list_symbols", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::StringList(values)) => TdxStringArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::StringList(values)) => match TdxStringArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_list_symbols: {other:?}"));
             empty
@@ -4122,7 +4410,13 @@ pub unsafe extern "C" fn tdx_index_list_dates_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_list_dates", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::StringList(values)) => TdxStringArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::StringList(values)) => match TdxStringArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_list_dates: {other:?}"));
             empty
@@ -4167,7 +4461,13 @@ pub unsafe extern "C" fn tdx_index_snapshot_ohlc_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_snapshot_ohlc", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => TdxOhlcTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => match TdxOhlcTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_snapshot_ohlc: {other:?}"));
             empty
@@ -4212,7 +4512,13 @@ pub unsafe extern "C" fn tdx_index_snapshot_price_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_snapshot_price", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::PriceTicks(values)) => TdxPriceTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::PriceTicks(values)) => match TdxPriceTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_snapshot_price: {other:?}"));
             empty
@@ -4257,7 +4563,13 @@ pub unsafe extern "C" fn tdx_index_snapshot_market_value_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_snapshot_market_value", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::MarketValueTicks(values)) => TdxMarketValueTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::MarketValueTicks(values)) => match TdxMarketValueTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_snapshot_market_value: {other:?}"));
             empty
@@ -4331,7 +4643,13 @@ pub unsafe extern "C" fn tdx_index_history_eod_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_history_eod", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::EodTicks(values)) => TdxEodTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::EodTicks(values)) => match TdxEodTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_history_eod: {other:?}"));
             empty
@@ -4418,7 +4736,13 @@ pub unsafe extern "C" fn tdx_index_history_ohlc_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_history_ohlc", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => TdxOhlcTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => match TdxOhlcTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_history_ohlc: {other:?}"));
             empty
@@ -4492,7 +4816,13 @@ pub unsafe extern "C" fn tdx_index_history_price_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_history_price", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::PriceTicks(values)) => TdxPriceTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::PriceTicks(values)) => match TdxPriceTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_history_price: {other:?}"));
             empty
@@ -4579,7 +4909,13 @@ pub unsafe extern "C" fn tdx_index_at_time_price_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "index_at_time_price", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::PriceTicks(values)) => TdxPriceTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::PriceTicks(values)) => match TdxPriceTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for index_at_time_price: {other:?}"));
             empty
@@ -4614,7 +4950,13 @@ pub unsafe extern "C" fn tdx_calendar_open_today_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "calendar_open_today", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::CalendarDays(values)) => TdxCalendarDayArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::CalendarDays(values)) => match TdxCalendarDayArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for calendar_open_today: {other:?}"));
             empty
@@ -4662,7 +5004,13 @@ pub unsafe extern "C" fn tdx_calendar_on_date_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "calendar_on_date", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::CalendarDays(values)) => TdxCalendarDayArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::CalendarDays(values)) => match TdxCalendarDayArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for calendar_on_date: {other:?}"));
             empty
@@ -4710,7 +5058,13 @@ pub unsafe extern "C" fn tdx_calendar_year_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "calendar_year", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::CalendarDays(values)) => TdxCalendarDayArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::CalendarDays(values)) => match TdxCalendarDayArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for calendar_year: {other:?}"));
             empty
@@ -4784,7 +5138,13 @@ pub unsafe extern "C" fn tdx_interest_rate_history_eod_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "interest_rate_history_eod", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::InterestRateTicks(values)) => TdxInterestRateTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::InterestRateTicks(values)) => match TdxInterestRateTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for interest_rate_history_eod: {other:?}"));
             empty
@@ -4871,7 +5231,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_range_with_options(
     match runtime().block_on(async {
         thetadatadx::endpoint::invoke_endpoint(&client.inner, "stock_history_ohlc_range", &args).await
     }) {
-        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => TdxOhlcTickArray::from_vec(values),
+        Ok(thetadatadx::EndpointOutput::OhlcTicks(values)) => match TdxOhlcTickArray::from_vec(values) {
+            Ok(arr) => arr,
+            Err(e) => {
+                set_error(&format!("interior NUL in server string: {e}"));
+                empty
+            }
+        },
         Ok(other) => {
             set_error(&format!("internal error: unexpected endpoint output for stock_history_ohlc_range: {other:?}"));
             empty

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -893,17 +893,21 @@ macro_rules! tick_array_type {
         }
 
         impl $name {
-            pub(crate) fn from_vec(v: Vec<$tick>) -> Self {
+            /// Infallible for tick types (no `CString` allocation). Returns
+            /// `Result` to match the signature of fallible sibling arrays
+            /// (`TdxStringArray`, `TdxOptionContractArray`) so the shared
+            /// FFI endpoint macros stay generic over `$array_type`.
+            pub(crate) fn from_vec(v: Vec<$tick>) -> Result<Self, std::ffi::NulError> {
                 let len = v.len();
                 if len == 0 {
-                    return Self {
+                    return Ok(Self {
                         data: ptr::null(),
                         len: 0,
-                    };
+                    });
                 }
                 let boxed = v.into_boxed_slice();
                 let data = Box::into_raw(boxed) as *const $tick;
-                Self { data, len }
+                Ok(Self { data, len })
             }
 
             unsafe fn free(self) {
@@ -981,29 +985,28 @@ pub struct TdxOptionContractArray {
 }
 
 impl TdxOptionContractArray {
-    fn from_vec(contracts: Vec<tdbe::OptionContract>) -> Self {
+    fn from_vec(contracts: Vec<tdbe::OptionContract>) -> Result<Self, std::ffi::NulError> {
         let len = contracts.len();
         if len == 0 {
-            return Self {
+            return Ok(Self {
                 data: ptr::null(),
                 len: 0,
-            };
+            });
         }
-        let ffi_contracts: Vec<TdxOptionContract> = contracts
+        let ffi_contracts = contracts
             .into_iter()
             .map(|c| {
-                let root = CString::new(c.root).unwrap_or_default();
-                TdxOptionContract {
-                    root: root.into_raw().cast_const(),
+                Ok(TdxOptionContract {
+                    root: CString::new(c.root)?.into_raw().cast_const(),
                     expiration: c.expiration,
                     strike: c.strike,
                     right: c.right,
-                }
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, std::ffi::NulError>>()?;
         let boxed = ffi_contracts.into_boxed_slice();
         let data = Box::into_raw(boxed) as *const TdxOptionContract;
-        Self { data, len }
+        Ok(Self { data, len })
     }
 }
 
@@ -1041,21 +1044,21 @@ pub struct TdxStringArray {
 }
 
 impl TdxStringArray {
-    fn from_vec(strings: Vec<String>) -> Self {
+    fn from_vec(strings: Vec<String>) -> Result<Self, std::ffi::NulError> {
         let len = strings.len();
         if len == 0 {
-            return Self {
+            return Ok(Self {
                 data: ptr::null(),
                 len: 0,
-            };
+            });
         }
-        let cstrings: Vec<*const c_char> = strings
+        let cstrings = strings
             .into_iter()
-            .map(|s| CString::new(s).unwrap_or_default().into_raw().cast_const())
-            .collect();
+            .map(|s| CString::new(s).map(|c| c.into_raw().cast_const()))
+            .collect::<Result<Vec<*const c_char>, std::ffi::NulError>>()?;
         let boxed = cstrings.into_boxed_slice();
         let data = Box::into_raw(boxed) as *const *const c_char;
-        Self { data, len }
+        Ok(Self { data, len })
     }
 }
 
@@ -1098,7 +1101,13 @@ macro_rules! ffi_list_endpoint_no_params {
             }
             let client = unsafe { &*client };
             match runtime().block_on(async { client.inner.$method().await }) {
-                Ok(items) => TdxStringArray::from_vec(items),
+                Ok(items) => match TdxStringArray::from_vec(items) {
+                    Ok(arr) => arr,
+                    Err(e) => {
+                        set_error(&format!("interior NUL in server string: {e}"));
+                        empty
+                    }
+                },
                 Err(e) => {
                     set_error(&e.to_string());
                     empty
@@ -1136,7 +1145,13 @@ macro_rules! ffi_list_endpoint {
                 };
             )+
             match runtime().block_on(async { client.inner.$method($($param),+).await }) {
-                Ok(items) => TdxStringArray::from_vec(items),
+                Ok(items) => match TdxStringArray::from_vec(items) {
+                    Ok(arr) => arr,
+                    Err(e) => {
+                        set_error(&format!("interior NUL in server string: {e}"));
+                        empty
+                    }
+                },
                 Err(e) => {
                     set_error(&e.to_string());
                     empty
@@ -1203,7 +1218,13 @@ macro_rules! ffi_typed_snapshot_endpoint {
             };
             let refs: Vec<&str> = syms.iter().map(|s| s.as_str()).collect();
             match runtime().block_on(async { client.inner.$method(&refs).await }) {
-                Ok(ticks) => $array_type::from_vec(ticks),
+                Ok(ticks) => match $array_type::from_vec(ticks) {
+                    Ok(arr) => arr,
+                    Err(e) => {
+                        set_error(&format!("interior NUL in server string: {e}"));
+                        empty
+                    }
+                },
                 Err(e) => {
                     set_error(&e.to_string());
                     empty
@@ -1235,7 +1256,13 @@ macro_rules! ffi_typed_snapshot_endpoint {
             };
             let refs: Vec<&str> = syms.iter().map(|s| s.as_str()).collect();
             match runtime().block_on(async { client.inner.$method(&refs).await }) {
-                Ok(ticks) => $array_type::from_vec(ticks),
+                Ok(ticks) => match $array_type::from_vec(ticks) {
+                    Ok(arr) => arr,
+                    Err(e) => {
+                        set_error(&format!("interior NUL in server string: {e}"));
+                        empty
+                    }
+                },
                 Err(e) => {
                     set_error(&e.to_string());
                     empty
@@ -1274,7 +1301,13 @@ macro_rules! ffi_typed_endpoint {
                 };
             )+
             match runtime().block_on(async { client.inner.$method($($param),+).await }) {
-                Ok(ticks) => $array_type::from_vec(ticks),
+                Ok(ticks) => match $array_type::from_vec(ticks) {
+                    Ok(arr) => arr,
+                    Err(e) => {
+                        set_error(&format!("interior NUL in server string: {e}"));
+                        empty
+                    }
+                },
                 Err(e) => {
                     set_error(&e.to_string());
                     empty
@@ -1300,7 +1333,13 @@ macro_rules! ffi_typed_endpoint_no_params {
             }
             let client = unsafe { &*client };
             match runtime().block_on(async { client.inner.$method().await }) {
-                Ok(ticks) => $array_type::from_vec(ticks),
+                Ok(ticks) => match $array_type::from_vec(ticks) {
+                    Ok(arr) => arr,
+                    Err(e) => {
+                        set_error(&format!("interior NUL in server string: {e}"));
+                        empty
+                    }
+                },
                 Err(e) => {
                     set_error(&e.to_string());
                     empty

--- a/sdks/go/historical.go
+++ b/sdks/go/historical.go
@@ -46,7 +46,7 @@ func (c *Client) StockSnapshotOHLC(symbols []string, opts ...EndpointOption) ([]
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_snapshot_ohlc_with_options(c.handle, cSymbols, cSymbolsLen, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_ohlc_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -64,7 +64,7 @@ func (c *Client) StockSnapshotTrade(symbols []string, opts ...EndpointOption) ([
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_snapshot_trade_with_options(c.handle, cSymbols, cSymbolsLen, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_trade_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -82,7 +82,7 @@ func (c *Client) StockSnapshotQuote(symbols []string, opts ...EndpointOption) ([
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_snapshot_quote_with_options(c.handle, cSymbols, cSymbolsLen, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_quote_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -100,7 +100,7 @@ func (c *Client) StockSnapshotMarketValue(symbols []string, opts ...EndpointOpti
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_snapshot_market_value_with_options(c.handle, cSymbols, cSymbolsLen, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_market_value_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -122,7 +122,7 @@ func (c *Client) StockHistoryEOD(symbol string, startDate string, endDate string
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_history_eod_with_options(c.handle, cSymbol, cStartDate, cEndDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_eod_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -144,7 +144,7 @@ func (c *Client) StockHistoryOHLC(symbol string, date string, interval string, o
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_history_ohlc_with_options(c.handle, cSymbol, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_ohlc_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -164,7 +164,7 @@ func (c *Client) StockHistoryTrade(symbol string, date string, opts ...EndpointO
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_history_trade_with_options(c.handle, cSymbol, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_trade_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -186,7 +186,7 @@ func (c *Client) StockHistoryQuote(symbol string, date string, interval string, 
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_history_quote_with_options(c.handle, cSymbol, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_quote_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -206,7 +206,7 @@ func (c *Client) StockHistoryTradeQuote(symbol string, date string, opts ...Endp
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_history_trade_quote_with_options(c.handle, cSymbol, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_trade_quote_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -230,7 +230,7 @@ func (c *Client) StockAtTimeTrade(symbol string, startDate string, endDate strin
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_at_time_trade_with_options(c.handle, cSymbol, cStartDate, cEndDate, cTimeOfDay, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_trade_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -254,7 +254,7 @@ func (c *Client) StockAtTimeQuote(symbol string, startDate string, endDate strin
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_at_time_quote_with_options(c.handle, cSymbol, cStartDate, cEndDate, cTimeOfDay, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_quote_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -332,7 +332,7 @@ func (c *Client) OptionListContracts(requestType string, symbol string, date str
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_list_contracts_with_options(c.handle, cRequestType, cSymbol, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_option_contract_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -356,7 +356,7 @@ func (c *Client) OptionSnapshotOHLC(symbol string, expiration string, strike str
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_ohlc_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_ohlc_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -380,7 +380,7 @@ func (c *Client) OptionSnapshotTrade(symbol string, expiration string, strike st
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_trade_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_trade_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -404,7 +404,7 @@ func (c *Client) OptionSnapshotQuote(symbol string, expiration string, strike st
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_quote_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_quote_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -428,7 +428,7 @@ func (c *Client) OptionSnapshotOpenInterest(symbol string, expiration string, st
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_open_interest_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_open_interest_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -452,7 +452,7 @@ func (c *Client) OptionSnapshotMarketValue(symbol string, expiration string, str
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_market_value_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_market_value_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -476,7 +476,7 @@ func (c *Client) OptionSnapshotGreeksImpliedVolatility(symbol string, expiration
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_greeks_implied_volatility_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_iv_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -500,7 +500,7 @@ func (c *Client) OptionSnapshotGreeksAll(symbol string, expiration string, strik
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_greeks_all_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -524,7 +524,7 @@ func (c *Client) OptionSnapshotGreeksFirstOrder(symbol string, expiration string
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_greeks_first_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -548,7 +548,7 @@ func (c *Client) OptionSnapshotGreeksSecondOrder(symbol string, expiration strin
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_greeks_second_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -572,7 +572,7 @@ func (c *Client) OptionSnapshotGreeksThirdOrder(symbol string, expiration string
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_snapshot_greeks_third_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -600,7 +600,7 @@ func (c *Client) OptionHistoryEOD(symbol string, expiration string, strike strin
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_eod_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cStartDate, cEndDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_eod_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -628,7 +628,7 @@ func (c *Client) OptionHistoryOHLC(symbol string, expiration string, strike stri
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_ohlc_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_ohlc_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -654,7 +654,7 @@ func (c *Client) OptionHistoryTrade(symbol string, expiration string, strike str
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_trade_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_trade_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -682,7 +682,7 @@ func (c *Client) OptionHistoryQuote(symbol string, expiration string, strike str
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_quote_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_quote_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -708,7 +708,7 @@ func (c *Client) OptionHistoryTradeQuote(symbol string, expiration string, strik
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_trade_quote_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_trade_quote_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -734,7 +734,7 @@ func (c *Client) OptionHistoryOpenInterest(symbol string, expiration string, str
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_open_interest_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_open_interest_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -762,7 +762,7 @@ func (c *Client) OptionHistoryGreeksEOD(symbol string, expiration string, strike
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_greeks_eod_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cStartDate, cEndDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -790,7 +790,7 @@ func (c *Client) OptionHistoryGreeksAll(symbol string, expiration string, strike
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_greeks_all_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -816,7 +816,7 @@ func (c *Client) OptionHistoryTradeGreeksAll(symbol string, expiration string, s
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_trade_greeks_all_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -844,7 +844,7 @@ func (c *Client) OptionHistoryGreeksFirstOrder(symbol string, expiration string,
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_greeks_first_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -870,7 +870,7 @@ func (c *Client) OptionHistoryTradeGreeksFirstOrder(symbol string, expiration st
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_trade_greeks_first_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -898,7 +898,7 @@ func (c *Client) OptionHistoryGreeksSecondOrder(symbol string, expiration string
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_greeks_second_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -924,7 +924,7 @@ func (c *Client) OptionHistoryTradeGreeksSecondOrder(symbol string, expiration s
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_trade_greeks_second_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -952,7 +952,7 @@ func (c *Client) OptionHistoryGreeksThirdOrder(symbol string, expiration string,
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_greeks_third_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -978,7 +978,7 @@ func (c *Client) OptionHistoryTradeGreeksThirdOrder(symbol string, expiration st
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_trade_greeks_third_order_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_greeks_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1006,7 +1006,7 @@ func (c *Client) OptionHistoryGreeksImpliedVolatility(symbol string, expiration 
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_greeks_implied_volatility_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_iv_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1032,7 +1032,7 @@ func (c *Client) OptionHistoryTradeGreeksImpliedVolatility(symbol string, expira
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_history_trade_greeks_implied_volatility_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_iv_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1062,7 +1062,7 @@ func (c *Client) OptionAtTimeTrade(symbol string, expiration string, strike stri
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_at_time_trade_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cStartDate, cEndDate, cTimeOfDay, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_trade_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1092,7 +1092,7 @@ func (c *Client) OptionAtTimeQuote(symbol string, expiration string, strike stri
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_option_at_time_quote_with_options(c.handle, cSymbol, cExpiration, cStrike, cRight, cStartDate, cEndDate, cTimeOfDay, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_quote_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1132,7 +1132,7 @@ func (c *Client) IndexSnapshotOHLC(symbols []string, opts ...EndpointOption) ([]
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_index_snapshot_ohlc_with_options(c.handle, cSymbols, cSymbolsLen, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_ohlc_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1150,7 +1150,7 @@ func (c *Client) IndexSnapshotPrice(symbols []string, opts ...EndpointOption) ([
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_index_snapshot_price_with_options(c.handle, cSymbols, cSymbolsLen, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_price_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1168,7 +1168,7 @@ func (c *Client) IndexSnapshotMarketValue(symbols []string, opts ...EndpointOpti
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_index_snapshot_market_value_with_options(c.handle, cSymbols, cSymbolsLen, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_market_value_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1190,7 +1190,7 @@ func (c *Client) IndexHistoryEOD(symbol string, startDate string, endDate string
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_index_history_eod_with_options(c.handle, cSymbol, cStartDate, cEndDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_eod_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1214,7 +1214,7 @@ func (c *Client) IndexHistoryOHLC(symbol string, startDate string, endDate strin
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_index_history_ohlc_with_options(c.handle, cSymbol, cStartDate, cEndDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_ohlc_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1236,7 +1236,7 @@ func (c *Client) IndexHistoryPrice(symbol string, date string, interval string, 
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_index_history_price_with_options(c.handle, cSymbol, cDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_price_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1260,7 +1260,7 @@ func (c *Client) IndexAtTimePrice(symbol string, startDate string, endDate strin
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_index_at_time_price_with_options(c.handle, cSymbol, cStartDate, cEndDate, cTimeOfDay, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_price_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1276,7 +1276,7 @@ func (c *Client) CalendarOpenToday(opts ...EndpointOption) ([]CalendarDay, error
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_calendar_open_today_with_options(c.handle, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_calendar_day_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1294,7 +1294,7 @@ func (c *Client) CalendarOnDate(date string, opts ...EndpointOption) ([]Calendar
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_calendar_on_date_with_options(c.handle, cDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_calendar_day_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1312,7 +1312,7 @@ func (c *Client) CalendarYear(year string, opts ...EndpointOption) ([]CalendarDa
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_calendar_year_with_options(c.handle, cYear, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_calendar_day_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1334,7 +1334,7 @@ func (c *Client) InterestRateHistoryEOD(symbol string, startDate string, endDate
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_interest_rate_history_eod_with_options(c.handle, cSymbol, cStartDate, cEndDate, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_interest_rate_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}
@@ -1358,7 +1358,7 @@ func (c *Client) StockHistoryOHLCRange(symbol string, startDate string, endDate 
 	defer freeOpts()
 	C.tdx_clear_error()
 	arr := C.tdx_stock_history_ohlc_range_with_options(c.handle, cSymbol, cStartDate, cEndDate, cInterval, cOpts)
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_ohlc_tick_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}

--- a/sdks/go/thetadx.go
+++ b/sdks/go/thetadx.go
@@ -14,20 +14,16 @@ import (
 	"unsafe"
 )
 
-// lastError returns the most recent FFI error string.
+// lastError returns the most recent FFI error string, or "" if none is set.
+// Callers that need to distinguish "error" from "no error" (e.g. after a
+// sentinel-returning call like a list endpoint that returns `{nil, 0}` on
+// both success-with-no-rows and failure) MUST rely on `!= ""` rather than
+// a non-empty guard against a fallback string.
+//
+// The slot is a Rust thread_local, so the tdx_clear_error / FFI call /
+// lastError read sequence must run on a single OS thread — wrappers pin the
+// goroutine via runtime.LockOSThread.
 func lastError() string {
-	p := C.tdx_last_error()
-	if p == nil {
-		return "unknown error"
-	}
-	return C.GoString(p)
-}
-
-// lastErrorRaw returns the FFI error string verbatim, with empty-string
-// indicating "no error set since the last tdx_clear_error". Used by
-// stringArrayToGo to disambiguate a successful empty result from a
-// failure-with-empty-sentinel (e.g. timeout on a list endpoint).
-func lastErrorRaw() string {
 	p := C.tdx_last_error()
 	if p == nil {
 		return ""
@@ -48,7 +44,7 @@ func lastErrorRaw() string {
 // pin the goroutine via `runtime.LockOSThread()` + deferred unlock
 // before entering this helper (W3 round-3 fix). Without the pin, Go's
 // runtime can migrate the goroutine mid-sequence and the post-call
-// `lastErrorRaw()` below would read a stale/empty slot on the wrong
+// `lastError()` below would read a stale/empty slot on the wrong
 // OS thread.
 //
 // We also pin here defensively — Lock/UnlockOSThread nest safely, so
@@ -58,7 +54,7 @@ func lastErrorRaw() string {
 func stringArrayToGo(arr C.TdxStringArray) ([]string, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	if e := lastErrorRaw(); e != "" {
+	if e := lastError(); e != "" {
 		C.tdx_string_array_free(arr)
 		return nil, fmt.Errorf("thetadatadx: %s", e)
 	}

--- a/sdks/go/timeout_test.go
+++ b/sdks/go/timeout_test.go
@@ -10,7 +10,7 @@ import (
 // TestStringListEndpointTimeoutReturnsError covers Finding 2 end-to-end:
 // `stock_list_symbols` returns `{nullptr, 0}` for both success-empty
 // (rare) AND failure-empty (e.g. timeout). With the W3 round-2 fix the
-// Go wrapper must consult `tdx_last_error` via `lastErrorRaw()` and
+// Go wrapper must consult `tdx_last_error` via `lastError()` and
 // surface a real error, not silently return `(nil, nil)`.
 //
 // Gated on `THETADX_TEST_CREDS=path/to/creds.txt` because it needs


### PR DESCRIPTION
Audit surfaced six findings; each is fixed in its own bisectable commit.

## Findings

**1. HIGH — typed gRPC metadata lookup** (`b100d95`)
`tonic::Status::metadata()` was `Debug`-formatted to a string, then string-searched for `http_status_code=NNN`. Any upstream change to the `Debug` impl silently breaks the lookup. Now reads `MetadataMap::get("http_status_code")` directly, parses to `u16`, and calls `tdbe::errors::error_from_http_code`. Drops the now-dead `error_from_grpc_metadata` string parser from `tdbe`; exposes `HTTP_STATUS_CODE_KEY` as the SSOT for the key name.

**2. HIGH — SessionToken newtype** (`0820ef1`)
`SessionToken::from_response` re-ran `Uuid::parse_str` microseconds after `authenticate()` already validated the same string. The wrapper added zero invariant beyond re-validation. `DirectClient` now holds `session_uuid: String` directly; public `session_uuid()` accessor signature is unchanged.

**3. HIGH — FFI interior-NUL error swallowing** (`8df6aa7`)
`CString::new(...).unwrap_or_default()` at two FFI sites silently converted a NUL-containing server string into an empty C string — data corruption at the FFI boundary with no signal to the caller. All `#[repr(C)]` array `from_vec` methods now return `Result<Self, std::ffi::NulError>`; the shared macros and generator emit an inline match that forwards the error through `set_error` (readable via `tdx_last_error`). Infallible tick arrays keep trivial bodies wrapped in `Ok(...)` so the macros stay generic over `$array_type`.

**4. MEDIUM — `lastError()` / `lastErrorRaw()` duplication + always-true bug** (`fe283e6`)
Two near-identical Go helpers diverged only in the fallback (`"unknown error"` vs `""`). The ContractLookup generator emitted `if msg := lastError(); msg != ""` — always true because `lastError()` never returned empty. Result: the no-error case returned `("", errors.New("thetadatadx: unknown error"))` instead of `("", nil)`. Unified on one `lastError()` with strict empty-is-empty semantics; `lastErrorRaw()` deleted; all 50+ generated and hand-written callers (stringArrayToGo, historical wrappers, fpss methods) now use the same function. Behavioural change verified at the ContractLookup callsite.

**5. MEDIUM — debug_assert + clamp redundancy** (`d878f7c`)
`Price::new` asserted `price_type ∈ 0..20` in debug builds, then clamped to `0..=19` in release. Either the clamp is the contract (assert is noise) or the assert is the contract (clamp is dead code). Clamp wins — it's the runtime guarantee the downstream cast-to-usize relies on.

**6. LOW — three per-field `#[allow(dead_code)]`** (`e8021b3`)
Consolidated on `SurfaceGlobalRequestOption` into one struct-level attribute plus a doc comment explaining the struct's schema-validation-only purpose.

## Full gate passed per commit

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces -- --check`
- `cargo build -p thetadatadx-ffi --release && go test ./...` (Go SDK)
- `cmake --build build/cpp --config Release --target thetadatadx_cpp thetadatadx_validate` (C++ SDK)
- `cargo check --manifest-path sdks/python/Cargo.toml --locked` (Python SDK)

## Test plan

- [ ] CI green across the matrix
- [ ] Spot-check generated `ffi/src/endpoint_with_options.rs` — every array return path now routes through the interior-NUL match
- [ ] Spot-check generated `sdks/go/historical.go` — all `lastError()`-guarded branches use strict `!= ""`
- [ ] Live smoke: trigger an `OS_LIMIT` (429) response and confirm `Error::Grpc` message still reads `(ThetaData: OS_LIMIT -- ...)`
