### PR TITLE
fix: address 13 correctness / security / perf findings

### DIFF
--- a/crates/tdbe/benches/bench_fit.rs
+++ b/crates/tdbe/benches/bench_fit.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
 
-use tdbe::codec::fit::{apply_deltas, FitReader};
+use tdbe::codec::fit::{apply_deltas, decode_fit_buffer_bulk, FitReader};
 
 // ═══════════════════════════════════════════════════════════════════════════
 //  Helpers
@@ -127,12 +127,23 @@ fn bench_fit_delta_decompression(c: &mut Criterion) {
     });
 }
 
+fn bench_fit_bulk_1000_rows(c: &mut Criterion) {
+    let buf = build_fit_buffer(1000);
+    c.bench_function("fit_bulk_1000_rows", |b| {
+        b.iter(|| {
+            let rows = decode_fit_buffer_bulk(black_box(&buf), 16);
+            black_box(rows);
+        });
+    });
+}
+
 criterion_group!(
     fit_benches,
     bench_fit_decode_100_rows,
     bench_fit_decode_1000_rows_scalar,
     bench_fit_decode_single_row,
     bench_fit_delta_decompression,
+    bench_fit_bulk_1000_rows,
 );
 
 criterion_main!(fit_benches);

--- a/crates/tdbe/src/codec/fit.rs
+++ b/crates/tdbe/src/codec/fit.rs
@@ -56,11 +56,7 @@ impl FitRows {
     /// Number of decoded rows.
     #[must_use]
     pub fn len(&self) -> usize {
-        if self.num_columns == 0 {
-            0
-        } else {
-            self.data.len() / self.num_columns
-        }
+        self.data.len().checked_div(self.num_columns).unwrap_or(0)
     }
 
     /// Whether no rows were decoded.

--- a/crates/tdbe/src/codec/fit.rs
+++ b/crates/tdbe/src/codec/fit.rs
@@ -39,16 +39,77 @@ const MAX_DIGITS: usize = 10;
 /// DATE marker byte (0xCE as unsigned). In Java's signed byte world this is -50.
 const DATE_MARKER: u8 = 0xCE;
 
-/// Decode a FIT buffer in bulk, returning all rows as `Vec<Vec<i32>>`.
+/// Row-major buffer of decoded FIT ticks.
 ///
-/// This is a higher-level convenience that reads all rows from `buf` and
-/// applies delta decompression, returning absolute values per row.
+/// Stores all rows contiguously in a single `Vec<i32>` with `num_columns`
+/// stride, rather than a `Vec<Vec<i32>>` that allocates per-row. Callers
+/// get rows via [`row`](Self::row) or iterate with [`iter`](Self::iter).
 ///
-/// Each inner `Vec<i32>` has exactly `fields_per_row` elements (zero-padded).
+/// For `N` rows of `C` columns this is one allocation instead of `N+1`.
+#[derive(Debug, Clone)]
+pub struct FitRows {
+    data: Vec<i32>,
+    num_columns: usize,
+}
+
+impl FitRows {
+    /// Number of decoded rows.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        if self.num_columns == 0 {
+            0
+        } else {
+            self.data.len() / self.num_columns
+        }
+    }
+
+    /// Whether no rows were decoded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Column count (same for every row).
+    #[must_use]
+    pub fn num_columns(&self) -> usize {
+        self.num_columns
+    }
+
+    /// Borrow the row at index `i`. Panics if `i >= self.len()`.
+    #[must_use]
+    pub fn row(&self, i: usize) -> &[i32] {
+        let start = i * self.num_columns;
+        &self.data[start..start + self.num_columns]
+    }
+
+    /// Iterator over rows as slices.
+    pub fn iter(&self) -> impl Iterator<Item = &[i32]> + '_ {
+        self.data.chunks_exact(self.num_columns.max(1))
+    }
+
+    /// Consume into a `Vec<Vec<i32>>`. Reallocates per row; prefer
+    /// [`iter`](Self::iter) or [`row`](Self::row).
+    #[must_use]
+    pub fn into_vec_of_vec(self) -> Vec<Vec<i32>> {
+        if self.num_columns == 0 {
+            return Vec::new();
+        }
+        self.data
+            .chunks_exact(self.num_columns)
+            .map(<[i32]>::to_vec)
+            .collect()
+    }
+}
+
+/// Decode a FIT buffer in bulk, returning all rows in a single flat
+/// allocation.
+///
+/// Each row has exactly `fields_per_row` elements (zero-padded); use
+/// [`FitRows::row`] / [`FitRows::iter`] to access them.
 #[must_use]
-pub fn decode_fit_buffer_bulk(buf: &[u8], fields_per_row: usize) -> Vec<Vec<i32>> {
+pub fn decode_fit_buffer_bulk(buf: &[u8], fields_per_row: usize) -> FitRows {
     let mut reader = FitReader::new(buf);
-    let mut rows = Vec::new();
+    let mut data: Vec<i32> = Vec::new();
     let mut prev = vec![0i32; fields_per_row];
     let mut alloc = vec![0i32; fields_per_row];
     let mut first = true;
@@ -66,9 +127,12 @@ pub fn decode_fit_buffer_bulk(buf: &[u8], fields_per_row: usize) -> Vec<Vec<i32>
             apply_deltas(&mut alloc, &prev, n);
             prev.copy_from_slice(&alloc);
         }
-        rows.push(alloc.clone());
+        data.extend_from_slice(&alloc);
     }
-    rows
+    FitRows {
+        data,
+        num_columns: fields_per_row,
+    }
 }
 
 /// Stateful FIT stream reader.

--- a/crates/tdbe/src/codec/mod.rs
+++ b/crates/tdbe/src/codec/mod.rs
@@ -19,3 +19,4 @@ pub mod fit;
 pub use fie::string_to_fie_line;
 pub use fit::decode_fit_buffer_bulk;
 pub use fit::FitReader;
+pub use fit::FitRows;

--- a/crates/tdbe/src/greeks.rs
+++ b/crates/tdbe/src/greeks.rs
@@ -101,6 +101,23 @@ pub fn d2(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     d1(s, x, v, r, q, t) - v * t.sqrt()
 }
 
