### PR TITLE
ci: drop dead go_enabled matrix flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,35 +85,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            go_enabled: true
-          - os: macos-latest
-            go_enabled: true
-          - os: windows-latest
-            go_enabled: true
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - if: matrix.go_enabled
-        uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu
       - run: cargo build --release -p thetadatadx-ffi --locked
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: gcc
         run: cargo build --release --target x86_64-pc-windows-gnu -p thetadatadx-ffi --locked
       - run: cmake -S sdks/cpp -B build/cpp
       - run: cmake --build build/cpp --config Release --target thetadatadx_cpp
-      - if: matrix.go_enabled
-        shell: bash
+      - shell: bash
         working-directory: sdks/go
         run: |
           set -euo pipefail

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -49,26 +49,19 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        include:
-          - os: ubuntu-latest
-            go_enabled: true
-          - os: macos-latest
-            go_enabled: true
-          - os: windows-latest
-            go_enabled: true
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - if: matrix.go_enabled
-        uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu
       - name: Materialize creds.txt
@@ -84,7 +77,7 @@ jobs:
               encoding="utf-8",
           )
       - run: cargo build --release -p thetadatadx-cli -p thetadatadx-ffi --locked
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: gcc
@@ -131,31 +124,31 @@ jobs:
         run: |
           $env:PATH = "${{ github.workspace }}\target\release;$env:PATH"
           .\build\cpp\Release\thetadatadx_fpss_smoke.exe creds.txt
-      - if: matrix.go_enabled && runner.os == 'Linux'
+      - if: runner.os == 'Linux'
         shell: bash
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/live_smoke ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'Linux'
+      - if: runner.os == 'Linux'
         shell: bash
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/fpss_smoke ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'macOS'
+      - if: runner.os == 'macOS'
         shell: bash
         env:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/live_smoke ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'macOS'
+      - if: runner.os == 'macOS'
         shell: bash
         env:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/fpss_smoke ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'Windows'
+      - if: runner.os == 'Windows'
         shell: pwsh
         env:
           CGO_LDFLAGS: -L${{ github.workspace }}\target\x86_64-pc-windows-gnu\release
@@ -163,7 +156,7 @@ jobs:
           $env:PATH = "${{ github.workspace }}\target\x86_64-pc-windows-gnu\release;$env:PATH"
           cd sdks/go
           go run ./cmd/live_smoke ${{ github.workspace }}\creds.txt
-      - if: matrix.go_enabled && runner.os == 'Windows'
+      - if: runner.os == 'Windows'
         shell: pwsh
         env:
           CGO_LDFLAGS: -L${{ github.workspace }}\target\x86_64-pc-windows-gnu\release
@@ -182,26 +175,19 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        include:
-          - os: ubuntu-latest
-            go_enabled: true
-          - os: macos-latest
-            go_enabled: true
-          - os: windows-latest
-            go_enabled: true
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - if: matrix.go_enabled
-        uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu
       - name: Materialize creds.txt
@@ -217,7 +203,7 @@ jobs:
               encoding="utf-8",
           )
       - run: cargo build --release -p thetadatadx-cli -p thetadatadx-ffi --locked
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: gcc
@@ -247,19 +233,19 @@ jobs:
         run: |
           $env:PATH = "${{ github.workspace }}\target\release;$env:PATH"
           .\build\cpp\Release\thetadatadx_validate.exe creds.txt
-      - if: matrix.go_enabled && runner.os == 'Linux'
+      - if: runner.os == 'Linux'
         shell: bash
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/validate ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'macOS'
+      - if: runner.os == 'macOS'
         shell: bash
         env:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/validate ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'Windows'
+      - if: runner.os == 'Windows'
         shell: pwsh
         env:
           CGO_LDFLAGS: -L${{ github.workspace }}\target\x86_64-pc-windows-gnu\release


### PR DESCRIPTION
## What
Remove the \`go_enabled: true\` matrix dimension (and every \`if: matrix.go_enabled\` step guard) from \`ci.yml\`'s \`sdk-bindings\` job and \`live.yml\`'s \`smoke\` + \`endpoint-validation\` jobs.

## Why
The flag was set to \`true\` on every matrix entry and never false. The step guards therefore never short-circuited. Dead code pretending to be configurability.

If a future job genuinely needs to opt out of Go, we can reintroduce the flag at that point with a row that sets it to \`false\`.

## How
- \`ci.yml\` \`sdk-bindings\`: collapse \`include:\` matrix to \`os: [ubuntu-latest, macos-latest, windows-latest]\`; drop all \`matrix.go_enabled\` guards.
- \`live.yml\` \`smoke\` + \`endpoint-validation\`: same treatment. \`if: runner.os == 'X' && matrix.go_enabled\` reduces to \`if: runner.os == 'X'\`.

## Test plan
- [ ] CI green (sdk-bindings still builds + Go tests on all 3 OSes)
- [ ] live.yml syntactically valid (\`workflow_dispatch\` only, so not exercised by PR CI)