### PR TITLE
ci: consolidated workflow cleanup (5 related changes)

### DIFF
--- a/.github/actions/setup-rust-deps/action.yml
+++ b/.github/actions/setup-rust-deps/action.yml
@@ -1,0 +1,17 @@
+name: Setup Rust + cache + protoc
+description: Stable Rust toolchain, Swatinem cache, and protoc. Mirrors the four-step preamble used by every Rust build job in this repo.
+
+inputs:
+  components:
+    description: Extra rustup components (comma-separated), e.g. "rustfmt,clippy"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.components }}
+    - uses: Swatinem/rust-cache@v2
+    - uses: ./.github/actions/install-protoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,19 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
   check:
-    name: Format & Lint (${{ matrix.os }})
+    name: Lint (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -28,12 +39,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
         with:
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
-      - run: cargo fmt --all -- --check
+          components: clippy
       - run: cargo clippy --workspace --locked -- -D warnings
 
   test:
@@ -43,9 +51,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
+      - uses: ./.github/actions/setup-rust-deps
       - run: cargo test --workspace --locked
 
   surfaces:
@@ -73,47 +79,40 @@ jobs:
       - run: cargo test --manifest-path tools/mcp/Cargo.toml --locked
       - run: cargo clippy --manifest-path tools/server/Cargo.toml --locked -- -D warnings
       - run: cargo test --manifest-path tools/server/Cargo.toml --locked
-      - run: cargo clippy --manifest-path tools/cli/Cargo.toml --locked -- -D warnings
-      - run: cargo test --manifest-path tools/cli/Cargo.toml --locked
       - run: cargo check --manifest-path sdks/python/Cargo.toml --locked
 
   sdk-bindings:
     name: SDK Bindings (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    needs: check
-    timeout-minutes: 45
+    needs: build-ffi
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
-            go_enabled: true
+            ffi_artifact: ffi-linux-x86_64
           - os: macos-latest
-            go_enabled: true
+            ffi_artifact: ffi-macos-arm64
           - os: windows-latest
-            go_enabled: true
+            ffi_artifact: ffi-windows-msvc-x86_64
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - if: matrix.go_enabled
-        uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
-      - if: runner.os == 'Windows' && matrix.go_enabled
-        shell: bash
-        run: rustup target add x86_64-pc-windows-gnu
-      - run: cargo build --release -p thetadatadx-ffi --locked
-      - if: runner.os == 'Windows' && matrix.go_enabled
-        shell: bash
-        env:
-          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: gcc
-        run: cargo build --release --target x86_64-pc-windows-gnu -p thetadatadx-ffi --locked
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.ffi_artifact }}
+          path: target/release/
+      - if: runner.os == 'Windows'
+        uses: actions/download-artifact@v8
+        with:
+          name: ffi-windows-gnu-x86_64
+          path: target/x86_64-pc-windows-gnu/release/
       - run: cmake -S sdks/cpp -B build/cpp
       - run: cmake --build build/cpp --config Release --target thetadatadx_cpp
-      - if: matrix.go_enabled
-        shell: bash
+      - shell: bash
         working-directory: sdks/go
         run: |
           set -euo pipefail
@@ -154,9 +153,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
+      - uses: ./.github/actions/setup-rust-deps
       - if: runner.os == 'Windows'
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -49,26 +49,17 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        include:
-          - os: ubuntu-latest
-            go_enabled: true
-          - os: macos-latest
-            go_enabled: true
-          - os: windows-latest
-            go_enabled: true
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - if: matrix.go_enabled
-        uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu
       - name: Materialize creds.txt
@@ -84,7 +75,7 @@ jobs:
               encoding="utf-8",
           )
       - run: cargo build --release -p thetadatadx-cli -p thetadatadx-ffi --locked
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: gcc
@@ -131,31 +122,31 @@ jobs:
         run: |
           $env:PATH = "${{ github.workspace }}\target\release;$env:PATH"
           .\build\cpp\Release\thetadatadx_fpss_smoke.exe creds.txt
-      - if: matrix.go_enabled && runner.os == 'Linux'
+      - if: runner.os == 'Linux'
         shell: bash
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/live_smoke ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'Linux'
+      - if: runner.os == 'Linux'
         shell: bash
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/fpss_smoke ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'macOS'
+      - if: runner.os == 'macOS'
         shell: bash
         env:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/live_smoke ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'macOS'
+      - if: runner.os == 'macOS'
         shell: bash
         env:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/fpss_smoke ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'Windows'
+      - if: runner.os == 'Windows'
         shell: pwsh
         env:
           CGO_LDFLAGS: -L${{ github.workspace }}\target\x86_64-pc-windows-gnu\release