+/// Compute `d1` and `d2` together, sharing `t.sqrt()`.
+///
+/// Callers that need both values should use this helper; calling `d1()` and
+/// then `d2()` separately recomputes `d1` inside `d2` and double-pays the
+/// `sqrt`/`ln`/`exp` cost of the formula.
+// Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
+#[allow(clippy::many_single_char_names)]
+#[inline]
+fn d1_d2(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> (f64, f64) {
+    if is_degenerate(v, t) {
+        return (0.0, 0.0);
+    }
+    let v_sqrt_t = v * t.sqrt();
+    let d1 = ((s / x).ln() + t * (r - q + v * v / 2.0)) / v_sqrt_t;
+    (d1, d1 - v_sqrt_t)
+}
+
 fn e1_from_d1(d1_val: f64) -> f64 {
     (-d1_val.powi(2) / 2.0).exp()
 }
@@ -119,8 +136,7 @@ pub fn value(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> f
         };
         return intrinsic;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     if is_call {
         s * (-q * t).exp() * norm_cdf(d1_val) - (-r * t).exp() * x * norm_cdf(d2_val)
     } else {
@@ -150,8 +166,7 @@ pub fn theta(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> f
     if is_degenerate(v, t) {
         return 0.0;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     let term1 = -(-q * t).exp() * (s * f1(d1_val) * v) / (2.0 * t.sqrt());
     if is_call {
         (term1 - r * x * (-r * t).exp() * norm_cdf(d2_val)
@@ -233,8 +248,7 @@ pub fn vanna(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     if is_degenerate(v, t) {
         return 0.0;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     -(-q * t).exp() * f1(d1_val) * d2_val / v
 }
 
@@ -245,8 +259,7 @@ pub fn charm(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> f
     if is_degenerate(v, t) {
         return 0.0;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     let p1 = (2.0 * (r - q) * t - d2_val * v * t.sqrt()) / (2.0 * t * v * t.sqrt());
     if is_call {
         q * (-q * t).exp() * norm_cdf(d1_val) - (-q * t).exp() * f1(d1_val) * p1
@@ -262,8 +275,7 @@ pub fn vomma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     if is_degenerate(v, t) {
         return 0.0;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     vega(s, x, v, r, q, t) * (d1_val * d2_val / v)
 }
 
@@ -274,8 +286,7 @@ pub fn veta(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     if is_degenerate(v, t) {
         return 0.0;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     -s * (-q * t).exp()
         * f1(d1_val)
         * t.sqrt()
@@ -300,8 +311,7 @@ pub fn zomma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     if is_degenerate(v, t) {
         return 0.0;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     (-q * t).exp() * f1(d1_val) * (d1_val * d2_val - 1.0) / (s * v * v * t.sqrt())
 }
 
@@ -312,8 +322,7 @@ pub fn color(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     if is_degenerate(v, t) {
         return 0.0;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     -(-q * t).exp() * f1(d1_val) / (2.0 * s * t * v * t.sqrt())
         * (2.0 * q * t
             + 1.0
@@ -327,8 +336,7 @@ pub fn ultima(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     if is_degenerate(v, t) {
         return 0.0;
     }
-    let d1_val = d1(s, x, v, r, q, t);
-    let d2_val = d2(s, x, v, r, q, t);
+    let (d1_val, d2_val) = d1_d2(s, x, v, r, q, t);
     let out = -vega(s, x, v, r, q, t) / (v * v)
         * (d1_val * d2_val * (1.0 - d1_val * d2_val) + d1_val * d1_val + d2_val * d2_val);
     out.clamp(-100.0, 100.0)

--- a/crates/thetadatadx/benches/bench_protocol.rs
+++ b/crates/thetadatadx/benches/bench_protocol.rs
@@ -17,7 +17,7 @@ fn bench_contract_stock_to_bytes(c: &mut Criterion) {
 }
 
 fn bench_contract_option_to_bytes(c: &mut Criterion) {
-    let contract = Contract::option("SPY", "20261218", "60", "C");
+    let contract = Contract::option("SPY", "20261218", "60", "C").unwrap();
     c.bench_function("contract_option_to_bytes", |b| {
         b.iter(|| {
             black_box(black_box(&contract).to_bytes());
@@ -26,7 +26,7 @@ fn bench_contract_option_to_bytes(c: &mut Criterion) {
 }
 
 fn bench_contract_from_bytes(c: &mut Criterion) {
-    let contract = Contract::option("SPY", "20261218", "60", "C");
+    let contract = Contract::option("SPY", "20261218", "60", "C").unwrap();
     let bytes = contract.to_bytes();
     c.bench_function("contract_from_bytes", |b| {
         b.iter(|| {
@@ -36,7 +36,7 @@ fn bench_contract_from_bytes(c: &mut Criterion) {
 }
 
 fn bench_contract_roundtrip(c: &mut Criterion) {
-    let contract = Contract::option("AAPL", "20261220", "17.5", "P");
+    let contract = Contract::option("AAPL", "20261220", "17.5", "P").unwrap();
     c.bench_function("contract_roundtrip", |b| {
         b.iter(|| {
             let bytes = black_box(&contract).to_bytes();
@@ -58,7 +58,7 @@ fn bench_build_credentials_payload(c: &mut Criterion) {
 }
 
 fn bench_build_subscribe_payload(c: &mut Criterion) {
-    let contract = Contract::option("SPY", "20261218", "60", "C");
+    let contract = Contract::option("SPY", "20261218", "60", "C").unwrap();
     c.bench_function("build_subscribe_payload", |b| {
         b.iter(|| {
             black_box(build_subscribe_payload(black_box(42), black_box(&contract)));

--- a/crates/thetadatadx/build_support/endpoints/modes.rs
+++ b/crates/thetadatadx/build_support/endpoints/modes.rs
@@ -516,7 +516,13 @@ fn canonicalize_wire_arg(param_name: &str, value: &str) -> String {
     match param_name {
         "expiration" => normalize_expiration(value),
         "strike" => wire_strike_opt(value).unwrap_or_else(|| UNSET_WIRE_ARG_SENTINEL.to_string()),
-        "right" => wire_right_opt(value).unwrap_or_else(|| UNSET_WIRE_ARG_SENTINEL.to_string()),
+        // Build-time only: fixture inputs come from this repo's TOML, so a
+        // bad `right` here is a build script bug -- treat it as the sentinel
+        // and let the downstream validator flag it.
+        "right" => wire_right_opt(value)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| UNSET_WIRE_ARG_SENTINEL.to_string()),
         _ => value.to_string(),
     }
 }

--- a/crates/thetadatadx/build_support/endpoints/render/build_out.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/build_out.rs
@@ -65,8 +65,6 @@ const VALIDATOR_TEMPLATES: &[&str] = &[
     "cpp/ffi_string_case.cpp.tmpl",
     "python/string_list_dispatch.py.tmpl",
     "python/streaming_dispatch.py.tmpl",
-    "python/non_streaming_dispatch.py.tmpl",
-    "python/with_deadline_builder.py.tmpl",
     "ffi/symbols_extract.rs.tmpl",
     "ffi/cstr_extract.rs.tmpl",
     "direct/stream_method_header.rs.tmpl",

--- a/crates/thetadatadx/build_support/endpoints/render/python.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/python.rs
@@ -94,13 +94,8 @@ fn render_python_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
         );
     }
 
-    out.push_str("        ");
-    if is_string_list {
-        out.push_str("py.detach(|| {\n");
-    } else {
-        out.push_str("let ticks = py.detach(|| {\n");
-    }
-
+    // `run_blocking` wraps the future with its own `py.detach` + signal
+    // polling, so no outer `py.detach` closure is emitted here.
     if is_string_list {
         // List endpoints: parallel `<name>_with_deadline(d, ...)` async fn.
         // The deadline-less variant stays for backwards compat; we only
@@ -127,53 +122,44 @@ fn render_python_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
                 .replace("__LEADING_COMMA_ARGS__", &leading_comma_args)
                 .replace("__POSITIONAL_ARGS__", &positional_args),
         );
-    } else {
-        // Builder-backed endpoints: chain optional setters + with_deadline.
-        let positional_args = method_params
-            .iter()
-            .map(|param| {
-                if param.param_type == "Symbols" {
-                    "&refs".into()
-                } else {
-                    sdk_method_arg_name(param)
-                }
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        writeln!(
-            out,
-            "            let mut request = self.tdx.{}({});",
-            endpoint.name, positional_args
-        )
-        .unwrap();
-        for param in &builder_params {
-            writeln!(out, "            if let Some(value) = {} {{", param.name).unwrap();
-            writeln!(
-                out,
-                "                request = request.{}(value);",
-                param.name
-            )
-            .unwrap();
-            out.push_str("            }\n");
-        }
-        out.push_str(include_str!(
-            "templates/python/with_deadline_builder.py.tmpl"
-        ));
-        if is_streaming_kind {
-            out.push_str(include_str!("templates/python/streaming_dispatch.py.tmpl"));
-        } else {
-            out.push_str(include_str!(
-                "templates/python/non_streaming_dispatch.py.tmpl"
-            ));
-        }
-    }
-    if is_string_list {
-        out.push_str("        })\n");
         out.push_str("    }\n");
         return out;
     }
 
-    out.push_str("        })?;\n");
+    // Builder-backed endpoints: chain optional setters + with_deadline.
+    let positional_args = method_params
+        .iter()
+        .map(|param| {
+            if param.param_type == "Symbols" {
+                "&refs".into()
+            } else {
+                sdk_method_arg_name(param)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    writeln!(
+        out,
+        "        let mut request = self.tdx.{}({});",
+        endpoint.name, positional_args
+    )
+    .unwrap();
+    for param in &builder_params {
+        writeln!(out, "        if let Some(value) = {} {{", param.name).unwrap();
+        writeln!(out, "            request = request.{}(value);", param.name).unwrap();
+        out.push_str("        }\n");
+    }
+    out.push_str("        if let Some(ms) = timeout_ms {\n");
+    out.push_str(
+        "            request = request.with_deadline(std::time::Duration::from_millis(ms));\n",
+    );
+    out.push_str("        }\n");
+    if is_streaming_kind {
+        out.push_str(include_str!("templates/python/streaming_dispatch.py.tmpl"));
+        out.push_str("    }\n");
+        return out;
+    }
+    out.push_str("        let ticks = run_blocking(py, async move { request.await })?;\n");
     writeln!(
         out,
         "        Ok({}(py, &ticks))",

--- a/crates/thetadatadx/build_support/endpoints/render/templates/ffi/cstr_extract.rs.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/ffi/cstr_extract.rs.tmpl
@@ -1,7 +1,11 @@
     let __NAME__ = match unsafe { cstr_to_str(__NAME__) } {
-        Some(value) => value,
-        None => {
-            set_error("__NAME__ is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("__NAME__ is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("__NAME__ is not valid UTF-8: {e}"));
             return empty;
         }
     };

--- a/crates/thetadatadx/build_support/endpoints/render/templates/python/non_streaming_dispatch.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/python/non_streaming_dispatch.py.tmpl
@@ -1,3 +1,0 @@
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)

--- a/crates/thetadatadx/build_support/endpoints/render/templates/python/string_list_dispatch.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/python/string_list_dispatch.py.tmpl
@@ -1,9 +1,7 @@
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.__NAME___with_deadline(std::time::Duration::from_millis(ms)__LEADING_COMMA_ARGS__).await
-                    } else {
-                        self.tdx.__NAME__(__POSITIONAL_ARGS__).await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.__NAME___with_deadline(std::time::Duration::from_millis(ms)__LEADING_COMMA_ARGS__).await
+            } else {
+                self.tdx.__NAME__(__POSITIONAL_ARGS__).await
+            }
+        })

--- a/crates/thetadatadx/build_support/endpoints/render/templates/python/with_deadline_builder.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/python/with_deadline_builder.py.tmpl
@@ -1,3 +1,0 @@
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }

--- a/crates/thetadatadx/build_support/sdk_surface.rs
+++ b/crates/thetadatadx/build_support/sdk_surface.rs
@@ -1204,9 +1204,40 @@ fn python_streaming_method(method: &MethodSpec) -> String {
             .unwrap();
             out.push_str("        let result = py.detach(move || {\n");
             out.push_str(
-                "            let rx = rx_arc.lock().unwrap_or_else(|e| e.into_inner());\n",
+                "            // Poll with `try_recv` + short sleep so the inner lock is only\n",
             );
-            out.push_str("            rx.recv_timeout(timeout).ok()\n");
+            out.push_str(
+                "            // held for nanoseconds per iteration. A blocking `recv_timeout`\n",
+            );
+            out.push_str(
+                "            // would pin the mutex for the full timeout and serialize any\n",
+            );
+            out.push_str(
+                "            // concurrent `next_event` / `reconnect` caller behind it.\n",
+            );
+            out.push_str("            let deadline = std::time::Instant::now() + timeout;\n");
+            out.push_str("            let poll_interval = std::time::Duration::from_millis(1);\n");
+            out.push_str("            loop {\n");
+            out.push_str("                {\n");
+            out.push_str(
+                "                    let rx = rx_arc.lock().unwrap_or_else(|e| e.into_inner());\n",
+            );
+            out.push_str("                    match rx.try_recv() {\n");
+            out.push_str("                        Ok(event) => return Some(event),\n");
+            out.push_str("                        Err(std::sync::mpsc::TryRecvError::Disconnected) => return None,\n");
+            out.push_str(
+                "                        Err(std::sync::mpsc::TryRecvError::Empty) => {}\n",
+            );
+            out.push_str("                    }\n");
+            out.push_str("                }\n");
+            out.push_str("                let now = std::time::Instant::now();\n");
+            out.push_str("                if now >= deadline {\n");
+            out.push_str("                    return None;\n");
+            out.push_str("                }\n");
+            out.push_str(
+                "                std::thread::sleep(poll_interval.min(deadline - now));\n",
+            );
+            out.push_str("            }\n");
             out.push_str("        });\n");
             out.push_str("        match result {\n");
             out.push_str(

--- a/crates/thetadatadx/build_support/sdk_surface.rs
+++ b/crates/thetadatadx/build_support/sdk_surface.rs
@@ -1086,7 +1086,7 @@ fn python_streaming_method(method: &MethodSpec) -> String {
             out.push_str("    ) -> PyResult<()> {\n");
             writeln!(
                 out,
-                "        let contract = fpss::protocol::Contract::option({}, {}, {}, {});",
+                "        let contract = fpss::protocol::Contract::option({}, {}, {}, {}).map_err(to_py_err)?;",
                 method.params[0].name,
                 method.params[1].name,
                 method.params[2].name,

--- a/crates/thetadatadx/src/auth/nexus.rs
+++ b/crates/thetadatadx/src/auth/nexus.rs
@@ -76,7 +76,10 @@ struct AuthRequest<'a> {
 ///
 /// Only the fields we need are deserialized; unknown fields are ignored
 /// via `#[serde(deny_unknown_fields)]` being absent.
-#[derive(Debug, Deserialize)]
+///
+/// `Debug` is implemented manually so `session_id` (a bearer token used in
+/// every MDDS request) is never written to logs.
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthResponse {
     /// Session UUID — the primary auth token for MDDS gRPC requests.
@@ -87,6 +90,16 @@ pub struct AuthResponse {
 
     /// ISO 8601 timestamp of session creation.
     pub session_created: Option<String>,
+}
+
+impl std::fmt::Debug for AuthResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthResponse")
+            .field("session_id", &"***")
+            .field("user", &self.user)
+            .field("session_created", &self.session_created)
+            .finish()
+    }
 }
 
 /// User info returned by the Nexus auth endpoint.
@@ -294,5 +307,17 @@ mod tests {
     fn terminal_key_is_valid_uuid() {
         // Sanity check: the hardcoded terminal key should be a valid UUID.
         Uuid::parse_str(TERMINAL_KEY).expect("TERMINAL_KEY must be a valid UUID");
+    }
+
+    #[test]
+    fn auth_response_debug_redacts_session_id() {
+        let resp = AuthResponse {
+            session_id: "11111111-2222-3333-4444-555555555555".to_string(),
+            user: None,
+            session_created: None,
+        };
+        let dbg = format!("{resp:?}");
+        assert!(!dbg.contains("11111111"), "session_id leaked: {dbg}");
+        assert!(dbg.contains("***"), "session_id not redacted: {dbg}");
     }
 }

--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -375,6 +375,11 @@ pub fn extract_price_column(table: &proto::DataTable, header: &str) -> Vec<Optio
 /// in column-oriented endpoints like Greeks/calendar which use `extract_number_column`
 /// (which returns `Option`). For tick parsing, defaulting to 0 is correct and
 /// matches the Java terminal's behavior.
+///
+/// `NullValue` is expected and silent. Any other type mismatch (Price, Text,
+/// etc.) is logged at `warn` level with the column index and observed type —
+/// these indicate upstream schema drift and should be surfaced in production
+/// logs, not buried at `trace`.
 // Reason: protocol-defined integer widths from Java FPSS specification.
 #[allow(clippy::cast_possible_truncation)]
 pub(crate) fn row_number(row: &proto::DataValueList, idx: usize) -> i32 {
@@ -386,11 +391,12 @@ pub(crate) fn row_number(row: &proto::DataValueList, idx: usize) -> i32 {
             // v3 MDDS returns Timestamp for time columns.
             // Extract milliseconds-of-day (ET timezone).
             proto::data_value::DataType::Timestamp(ts) => Some(timestamp_to_ms_of_day(ts.epoch_ms)),
+            proto::data_value::DataType::NullValue(_) => None,
             other => {
-                tracing::trace!(
+                tracing::warn!(
                     column = idx,
                     data_type = ?other,
-                    "unexpected cell type in tick row, defaulting to 0"
+                    "row_number: unexpected cell type, defaulting to 0 (schema drift?)"
                 );
                 None
             }
@@ -451,6 +457,10 @@ pub(crate) fn row_price_f64(row: &proto::DataValueList, idx: usize) -> f64 {
 /// Handles both `Number` cells (raw f64) and `Price` cells (value + `price_type`
 /// encoding). The v3 MDDS server sends Greeks, IV, and other f64 fields as
 /// Price-encoded values.
+///
+/// `NullValue` is expected and silent. Any other type mismatch (Timestamp,
+/// Text, etc.) is logged at `warn` level with the column index and observed
+/// type so schema drift is visible in production logs.
 // Reason: market-data i64 values are within f64 mantissa range; items defined near usage.
 #[allow(clippy::items_after_statements, clippy::cast_precision_loss)]
 pub(crate) fn row_float(row: &proto::DataValueList, idx: usize) -> f64 {
@@ -471,7 +481,15 @@ pub(crate) fn row_float(row: &proto::DataValueList, idx: usize) -> f64 {
                     }
                 }
             }
-            _ => None,
+            proto::data_value::DataType::NullValue(_) => None,
+            other => {
+                tracing::warn!(
+                    column = idx,
+                    data_type = ?other,
+                    "row_float: unexpected cell type, defaulting to 0.0 (schema drift?)"
+                );
+                None
+            }
         })
         .unwrap_or(0.0)
 }

--- a/crates/thetadatadx/src/direct.rs
+++ b/crates/thetadatadx/src/direct.rs
@@ -84,13 +84,16 @@ pub(crate) fn wire_strike_opt(strike: &str) -> Option<String> {
 /// filter" state and `*` as its explicit wildcard. Both collapse to
 /// proto-unset here so the server applies the documented default; single
 /// sides (`C` / `P` / `call` / `put`, any case) normalize to `"call"` /
-/// `"put"`. Any other input reaches
-/// [`crate::wire_semantics::normalize_right`] via
-/// [`crate::right::parse_right`], which panics with a descriptive message
-/// on unrecognized values — matching the panic-on-bad-right convention
-/// used by [`crate::fpss::protocol::Contract::option`].
-pub(crate) fn wire_right_opt(right: &str) -> Option<String> {
-    crate::wire_semantics::wire_right_opt(right)
+/// `"put"`. Any other input produces
+/// [`Error::Config`](crate::error::Error::Config) carrying the message
+/// from [`crate::right::parse_right`].
+///
+/// # Errors
+///
+/// Returns `Error::Config` if `right` is not one of the accepted SDK
+/// surface forms.
+pub(crate) fn wire_right_opt(right: &str) -> Result<Option<String>, Error> {
+    crate::wire_semantics::wire_right_opt(right).map_err(Error::from)
 }
 
 /// Helper: build a `proto::ContractSpec` from the four standard option params.
@@ -106,7 +109,7 @@ macro_rules! contract_spec {
             symbol: $symbol.to_string(),
             expiration: normalize_expiration(&$expiration.to_string()),
             strike: wire_strike_opt(&$strike.to_string()),
-            right: wire_right_opt(&$right.to_string()),
+            right: wire_right_opt(&$right.to_string())?,
         })
     };
 }
@@ -698,33 +701,32 @@ mod tests {
 
     #[test]
     fn wire_right_opt_treats_wildcards_as_unset() {
-        assert_eq!(wire_right_opt("*"), None);
-        assert_eq!(wire_right_opt("both"), None);
-        assert_eq!(wire_right_opt("BOTH"), None);
-        assert_eq!(wire_right_opt("Both"), None);
+        assert_eq!(wire_right_opt("*").unwrap(), None);
+        assert_eq!(wire_right_opt("both").unwrap(), None);
+        assert_eq!(wire_right_opt("BOTH").unwrap(), None);
+        assert_eq!(wire_right_opt("Both").unwrap(), None);
     }
 
     #[test]
-    #[should_panic(expected = "invalid option right")]
     fn wire_right_opt_rejects_undocumented_forms() {
-        // Matches Contract::option's panic-on-bad-right convention;
-        // validate_right catches these earlier on the endpoint path.
-        let _ = wire_right_opt("");
+        // validate_right catches these earlier on the endpoint path;
+        // wire_right_opt is the last defense and now returns an error
+        // instead of panicking across FFI.
+        assert!(wire_right_opt("").is_err());
     }
 
     #[test]
-    #[should_panic(expected = "invalid option right")]
     fn wire_right_opt_rejects_zero_sentinel() {
-        let _ = wire_right_opt("0");
+        assert!(wire_right_opt("0").is_err());
     }
 
     #[test]
     fn wire_right_opt_forwards_single_sides_normalized() {
-        assert_eq!(wire_right_opt("C"), Some("call".to_string()));
-        assert_eq!(wire_right_opt("c"), Some("call".to_string()));
-        assert_eq!(wire_right_opt("call"), Some("call".to_string()));
-        assert_eq!(wire_right_opt("CALL"), Some("call".to_string()));
-        assert_eq!(wire_right_opt("P"), Some("put".to_string()));
-        assert_eq!(wire_right_opt("put"), Some("put".to_string()));
+        assert_eq!(wire_right_opt("C").unwrap(), Some("call".to_string()));
+        assert_eq!(wire_right_opt("c").unwrap(), Some("call".to_string()));
+        assert_eq!(wire_right_opt("call").unwrap(), Some("call".to_string()));
+        assert_eq!(wire_right_opt("CALL").unwrap(), Some("call".to_string()));
+        assert_eq!(wire_right_opt("P").unwrap(), Some("put".to_string()));
+        assert_eq!(wire_right_opt("put").unwrap(), Some("put".to_string()));
     }
 }

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -1778,7 +1778,9 @@ fn decode_frame(
                 tracing::debug!(id, contract = %contract, "contract assigned");
                 // Pre-render the symbol string once and cache as Arc<str>
                 // so resolve_symbol() on the hot path is just Arc::clone.
-                let symbol_str: Arc<str> = Arc::from(contract.to_string().as_str());
+                // `Arc::<str>::from(String)` consumes the String's heap buffer
+                // directly instead of allocating a fresh copy from the &str.
+                let symbol_str: Arc<str> = Arc::<str>::from(contract.to_string());
                 // Insert into thread-local cache (zero-lock hot-path lookups).
                 local_symbols.insert(id, symbol_str);
                 // Also update shared map for external callers (contract_map(),

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -307,7 +307,11 @@ enum IoCommand {
 /// Source: `FPSSClient.java` -- main connection/reconnection state machine.
 pub struct FpssClient {
     /// Channel to send write commands to the I/O thread.
-    cmd_tx: std_mpsc::Sender<IoCommand>,
+    ///
+    /// `std::sync::mpsc::Sender` is `Send` but explicitly not `Sync` -- concurrent
+    /// `&self.send()` calls are UB. The `Mutex` makes `FpssClient: Sync` sound
+    /// under stdlib's own contract.
+    cmd_tx: Mutex<std_mpsc::Sender<IoCommand>>,
     /// Handle to the I/O thread (blocking TLS read + write drain).
     io_handle: Option<JoinHandle<()>>,
     /// Handle to the ping heartbeat thread.
@@ -327,12 +331,6 @@ pub struct FpssClient {
     /// The server address we connected to.
     server_addr: String,
 }
-
-// SAFETY: `Sender<IoCommand>` is `Send` but not `Sync`; however `Sender::send(&self)`
-// is internally synchronized and safe to call from multiple threads. `JoinHandle`
-// fields are only consumed in `Drop::drop(&mut self)` which requires exclusive access.
-// All other fields are `Send+Sync` or behind `Mutex`/`Atomic`.
-unsafe impl Sync for FpssClient {}
 
 impl FpssClient {
     /// Connect to a `ThetaData` FPSS server, authenticate, and start processing
@@ -523,7 +521,7 @@ impl FpssClient {
             })?;
 
         Ok(FpssClient {
-            cmd_tx,
+            cmd_tx: Mutex::new(cmd_tx),
             io_handle: Some(io_handle),
             ping_handle: Some(ping_handle),
             shutdown,
@@ -620,15 +618,10 @@ impl FpssClient {
         let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
         let payload = protocol::build_full_type_subscribe_payload(req_id, sec_type);
 
-        self.cmd_tx
-            .send(IoCommand::WriteFrame {
-                code: StreamMsgType::Trade,
-                payload,
-            })
-            .map_err(|_| Error::Fpss {
-                kind: crate::error::FpssErrorKind::Disconnected,
-                message: "I/O thread has exited".to_string(),
-            })?;
+        self.send_cmd(IoCommand::WriteFrame {
+            code: StreamMsgType::Trade,
+            payload,
+        })?;
 
         tracing::debug!(req_id, sec_type = ?sec_type, "sent full trade subscription");
 
@@ -664,15 +657,10 @@ impl FpssClient {
         let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
         let payload = protocol::build_full_type_subscribe_payload(req_id, sec_type);
 
-        self.cmd_tx
-            .send(IoCommand::WriteFrame {
-                code: StreamMsgType::OpenInterest,
-                payload,
-            })
-            .map_err(|_| Error::Fpss {
-                kind: crate::error::FpssErrorKind::Disconnected,
-                message: "I/O thread has exited".to_string(),
-            })?;
+        self.send_cmd(IoCommand::WriteFrame {
+            code: StreamMsgType::OpenInterest,
+            payload,
+        })?;
 
         tracing::debug!(req_id, sec_type = ?sec_type, "sent full open interest subscription");
 
@@ -706,15 +694,10 @@ impl FpssClient {
         let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
         let payload = protocol::build_full_type_subscribe_payload(req_id, sec_type);
 
-        self.cmd_tx
-            .send(IoCommand::WriteFrame {
-                code: StreamMsgType::RemoveTrade,
-                payload,
-            })
-            .map_err(|_| Error::Fpss {
-                kind: crate::error::FpssErrorKind::Disconnected,
-                message: "I/O thread has exited".to_string(),
-            })?;
+        self.send_cmd(IoCommand::WriteFrame {
+            code: StreamMsgType::RemoveTrade,
+            payload,
+        })?;
 
         // Remove from tracked subscriptions
         {
@@ -747,15 +730,10 @@ impl FpssClient {
         let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
         let payload = protocol::build_full_type_subscribe_payload(req_id, sec_type);
 
-        self.cmd_tx
-            .send(IoCommand::WriteFrame {
-                code: StreamMsgType::RemoveOpenInterest,
-                payload,
-            })
-            .map_err(|_| Error::Fpss {
-                kind: crate::error::FpssErrorKind::Disconnected,
-                message: "I/O thread has exited".to_string(),
-            })?;
+        self.send_cmd(IoCommand::WriteFrame {
+            code: StreamMsgType::RemoveOpenInterest,
+            payload,
+        })?;
 
         // Remove from tracked subscriptions
         {
@@ -808,12 +786,7 @@ impl FpssClient {
         let payload = build_subscribe_payload(req_id, contract);
         let code = kind.subscribe_code();
 
-        self.cmd_tx
-            .send(IoCommand::WriteFrame { code, payload })
-            .map_err(|_| Error::Fpss {
-                kind: crate::error::FpssErrorKind::Disconnected,
-                message: "I/O thread has exited".to_string(),
-            })?;
+        self.send_cmd(IoCommand::WriteFrame { code, payload })?;
 
         // Track for reconnection
         {
@@ -841,12 +814,7 @@ impl FpssClient {
         let payload = build_subscribe_payload(req_id, contract);
         let code = kind.unsubscribe_code();
 
-        self.cmd_tx
-            .send(IoCommand::WriteFrame { code, payload })
-            .map_err(|_| Error::Fpss {
-                kind: crate::error::FpssErrorKind::Disconnected,
-                message: "I/O thread has exited".to_string(),
-            })?;
+        self.send_cmd(IoCommand::WriteFrame { code, payload })?;
 
         // Remove from tracked subscriptions
         {
@@ -877,7 +845,7 @@ impl FpssClient {
         tracing::info!(server = %self.server_addr, "shutting down FPSS client");
 
         // Send shutdown command to I/O thread (which will send STOP to server).
-        let _ = self.cmd_tx.send(IoCommand::Shutdown);
+        let _ = self.send_cmd(IoCommand::Shutdown);
 
         // Clear active subscriptions on explicit shutdown. Involuntary disconnects
         // preserve the lists so `reconnect()` can re-subscribe automatically.
@@ -966,6 +934,19 @@ impl FpssClient {
         }
         Ok(())
     }
+
+    /// Send a command to the I/O thread. Maps channel-send failure to a
+    /// `Disconnected` FPSS error.
+    fn send_cmd(&self, cmd: IoCommand) -> Result<(), Error> {
+        self.cmd_tx
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .send(cmd)
+            .map_err(|_| Error::Fpss {
+                kind: crate::error::FpssErrorKind::Disconnected,
+                message: "I/O thread has exited".to_string(),
+            })
+    }
 }
 
 impl Drop for FpssClient {
@@ -973,7 +954,7 @@ impl Drop for FpssClient {
         // Signal shutdown if not already done.
         self.shutdown.store(true, Ordering::Release);
         // Send shutdown command so I/O thread exits its loop.
-        let _ = self.cmd_tx.send(IoCommand::Shutdown);
+        let _ = self.send_cmd(IoCommand::Shutdown);
 
         // Join background threads.
         if let Some(h) = self.ping_handle.take() {
@@ -2252,13 +2233,7 @@ where
         let payload = build_subscribe_payload(-1, contract);
         let code = kind.subscribe_code();
 
-        client
-            .cmd_tx
-            .send(IoCommand::WriteFrame { code, payload })
-            .map_err(|_| Error::Fpss {
-                kind: crate::error::FpssErrorKind::Disconnected,
-                message: "I/O thread exited during reconnect".to_string(),
-            })?;
+        client.send_cmd(IoCommand::WriteFrame { code, payload })?;
 
         tracing::debug!(
             kind = ?kind,
@@ -2272,13 +2247,7 @@ where
         let payload = protocol::build_full_type_subscribe_payload(-1, *sec_type);
         let code = kind.subscribe_code();
 
-        client
-            .cmd_tx
-            .send(IoCommand::WriteFrame { code, payload })
-            .map_err(|_| Error::Fpss {
-                kind: crate::error::FpssErrorKind::Disconnected,
-                message: "I/O thread exited during reconnect".to_string(),
-            })?;
+        client.send_cmd(IoCommand::WriteFrame { code, payload })?;
 
         tracing::debug!(
             kind = ?kind,

--- a/crates/thetadatadx/src/fpss/protocol.rs
+++ b/crates/thetadatadx/src/fpss/protocol.rs
@@ -40,6 +40,8 @@
 
 use tdbe::types::enums::{RemoveReason, SecType, StreamMsgType, StreamResponseType};
 
+use crate::error::Error;
+
 /// Maximum payload size for a single FPSS frame (1-byte length field).
 ///
 /// Source: `PacketStream.java` — `LEN` field is a single unsigned byte.
@@ -142,31 +144,48 @@ impl Contract {
     ///   (case-insensitive). FPSS per-contract subscriptions cannot carry
     ///   the `both` / `*` wildcard, so those values are rejected.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics with a descriptive message if `exp_date`, `strike`, or
-    /// `right` cannot be parsed. This matches the existing panic-on-
-    /// invalid-input style for strike/expiration. Use
-    /// [`crate::right::parse_right_strict`] upstream for fallible parsing
-    /// of untrusted input.
-    pub fn option(root: impl Into<String>, exp_date: &str, strike: &str, right: &str) -> Self {
+    /// Returns [`Error::Config`] if `exp_date` is not a valid integer date,
+    /// if `right` cannot be parsed to a single side, if `strike` is not a
+    /// valid f64, or if `strike * 1000` would overflow `i32`.
+    pub fn option(
+        root: impl Into<String>,
+        exp_date: &str,
+        strike: &str,
+        right: &str,
+    ) -> Result<Self, Error> {
         let exp: i32 = exp_date
             .replace('-', "")
             .parse()
-            .expect("invalid expiration date");
-        let is_call = crate::right::parse_right_strict(right)
-            .unwrap_or_else(|err| panic!("{err}"))
+            .map_err(|e| Error::Config(format!("invalid expiration date {exp_date:?}: {e}")))?;
+        let is_call = crate::right::parse_right_strict(right)?
             .as_is_call()
-            .expect("parse_right_strict guarantees single-side resolution");
-        let strike_dollars: f64 = strike.parse().expect("invalid strike price");
-        let strike_raw = (strike_dollars * 1000.0).round() as i32;
-        Self {
+            .ok_or_else(|| {
+                Error::Config("parse_right_strict returned Both despite strict mode".to_string())
+            })?;
+        let strike_dollars: f64 = strike
+            .parse()
+            .map_err(|e| Error::Config(format!("invalid strike price {strike:?}: {e}")))?;
+        let strike_scaled = (strike_dollars * 1000.0).round();
+        if !strike_scaled.is_finite()
+            || strike_scaled < f64::from(i32::MIN)
+            || strike_scaled > f64::from(i32::MAX)
+        {
+            return Err(Error::Config(format!(
+                "strike {strike_dollars} out of i32 range after *1000 scaling"
+            )));
+        }
+        // Reason: bounds checked above.
+        #[allow(clippy::cast_possible_truncation)]
+        let strike_raw = strike_scaled as i32;
+        Ok(Self {
             root: root.into(),
             sec_type: SecType::Option,
             exp_date: Some(exp),
             is_call: Some(is_call),
             strike: Some(strike_raw),
-        }
+        })
     }
 
     /// Construct from raw wire-format values (integer expiration, bool call/put, raw strike).
@@ -661,7 +680,7 @@ mod tests {
 
     #[test]
     fn option_contract_roundtrip() {
-        let c = Contract::option("SPY", "20261218", "60", "C");
+        let c = Contract::option("SPY", "20261218", "60", "C").unwrap();
         let bytes = c.to_bytes();
         // Java: 12 + root.length() = 12 + 3 = 15 total bytes, size byte = 15
         assert_eq!(bytes.len(), 15);
@@ -796,7 +815,7 @@ mod tests {
 
     #[test]
     fn contract_display_option() {
-        let c = Contract::option("SPY", "20261218", "45", "P");
+        let c = Contract::option("SPY", "20261218", "45", "P").unwrap();
         assert_eq!(c.to_string(), "SPY OPTION 20261218 P 45000");
     }
 
@@ -856,7 +875,7 @@ mod tests {
         // Java: root="SPY" (3 bytes), sec=OPTION, exp=20261218, isCall=true, strike=60000
         // Java allocates: 12 + 3 = 15 bytes
         // Wire: [15, 3, 'S','P','Y', sec_type, exp(4), is_call(1), strike(4)]
-        let c = Contract::option("SPY", "20261218", "60", "C");
+        let c = Contract::option("SPY", "20261218", "60", "C").unwrap();
         let bytes = c.to_bytes();
         assert_eq!(bytes[0], 15); // size byte = 12 + root.length()
         assert_eq!(bytes[1], 3); // root_len
@@ -880,6 +899,24 @@ mod tests {
         assert_eq!(&bytes[2..5], b"SPX");
         assert_eq!(bytes[5], SecType::Index as u8);
         assert_eq!(bytes.len(), 6);
+    }
+
+    #[test]
+    fn option_rejects_invalid_strike() {
+        // Garbage strike string -- must return Err, not panic.
+        assert!(Contract::option("SPY", "20261218", "not-a-number", "C").is_err());
+    }
+
+    #[test]
+    fn option_rejects_overflowing_strike() {
+        // Strike * 1000 exceeds i32::MAX. Must return Err, not wrap silently.
+        assert!(Contract::option("SPY", "20261218", "3000000", "C").is_err());
+    }
+
+    #[test]
+    fn option_rejects_invalid_expiration() {
+        // Non-numeric expiration -- must return Err, not panic.
+        assert!(Contract::option("SPY", "not-a-date", "60", "C").is_err());
     }
 
     #[test]

--- a/crates/thetadatadx/src/wire_semantics.rs
+++ b/crates/thetadatadx/src/wire_semantics.rs
@@ -11,14 +11,12 @@ pub(crate) const DEFAULT_STOCK_VENUE: &str = "nqb";
 /// Lowercase string expected by the MDDS server (`"call"` / `"put"` /
 /// `"both"`).
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if `right` is not one of the accepted SDK surface forms.
-pub(crate) fn normalize_right(right: &str) -> String {
-    tdbe::right::parse_right(right)
-        .unwrap_or_else(|err| panic!("{err}"))
-        .as_mdds_str()
-        .to_string()
+/// Returns the underlying `tdbe::right::parse_right` error if `right`
+/// is not one of the accepted SDK surface forms.
+pub(crate) fn normalize_right(right: &str) -> Result<String, tdbe::error::Error> {
+    Ok(tdbe::right::parse_right(right)?.as_mdds_str().to_string())
 }
 
 /// Canonicalize the `expiration` parameter for the MDDS server.
@@ -43,11 +41,16 @@ pub(crate) fn wire_strike_opt(strike: &str) -> Option<String> {
 }
 
 /// Map the SDK `right` vocabulary to the wire representation.
-pub(crate) fn wire_right_opt(right: &str) -> Option<String> {
-    match tdbe::right::parse_right(right).unwrap_or_else(|err| panic!("{err}")) {
-        tdbe::right::ParsedRight::Both => None,
+///
+/// # Errors
+///
+/// Returns the underlying `tdbe::right::parse_right` error if `right`
+/// is not one of the accepted SDK surface forms.
+pub(crate) fn wire_right_opt(right: &str) -> Result<Option<String>, tdbe::error::Error> {
+    match tdbe::right::parse_right(right)? {
+        tdbe::right::ParsedRight::Both => Ok(None),
         tdbe::right::ParsedRight::Call | tdbe::right::ParsedRight::Put => {
-            Some(normalize_right(right))
+            Ok(Some(normalize_right(right)?))
         }
     }
 }

--- a/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
+++ b/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
@@ -1416,8 +1416,8 @@ async fn main() -> Result<(), thetadatadx::Error> {
     let strikes = tdx.option_list_strikes(symbol, exp).await?;
     for strike in &strikes {
         // Subscribe to both calls and puts
-        tdx.subscribe_quotes(&Contract::option(symbol, exp, strike, "C"))?;
-        tdx.subscribe_quotes(&Contract::option(symbol, exp, strike, "P"))?;
+        tdx.subscribe_quotes(&Contract::option(symbol, exp, strike, "C")?)?;
+        tdx.subscribe_quotes(&Contract::option(symbol, exp, strike, "P")?)?;
     }
     println!("Live chain: {} {}  ({} contracts)", symbol, exp, strikes.len() * 2);
 

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -2521,7 +2521,7 @@ Identifies a security for streaming subscriptions.
 Contract::stock("AAPL")
 Contract::index("SPX")
 Contract::rate("SOFR")
-Contract::option("SPY", "20261218", "60", "C")
+Contract::option("SPY", "20261218", "60", "C")? // Result<Contract, Error>
 ```
 ```python [Python]
 # Passed as string symbol to subscribe methods

--- a/docs-site/docs/streaming/connection.md
+++ b/docs-site/docs/streaming/connection.md
@@ -255,7 +255,7 @@ tdx.subscribe_trades(&Contract::stock("MSFT"))?;
 tdx.subscribe_all(&Contract::stock("TSLA"))?;
 
 // Option quotes
-let opt = Contract::option("SPY", "20261218", "600", "C");
+let opt = Contract::option("SPY", "20261218", "600", "C")?;
 tdx.subscribe_quotes(&opt)?;
 
 // Open interest

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -927,7 +927,7 @@ Constructors:
 Contract::stock("AAPL")
 Contract::index("SPX")
 Contract::rate("SOFR")
-Contract::option("SPY", "20261218", "60", "C")
+Contract::option("SPY", "20261218", "60", "C")? // Result<Contract, Error>
 ```
 
 Serialization:

--- a/ffi/src/endpoint_with_options.rs
+++ b/ffi/src/endpoint_with_options.rs
@@ -59,9 +59,13 @@ pub unsafe extern "C" fn tdx_stock_list_dates_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let request_type = match unsafe { cstr_to_str(request_type) } {
-        Some(value) => value,
-        None => {
-            set_error("request_type is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("request_type is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("request_type is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -70,9 +74,13 @@ pub unsafe extern "C" fn tdx_stock_list_dates_with_options(
         thetadatadx::EndpointArgValue::Str(request_type.to_string()),
     );
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -332,9 +340,13 @@ pub unsafe extern "C" fn tdx_stock_history_eod_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -343,9 +355,13 @@ pub unsafe extern "C" fn tdx_stock_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -354,9 +370,13 @@ pub unsafe extern "C" fn tdx_stock_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -412,9 +432,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -423,9 +447,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -434,9 +462,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -490,9 +522,13 @@ pub unsafe extern "C" fn tdx_stock_history_trade_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -501,9 +537,13 @@ pub unsafe extern "C" fn tdx_stock_history_trade_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -559,9 +599,13 @@ pub unsafe extern "C" fn tdx_stock_history_quote_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -570,9 +614,13 @@ pub unsafe extern "C" fn tdx_stock_history_quote_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -581,9 +629,13 @@ pub unsafe extern "C" fn tdx_stock_history_quote_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -637,9 +689,13 @@ pub unsafe extern "C" fn tdx_stock_history_trade_quote_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -648,9 +704,13 @@ pub unsafe extern "C" fn tdx_stock_history_trade_quote_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -708,9 +768,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_trade_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -719,9 +783,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -730,9 +798,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -741,9 +813,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(end_date.to_string()),
     );
     let time_of_day = match unsafe { cstr_to_str(time_of_day) } {
-        Some(value) => value,
-        None => {
-            set_error("time_of_day is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("time_of_day is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("time_of_day is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -801,9 +877,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_quote_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -812,9 +892,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -823,9 +907,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -834,9 +922,13 @@ pub unsafe extern "C" fn tdx_stock_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(end_date.to_string()),
     );
     let time_of_day = match unsafe { cstr_to_str(time_of_day) } {
-        Some(value) => value,
-        None => {
-            set_error("time_of_day is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("time_of_day is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("time_of_day is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -937,9 +1029,13 @@ pub unsafe extern "C" fn tdx_option_list_dates_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let request_type = match unsafe { cstr_to_str(request_type) } {
-        Some(value) => value,
-        None => {
-            set_error("request_type is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("request_type is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("request_type is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -948,9 +1044,13 @@ pub unsafe extern "C" fn tdx_option_list_dates_with_options(
         thetadatadx::EndpointArgValue::Str(request_type.to_string()),
     );
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -959,9 +1059,13 @@ pub unsafe extern "C" fn tdx_option_list_dates_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -970,9 +1074,13 @@ pub unsafe extern "C" fn tdx_option_list_dates_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -981,9 +1089,13 @@ pub unsafe extern "C" fn tdx_option_list_dates_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1035,9 +1147,13 @@ pub unsafe extern "C" fn tdx_option_list_expirations_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1091,9 +1207,13 @@ pub unsafe extern "C" fn tdx_option_list_strikes_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1102,9 +1222,13 @@ pub unsafe extern "C" fn tdx_option_list_strikes_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1160,9 +1284,13 @@ pub unsafe extern "C" fn tdx_option_list_contracts_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let request_type = match unsafe { cstr_to_str(request_type) } {
-        Some(value) => value,
-        None => {
-            set_error("request_type is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("request_type is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("request_type is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1171,9 +1299,13 @@ pub unsafe extern "C" fn tdx_option_list_contracts_with_options(
         thetadatadx::EndpointArgValue::Str(request_type.to_string()),
     );
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1182,9 +1314,13 @@ pub unsafe extern "C" fn tdx_option_list_contracts_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1242,9 +1378,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_ohlc_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1253,9 +1393,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1264,9 +1408,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1275,9 +1423,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1335,9 +1487,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_trade_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1346,9 +1502,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_trade_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1357,9 +1517,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_trade_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1368,9 +1532,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_trade_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1428,9 +1596,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_quote_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1439,9 +1611,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_quote_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1450,9 +1626,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_quote_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1461,9 +1641,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_quote_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1521,9 +1705,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_open_interest_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1532,9 +1720,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_open_interest_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1543,9 +1735,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_open_interest_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1554,9 +1750,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_open_interest_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1614,9 +1814,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_market_value_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1625,9 +1829,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_market_value_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1636,9 +1844,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_market_value_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1647,9 +1859,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_market_value_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1707,9 +1923,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_implied_volatility_with_opti
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1718,9 +1938,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_implied_volatility_with_opti
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1729,9 +1953,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_implied_volatility_with_opti
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1740,9 +1968,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_implied_volatility_with_opti
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1800,9 +2032,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_all_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1811,9 +2047,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1822,9 +2062,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1833,9 +2077,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1893,9 +2141,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_first_order_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1904,9 +2156,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_first_order_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1915,9 +2171,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_first_order_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1926,9 +2186,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_first_order_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1986,9 +2250,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_second_order_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -1997,9 +2265,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_second_order_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2008,9 +2280,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_second_order_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2019,9 +2295,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_second_order_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2079,9 +2359,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_third_order_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2090,9 +2374,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_third_order_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2101,9 +2389,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_third_order_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2112,9 +2404,13 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_third_order_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2176,9 +2472,13 @@ pub unsafe extern "C" fn tdx_option_history_eod_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2187,9 +2487,13 @@ pub unsafe extern "C" fn tdx_option_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2198,9 +2502,13 @@ pub unsafe extern "C" fn tdx_option_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2209,9 +2517,13 @@ pub unsafe extern "C" fn tdx_option_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2220,9 +2532,13 @@ pub unsafe extern "C" fn tdx_option_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2231,9 +2547,13 @@ pub unsafe extern "C" fn tdx_option_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2295,9 +2615,13 @@ pub unsafe extern "C" fn tdx_option_history_ohlc_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2306,9 +2630,13 @@ pub unsafe extern "C" fn tdx_option_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2317,9 +2645,13 @@ pub unsafe extern "C" fn tdx_option_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2328,9 +2660,13 @@ pub unsafe extern "C" fn tdx_option_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2339,9 +2675,13 @@ pub unsafe extern "C" fn tdx_option_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2350,9 +2690,13 @@ pub unsafe extern "C" fn tdx_option_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2412,9 +2756,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2423,9 +2771,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2434,9 +2786,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2445,9 +2801,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2456,9 +2816,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2520,9 +2884,13 @@ pub unsafe extern "C" fn tdx_option_history_quote_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2531,9 +2899,13 @@ pub unsafe extern "C" fn tdx_option_history_quote_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2542,9 +2914,13 @@ pub unsafe extern "C" fn tdx_option_history_quote_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2553,9 +2929,13 @@ pub unsafe extern "C" fn tdx_option_history_quote_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2564,9 +2944,13 @@ pub unsafe extern "C" fn tdx_option_history_quote_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2575,9 +2959,13 @@ pub unsafe extern "C" fn tdx_option_history_quote_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2637,9 +3025,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_quote_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2648,9 +3040,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_quote_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2659,9 +3055,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_quote_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2670,9 +3070,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_quote_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2681,9 +3085,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_quote_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2743,9 +3151,13 @@ pub unsafe extern "C" fn tdx_option_history_open_interest_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2754,9 +3166,13 @@ pub unsafe extern "C" fn tdx_option_history_open_interest_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2765,9 +3181,13 @@ pub unsafe extern "C" fn tdx_option_history_open_interest_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2776,9 +3196,13 @@ pub unsafe extern "C" fn tdx_option_history_open_interest_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2787,9 +3211,13 @@ pub unsafe extern "C" fn tdx_option_history_open_interest_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2851,9 +3279,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_eod_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2862,9 +3294,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_eod_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2873,9 +3309,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_eod_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2884,9 +3324,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_eod_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2895,9 +3339,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_eod_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2906,9 +3354,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_eod_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2970,9 +3422,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_all_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2981,9 +3437,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -2992,9 +3452,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3003,9 +3467,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3014,9 +3482,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3025,9 +3497,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3087,9 +3563,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_all_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3098,9 +3578,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3109,9 +3593,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3120,9 +3608,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3131,9 +3623,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_all_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3195,9 +3691,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_first_order_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3206,9 +3706,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_first_order_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3217,9 +3721,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_first_order_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3228,9 +3736,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_first_order_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3239,9 +3751,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_first_order_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3250,9 +3766,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_first_order_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3312,9 +3832,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_first_order_with_option
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3323,9 +3847,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_first_order_with_option
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3334,9 +3862,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_first_order_with_option
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3345,9 +3877,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_first_order_with_option
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3356,9 +3892,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_first_order_with_option
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3420,9 +3960,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_second_order_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3431,9 +3975,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_second_order_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3442,9 +3990,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_second_order_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3453,9 +4005,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_second_order_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3464,9 +4020,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_second_order_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3475,9 +4035,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_second_order_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3537,9 +4101,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_second_order_with_optio
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3548,9 +4116,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_second_order_with_optio
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3559,9 +4131,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_second_order_with_optio
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3570,9 +4146,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_second_order_with_optio
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3581,9 +4161,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_second_order_with_optio
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3645,9 +4229,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_third_order_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3656,9 +4244,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_third_order_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3667,9 +4259,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_third_order_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3678,9 +4274,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_third_order_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3689,9 +4289,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_third_order_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3700,9 +4304,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_third_order_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3762,9 +4370,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_third_order_with_option
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3773,9 +4385,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_third_order_with_option
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3784,9 +4400,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_third_order_with_option
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3795,9 +4415,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_third_order_with_option
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3806,9 +4430,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_third_order_with_option
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3870,9 +4498,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_implied_volatility_with_optio
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3881,9 +4513,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_implied_volatility_with_optio
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3892,9 +4528,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_implied_volatility_with_optio
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3903,9 +4543,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_implied_volatility_with_optio
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3914,9 +4558,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_implied_volatility_with_optio
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3925,9 +4573,13 @@ pub unsafe extern "C" fn tdx_option_history_greeks_implied_volatility_with_optio
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3987,9 +4639,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_implied_volatility_with
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -3998,9 +4654,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_implied_volatility_with
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4009,9 +4669,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_implied_volatility_with
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4020,9 +4684,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_implied_volatility_with
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4031,9 +4699,13 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_implied_volatility_with
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4097,9 +4769,13 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4108,9 +4784,13 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4119,9 +4799,13 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4130,9 +4814,13 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4141,9 +4829,13 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4152,9 +4844,13 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4163,9 +4859,13 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
         thetadatadx::EndpointArgValue::Str(end_date.to_string()),
     );
     let time_of_day = match unsafe { cstr_to_str(time_of_day) } {
-        Some(value) => value,
-        None => {
-            set_error("time_of_day is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("time_of_day is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("time_of_day is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4229,9 +4929,13 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4240,9 +4944,13 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let expiration = match unsafe { cstr_to_str(expiration) } {
-        Some(value) => value,
-        None => {
-            set_error("expiration is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("expiration is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("expiration is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4251,9 +4959,13 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(expiration.to_string()),
     );
     let strike = match unsafe { cstr_to_str(strike) } {
-        Some(value) => value,
-        None => {
-            set_error("strike is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("strike is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("strike is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4262,9 +4974,13 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(strike.to_string()),
     );
     let right = match unsafe { cstr_to_str(right) } {
-        Some(value) => value,
-        None => {
-            set_error("right is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("right is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("right is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4273,9 +4989,13 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(right.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4284,9 +5004,13 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4295,9 +5019,13 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
         thetadatadx::EndpointArgValue::Str(end_date.to_string()),
     );
     let time_of_day = match unsafe { cstr_to_str(time_of_day) } {
-        Some(value) => value,
-        None => {
-            set_error("time_of_day is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("time_of_day is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("time_of_day is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4390,9 +5118,13 @@ pub unsafe extern "C" fn tdx_index_list_dates_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4601,9 +5333,13 @@ pub unsafe extern "C" fn tdx_index_history_eod_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4612,9 +5348,13 @@ pub unsafe extern "C" fn tdx_index_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4623,9 +5363,13 @@ pub unsafe extern "C" fn tdx_index_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4683,9 +5427,13 @@ pub unsafe extern "C" fn tdx_index_history_ohlc_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4694,9 +5442,13 @@ pub unsafe extern "C" fn tdx_index_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4705,9 +5457,13 @@ pub unsafe extern "C" fn tdx_index_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4716,9 +5472,13 @@ pub unsafe extern "C" fn tdx_index_history_ohlc_with_options(
         thetadatadx::EndpointArgValue::Str(end_date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4774,9 +5534,13 @@ pub unsafe extern "C" fn tdx_index_history_price_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4785,9 +5549,13 @@ pub unsafe extern "C" fn tdx_index_history_price_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4796,9 +5564,13 @@ pub unsafe extern "C" fn tdx_index_history_price_with_options(
         thetadatadx::EndpointArgValue::Str(date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4856,9 +5628,13 @@ pub unsafe extern "C" fn tdx_index_at_time_price_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4867,9 +5643,13 @@ pub unsafe extern "C" fn tdx_index_at_time_price_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4878,9 +5658,13 @@ pub unsafe extern "C" fn tdx_index_at_time_price_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4889,9 +5673,13 @@ pub unsafe extern "C" fn tdx_index_at_time_price_with_options(
         thetadatadx::EndpointArgValue::Str(end_date.to_string()),
     );
     let time_of_day = match unsafe { cstr_to_str(time_of_day) } {
-        Some(value) => value,
-        None => {
-            set_error("time_of_day is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("time_of_day is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("time_of_day is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -4984,9 +5772,13 @@ pub unsafe extern "C" fn tdx_calendar_on_date_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let date = match unsafe { cstr_to_str(date) } {
-        Some(value) => value,
-        None => {
-            set_error("date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -5038,9 +5830,13 @@ pub unsafe extern "C" fn tdx_calendar_year_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let year = match unsafe { cstr_to_str(year) } {
-        Some(value) => value,
-        None => {
-            set_error("year is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("year is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("year is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -5096,9 +5892,13 @@ pub unsafe extern "C" fn tdx_interest_rate_history_eod_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -5107,9 +5907,13 @@ pub unsafe extern "C" fn tdx_interest_rate_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -5118,9 +5922,13 @@ pub unsafe extern "C" fn tdx_interest_rate_history_eod_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -5178,9 +5986,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_range_with_options(
 
     let mut args = thetadatadx::EndpointArgs::new();
     let symbol = match unsafe { cstr_to_str(symbol) } {
-        Some(value) => value,
-        None => {
-            set_error("symbol is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("symbol is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("symbol is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -5189,9 +6001,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_range_with_options(
         thetadatadx::EndpointArgValue::Str(symbol.to_string()),
     );
     let start_date = match unsafe { cstr_to_str(start_date) } {
-        Some(value) => value,
-        None => {
-            set_error("start_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("start_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("start_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -5200,9 +6016,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_range_with_options(
         thetadatadx::EndpointArgValue::Str(start_date.to_string()),
     );
     let end_date = match unsafe { cstr_to_str(end_date) } {
-        Some(value) => value,
-        None => {
-            set_error("end_date is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("end_date is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("end_date is not valid UTF-8: {e}"));
             return empty;
         }
     };
@@ -5211,9 +6031,13 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_range_with_options(
         thetadatadx::EndpointArgValue::Str(end_date.to_string()),
     );
     let interval = match unsafe { cstr_to_str(interval) } {
-        Some(value) => value,
-        None => {
-            set_error("interval is null or invalid UTF-8");
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            set_error("interval is null");
+            return empty;
+        }
+        Err(e) => {
+            set_error(&format!("interval is not valid UTF-8: {e}"));
             return empty;
         }
     };

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2521,7 +2521,13 @@ pub unsafe extern "C" fn tdx_unified_subscribe_option_quotes(
             return -1;
         };
     let handle = unsafe { &*handle };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match handle.inner.subscribe_quotes(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -2553,7 +2559,13 @@ pub unsafe extern "C" fn tdx_unified_subscribe_option_trades(
             return -1;
         };
     let handle = unsafe { &*handle };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match handle.inner.subscribe_trades(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -2585,7 +2597,13 @@ pub unsafe extern "C" fn tdx_unified_subscribe_option_open_interest(
             return -1;
         };
     let handle = unsafe { &*handle };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match handle.inner.subscribe_open_interest(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -2617,7 +2635,13 @@ pub unsafe extern "C" fn tdx_unified_unsubscribe_option_quotes(
             return -1;
         };
     let handle = unsafe { &*handle };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match handle.inner.unsubscribe_quotes(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -2649,7 +2673,13 @@ pub unsafe extern "C" fn tdx_unified_unsubscribe_option_trades(
             return -1;
         };
     let handle = unsafe { &*handle };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match handle.inner.unsubscribe_trades(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -2681,7 +2711,13 @@ pub unsafe extern "C" fn tdx_unified_unsubscribe_option_open_interest(
             return -1;
         };
     let handle = unsafe { &*handle };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match handle.inner.unsubscribe_open_interest(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -3687,7 +3723,13 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_option_quotes(
         set_error("FPSS client is shut down");
         return -1;
     };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match client.subscribe_quotes(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -3729,7 +3771,13 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_option_trades(
         set_error("FPSS client is shut down");
         return -1;
     };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match client.subscribe_trades(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -3771,7 +3819,13 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_option_open_interest(
         set_error("FPSS client is shut down");
         return -1;
     };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match client.subscribe_open_interest(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -3813,7 +3867,13 @@ pub unsafe extern "C" fn tdx_fpss_unsubscribe_option_quotes(
         set_error("FPSS client is shut down");
         return -1;
     };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match client.unsubscribe_quotes(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -3855,7 +3915,13 @@ pub unsafe extern "C" fn tdx_fpss_unsubscribe_option_trades(
         set_error("FPSS client is shut down");
         return -1;
     };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match client.unsubscribe_trades(&contract) {
         Ok(()) => 0,
         Err(e) => {
@@ -3897,7 +3963,13 @@ pub unsafe extern "C" fn tdx_fpss_unsubscribe_option_open_interest(
         set_error("FPSS client is shut down");
         return -1;
     };
-    let contract = thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt);
+    let contract = match thetadatadx::fpss::protocol::Contract::option(sym, exp, stk, rt) {
+        Ok(c) => c,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
     match client.unsubscribe_open_interest(&contract) {
         Ok(()) => 0,
         Err(e) => {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -633,11 +633,39 @@ fn fpss_event_to_ffi(event: &thetadatadx::fpss::FpssEvent) -> FfiBufferedEvent {
 
 // ── Helper: C string to &str ──
 
-unsafe fn cstr_to_str<'a>(p: *const c_char) -> Option<&'a str> {
+/// Decode a possibly-null C string pointer.
+///
+/// - `p.is_null()` → `Ok(None)` (caller chose not to pass this argument).
+/// - Non-null with valid UTF-8 → `Ok(Some(&str))`.
+/// - Non-null with invalid UTF-8 → `Err(Utf8Error)`.
+///
+/// Callers must distinguish these cases: a null pointer is usually a
+/// legal "omit this optional arg" sentinel, while invalid UTF-8 is a bug
+/// in the caller that should be surfaced through `tdx_last_error`.
+unsafe fn cstr_to_str<'a>(p: *const c_char) -> Result<Option<&'a str>, std::str::Utf8Error> {
     if p.is_null() {
-        return None;
+        return Ok(None);
     }
-    unsafe { CStr::from_ptr(p) }.to_str().ok()
+    unsafe { CStr::from_ptr(p) }.to_str().map(Some)
+}
+
+/// Extract a required C string arg. On failure, calls `set_error` with a
+/// message that distinguishes null-pointer vs invalid-UTF-8 and returns
+/// the given fallback value from the enclosing function.
+macro_rules! require_cstr {
+    ($p:ident, $fallback:expr) => {
+        match unsafe { cstr_to_str($p) } {
+            Ok(Some(s)) => s,
+            Ok(None) => {
+                set_error(concat!(stringify!($p), " is null"));
+                return $fallback;
+            }
+            Err(e) => {
+                set_error(&format!("{} is not valid UTF-8: {e}", stringify!($p)));
+                return $fallback;
+            }
+        }
+    };
 }
 
 fn insert_optional_str_arg(
@@ -645,16 +673,17 @@ fn insert_optional_str_arg(
     key: &str,
     raw: *const c_char,
 ) -> Result<(), String> {
-    if raw.is_null() {
-        return Ok(());
+    match unsafe { cstr_to_str(raw) } {
+        Ok(None) => Ok(()),
+        Ok(Some(value)) => {
+            args.insert(
+                key.to_string(),
+                thetadatadx::EndpointArgValue::Str(value.to_string()),
+            );
+            Ok(())
+        }
+        Err(e) => Err(format!("{key} is not valid UTF-8: {e}")),
     }
-    let value =
-        unsafe { cstr_to_str(raw) }.ok_or_else(|| format!("{key} is null or invalid UTF-8"))?;
-    args.insert(
-        key.to_string(),
-        thetadatadx::EndpointArgValue::Str(value.to_string()),
-    );
-    Ok(())
 }
 
 fn insert_int_arg(args: &mut thetadatadx::EndpointArgs, key: &str, value: i32) {
@@ -696,17 +725,27 @@ pub unsafe extern "C" fn tdx_credentials_new(
     email: *const c_char,
     password: *const c_char,
 ) -> *mut TdxCredentials {
-    let email = if let Some(s) = unsafe { cstr_to_str(email) } {
-        s
-    } else {
-        set_error("email is null or invalid UTF-8");
-        return ptr::null_mut();
+    let email = match unsafe { cstr_to_str(email) } {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            set_error("email is null");
+            return ptr::null_mut();
+        }
+        Err(e) => {
+            set_error(&format!("email is not valid UTF-8: {e}"));
+            return ptr::null_mut();
+        }
     };
-    let password = if let Some(s) = unsafe { cstr_to_str(password) } {
-        s
-    } else {
-        set_error("password is null or invalid UTF-8");
-        return ptr::null_mut();
+    let password = match unsafe { cstr_to_str(password) } {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            set_error("password is null");
+            return ptr::null_mut();
+        }
+        Err(e) => {
+            set_error(&format!("password is not valid UTF-8: {e}"));
+            return ptr::null_mut();
+        }
     };
     let creds = thetadatadx::Credentials::new(email, password);
     Box::into_raw(Box::new(TdxCredentials { inner: creds }))
@@ -717,11 +756,16 @@ pub unsafe extern "C" fn tdx_credentials_new(
 /// Returns null on error (check `tdx_last_error()`).
 #[no_mangle]
 pub unsafe extern "C" fn tdx_credentials_from_file(path: *const c_char) -> *mut TdxCredentials {
-    let path = if let Some(s) = unsafe { cstr_to_str(path) } {
-        s
-    } else {
-        set_error("path is null or invalid UTF-8");
-        return ptr::null_mut();
+    let path = match unsafe { cstr_to_str(path) } {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            set_error("path is null");
+            return ptr::null_mut();
+        }
+        Err(e) => {
+            set_error(&format!("path is not valid UTF-8: {e}"));
+            return ptr::null_mut();
+        }
     };
     match thetadatadx::Credentials::from_file(path) {
         Ok(creds) => Box::into_raw(Box::new(TdxCredentials { inner: creds })),
@@ -1137,9 +1181,16 @@ macro_rules! ffi_list_endpoint {
             let client = unsafe { &*client };
             $(
                 let $param = match unsafe { cstr_to_str($param) } {
-                    Some(s) => s,
-                    None => {
-                        set_error(concat!(stringify!($param), " is null or invalid UTF-8"));
+                    Ok(Some(s)) => s,
+                    Ok(None) => {
+                        set_error(concat!(stringify!($param), " is null"));
+                        return empty;
+                    }
+                    Err(e) => {
+                        set_error(&format!(
+                            "{} is not valid UTF-8: {e}",
+                            stringify!($param)
+                        ));
                         return empty;
                     }
                 };
@@ -1182,11 +1233,16 @@ unsafe fn parse_symbol_array(
     let ptrs = unsafe { std::slice::from_raw_parts(symbols, symbols_len) };
     let mut out = Vec::with_capacity(symbols_len);
     for (i, &p) in ptrs.iter().enumerate() {
-        if let Some(s) = unsafe { cstr_to_str(p) } {
-            out.push(s.to_owned())
-        } else {
-            set_error(&format!("symbols[{i}] is null or invalid UTF-8"));
-            return None;
+        match unsafe { cstr_to_str(p) } {
+            Ok(Some(s)) => out.push(s.to_owned()),
+            Ok(None) => {
+                set_error(&format!("symbols[{i}] is null"));
+                return None;
+            }
+            Err(e) => {
+                set_error(&format!("symbols[{i}] is not valid UTF-8: {e}"));
+                return None;
+            }
         }
     }
     Some(out)
@@ -1293,9 +1349,16 @@ macro_rules! ffi_typed_endpoint {
             let client = unsafe { &*client };
             $(
                 let $param = match unsafe { cstr_to_str($param) } {
-                    Some(s) => s,
-                    None => {
-                        set_error(concat!(stringify!($param), " is null or invalid UTF-8"));
+                    Ok(Some(s)) => s,
+                    Ok(None) => {
+                        set_error(concat!(stringify!($param), " is null"));
+                        return empty;
+                    }
+                    Err(e) => {
+                        set_error(&format!(
+                            "{} is not valid UTF-8: {e}",
+                            stringify!($param)
+                        ));
                         return empty;
                     }
                 };
@@ -1830,10 +1893,7 @@ pub unsafe extern "C" fn tdx_all_greeks(
     option_price: f64,
     right: *const c_char,
 ) -> *mut TdxGreeksResult {
-    let Some(right_str) = (unsafe { cstr_to_str(right) }) else {
-        set_error("right is null or invalid UTF-8");
-        return std::ptr::null_mut();
-    };
+    let right_str = require_cstr!(right, std::ptr::null_mut());
     if let Err(e) = thetadatadx::parse_right_strict(right_str) {
         set_error(&e.to_string());
         return std::ptr::null_mut();
@@ -1901,10 +1961,7 @@ pub unsafe extern "C" fn tdx_implied_volatility(
         set_error("output pointers must not be null");
         return -1;
     }
-    let Some(right_str) = (unsafe { cstr_to_str(right) }) else {
-        set_error("right is null or invalid UTF-8");
-        return -1;
-    };
+    let right_str = require_cstr!(right, -1);
     if let Err(e) = thetadatadx::parse_right_strict(right_str) {
         set_error(&e.to_string());
         return -1;
@@ -2193,12 +2250,7 @@ pub unsafe extern "C" fn tdx_unified_subscribe_quotes(
         set_error("unified handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let contract = thetadatadx::fpss::protocol::Contract::stock(symbol);
     match handle.inner.subscribe_quotes(&contract) {
@@ -2222,12 +2274,7 @@ pub unsafe extern "C" fn tdx_unified_subscribe_trades(
         set_error("unified handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let contract = thetadatadx::fpss::protocol::Contract::stock(symbol);
     match handle.inner.subscribe_trades(&contract) {
@@ -2251,12 +2298,7 @@ pub unsafe extern "C" fn tdx_unified_unsubscribe_quotes(
         set_error("unified handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let contract = thetadatadx::fpss::protocol::Contract::stock(symbol);
     match handle.inner.unsubscribe_quotes(&contract) {
@@ -2280,12 +2322,7 @@ pub unsafe extern "C" fn tdx_unified_unsubscribe_trades(
         set_error("unified handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let contract = thetadatadx::fpss::protocol::Contract::stock(symbol);
     match handle.inner.unsubscribe_trades(&contract) {
@@ -2307,12 +2344,7 @@ pub unsafe extern "C" fn tdx_unified_subscribe_open_interest(
         set_error("unified handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let contract = thetadatadx::fpss::protocol::Contract::stock(symbol);
     match handle.inner.subscribe_open_interest(&contract) {
@@ -2335,12 +2367,7 @@ pub unsafe extern "C" fn tdx_unified_subscribe_full_trades(
         set_error("unified handle is null");
         return -1;
     }
-    let sec_type_str = if let Some(s) = unsafe { cstr_to_str(sec_type) } {
-        s
-    } else {
-        set_error("sec_type is null");
-        return -1;
-    };
+    let sec_type_str = require_cstr!(sec_type, -1);
     let st = match sec_type_str.to_uppercase().as_str() {
         "STOCK" => tdbe::types::enums::SecType::Stock,
         "OPTION" => tdbe::types::enums::SecType::Option,
@@ -2371,12 +2398,7 @@ pub unsafe extern "C" fn tdx_unified_subscribe_full_open_interest(
         set_error("unified handle is null");
         return -1;
     }
-    let sec_type_str = if let Some(s) = unsafe { cstr_to_str(sec_type) } {
-        s
-    } else {
-        set_error("sec_type is null");
-        return -1;
-    };
+    let sec_type_str = require_cstr!(sec_type, -1);
     let st = match sec_type_str.to_uppercase().as_str() {
         "STOCK" => tdbe::types::enums::SecType::Stock,
         "OPTION" => tdbe::types::enums::SecType::Option,
@@ -2407,12 +2429,7 @@ pub unsafe extern "C" fn tdx_unified_unsubscribe_full_trades(
         set_error("unified handle is null");
         return -1;
     }
-    let sec_type_str = if let Some(s) = unsafe { cstr_to_str(sec_type) } {
-        s
-    } else {
-        set_error("sec_type is null");
-        return -1;
-    };
+    let sec_type_str = require_cstr!(sec_type, -1);
     let st = match sec_type_str.to_uppercase().as_str() {
         "STOCK" => tdbe::types::enums::SecType::Stock,
         "OPTION" => tdbe::types::enums::SecType::Option,
@@ -2443,12 +2460,7 @@ pub unsafe extern "C" fn tdx_unified_unsubscribe_full_open_interest(
         set_error("unified handle is null");
         return -1;
     }
-    let sec_type_str = if let Some(s) = unsafe { cstr_to_str(sec_type) } {
-        s
-    } else {
-        set_error("sec_type is null");
-        return -1;
-    };
+    let sec_type_str = require_cstr!(sec_type, -1);
     let st = match sec_type_str.to_uppercase().as_str() {
         "STOCK" => tdbe::types::enums::SecType::Stock,
         "OPTION" => tdbe::types::enums::SecType::Option,
@@ -2478,12 +2490,7 @@ pub unsafe extern "C" fn tdx_unified_unsubscribe_open_interest(
         set_error("unified handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let contract = thetadatadx::fpss::protocol::Contract::stock(symbol);
     match handle.inner.unsubscribe_open_interest(&contract) {
@@ -3081,12 +3088,7 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_quotes(
         set_error("FPSS handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let guard = handle
         .inner
@@ -3120,12 +3122,7 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_trades(
         set_error("FPSS handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let guard = handle
         .inner
@@ -3159,12 +3156,7 @@ pub unsafe extern "C" fn tdx_fpss_unsubscribe_quotes(
         set_error("FPSS handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let guard = handle
         .inner
@@ -3198,12 +3190,7 @@ pub unsafe extern "C" fn tdx_fpss_unsubscribe_trades(
         set_error("FPSS handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let guard = handle
         .inner
@@ -3237,12 +3224,7 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_open_interest(
         set_error("FPSS handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let guard = handle
         .inner
@@ -3276,12 +3258,7 @@ pub unsafe extern "C" fn tdx_fpss_unsubscribe_open_interest(
         set_error("FPSS handle is null");
         return -1;
     }
-    let symbol = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return -1;
-    };
+    let symbol = require_cstr!(symbol, -1);
     let handle = unsafe { &*handle };
     let guard = handle
         .inner
@@ -3317,12 +3294,7 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_full_trades(
         set_error("FPSS handle is null");
         return -1;
     }
-    let sec_type_str = if let Some(s) = unsafe { cstr_to_str(sec_type) } {
-        s
-    } else {
-        set_error("sec_type is null or invalid UTF-8");
-        return -1;
-    };
+    let sec_type_str = require_cstr!(sec_type, -1);
     let st = match sec_type_str.to_uppercase().as_str() {
         "STOCK" => tdbe::types::enums::SecType::Stock,
         "OPTION" => tdbe::types::enums::SecType::Option,
@@ -3368,12 +3340,7 @@ pub unsafe extern "C" fn tdx_fpss_subscribe_full_open_interest(
         set_error("FPSS handle is null");
         return -1;
     }
-    let sec_type_str = if let Some(s) = unsafe { cstr_to_str(sec_type) } {
-        s
-    } else {
-        set_error("sec_type is null or invalid UTF-8");
-        return -1;
-    };
+    let sec_type_str = require_cstr!(sec_type, -1);
     let st = match sec_type_str.to_uppercase().as_str() {
         "STOCK" => tdbe::types::enums::SecType::Stock,
         "OPTION" => tdbe::types::enums::SecType::Option,
@@ -3419,12 +3386,7 @@ pub unsafe extern "C" fn tdx_fpss_unsubscribe_full_trades(
         set_error("FPSS handle is null");
         return -1;
     }
-    let sec_type_str = if let Some(s) = unsafe { cstr_to_str(sec_type) } {
-        s
-    } else {
-        set_error("sec_type is null or invalid UTF-8");
-        return -1;
-    };
+    let sec_type_str = require_cstr!(sec_type, -1);
     let st = match sec_type_str.to_uppercase().as_str() {
         "STOCK" => tdbe::types::enums::SecType::Stock,
         "OPTION" => tdbe::types::enums::SecType::Option,
@@ -3470,12 +3432,7 @@ pub unsafe extern "C" fn tdx_fpss_unsubscribe_full_open_interest(
         set_error("FPSS handle is null");
         return -1;
     }
-    let sec_type_str = if let Some(s) = unsafe { cstr_to_str(sec_type) } {
-        s
-    } else {
-        set_error("sec_type is null or invalid UTF-8");
-        return -1;
-    };
+    let sec_type_str = require_cstr!(sec_type, -1);
     let st = match sec_type_str.to_uppercase().as_str() {
         "STOCK" => tdbe::types::enums::SecType::Stock,
         "OPTION" => tdbe::types::enums::SecType::Option,
@@ -3662,30 +3619,10 @@ unsafe fn parse_option_args<'a>(
     strike: *const c_char,
     right: *const c_char,
 ) -> Option<(&'a str, &'a str, &'a str, &'a str)> {
-    let sym = if let Some(s) = unsafe { cstr_to_str(symbol) } {
-        s
-    } else {
-        set_error("symbol is null or invalid UTF-8");
-        return None;
-    };
-    let exp = if let Some(s) = unsafe { cstr_to_str(expiration) } {
-        s
-    } else {
-        set_error("expiration is null or invalid UTF-8");
-        return None;
-    };
-    let stk = if let Some(s) = unsafe { cstr_to_str(strike) } {
-        s
-    } else {
-        set_error("strike is null or invalid UTF-8");
-        return None;
-    };
-    let rt = if let Some(s) = unsafe { cstr_to_str(right) } {
-        s
-    } else {
-        set_error("right is null or invalid UTF-8");
-        return None;
-    };
+    let sym = require_cstr!(symbol, None);
+    let exp = require_cstr!(expiration, None);
+    let stk = require_cstr!(strike, None);
+    let rt = require_cstr!(right, None);
     Some((sym, exp, stk, rt))
 }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2742,9 +2742,24 @@ pub unsafe extern "C" fn tdx_unified_reconnect(handle: *const TdxUnified) -> i32
     }
     let handle = unsafe { &*handle };
 
-    // Save active subscriptions
-    let saved_subs = handle.inner.active_subscriptions().unwrap_or_default();
-    let saved_full_subs = handle.inner.active_full_subscriptions().unwrap_or_default();
+    // Save active subscriptions. If streaming isn't running (or the
+    // subscription locks are poisoned upstream) we must abort the
+    // reconnect -- silently falling back to an empty list drops every
+    // subscription on the floor.
+    let saved_subs = match handle.inner.active_subscriptions() {
+        Ok(subs) => subs,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
+    let saved_full_subs = match handle.inner.active_full_subscriptions() {
+        Ok(subs) => subs,
+        Err(e) => {
+            set_error(&e.to_string());
+            return -1;
+        }
+    };
 
     // Stop streaming
     handle.inner.stop_streaming();

--- a/sdks/python/src/historical_methods.rs
+++ b/sdks/python/src/historical_methods.rs
@@ -9,16 +9,12 @@ impl ThetaDataDx {
         py: Python<'_>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Vec<String>> {
-        py.detach(|| {
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.stock_list_symbols_with_deadline(std::time::Duration::from_millis(ms)).await
-                    } else {
-                        self.tdx.stock_list_symbols().await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.stock_list_symbols_with_deadline(std::time::Duration::from_millis(ms)).await
+            } else {
+                self.tdx.stock_list_symbols().await
+            }
         })
     }
 
@@ -31,16 +27,12 @@ impl ThetaDataDx {
         symbol: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Vec<String>> {
-        py.detach(|| {
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.stock_list_dates_with_deadline(std::time::Duration::from_millis(ms), request_type, symbol).await
-                    } else {
-                        self.tdx.stock_list_dates(request_type, symbol).await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.stock_list_dates_with_deadline(std::time::Duration::from_millis(ms), request_type, symbol).await
+            } else {
+                self.tdx.stock_list_dates(request_type, symbol).await
+            }
         })
     }
 
@@ -55,21 +47,17 @@ impl ThetaDataDx {
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_snapshot_ohlc(&refs);
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_snapshot_ohlc(&refs);
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(ohlc_ticks_to_columnar(py, &ticks))
     }
 
@@ -84,21 +72,17 @@ impl ThetaDataDx {
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_snapshot_trade(&refs);
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_snapshot_trade(&refs);
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(trade_ticks_to_columnar(py, &ticks))
     }
 
@@ -113,21 +97,17 @@ impl ThetaDataDx {
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_snapshot_quote(&refs);
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_snapshot_quote(&refs);
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(quote_ticks_to_columnar(py, &ticks))
     }
 
@@ -142,21 +122,17 @@ impl ThetaDataDx {
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_snapshot_market_value(&refs);
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_snapshot_market_value(&refs);
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(market_value_ticks_to_columnar(py, &ticks))
     }
 
@@ -170,15 +146,11 @@ impl ThetaDataDx {
         end_date: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_history_eod(symbol, start_date, end_date);
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_history_eod(symbol, start_date, end_date);
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(eod_ticks_to_columnar(py, &ticks))
     }
 
@@ -197,30 +169,26 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_history_ohlc(symbol, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_history_ohlc(symbol, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(ohlc_ticks_to_columnar(py, &ticks))
     }
 
@@ -238,30 +206,26 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_history_trade(symbol, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_history_trade(symbol, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(trade_ticks_to_columnar(py, &ticks))
     }
 
@@ -280,30 +244,26 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_history_quote(symbol, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_history_quote(symbol, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(quote_ticks_to_columnar(py, &ticks))
     }
 
@@ -322,33 +282,29 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_history_trade_quote(symbol, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = exclusive {
-                request = request.exclusive(value);
-            }
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_history_trade_quote(symbol, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = exclusive {
+            request = request.exclusive(value);
+        }
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(trade_quote_ticks_to_columnar(py, &ticks))
     }
 
@@ -364,18 +320,14 @@ impl ThetaDataDx {
         venue: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_at_time_trade(symbol, start_date, end_date, time_of_day);
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_at_time_trade(symbol, start_date, end_date, time_of_day);
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(trade_ticks_to_columnar(py, &ticks))
     }
 
@@ -391,18 +343,14 @@ impl ThetaDataDx {
         venue: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_at_time_quote(symbol, start_date, end_date, time_of_day);
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_at_time_quote(symbol, start_date, end_date, time_of_day);
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(quote_ticks_to_columnar(py, &ticks))
     }
 
@@ -413,16 +361,12 @@ impl ThetaDataDx {
         py: Python<'_>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Vec<String>> {
-        py.detach(|| {
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.option_list_symbols_with_deadline(std::time::Duration::from_millis(ms)).await
-                    } else {
-                        self.tdx.option_list_symbols().await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.option_list_symbols_with_deadline(std::time::Duration::from_millis(ms)).await
+            } else {
+                self.tdx.option_list_symbols().await
+            }
         })
     }
 
@@ -438,16 +382,12 @@ impl ThetaDataDx {
         right: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Vec<String>> {
-        py.detach(|| {
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.option_list_dates_with_deadline(std::time::Duration::from_millis(ms), request_type, symbol, expiration, strike, right).await
-                    } else {
-                        self.tdx.option_list_dates(request_type, symbol, expiration, strike, right).await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.option_list_dates_with_deadline(std::time::Duration::from_millis(ms), request_type, symbol, expiration, strike, right).await
+            } else {
+                self.tdx.option_list_dates(request_type, symbol, expiration, strike, right).await
+            }
         })
     }
 
@@ -459,16 +399,12 @@ impl ThetaDataDx {
         symbol: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Vec<String>> {
-        py.detach(|| {
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.option_list_expirations_with_deadline(std::time::Duration::from_millis(ms), symbol).await
-                    } else {
-                        self.tdx.option_list_expirations(symbol).await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.option_list_expirations_with_deadline(std::time::Duration::from_millis(ms), symbol).await
+            } else {
+                self.tdx.option_list_expirations(symbol).await
+            }
         })
     }
 
@@ -481,16 +417,12 @@ impl ThetaDataDx {
         expiration: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Vec<String>> {
-        py.detach(|| {
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.option_list_strikes_with_deadline(std::time::Duration::from_millis(ms), symbol, expiration).await
-                    } else {
-                        self.tdx.option_list_strikes(symbol, expiration).await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.option_list_strikes_with_deadline(std::time::Duration::from_millis(ms), symbol, expiration).await
+            } else {
+                self.tdx.option_list_strikes(symbol, expiration).await
+            }
         })
     }
 
@@ -505,18 +437,14 @@ impl ThetaDataDx {
         max_dte: Option<i32>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_list_contracts(request_type, symbol, date);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_list_contracts(request_type, symbol, date);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(option_contracts_to_columnar(py, &ticks))
     }
 
@@ -534,24 +462,20 @@ impl ThetaDataDx {
         min_time: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_ohlc(symbol, expiration, strike, right);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_ohlc(symbol, expiration, strike, right);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(ohlc_ticks_to_columnar(py, &ticks))
     }
 
@@ -568,21 +492,17 @@ impl ThetaDataDx {
         min_time: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_trade(symbol, expiration, strike, right);
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_trade(symbol, expiration, strike, right);
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(trade_ticks_to_columnar(py, &ticks))
     }
 
@@ -600,24 +520,20 @@ impl ThetaDataDx {
         min_time: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_quote(symbol, expiration, strike, right);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_quote(symbol, expiration, strike, right);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(quote_ticks_to_columnar(py, &ticks))
     }
 
@@ -635,24 +551,20 @@ impl ThetaDataDx {
         min_time: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_open_interest(symbol, expiration, strike, right);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_open_interest(symbol, expiration, strike, right);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(open_interest_ticks_to_columnar(py, &ticks))
     }
 
@@ -670,24 +582,20 @@ impl ThetaDataDx {
         min_time: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_market_value(symbol, expiration, strike, right);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_market_value(symbol, expiration, strike, right);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(market_value_ticks_to_columnar(py, &ticks))
     }
 
@@ -711,42 +619,38 @@ impl ThetaDataDx {
         use_market_value: Option<bool>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_greeks_implied_volatility(symbol, expiration, strike, right);
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = stock_price {
-                request = request.stock_price(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(value) = use_market_value {
-                request = request.use_market_value(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_greeks_implied_volatility(symbol, expiration, strike, right);
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = stock_price {
+            request = request.stock_price(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(value) = use_market_value {
+            request = request.use_market_value(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(iv_ticks_to_columnar(py, &ticks))
     }
 
@@ -770,42 +674,38 @@ impl ThetaDataDx {
         use_market_value: Option<bool>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_greeks_all(symbol, expiration, strike, right);
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = stock_price {
-                request = request.stock_price(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(value) = use_market_value {
-                request = request.use_market_value(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_greeks_all(symbol, expiration, strike, right);
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = stock_price {
+            request = request.stock_price(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(value) = use_market_value {
+            request = request.use_market_value(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -829,42 +729,38 @@ impl ThetaDataDx {
         use_market_value: Option<bool>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_greeks_first_order(symbol, expiration, strike, right);
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = stock_price {
-                request = request.stock_price(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(value) = use_market_value {
-                request = request.use_market_value(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_greeks_first_order(symbol, expiration, strike, right);
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = stock_price {
+            request = request.stock_price(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(value) = use_market_value {
+            request = request.use_market_value(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -888,42 +784,38 @@ impl ThetaDataDx {
         use_market_value: Option<bool>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_greeks_second_order(symbol, expiration, strike, right);
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = stock_price {
-                request = request.stock_price(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(value) = use_market_value {
-                request = request.use_market_value(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_greeks_second_order(symbol, expiration, strike, right);
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = stock_price {
+            request = request.stock_price(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(value) = use_market_value {
+            request = request.use_market_value(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -947,42 +839,38 @@ impl ThetaDataDx {
         use_market_value: Option<bool>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_snapshot_greeks_third_order(symbol, expiration, strike, right);
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = stock_price {
-                request = request.stock_price(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(value) = use_market_value {
-                request = request.use_market_value(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_snapshot_greeks_third_order(symbol, expiration, strike, right);
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = stock_price {
+            request = request.stock_price(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(value) = use_market_value {
+            request = request.use_market_value(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1001,21 +889,17 @@ impl ThetaDataDx {
         strike_range: Option<i32>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_eod(symbol, expiration, strike, right, start_date, end_date);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_eod(symbol, expiration, strike, right, start_date, end_date);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(eod_ticks_to_columnar(py, &ticks))
     }
 
@@ -1037,30 +921,26 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_ohlc(symbol, expiration, strike, right, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_ohlc(symbol, expiration, strike, right, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(ohlc_ticks_to_columnar(py, &ticks))
     }
 
@@ -1082,33 +962,29 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_trade(symbol, expiration, strike, right, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_trade(symbol, expiration, strike, right, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(trade_ticks_to_columnar(py, &ticks))
     }
 
@@ -1131,33 +1007,29 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_quote(symbol, expiration, strike, right, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_quote(symbol, expiration, strike, right, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(quote_ticks_to_columnar(py, &ticks))
     }
 
@@ -1180,36 +1052,32 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_trade_quote(symbol, expiration, strike, right, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = exclusive {
-                request = request.exclusive(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_trade_quote(symbol, expiration, strike, right, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = exclusive {
+            request = request.exclusive(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(trade_quote_ticks_to_columnar(py, &ticks))
     }
 
@@ -1229,27 +1097,23 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_open_interest(symbol, expiration, strike, right, date);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_open_interest(symbol, expiration, strike, right, date);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(open_interest_ticks_to_columnar(py, &ticks))
     }
 
@@ -1273,36 +1137,32 @@ impl ThetaDataDx {
         strike_range: Option<i32>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_greeks_eod(symbol, expiration, strike, right, start_date, end_date);
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = underlyer_use_nbbo {
-                request = request.underlyer_use_nbbo(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_greeks_eod(symbol, expiration, strike, right, start_date, end_date);
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = underlyer_use_nbbo {
+            request = request.underlyer_use_nbbo(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1328,42 +1188,38 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_greeks_all(symbol, expiration, strike, right, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_greeks_all(symbol, expiration, strike, right, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1389,45 +1245,41 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_trade_greeks_all(symbol, expiration, strike, right, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_trade_greeks_all(symbol, expiration, strike, right, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1453,42 +1305,38 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_greeks_first_order(symbol, expiration, strike, right, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_greeks_first_order(symbol, expiration, strike, right, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1514,45 +1362,41 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_trade_greeks_first_order(symbol, expiration, strike, right, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_trade_greeks_first_order(symbol, expiration, strike, right, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1578,42 +1422,38 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_greeks_second_order(symbol, expiration, strike, right, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_greeks_second_order(symbol, expiration, strike, right, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1639,45 +1479,41 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_trade_greeks_second_order(symbol, expiration, strike, right, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_trade_greeks_second_order(symbol, expiration, strike, right, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1703,42 +1539,38 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_greeks_third_order(symbol, expiration, strike, right, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_greeks_third_order(symbol, expiration, strike, right, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1764,45 +1596,41 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_trade_greeks_third_order(symbol, expiration, strike, right, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_trade_greeks_third_order(symbol, expiration, strike, right, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(greeks_ticks_to_columnar(py, &ticks))
     }
 
@@ -1828,42 +1656,38 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_greeks_implied_volatility(symbol, expiration, strike, right, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_greeks_implied_volatility(symbol, expiration, strike, right, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(iv_ticks_to_columnar(py, &ticks))
     }
 
@@ -1889,45 +1713,41 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_history_trade_greeks_implied_volatility(symbol, expiration, strike, right, date);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = annual_dividend {
-                request = request.annual_dividend(value);
-            }
-            if let Some(value) = rate_type {
-                request = request.rate_type(value);
-            }
-            if let Some(value) = rate_value {
-                request = request.rate_value(value);
-            }
-            if let Some(value) = version {
-                request = request.version(value);
-            }
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_history_trade_greeks_implied_volatility(symbol, expiration, strike, right, date);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = annual_dividend {
+            request = request.annual_dividend(value);
+        }
+        if let Some(value) = rate_type {
+            request = request.rate_type(value);
+        }
+        if let Some(value) = rate_value {
+            request = request.rate_value(value);
+        }
+        if let Some(value) = version {
+            request = request.version(value);
+        }
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(iv_ticks_to_columnar(py, &ticks))
     }
 
@@ -1947,21 +1767,17 @@ impl ThetaDataDx {
         strike_range: Option<i32>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_at_time_trade(symbol, expiration, strike, right, start_date, end_date, time_of_day);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_at_time_trade(symbol, expiration, strike, right, start_date, end_date, time_of_day);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(trade_ticks_to_columnar(py, &ticks))
     }
 
@@ -1981,21 +1797,17 @@ impl ThetaDataDx {
         strike_range: Option<i32>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.option_at_time_quote(symbol, expiration, strike, right, start_date, end_date, time_of_day);
-            if let Some(value) = max_dte {
-                request = request.max_dte(value);
-            }
-            if let Some(value) = strike_range {
-                request = request.strike_range(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.option_at_time_quote(symbol, expiration, strike, right, start_date, end_date, time_of_day);
+        if let Some(value) = max_dte {
+            request = request.max_dte(value);
+        }
+        if let Some(value) = strike_range {
+            request = request.strike_range(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(quote_ticks_to_columnar(py, &ticks))
     }
 
@@ -2006,16 +1818,12 @@ impl ThetaDataDx {
         py: Python<'_>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Vec<String>> {
-        py.detach(|| {
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.index_list_symbols_with_deadline(std::time::Duration::from_millis(ms)).await
-                    } else {
-                        self.tdx.index_list_symbols().await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.index_list_symbols_with_deadline(std::time::Duration::from_millis(ms)).await
+            } else {
+                self.tdx.index_list_symbols().await
+            }
         })
     }
 
@@ -2027,16 +1835,12 @@ impl ThetaDataDx {
         symbol: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Vec<String>> {
-        py.detach(|| {
-            runtime()
-                .block_on(async {
-                    if let Some(ms) = timeout_ms {
-                        self.tdx.index_list_dates_with_deadline(std::time::Duration::from_millis(ms), symbol).await
-                    } else {
-                        self.tdx.index_list_dates(symbol).await
-                    }
-                })
-                .map_err(to_py_err)
+        run_blocking(py, async move {
+            if let Some(ms) = timeout_ms {
+                self.tdx.index_list_dates_with_deadline(std::time::Duration::from_millis(ms), symbol).await
+            } else {
+                self.tdx.index_list_dates(symbol).await
+            }
         })
     }
 
@@ -2050,18 +1854,14 @@ impl ThetaDataDx {
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.index_snapshot_ohlc(&refs);
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.index_snapshot_ohlc(&refs);
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(ohlc_ticks_to_columnar(py, &ticks))
     }
 
@@ -2075,18 +1875,14 @@ impl ThetaDataDx {
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.index_snapshot_price(&refs);
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.index_snapshot_price(&refs);
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(price_ticks_to_columnar(py, &ticks))
     }
 
@@ -2100,18 +1896,14 @@ impl ThetaDataDx {
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
         let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.index_snapshot_market_value(&refs);
-            if let Some(value) = min_time {
-                request = request.min_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.index_snapshot_market_value(&refs);
+        if let Some(value) = min_time {
+            request = request.min_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(market_value_ticks_to_columnar(py, &ticks))
     }
 
@@ -2125,15 +1917,11 @@ impl ThetaDataDx {
         end_date: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.index_history_eod(symbol, start_date, end_date);
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.index_history_eod(symbol, start_date, end_date);
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(eod_ticks_to_columnar(py, &ticks))
     }
 
@@ -2150,21 +1938,17 @@ impl ThetaDataDx {
         end_time: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.index_history_ohlc(symbol, start_date, end_date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.index_history_ohlc(symbol, start_date, end_date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(ohlc_ticks_to_columnar(py, &ticks))
     }
 
@@ -2182,27 +1966,23 @@ impl ThetaDataDx {
         end_date: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.index_history_price(symbol, date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = start_date {
-                request = request.start_date(value);
-            }
-            if let Some(value) = end_date {
-                request = request.end_date(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.index_history_price(symbol, date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = start_date {
+            request = request.start_date(value);
+        }
+        if let Some(value) = end_date {
+            request = request.end_date(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(price_ticks_to_columnar(py, &ticks))
     }
 
@@ -2217,15 +1997,11 @@ impl ThetaDataDx {
         time_of_day: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.index_at_time_price(symbol, start_date, end_date, time_of_day);
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.index_at_time_price(symbol, start_date, end_date, time_of_day);
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(price_ticks_to_columnar(py, &ticks))
     }
 
@@ -2236,15 +2012,11 @@ impl ThetaDataDx {
         py: Python<'_>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.calendar_open_today();
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.calendar_open_today();
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(calendar_days_to_columnar(py, &ticks))
     }
 
@@ -2256,15 +2028,11 @@ impl ThetaDataDx {
         date: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.calendar_on_date(date);
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.calendar_on_date(date);
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(calendar_days_to_columnar(py, &ticks))
     }
 
@@ -2276,15 +2044,11 @@ impl ThetaDataDx {
         year: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.calendar_year(year);
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.calendar_year(year);
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(calendar_days_to_columnar(py, &ticks))
     }
 
@@ -2298,15 +2062,11 @@ impl ThetaDataDx {
         end_date: &str,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.interest_rate_history_eod(symbol, start_date, end_date);
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.interest_rate_history_eod(symbol, start_date, end_date);
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(interest_rate_ticks_to_columnar(py, &ticks))
     }
 
@@ -2324,24 +2084,20 @@ impl ThetaDataDx {
         venue: Option<&str>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let ticks = py.detach(|| {
-            let mut request = self.tdx.stock_history_ohlc_range(symbol, start_date, end_date, interval);
-            if let Some(value) = start_time {
-                request = request.start_time(value);
-            }
-            if let Some(value) = end_time {
-                request = request.end_time(value);
-            }
-            if let Some(value) = venue {
-                request = request.venue(value);
-            }
-            if let Some(ms) = timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms));
-            }
-            runtime()
-                .block_on(async { request.await })
-                .map_err(to_py_err)
-        })?;
+        let mut request = self.tdx.stock_history_ohlc_range(symbol, start_date, end_date, interval);
+        if let Some(value) = start_time {
+            request = request.start_time(value);
+        }
+        if let Some(value) = end_time {
+            request = request.end_time(value);
+        }
+        if let Some(value) = venue {
+            request = request.venue(value);
+        }
+        if let Some(ms) = timeout_ms {
+            request = request.with_deadline(std::time::Duration::from_millis(ms));
+        }
+        let ticks = run_blocking(py, async move { request.await })?;
         Ok(ohlc_ticks_to_columnar(py, &ticks))
     }
 

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -38,6 +38,36 @@ fn to_py_err(e: thetadatadx::Error) -> PyErr {
     }
 }
 
+/// Run an async future to completion while periodically honoring Python's
+/// signal handlers. A blocking `runtime().block_on` inside `py.detach`
+/// otherwise starves `KeyboardInterrupt` because the GIL is released and
+/// signals can never be delivered.
+///
+/// Polls `Python::check_signals()` every 100ms. On Ctrl+C, returns the
+/// `PyErr` raised by Python (typically `KeyboardInterrupt`); the in-flight
+/// future is dropped and its gRPC channel is cancelled.
+fn run_blocking<F, T>(py: Python<'_>, fut: F) -> PyResult<T>
+where
+    F: std::future::Future<Output = Result<T, thetadatadx::Error>> + Send,
+    T: Send,
+{
+    py.detach(|| {
+        runtime().block_on(async move {
+            tokio::pin!(fut);
+            loop {
+                tokio::select! {
+                    out = &mut fut => return out.map_err(to_py_err),
+                    _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                        if let Err(e) = Python::attach(|py| py.check_signals()) {
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+        })
+    })
+}
+
 fn parse_sec_type(sec_type: &str) -> PyResult<tdbe::types::enums::SecType> {
     match sec_type.to_uppercase().as_str() {
         "STOCK" => Ok(tdbe::types::enums::SecType::Stock),

--- a/sdks/python/src/streaming_methods.rs
+++ b/sdks/python/src/streaming_methods.rs
@@ -202,8 +202,27 @@ impl ThetaDataDx {
         drop(rx_outer);
         let timeout = std::time::Duration::from_millis(timeout_ms);
         let result = py.detach(move || {
-            let rx = rx_arc.lock().unwrap_or_else(|e| e.into_inner());
-            rx.recv_timeout(timeout).ok()
+            // Poll with `try_recv` + short sleep so the inner lock is only
+            // held for nanoseconds per iteration. A blocking `recv_timeout`
+            // would pin the mutex for the full timeout and serialize any
+            // concurrent `next_event` / `reconnect` caller behind it.
+            let deadline = std::time::Instant::now() + timeout;
+            let poll_interval = std::time::Duration::from_millis(1);
+            loop {
+                {
+                    let rx = rx_arc.lock().unwrap_or_else(|e| e.into_inner());
+                    match rx.try_recv() {
+                        Ok(event) => return Some(event),
+                        Err(std::sync::mpsc::TryRecvError::Disconnected) => return None,
+                        Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                    }
+                }
+                let now = std::time::Instant::now();
+                if now >= deadline {
+                    return None;
+                }
+                std::thread::sleep(poll_interval.min(deadline - now));
+            }
         });
         match result {
             Some(event) => Ok(Some(buffered_event_to_py(py, &event))),

--- a/sdks/python/src/streaming_methods.rs
+++ b/sdks/python/src/streaming_methods.rs
@@ -50,7 +50,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<()> {
-        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right);
+        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right).map_err(to_py_err)?;
         self.tdx.subscribe_quotes(&contract).map_err(to_py_err)
     }
 
@@ -62,7 +62,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<()> {
-        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right);
+        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right).map_err(to_py_err)?;
         self.tdx.subscribe_trades(&contract).map_err(to_py_err)
     }
 
@@ -74,7 +74,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<()> {
-        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right);
+        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right).map_err(to_py_err)?;
         self.tdx.subscribe_open_interest(&contract).map_err(to_py_err)
     }
 
@@ -116,7 +116,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<()> {
-        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right);
+        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right).map_err(to_py_err)?;
         self.tdx.unsubscribe_quotes(&contract).map_err(to_py_err)
     }
 
@@ -128,7 +128,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<()> {
-        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right);
+        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right).map_err(to_py_err)?;
         self.tdx.unsubscribe_trades(&contract).map_err(to_py_err)
     }
 
@@ -140,7 +140,7 @@ impl ThetaDataDx {
         strike: &str,
         right: &str,
     ) -> PyResult<()> {
-        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right);
+        let contract = fpss::protocol::Contract::option(symbol, expiration, strike, right).map_err(to_py_err)?;
         self.tdx.unsubscribe_open_interest(&contract).map_err(to_py_err)
     }
 

--- a/tools/server/src/ws.rs
+++ b/tools/server/src/ws.rs
@@ -471,16 +471,41 @@ fn contract_to_json(c: &Contract) -> sonic_rs::Value {
 
 /// Start the FPSS -> WebSocket bridge via `ThetaDataDx::start_streaming()`.
 ///
-/// Registers a callback that broadcasts events to WS clients.
+/// The Disruptor callback runs on a blocking consumer thread and must stay
+/// cheap. It only: (1) updates the contract map and connection flags,
+/// (2) hands a cloned event to an unbounded channel. A dedicated tokio task
+/// locks the map, serializes the JSON, and fans out to every WS client.
 pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
     let contract_map: Arc<Mutex<HashMap<i32, Contract>>> = state.contract_map();
-    let map_clone = Arc::clone(&contract_map);
-    let state_clone = state.clone();
+    let map_for_cb = Arc::clone(&contract_map);
+    let map_for_task = Arc::clone(&contract_map);
+    let state_for_cb = state.clone();
+    let state_for_task = state.clone();
+
+    // Unbounded mpsc keeps the Disruptor callback non-blocking even if the
+    // broadcast task is briefly slow. Memory is bounded by channel drain
+    // rate; clients get bounded per-client backpressure inside broadcast_ws.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<FpssEvent>();
+
+    tokio::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            let json = {
+                let map = map_for_task.lock().unwrap_or_else(|e| e.into_inner());
+                fpss_event_to_ws_json(&event, &map)
+            };
+            if let Some(ws_json) = json {
+                let msg: Arc<str> = Arc::from(ws_json);
+                state_for_task.broadcast_ws(msg);
+            }
+        }
+    });
 
     state.tdx().start_streaming(move |event: &FpssEvent| {
-        // Track contract assignments.
+        // Track contract assignments. Must happen on the callback thread so
+        // the broadcast task sees the mapping before it serializes the next
+        // event that references it.
         if let FpssEvent::Control(FpssControl::ContractAssigned { id, contract }) = event {
-            if let Ok(mut map) = map_clone.lock() {
+            if let Ok(mut map) = map_for_cb.lock() {
                 map.insert(*id, contract.clone());
             }
         }
@@ -488,20 +513,16 @@ pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
         // Update connection status.
         match event {
             FpssEvent::Control(FpssControl::LoginSuccess { .. }) => {
-                state_clone.set_fpss_connected(true);
+                state_for_cb.set_fpss_connected(true);
             }
             FpssEvent::Control(FpssControl::Disconnected { .. }) => {
-                state_clone.set_fpss_connected(false);
+                state_for_cb.set_fpss_connected(false);
             }
             _ => {}
         }
 
-        // Serialize once, fan out as Arc<str> (zero-copy per client).
-        let map = map_clone.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(ws_json) = fpss_event_to_ws_json(event, &map) {
-            let msg: Arc<str> = Arc::from(ws_json);
-            state_clone.broadcast_ws(msg);
-        }
+        // Hand off for serialization + broadcast. Callback returns immediately.
+        let _ = tx.send(event.clone());
     })?;
 
     state.set_fpss_connected(true);


### PR DESCRIPTION
## Summary
Batch fix for a recent audit pass covering 2 critical data races, 5 high-severity correctness issues (including a session-token log leak), 4 perf wins, and 2 cleanups.

## Issues closed
- Closes #310, #311 (CRITICAL)
- Closes #312, #313, #314, #315, #317 (HIGH)
- Closes #316 (MEDIUM)
- Closes #318, #319, #320 (PERF)
- Closes #321, #322 (LOW)

## Commits
- `security: redact session_id in AuthResponse Debug output` (#317)
- `fix: remove unsound unsafe impl Sync for FpssClient, wrap cmd_tx in Mutex` (#310)
- `fix: poll rx with try_recv + sleep in Python next_event` (#311)
- `fix: honor Ctrl+C during Python historical requests` (#312)
- `fix: propagate active-subscription read errors from tdx_unified_reconnect` (#313)
- `fix: surface tick-schema drift in row_number / row_float` (#314)
- `fix: make Contract::option fallible (panic/overflow → Result<_, Error>)` (#315)
- `fix: distinguish null pointer from invalid UTF-8 in cstr_to_str` (#316)
- `perf(greeks): share d1 across d1/d2 callers (~15% per individual sweep)` (#318)
- `perf(tdbe): flatten decode_fit_buffer_bulk storage (-22%)` (#319)
- `perf(fpss): consume String into Arc<str> instead of re-allocating` (#320)
- `perf(server): move WS JSON serialization off the FPSS callback thread` (#321)
- `fix: propagate invalid-right as Error from wire_right_opt / normalize_right` (#322)

## Perf numbers (criterion, this machine)
- `all_greeks_individual`: 443.5 ns → 376.3 ns (**-15.1%**)
- `fit_bulk_1000_rows`: 62.9 µs → 48.6 µs (**-22.7%**)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces -- --check`
- [x] `cargo build -p thetadatadx-ffi --release && (cd sdks/go && LD_LIBRARY_PATH=../../target/release go test ./...)`
- [x] `cmake -S sdks/cpp -B build/cpp && cmake --build build/cpp --config Release --target thetadatadx_cpp thetadatadx_validate`
- [x] `cargo check` on the Python SDK (out-of-workspace; verified in a scratch workspace since the worktree blocks `--manifest-path`)
- [x] `python3 scripts/check_docs_consistency.py`