### PR TITLE
ci: split format check into a single-OS job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,19 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
   check:
-    name: Format & Lint (${{ matrix.os }})
+    name: Lint (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -30,10 +41,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
-      - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --locked -- -D warnings
 
   test:


### PR DESCRIPTION
## What
Extract \`cargo fmt --check\` to its own \`fmt\` job on \`ubuntu-latest\`; rename the matrix job \`check\` → \`Lint\` and drop \`rustfmt\` from its toolchain components.

## Why
\`cargo fmt\` is platform-agnostic — the format rules and their enforcement don't differ between Ubuntu, macOS, and Windows. Running the same check 3× is pure CI duplication.

\`cargo clippy\`, by contrast, can surface platform-specific lints (cfg-gated code, OS-dependent APIs), so that stays on the 3-OS matrix.

## How
One structural change in \`.github/workflows/ci.yml\`: new \`fmt\` job, rename + component trim on \`check\`.

## Test plan
- [ ] CI green — fmt job runs on Linux, lint job runs on 3 OSes
- [ ] Clippy coverage unchanged