### PR TITLE
ci(python): stop rebuilding wheel for abi3 smoke tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,8 +64,7 @@ jobs:
           print(thetadatadx.__file__)
           print(round(iv, 6), round(err, 6))
           PY
-      - if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ runner.os }}
           path: dist/*.whl
@@ -73,7 +72,8 @@ jobs:
   compatibility:
     name: ABI3 smoke (${{ matrix.os }} py${{ matrix.python }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    needs: build
+    timeout-minutes: 15
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
@@ -81,22 +81,17 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.9", "3.14"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
-      - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
-      - shell: bash
-        run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"
-      - shell: bash
-        run: python -m maturin build --release -m sdks/python/Cargo.toml -o dist/ --interpreter python
+      - uses: actions/download-artifact@v8
+        with:
+          name: wheel-${{ runner.os }}
+          path: dist/
       - shell: bash
         run: python -m pip install --force-reinstall dist/*.whl
       - shell: bash
-        run: python -c "import thetadatadx"
+        run: python -c "import thetadatadx; print(thetadatadx.__file__)"
 
   sdist:
     name: Build source distribution


### PR DESCRIPTION
## What
The abi3 compatibility matrix was rebuilding the wheel 6 times (3 OS × Python 3.9 and 3.14) just to verify it imports. Switch to: build once per OS, smoke-test the same wheel on each Python version.

## Why
\`sdks/python/Cargo.toml:23\` pins \`abi3-py39\`, meaning the wheel bytes are identical regardless of build interpreter — one wheel per OS works on every Python ≥3.9. The six compatibility jobs were cargo-cult coverage, paying full Rust + maturin compile time to prove something the abi3 ABI guarantees by construction.

## How
- \`build\` always uploads the wheel artifact (removed the tag/dispatch gate). Publish job is tag-gated independently so its behaviour is unchanged.
- \`compatibility\` gains \`needs: build\`, downloads the matching \`wheel-\${runner.os}\` artifact, and runs \`pip install *.whl && python -c "import thetadatadx"\`. No Rust toolchain, no protoc, no maturin.
- Timeout dropped from 45 → 15 min per smoke job (install + import only).

Saves roughly 30-60 min of CI time per PR with zero loss of meaningful coverage: the build job still proves maturin produces a valid abi3 wheel; the smoke matrix now verifies the actual invariant (does the wheel load on 3.9 and 3.14?).

## Test plan
- [ ] CI green on Linux/macOS/Windows build jobs
- [ ] 6 compatibility smoke jobs pass (install + import on 3.9 and 3.14)
- [ ] sdist job still passes
- [ ] Publish job definition unchanged; next tag push should still upload to PyPI