### PR TITLE
ci: reuse build-ffi artifact in sdk-bindings instead of rebuilding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,36 +80,36 @@ jobs:
   sdk-bindings:
     name: SDK Bindings (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    needs: check
-    timeout-minutes: 45
+    needs: build-ffi
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             go_enabled: true
+            ffi_artifact: ffi-linux-x86_64
           - os: macos-latest
             go_enabled: true
+            ffi_artifact: ffi-macos-arm64
           - os: windows-latest
             go_enabled: true
+            ffi_artifact: ffi-windows-msvc-x86_64
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
       - if: matrix.go_enabled
         uses: actions/setup-go@v6
         with:
           go-version: "1.23"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.ffi_artifact }}
+          path: target/release/
       - if: runner.os == 'Windows' && matrix.go_enabled
-        shell: bash
-        run: rustup target add x86_64-pc-windows-gnu
-      - run: cargo build --release -p thetadatadx-ffi --locked
-      - if: runner.os == 'Windows' && matrix.go_enabled
-        shell: bash
-        env:
-          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: gcc
-        run: cargo build --release --target x86_64-pc-windows-gnu -p thetadatadx-ffi --locked
+        uses: actions/download-artifact@v8
+        with:
+          name: ffi-windows-gnu-x86_64
+          path: target/x86_64-pc-windows-gnu/release/
       - run: cmake -S sdks/cpp -B build/cpp
       - run: cmake --build build/cpp --config Release --target thetadatadx_cpp
       - if: matrix.go_enabled


### PR DESCRIPTION
## What
\`sdk-bindings\` now \`needs: build-ffi\`, downloads the matching FFI artifact, and runs the C++ + Go tests against it. The \`cargo build -p thetadatadx-ffi\` steps (plus rust toolchain, rust-cache, protoc install, and rustup target add) are gone from \`sdk-bindings\`.

## Why
Before: \`build-ffi\` produced FFI shared libraries as artifacts; \`sdk-bindings\` immediately rebuilt exactly the same FFI from scratch on the same three OSes. Six full release builds where three would do.

The cmake + Go binding tests don't need a Rust toolchain — only the shared library. The generated FFI headers (\`sdks/go/endpoint_request_options.h.inc\`, \`sdks/cpp/include/endpoint_options.hpp.inc\`, etc.) are checked in and emitted by \`generate_sdk_surfaces\` during \`build-ffi\`, not by \`cargo build\` at the consumer site.

Savings: roughly 30-60 min of CI time per PR (3 redundant FFI builds × 10-20 min each).

## How
- \`sdk-bindings\` strategy: \`include\` matrix now carries an \`ffi_artifact\` field mapping each OS to its upload name (\`ffi-linux-x86_64\`, \`ffi-macos-arm64\`, \`ffi-windows-msvc-x86_64\`).
- \`needs: build-ffi\`
- \`actions/download-artifact@v8\` drops the matching FFI into \`target/release/\`.
- On Windows, a second download pulls \`ffi-windows-gnu-x86_64\` into \`target/x86_64-pc-windows-gnu/release/\` for CGO.
- Timeout tightened 45 → 30 min (no Rust compile).

## Test plan
- [ ] CI green: cmake target builds in sdk-bindings
- [ ] CI green: Go tests pass on Linux/macOS/Windows
- [ ] \`publish-crate\` still gates on \`sdk-bindings\` (unchanged dependency graph)