### PR TITLE
ci: extract common Rust + cache + protoc preamble into composite action

### DIFF
--- a/.github/actions/setup-rust-deps/action.yml
+++ b/.github/actions/setup-rust-deps/action.yml
@@ -1,0 +1,17 @@
+name: Setup Rust + cache + protoc
+description: Stable Rust toolchain, Swatinem cache, and protoc. Mirrors the four-step preamble used by every Rust build job in this repo.
+
+inputs:
+  components:
+    description: Extra rustup components (comma-separated), e.g. "rustfmt,clippy"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.components }}
+    - uses: Swatinem/rust-cache@v2
+    - uses: ./.github/actions/install-protoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --locked -- -D warnings
 
@@ -43,9 +41,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
+      - uses: ./.github/actions/setup-rust-deps
       - run: cargo test --workspace --locked
 
   surfaces:
@@ -154,9 +150,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
+      - uses: ./.github/actions/setup-rust-deps
       - if: runner.os == 'Windows'
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -58,7 +58,7 @@ jobs:
             go_enabled: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -66,8 +66,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.23"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - if: runner.os == 'Windows' && matrix.go_enabled
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu
@@ -191,7 +189,7 @@ jobs:
             go_enabled: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -199,8 +197,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.23"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - if: runner.os == 'Windows' && matrix.go_enabled
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu
@@ -276,15 +272,13 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - name: Materialize creds.txt
         shell: python
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,12 +38,10 @@ jobs:
             label: windows py3.12
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       - shell: bash
         run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"
@@ -82,12 +80,10 @@ jobs:
         python: ["3.9", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       - shell: bash
         run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"
@@ -104,12 +100,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       - shell: bash
         run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"


### PR DESCRIPTION
## What
Factor the repeated three-step preamble (\`dtolnay/rust-toolchain\`, \`Swatinem/rust-cache\`, \`./.github/actions/install-protoc\`) into a new composite action at \`.github/actions/setup-rust-deps\`. Accept an optional \`components:\` input for jobs that need \`rustfmt\` or \`clippy\`.

## Why
Nine jobs across \`ci.yml\`, \`live.yml\`, and \`python.yml\` repeated this exact sequence. Drift risk (one job forgets to update a version) + readability noise.

## How
- New file \`.github/actions/setup-rust-deps/action.yml\` (17 lines)
- ci.yml: 3 preambles replaced (check / test / build-ffi)
- python.yml: 3 preambles replaced (build / compatibility / sdist)
- live.yml: 3 preambles replaced (preflight / smoke / endpoint-validation)
- \`publish-crate\` in ci.yml left as-is — it doesn't use \`rust-cache\` and adding a \`cache: false\` input for one caller is more ceremony than the savings justify.

Net diff: \`-27 / +9\` in workflows, \`+17\` new action = roughly −10 lines overall.

## Test plan
- [ ] CI green across Linux/macOS/Windows
- [ ] Extended Surfaces still runs
- [ ] SDK Bindings still builds
- [ ] Python wheel builds still succeed