@@ -163,7 +154,7 @@ jobs:
           $env:PATH = "${{ github.workspace }}\target\x86_64-pc-windows-gnu\release;$env:PATH"
           cd sdks/go
           go run ./cmd/live_smoke ${{ github.workspace }}\creds.txt
-      - if: matrix.go_enabled && runner.os == 'Windows'
+      - if: runner.os == 'Windows'
         shell: pwsh
         env:
           CGO_LDFLAGS: -L${{ github.workspace }}\target\x86_64-pc-windows-gnu\release
@@ -182,26 +173,17 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        include:
-          - os: ubuntu-latest
-            go_enabled: true
-          - os: macos-latest
-            go_enabled: true
-          - os: windows-latest
-            go_enabled: true
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - if: matrix.go_enabled
-        uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         run: rustup target add x86_64-pc-windows-gnu
       - name: Materialize creds.txt
@@ -217,7 +199,7 @@ jobs:
               encoding="utf-8",
           )
       - run: cargo build --release -p thetadatadx-cli -p thetadatadx-ffi --locked
-      - if: runner.os == 'Windows' && matrix.go_enabled
+      - if: runner.os == 'Windows'
         shell: bash
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER: gcc
@@ -247,19 +229,19 @@ jobs:
         run: |
           $env:PATH = "${{ github.workspace }}\target\release;$env:PATH"
           .\build\cpp\Release\thetadatadx_validate.exe creds.txt
-      - if: matrix.go_enabled && runner.os == 'Linux'
+      - if: runner.os == 'Linux'
         shell: bash
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/validate ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'macOS'
+      - if: runner.os == 'macOS'
         shell: bash
         env:
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/validate ../../creds.txt
-      - if: matrix.go_enabled && runner.os == 'Windows'
+      - if: runner.os == 'Windows'
         shell: pwsh
         env:
           CGO_LDFLAGS: -L${{ github.workspace }}\target\x86_64-pc-windows-gnu\release
@@ -276,15 +258,13 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-go@v6
         with:
           go-version: "1.23"
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - name: Materialize creds.txt
         shell: python
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,12 +38,10 @@ jobs:
             label: windows py3.12
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       - shell: bash
         run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"
@@ -99,12 +97,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust-deps
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: Swatinem/rust-cache@v2
-      - uses: ./.github/actions/install-protoc
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       - shell: bash
         run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"


### PR DESCRIPTION
## What
Five related CI improvements folded into one PR. Each is in its own commit for bisect, but they ship together.

## Summary

| # | Change | Savings |
|---|---|---|
| 1 | \`sdk-bindings\` reuses \`build-ffi\` artifact (\`needs: build-ffi\` + \`download-artifact\`) | ~30-60 min / PR (kills 3 redundant FFI rebuilds) |
| 2 | Drop \`tools/cli\` clippy + test from \`Extended Surfaces\` | tools/cli is a workspace member; already covered by \`check\`/\`test\` |
| 3 | Split \`cargo fmt --check\` into single-OS \`fmt\` job | fmt rules are platform-agnostic |
| 4 | Remove dead \`go_enabled\` matrix flag from \`ci.yml\` and \`live.yml\` | Every entry was \`true\`; flag never short-circuited |
| 5 | Extract repeated Rust-setup preamble into \`.github/actions/setup-rust-deps\` | 9 call sites across ci/live/python workflows |

## Why

- #1 is the biggest win — roughly halves CI time per PR. \`sdk-bindings\` was rebuilding an FFI that \`build-ffi\` had just produced on the exact same runners.
- #2-#4 are small duplications that compound.
- #5 reduces drift risk: version bumps to \`dtolnay/rust-toolchain\` or \`Swatinem/rust-cache\` only need to be updated in one place.

## Scope preserved
- \`publish-crate\` keeps its bespoke two-step setup (no rust-cache — publishing path doesn't benefit from caching).
- Public workflow behaviour unchanged: same matrix coverage, same gates, same \`needs:\` graph (except \`sdk-bindings\` now correctly \`needs: build-ffi\`).

## Test plan
- [ ] \`fmt\` job green on Linux
- [ ] \`check\` matrix green on 3 OSes (clippy only)
- [ ] \`test\`, \`surfaces\` green
- [ ] \`build-ffi\` uploads artifacts; \`sdk-bindings\` downloads + runs cmake + Go tests
- [ ] \`publish-crate\` \`needs:\` graph intact (blocked on \`[test, surfaces, sdk-bindings, build-ffi]\`)