### PR TITLE
ci: drop redundant tools/cli clippy + test from surfaces job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,6 @@ jobs:
       - run: cargo test --manifest-path tools/mcp/Cargo.toml --locked
       - run: cargo clippy --manifest-path tools/server/Cargo.toml --locked -- -D warnings
       - run: cargo test --manifest-path tools/server/Cargo.toml --locked
-      - run: cargo clippy --manifest-path tools/cli/Cargo.toml --locked -- -D warnings
-      - run: cargo test --manifest-path tools/cli/Cargo.toml --locked
       - run: cargo check --manifest-path sdks/python/Cargo.toml --locked
 
   sdk-bindings:


### PR DESCRIPTION
## What
\`surfaces\` job re-ran \`cargo clippy\` + \`cargo test\` on \`tools/cli/Cargo.toml\`. Delete those two lines.

## Why
\`tools/cli\` is a workspace member per root \`Cargo.toml:9\` (\`members = [\"crates/tdbe\", \"crates/thetadatadx\", \"tools/cli\", \"ffi\"]\`), so \`check\`'s \`cargo clippy --workspace --locked -- -D warnings\` and \`test\`'s \`cargo test --workspace --locked\` already cover it. Pure duplication.

\`tools/mcp\`, \`tools/server\`, and \`sdks/python\` are excluded from the workspace (root \`Cargo.toml:10\`), so their per-manifest calls remain legitimate and are kept.

## How
Two-line deletion in \`.github/workflows/ci.yml\`.

## Test plan
- [ ] CI green
- [ ] \`tools/cli\` still covered by workspace-wide clippy/test