### PR TITLE
release: thetadatadx 7.2.1 — Greek decoder + bulk timeout

### DIFF
--- a/.github/release-notes/v7.2.1.md
+++ b/.github/release-notes/v7.2.1.md
@@ -1,0 +1,14 @@
+## Breaking Changes
+
+None. Patch release restoring Greek endpoint behavior broken by the v7.2.0 strict-decode tightening.
+
+## Fixed
+
+- **Greek and IV decoders reject live payloads** -- every `option_snapshot_greeks_*` and `option_history_greeks_*` endpoint failed with `Decode failed: column N: expected Number, got Price` on the v7.2.0 release. The v3 MDDS server legitimately sends Greeks and implied-volatility values as `Price`-encoded cells, mirroring Java's `PojoMessageUtils.dataValue2Object` PRICE → BigDecimal arm; the v7.2.0 tightening routed every `f64` tick column through `row_float`, which accepts only `Number`. `f64` columns now decode through `row_price_f64` and accept both `Price` and `Number` cells. Pinned with two regression tests on `parse_greeks_ticks` covering Price-cell and Number-cell decoding. Live run 24520486541 on main reproduced the regression on 11 cells across 7 endpoints.
+- **Bulk option-chain validator cells timed out at 60 s** -- `all_strikes_one_exp` and `bulk_chain` modes on `option_history_ohlc`, `option_history_quote`, `option_history_trade_quote`, `option_history_greeks_first_order`, `option_history_greeks_implied_volatility`, and `option_at_time_quote` legitimately stream more data than fits in the 60-second per-cell budget. The CLI / Python / Go / C++ validators now apply a 180-second deadline to bulk-chain / all-strike cells and keep the 60-second baseline elsewhere.
+
+## Internal
+
+- Dropped the unused `row_float` helper and the test pinning its now-obsolete strict-Number invariant.
+
+Full changelog: https://github.com/userFRM/ThetaDataDx/blob/main/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.2.1] - 2026-04-16
+
+### Fixed
+
+- **Greek and IV decoders regressed by v7.2.0 strict decode** -- every Greek endpoint (`option_snapshot_greeks_*`, `option_history_greeks_*`) returned `Decode failed: column N: expected Number, got Price` on live payloads. The v7.2.0 tightening routed every `f64` tick column through `row_float`, which accepts only `Number` cells, but the v3 MDDS server legitimately sends Greeks and implied-volatility values as `Price`-encoded cells (matching Java's `PojoMessageUtils.dataValue2Object` PRICE → BigDecimal arm). `f64` columns now decode through `row_price_f64` and accept both `Price` and `Number` cells. Regression surfaced on live run 24520486541.
+- **Bulk option-chain validator cells timed out at 60 s** -- `all_strikes_one_exp` and `bulk_chain` cells on `option_history_ohlc`, `option_history_quote`, `option_history_trade_quote`, `option_history_greeks_first_order`, `option_history_greeks_implied_volatility`, and `option_at_time_quote` legitimately stream a full-chain payload that does not fit in the 60-second per-cell budget. The CLI / Python / Go / C++ validators now apply a 180-second deadline to bulk-chain / all-strike modes and keep the 60-second baseline for every other cell.
+
 ## [7.2.0] - 2026-04-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "7.2.0"
+version = "7.2.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/crates/thetadatadx/build_support/endpoints/render/cli_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/cli_validate.rs
@@ -32,6 +32,12 @@ pub(super) fn render_cli_validate(
                 .map(|token| format!("{token:?}"))
                 .collect::<Vec<_>>()
                 .join(", ");
+            // Full-chain / all-strike bulk modes legitimately stream more
+            // than a 60s-per-cell budget allows on `option_history_*` and
+            // `option_at_time_*`. Mark them so the postamble picks a
+            // longer deadline for just those cells. See
+            // [`SLOW_MODE_TIMEOUT_MS`] in the postamble.
+            let slow = matches!(mode.name.as_str(), "all_strikes_one_exp" | "bulk_chain");
             write!(
                 out,
                 include_str!("templates/validate_cli/cell.py.tmpl"),
@@ -40,6 +46,7 @@ pub(super) fn render_cli_validate(
                 min_tier = mode.min_tier,
                 rationale = mode.rationale,
                 args = tokens,
+                slow = if slow { "True" } else { "False" },
             )
             .unwrap();
         }

--- a/crates/thetadatadx/build_support/endpoints/render/cpp_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/cpp_validate.rs
@@ -41,8 +41,17 @@ pub(super) fn render_cpp_validate(
                 .iter()
                 .filter_map(|(name, value)| cpp_builder_setter(endpoint, name, value))
                 .collect();
+            // Bulk-chain / all-strike cells use `kSlowModeTimeoutMs` since
+            // a full option chain payload legitimately takes longer than
+            // 60s; all other cells use `kPerCellTimeoutMs`.
+            let timeout_sym = if matches!(mode.name.as_str(), "all_strikes_one_exp" | "bulk_chain")
+            {
+                "kSlowModeTimeoutMs"
+            } else {
+                "kPerCellTimeoutMs"
+            };
             args_parts.push(format!(
-                "tdx::EndpointRequestOptions{{}}{setters}.with_timeout_ms(kPerCellTimeoutMs)"
+                "tdx::EndpointRequestOptions{{}}{setters}.with_timeout_ms({timeout_sym})"
             ));
             let args = args_parts.join(", ");
             write!(

--- a/crates/thetadatadx/build_support/endpoints/render/go_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/go_validate.rs
@@ -36,7 +36,15 @@ pub(super) fn render_go_validate(
                 }
             }
             // Cross-cutting deadline (W3): SDK enforces and cancels on expiry.
-            args_parts.push("WithTimeoutMs(perCellTimeoutMs)".into());
+            // Bulk-chain / all-strike cells use `slowModeTimeoutMs` since a
+            // full option chain payload legitimately takes longer than 60s.
+            let timeout_sym = if matches!(mode.name.as_str(), "all_strikes_one_exp" | "bulk_chain")
+            {
+                "slowModeTimeoutMs"
+            } else {
+                "perCellTimeoutMs"
+            };
+            args_parts.push(format!("WithTimeoutMs({timeout_sym})"));
             let args = args_parts.join(", ");
             write!(
                 out,

--- a/crates/thetadatadx/build_support/endpoints/render/python_validate.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/python_validate.rs
@@ -37,8 +37,16 @@ pub(super) fn render_python_validate(
             }
             // Cross-cutting per-call deadline (W3): SDK cancels the in-flight
             // gRPC stream on expiry and raises a RuntimeError; no daemon
-            // thread / os._exit gymnastics needed any more.
-            args_parts.push("timeout_ms=PER_CELL_TIMEOUT_MS".into());
+            // thread / os._exit gymnastics needed any more. Bulk-chain /
+            // all-strike modes use `SLOW_MODE_TIMEOUT_MS` since a full
+            // option chain payload legitimately takes longer than 60s.
+            let timeout_sym = if matches!(mode.name.as_str(), "all_strikes_one_exp" | "bulk_chain")
+            {
+                "SLOW_MODE_TIMEOUT_MS"
+            } else {
+                "PER_CELL_TIMEOUT_MS"
+            };
+            args_parts.push(format!("timeout_ms={timeout_sym}"));
             let args = args_parts.join(", ");
             write!(
                 out,

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/cell.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/cell.py.tmpl
@@ -1,3 +1,3 @@
     # {endpoint}::{mode}
     #   rationale: {rationale}
-    ({endpoint:?}, {mode:?}, {min_tier:?}, {rationale:?}, [{args}]),
+    ({endpoint:?}, {mode:?}, {min_tier:?}, {rationale:?}, [{args}], {slow}),

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/postamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/postamble.py.tmpl
@@ -82,9 +82,10 @@ def _extract_first_row(parsed):
         return _canonicalize(parsed)
     return None
 
-for endpoint, mode, min_tier, rationale, argv in CELLS:
+for endpoint, mode, min_tier, rationale, argv, slow in CELLS:
     label = f"{endpoint}::{mode}"
     t0 = time.monotonic()
+    cell_timeout_ms = SLOW_MODE_TIMEOUT_MS if slow else PER_CELL_TIMEOUT_MS
     try:
         proc = subprocess.run(
             # --format json-raw keeps dates as YYYYMMDD ints and ms_of_day as raw
@@ -95,7 +96,7 @@ for endpoint, mode, min_tier, rationale, argv in CELLS:
             # instead of being SIGKILLed by the subprocess kill-switch below.
             [
                 str(TDX), "--creds", creds,
-                "--timeout-ms", str(PER_CELL_TIMEOUT_MS),
+                "--timeout-ms", str(cell_timeout_ms),
                 *argv, "--format", "json-raw",
             ],
             cwd=REPO,

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/preamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cli/preamble.py.tmpl
@@ -11,12 +11,15 @@ and are classified `SKIP: tier-permission`. Real configuration bugs
 (invalid arguments, wire-format errors) surface as `FAIL`. See issue
 #287.
 
-Each cell is bounded by a 60-second per-call deadline that the CLI
-forwards to the SDK via `--timeout-ms 60000` (W3). On expiry the SDK
-cancels the in-flight gRPC stream and the subprocess exits cleanly with
-an error containing "Request deadline exceeded". A 90-second subprocess
-timeout remains as a safety net in case the SDK itself wedges (it
-shouldn't), in which case the OS reaps the child via SIGKILL.
+Each cell is bounded by a per-call deadline that the CLI forwards to the
+SDK via `--timeout-ms` (W3). Concrete and list-style cells get the
+60-second baseline; bulk cells flagged `slow=True` (`all_strikes_one_exp`,
+`bulk_chain` on option history / at-time endpoints) get 180 seconds
+because a full-chain payload legitimately takes longer than a minute.
+On expiry the SDK cancels the in-flight gRPC stream and the subprocess
+exits cleanly with an error containing "Request deadline exceeded". The
+subprocess kill-switch remains as a safety net in case the SDK itself
+wedges (it shouldn't), in which case the OS reaps the child via SIGKILL.
 See issues #287, #290.
 """
 from __future__ import annotations
@@ -29,18 +32,21 @@ import sys
 import time
 
 PER_CELL_TIMEOUT_MS = 60_000
-# Subprocess kill-switch one-and-a-half times the SDK budget. Triggers
-# only if the SDK itself wedges past its own deadline (it shouldn't);
-# the OS reaps the child via SIGKILL on expiry.
-SUBPROCESS_KILL_SECS = (PER_CELL_TIMEOUT_MS * 3) // 2000
+SLOW_MODE_TIMEOUT_MS = 180_000
+# Subprocess kill-switch one-and-a-half times the slowest SDK budget.
+# Triggers only if the SDK itself wedges past its own deadline (it
+# shouldn't); the OS reaps the child via SIGKILL on expiry.
+SUBPROCESS_KILL_SECS = (SLOW_MODE_TIMEOUT_MS * 3) // 2000
 
 REPO = pathlib.Path(__file__).resolve().parents[1]
 TDX = REPO / "target" / "release" / ("tdx.exe" if os.name == "nt" else "tdx")
 ARTIFACT_PATH = REPO / "artifacts" / "validator_cli.json"
 
-# (endpoint, mode_name, declared_min_tier, rationale, [argv...])
+# (endpoint, mode_name, declared_min_tier, rationale, [argv...], slow)
 # `declared_min_tier` is informational only (printed on tier-permission
 # skips so you can see which modes the server refused). `rationale` is a
 # one-sentence description of what the cell proves; surfaces in the
 # per-cell JSON artifact and in scripts/validate_agreement.py output.
+# `slow` selects `SLOW_MODE_TIMEOUT_MS` over `PER_CELL_TIMEOUT_MS` for
+# bulk-chain / all-strike cells whose payload doesn't fit in 60s.
 CELLS = [

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_cpp/preamble.cpp.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_cpp/preamble.cpp.tmpl
@@ -5,13 +5,15 @@
 // live account tier come back as a permission error and are classified
 // SKIP: tier-permission. Real configuration bugs surface as FAIL.
 //
-// Per-cell deadline (W3): each cell sets
-// EndpointRequestOptions::timeout_ms = 60_000 so the Rust SDK enforces
-// the budget via tokio::time::timeout and cancels the in-flight gRPC
-// stream on expiry; the throw surfaces as a tdx::Error carrying
-// "Request deadline exceeded". RAII destructors run normally because
-// the SDK has already cleaned up its in-flight state. See issues #287,
-// #290 and [docs/dev/w3-async-cancellation-design.md].
+// Per-cell deadline (W3): concrete and list-style cells set
+// EndpointRequestOptions::timeout_ms = 60_000; bulk-chain / all-strike
+// cells use 180_000 because a full option chain payload legitimately
+// takes longer than a minute. The Rust SDK enforces the budget via
+// tokio::time::timeout and cancels the in-flight gRPC stream on expiry;
+// the throw surfaces as a tdx::Error carrying "Request deadline
+// exceeded". RAII destructors run normally because the SDK has already
+// cleaned up its in-flight state. See issues #287, #290 and
+// [docs/dev/w3-async-cancellation-design.md].
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -29,6 +31,7 @@
 namespace {
 
 constexpr uint64_t kPerCellTimeoutMs = 60'000;
+constexpr uint64_t kSlowModeTimeoutMs = 180'000;
 
 std::string lower(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
@@ -102,10 +105,11 @@ int main(int argc, char** argv) {
                 if (msg.find("request deadline exceeded") != std::string::npos) {
                     // SDK cancelled the in-flight gRPC stream on deadline elapse;
                     // the next cell runs normally on the same Client handle.
-                    std::cout << "  " << std::left << std::setw(60) << label << " FAIL  timeout after 60s" << std::endl;
+                    const long long elapsed_s = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - t0).count();
+                    std::cout << "  " << std::left << std::setw(60) << label << " FAIL  timeout after " << elapsed_s << "s" << std::endl;
                     ++fail;
                     rec.status = "FAIL";
-                    rec.detail = "timeout after 60s";
+                    rec.detail = "timeout after " + std::to_string(elapsed_s) + "s";
                 } else if (msg.find("permission") != std::string::npos || msg.find("subscription") != std::string::npos) {
                     std::cout << "  " << std::left << std::setw(60) << label << " SKIP: tier-permission (declared min_tier=" << declared_min_tier << ")" << std::endl;
                     ++skip;

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/postamble.go.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/postamble.go.tmpl
@@ -16,10 +16,11 @@ func classify(endpoint, mode, declaredMinTier, rationale string, v interface{}, 
 	// Per-call deadline elapsed: SDK cancelled the in-flight gRPC stream
 	// (the next cell runs normally on the same *Client).
 	if strings.Contains(lowered, "request deadline exceeded") {
-		fmt.Printf("  %-60s FAIL  timeout after 60s\n", label)
+		secs := int(dur / time.Second)
+		fmt.Printf("  %-60s FAIL  timeout after %ds\n", label, secs)
 		*fail++
 		rec.Status = "FAIL"
-		rec.Detail = "timeout after 60s"
+		rec.Detail = fmt.Sprintf("timeout after %ds", secs)
 		rec.RowCount = 0
 		return append(records, rec)
 	}

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/preamble.go.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_go/preamble.go.tmpl
@@ -9,11 +9,16 @@ import (
 	"time"
 )
 
-// perCellTimeoutMs caps each live cell at 60 seconds. The Rust SDK
+// perCellTimeoutMs caps each live cell at 60 seconds; slowModeTimeoutMs
+// applies to bulk-chain / all-strike cells whose full option chain
+// payload legitimately takes longer than a minute. The Rust SDK
 // enforces the deadline via tokio::time::timeout and cancels the
 // in-flight gRPC stream on expiry; the *Client handle stays usable.
 // See [docs/dev/w3-async-cancellation-design.md] (W3).
-const perCellTimeoutMs uint64 = 60_000
+const (
+	perCellTimeoutMs  uint64 = 60_000
+	slowModeTimeoutMs uint64 = 180_000
+)
 
 // CellRecord is one row of the validator's per-cell JSON artifact used
 // by the cross-language agreement check. `Status` is PASS|SKIP|FAIL.

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/postamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/postamble.py.tmpl
@@ -37,13 +37,13 @@ for endpoint, mode, min_tier, rationale, call in CELLS:
         # stream and raised RuntimeError carrying our timeout sentinel.
         # No daemon threads to clean up — the next cell runs immediately.
         if "request deadline exceeded" in msg:
-            print(f"  {label:60s} FAIL  timeout after {PER_CELL_TIMEOUT_MS//1000}s", flush=True)
+            print(f"  {label:60s} FAIL  timeout after {duration_ms//1000}s", flush=True)
             fail_count += 1
             records.append({
                 "endpoint": endpoint, "mode": mode, "rationale": rationale,
                 "status": "FAIL",
                 "row_count": 0, "duration_ms": duration_ms,
-                "detail": f"timeout after {PER_CELL_TIMEOUT_MS//1000}s",
+                "detail": f"timeout after {duration_ms//1000}s",
             })
             continue
         if "permission" in msg or "subscription" in msg:

--- a/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/preamble.py.tmpl
+++ b/crates/thetadatadx/build_support/endpoints/render/templates/validate_python/preamble.py.tmpl
@@ -11,11 +11,14 @@ and are classified `SKIP: tier-permission`. Real configuration bugs
 (invalid arguments, wire-format errors) surface as `FAIL`. See issue
 #287.
 
-Each cell carries a 60-second per-call deadline that the Rust SDK enforces
-via `tokio::time::timeout`. On expiry the in-flight gRPC stream is
-cancelled and a RuntimeError carrying "Request deadline exceeded" is
-raised. The `ThetaDataDx` handle stays usable for subsequent cells.
-See [docs/dev/w3-async-cancellation-design.md] (W3).
+Each cell carries a per-call deadline that the Rust SDK enforces via
+`tokio::time::timeout`. Concrete and list-style cells use the 60-second
+baseline; bulk cells (`all_strikes_one_exp`, `bulk_chain` on option
+history / at-time endpoints) use 180 seconds because a full-chain
+payload legitimately takes longer than a minute. On expiry the in-flight
+gRPC stream is cancelled and a RuntimeError carrying "Request deadline
+exceeded" is raised. The `ThetaDataDx` handle stays usable for
+subsequent cells. See [docs/dev/w3-async-cancellation-design.md] (W3).
 """
 import json
 import pathlib
@@ -25,6 +28,7 @@ import time
 from thetadatadx import Credentials, Config, ThetaDataDx
 
 PER_CELL_TIMEOUT_MS = 60_000
+SLOW_MODE_TIMEOUT_MS = 180_000
 ARTIFACT_PATH = pathlib.Path(__file__).resolve().parents[1] / "artifacts" / "validator_python.json"
 
 client = ThetaDataDx(Credentials.from_file(sys.argv[1]), Config.production())

--- a/crates/thetadatadx/build_support/ticks.rs
+++ b/crates/thetadatadx/build_support/ticks.rs
@@ -217,9 +217,14 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
             out.push_str("    }\n\n");
         }
         if needs_opt_float {
+            // `f64` columns (greeks, IV, interest rates) legitimately arrive
+            // as Price or Number on the v3 MDDS server; dispatch on the wire
+            // type the same way Java's `dataValue2Object` does (PRICE →
+            // BigDecimal, NUMBER → Long). See `row_price_f64` for the
+            // accept-list.
             out.push_str("    fn opt_float(row: &crate::proto::DataValueList, idx: Option<usize>) -> Result<f64, DecodeError> {\n");
             out.push_str("        match idx {\n");
-            out.push_str("            Some(i) => Ok(row_float(row, i)?.unwrap_or(0.0)),\n");
+            out.push_str("            Some(i) => Ok(row_price_f64(row, i)?.unwrap_or(0.0)),\n");
             out.push_str("            None => Ok(0.0),\n");
             out.push_str("        }\n");
             out.push_str("    }\n\n");
@@ -349,7 +354,7 @@ fn generate_parser(out: &mut String, type_name: &str, def: &TickTypeDef) {
                 if is_required {
                     writeln!(
                         out,
-                        "                {}: row_float(row, {var})?.unwrap_or(0.0),",
+                        "                {}: row_price_f64(row, {var})?.unwrap_or(0.0),",
                         col.field
                     )
                     .unwrap();

--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -536,36 +536,6 @@ pub(crate) fn row_price_f64(
     }
 }
 
-/// Decode an `f64`-valued cell.
-///
-/// Accepts `Number(n)` only (greeks, IV, interest rates). `NullValue` returns
-/// `Ok(None)`. Float-as-Price decoding is deliberately kept in [`row_price_f64`]
-/// so that this helper fails loudly when a greek column is served as a `Price`
-/// cell against schema.
-///
-/// # Errors
-///
-/// Errors on non-`Number` / non-null cells or missing cells.
-// Reason: market-data i64 values are within f64 mantissa range.
-#[allow(clippy::cast_precision_loss)]
-pub(crate) fn row_float(
-    row: &proto::DataValueList,
-    idx: usize,
-) -> Result<Option<f64>, DecodeError> {
-    let Some(dv) = row.values.get(idx) else {
-        return Err(DecodeError::MissingCell { column: idx });
-    };
-    match dv.data_type.as_ref() {
-        Some(proto::data_value::DataType::Number(n)) => Ok(Some(*n as f64)),
-        Some(proto::data_value::DataType::NullValue(_)) => Ok(None),
-        other => Err(DecodeError::TypeMismatch {
-            column: idx,
-            expected: "Number",
-            observed: observed_name(other),
-        }),
-    }
-}
-
 /// Decode a text-valued cell.
 ///
 /// `Text(s)` → `Ok(Some(s))`, `NullValue` → `Ok(None)`.
@@ -1070,22 +1040,6 @@ mod tests {
         let epoch_ms: u64 = 1_775_050_200_000; // 2026-04-01 09:30 ET
         let row = row_of(vec![dv_timestamp(epoch_ms)]);
         assert_eq!(row_number(&row, 0).unwrap(), Some(34_200_000));
-    }
-
-    #[test]
-    fn row_float_errors_on_price_cell() {
-        // f64 columns (greeks, IV) must NOT silently accept Price cells;
-        // if a server sends a Price for a Number-declared column it's a
-        // schema drift we want to catch, not coalesce.
-        let row = row_of(vec![dv_price(12345, 10)]);
-        assert_eq!(
-            row_float(&row, 0),
-            Err(DecodeError::TypeMismatch {
-                column: 0,
-                expected: "Number",
-                observed: "Price",
-            })
-        );
     }
 
     #[test]
@@ -1599,5 +1553,48 @@ mod tests {
                 observed: "Unset",
             }
         );
+    }
+
+    #[test]
+    fn parse_greeks_ticks_decodes_price_encoded_greeks() {
+        // Regression: v7.2.0 strict decode rejected Price cells for Greek
+        // columns, but the v3 MDDS server sends Greeks as Price-encoded
+        // values (mirroring Java's `dataValue2Object` -> BigDecimal path).
+        // Live run #24520486541 on main surfaced this as
+        //   "column 13: expected Number, got Price"
+        // on `option_snapshot_greeks_first_order::bulk_chain` and peers.
+        // Pin Price-cell decoding for both IV and a Greek so a future
+        // strict-Number tightening can't re-break it silently.
+        let table = proto::DataTable {
+            headers: vec![
+                "ms_of_day".into(),
+                "implied_volatility".into(),
+                "delta".into(),
+            ],
+            data_table: vec![row_of(vec![
+                dv_number(34_200_000),
+                // IV = 0.1234 encoded with price_type = 6 (value * 10^-4).
+                dv_price(1234, 6),
+                // Delta = 0.5 encoded with price_type = 9 (value * 10^-1).
+                dv_price(5, 9),
+            ])],
+        };
+        let ticks = parse_greeks_ticks(&table).unwrap();
+        assert_eq!(ticks.len(), 1);
+        assert!((ticks[0].implied_volatility - 0.1234).abs() < 1e-10);
+        assert!((ticks[0].delta - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn parse_greeks_ticks_still_decodes_number_cells() {
+        // Companion to the Price-cell regression test: Number cells must
+        // still decode, matching Java's dispatch-on-wire-type semantics.
+        let table = proto::DataTable {
+            headers: vec!["ms_of_day".into(), "implied_volatility".into()],
+            data_table: vec![row_of(vec![dv_number(34_200_000), dv_number(0)])],
+        };
+        let ticks = parse_greeks_ticks(&table).unwrap();
+        assert_eq!(ticks.len(), 1);
+        assert!(ticks[0].implied_volatility.abs() < 1e-10);
     }
 }

--- a/crates/thetadatadx/tick_schema.toml
+++ b/crates/thetadatadx/tick_schema.toml
@@ -6,7 +6,7 @@
 # Column types:
 #   i32     -> row_number(row, i)                         default: 0
 #   i64     -> row_number_i64(row, i)                     default: 0
-#   f64     -> row_float(row, i)                          default: 0.0
+#   f64     -> row_price_f64(row, i) (accepts Price|Number)  default: 0.0
 #   String  -> row_text(row, i)                           default: ""
 #   price   -> decode to f64 via Price::new(raw, pt).to_f64()
 #   eod_num -> EOD numeric/time field: Price/Number direct, Timestamp -> ms_of_day

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.2.1] - 2026-04-16
+
+### Fixed
+
+- **Greek and IV decoders regressed by v7.2.0 strict decode** -- every Greek endpoint (`option_snapshot_greeks_*`, `option_history_greeks_*`) returned `Decode failed: column N: expected Number, got Price` on live payloads. The v7.2.0 tightening routed every `f64` tick column through `row_float`, which accepts only `Number` cells, but the v3 MDDS server legitimately sends Greeks and implied-volatility values as `Price`-encoded cells (matching Java's `PojoMessageUtils.dataValue2Object` PRICE → BigDecimal arm). `f64` columns now decode through `row_price_f64` and accept both `Price` and `Number` cells. Regression surfaced on live run 24520486541.
+- **Bulk option-chain validator cells timed out at 60 s** -- `all_strikes_one_exp` and `bulk_chain` cells on `option_history_ohlc`, `option_history_quote`, `option_history_trade_quote`, `option_history_greeks_first_order`, `option_history_greeks_implied_volatility`, and `option_at_time_quote` legitimately stream a full-chain payload that does not fit in the 60-second per-cell budget. The CLI / Python / Go / C++ validators now apply a 180-second deadline to bulk-chain / all-strike modes and keep the 60-second baseline for every other cell.
+
 ## [7.2.0] - 2026-04-16
 
 ### Added

--- a/docs/endpoint-schema.md
+++ b/docs/endpoint-schema.md
@@ -25,7 +25,7 @@ must stay aligned with the schema.
 |:-------------|:----------------|:-----------------------------------|:--------|
 | `i32`        | `i32`           | `row_number(row, i)`               | `0`     |
 | `i64`        | `i64`           | `row_number_i64(row, i)`           | `0`     |
-| `f64`        | `f64`           | `row_float(row, i)`                | `0.0`   |
+| `f64`        | `f64`           | `row_price_f64(row, i)` (accepts `Price` or `Number`) | `0.0`   |
 | `String`     | `String`        | `row_text(row, i)`                 | `""`    |
 | `price`      | `i32`           | `row_price_value(row, i)` or `row_number(row, i)` depending on whether the column carries Price-typed cells | `0` |
 | `price_value`| `i32`           | Always `row_price_value(row, i)`   | `0`     |

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "7.2.0"
+version = "7.2.1"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"

--- a/scripts/validate_cli.py
+++ b/scripts/validate_cli.py
@@ -11,12 +11,15 @@ and are classified `SKIP: tier-permission`. Real configuration bugs
 (invalid arguments, wire-format errors) surface as `FAIL`. See issue
 #287.
 
-Each cell is bounded by a 60-second per-call deadline that the CLI
-forwards to the SDK via `--timeout-ms 60000` (W3). On expiry the SDK
-cancels the in-flight gRPC stream and the subprocess exits cleanly with
-an error containing "Request deadline exceeded". A 90-second subprocess
-timeout remains as a safety net in case the SDK itself wedges (it
-shouldn't), in which case the OS reaps the child via SIGKILL.
+Each cell is bounded by a per-call deadline that the CLI forwards to the
+SDK via `--timeout-ms` (W3). Concrete and list-style cells get the
+60-second baseline; bulk cells flagged `slow=True` (`all_strikes_one_exp`,
+`bulk_chain` on option history / at-time endpoints) get 180 seconds
+because a full-chain payload legitimately takes longer than a minute.
+On expiry the SDK cancels the in-flight gRPC stream and the subprocess
+exits cleanly with an error containing "Request deadline exceeded". The
+subprocess kill-switch remains as a safety net in case the SDK itself
+wedges (it shouldn't), in which case the OS reaps the child via SIGKILL.
 See issues #287, #290.
 """
 from __future__ import annotations
@@ -29,423 +32,426 @@ import sys
 import time
 
 PER_CELL_TIMEOUT_MS = 60_000
-# Subprocess kill-switch one-and-a-half times the SDK budget. Triggers
-# only if the SDK itself wedges past its own deadline (it shouldn't);
-# the OS reaps the child via SIGKILL on expiry.
-SUBPROCESS_KILL_SECS = (PER_CELL_TIMEOUT_MS * 3) // 2000
+SLOW_MODE_TIMEOUT_MS = 180_000
+# Subprocess kill-switch one-and-a-half times the slowest SDK budget.
+# Triggers only if the SDK itself wedges past its own deadline (it
+# shouldn't); the OS reaps the child via SIGKILL on expiry.
+SUBPROCESS_KILL_SECS = (SLOW_MODE_TIMEOUT_MS * 3) // 2000
 
 REPO = pathlib.Path(__file__).resolve().parents[1]
 TDX = REPO / "target" / "release" / ("tdx.exe" if os.name == "nt" else "tdx")
 ARTIFACT_PATH = REPO / "artifacts" / "validator_cli.json"
 
-# (endpoint, mode_name, declared_min_tier, rationale, [argv...])
+# (endpoint, mode_name, declared_min_tier, rationale, [argv...], slow)
 # `declared_min_tier` is informational only (printed on tier-permission
 # skips so you can see which modes the server refused). `rationale` is a
 # one-sentence description of what the cell proves; surfaces in the
 # per-cell JSON artifact and in scripts/validate_agreement.py output.
+# `slow` selects `SLOW_MODE_TIMEOUT_MS` over `PER_CELL_TIMEOUT_MS` for
+# bulk-chain / all-strike cells whose payload doesn't fit in 60s.
 CELLS = [
     # stock_list_symbols::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("stock_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["stock", "list_symbols"]),
+    ("stock_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["stock", "list_symbols"], False),
     # stock_list_dates::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["stock", "list_dates", "TRADE", "AAPL"]),
+    ("stock_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["stock", "list_dates", "TRADE", "AAPL"], False),
     # stock_snapshot_ohlc::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "snapshot_ohlc", "AAPL"]),
+    ("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "snapshot_ohlc", "AAPL"], False),
     # stock_snapshot_trade::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "snapshot_trade", "AAPL"]),
+    ("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "snapshot_trade", "AAPL"], False),
     # stock_snapshot_quote::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "snapshot_quote", "AAPL"]),
+    ("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "snapshot_quote", "AAPL"], False),
     # stock_snapshot_market_value::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "snapshot_market_value", "AAPL"]),
+    ("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "snapshot_market_value", "AAPL"], False),
     # stock_history_eod::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["stock", "history_eod", "AAPL", "20250303", "20250303"]),
+    ("stock_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["stock", "history_eod", "AAPL", "20250303", "20250303"], False),
     # stock_history_ohlc::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_ohlc", "AAPL", "20250303", "60000"]),
+    ("stock_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_ohlc", "AAPL", "20250303", "60000"], False),
     # stock_history_trade::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "history_trade", "AAPL", "20250303"]),
+    ("stock_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "history_trade", "AAPL", "20250303"], False),
     # stock_history_quote::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_quote", "AAPL", "20250303", "60000"]),
+    ("stock_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_quote", "AAPL", "20250303", "60000"], False),
     # stock_history_trade_quote::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "history_trade_quote", "AAPL", "20250303"]),
+    ("stock_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "history_trade_quote", "AAPL", "20250303"], False),
     # stock_at_time_trade::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "at_time_trade", "AAPL", "20250303", "20250303", "12:00:00.000"]),
+    ("stock_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["stock", "at_time_trade", "AAPL", "20250303", "20250303", "12:00:00.000"], False),
     # stock_at_time_quote::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "at_time_quote", "AAPL", "20250303", "20250303", "12:00:00.000"]),
+    ("stock_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "at_time_quote", "AAPL", "20250303", "20250303", "12:00:00.000"], False),
     # option_list_symbols::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_symbols"]),
+    ("option_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_symbols"], False),
     # option_list_dates::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("option_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_dates", "TRADE", "SPY", "20250321", "570", "C"]),
+    ("option_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_dates", "TRADE", "SPY", "20250321", "570", "C"], False),
     # option_list_expirations::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("option_list_expirations", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_expirations", "SPY"]),
+    ("option_list_expirations", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_expirations", "SPY"], False),
     # option_list_strikes::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("option_list_strikes", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_strikes", "SPY", "20250321"]),
+    ("option_list_strikes", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["option", "list_strikes", "SPY", "20250321"], False),
     # option_list_contracts::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_list_contracts", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "list_contracts", "TRADE", "SPY", "20250303"]),
+    ("option_list_contracts", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "list_contracts", "TRADE", "SPY", "20250303"], False),
     # option_snapshot_ohlc::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_ohlc", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_ohlc", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_ohlc::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_ohlc", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_ohlc", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_ohlc::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_ohlc", "SPY", "*", "570", "both"]),
+    ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_ohlc", "SPY", "*", "570", "both"], False),
     # option_snapshot_ohlc::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_ohlc", "SPY", "*", "*", "both"]),
+    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_ohlc", "SPY", "*", "*", "both"], True),
     # option_snapshot_trade::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_trade", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_trade", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_trade::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_trade", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_trade", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_quote::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_quote", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_quote", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_quote::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_quote", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_quote", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_quote::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_quote", "SPY", "*", "570", "both"]),
+    ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_quote", "SPY", "*", "570", "both"], False),
     # option_snapshot_quote::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_quote", "SPY", "*", "*", "both"]),
+    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_quote", "SPY", "*", "*", "both"], True),
     # option_snapshot_open_interest::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_open_interest", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "snapshot_open_interest", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_open_interest::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_open_interest", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_open_interest", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_open_interest::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_open_interest", "SPY", "*", "570", "both"]),
+    ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_open_interest", "SPY", "*", "570", "both"], False),
     # option_snapshot_open_interest::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_open_interest", "SPY", "*", "*", "both"]),
+    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_open_interest", "SPY", "*", "*", "both"], True),
     # option_snapshot_market_value::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_market_value", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_market_value", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_market_value::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_market_value", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_market_value", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_market_value::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_market_value", "SPY", "*", "570", "both"]),
+    ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_market_value", "SPY", "*", "570", "both"], False),
     # option_snapshot_market_value::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_market_value", "SPY", "*", "*", "both"]),
+    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_market_value", "SPY", "*", "*", "both"], True),
     # option_snapshot_greeks_implied_volatility::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_greeks_implied_volatility::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_implied_volatility", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_greeks_implied_volatility::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "570", "both"]),
+    ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "570", "both"], False),
     # option_snapshot_greeks_implied_volatility::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "*", "both"]),
+    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_implied_volatility", "SPY", "*", "*", "both"], True),
     # option_snapshot_greeks_all::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_all", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_all", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_greeks_all::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_all", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_all", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_greeks_all::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_all", "SPY", "*", "570", "both"]),
+    ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_all", "SPY", "*", "570", "both"], False),
     # option_snapshot_greeks_all::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_all", "SPY", "*", "*", "both"]),
+    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_all", "SPY", "*", "*", "both"], True),
     # option_snapshot_greeks_first_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_greeks_first_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_first_order", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_greeks_first_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_first_order", "SPY", "*", "570", "both"]),
+    ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_first_order", "SPY", "*", "570", "both"], False),
     # option_snapshot_greeks_first_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_first_order", "SPY", "*", "*", "both"]),
+    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_first_order", "SPY", "*", "*", "both"], True),
     # option_snapshot_greeks_second_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_greeks_second_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_second_order", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_greeks_second_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_second_order", "SPY", "*", "570", "both"]),
+    ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_second_order", "SPY", "*", "570", "both"], False),
     # option_snapshot_greeks_second_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_second_order", "SPY", "*", "*", "both"]),
+    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_second_order", "SPY", "*", "*", "both"], True),
     # option_snapshot_greeks_third_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "570", "C"]),
+    ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "570", "C"], False),
     # option_snapshot_greeks_third_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "*", "both"]),
+    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "snapshot_greeks_third_order", "SPY", "20250321", "*", "both"], True),
     # option_snapshot_greeks_third_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_third_order", "SPY", "*", "570", "both"]),
+    ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "snapshot_greeks_third_order", "SPY", "*", "570", "both"], False),
     # option_snapshot_greeks_third_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_third_order", "SPY", "*", "*", "both"]),
+    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "snapshot_greeks_third_order", "SPY", "*", "*", "both"], True),
     # option_history_eod::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["option", "history_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
+    ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["option", "history_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"], False),
     # option_history_eod::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
+    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"], True),
     # option_history_eod::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
+    ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_eod", "SPY", "*", "570", "both", "20250303", "20250303"], False),
     # option_history_eod::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
+    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_eod", "SPY", "*", "*", "both", "20250303", "20250303"], True),
     # option_history_ohlc::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_ohlc", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_ohlc", "SPY", "20250321", "570", "C", "20250303", "60000"], False),
     # option_history_ohlc::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_ohlc", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_ohlc", "SPY", "20250321", "*", "both", "20250303", "60000"], True),
     # option_history_trade::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_trade", "SPY", "20250321", "570", "C", "20250303"]),
+    ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_trade", "SPY", "20250321", "570", "C", "20250303"], False),
     # option_history_trade::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade", "SPY", "20250321", "*", "both", "20250303"]),
+    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade", "SPY", "20250321", "*", "both", "20250303"], True),
     # option_history_trade::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade", "SPY", "*", "570", "both", "20250303"]),
+    ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade", "SPY", "*", "570", "both", "20250303"], False),
     # option_history_trade::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade", "SPY", "*", "*", "both", "20250303"]),
+    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade", "SPY", "*", "*", "both", "20250303"], True),
     # option_history_quote::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_quote", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_quote", "SPY", "20250321", "570", "C", "20250303", "60000"], False),
     # option_history_quote::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_quote", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_quote", "SPY", "20250321", "*", "both", "20250303", "60000"], True),
     # option_history_quote::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_quote", "SPY", "*", "570", "both", "20250303", "60000"]),
+    ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_quote", "SPY", "*", "570", "both", "20250303", "60000"], False),
     # option_history_quote::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_quote", "SPY", "*", "*", "both", "20250303", "60000"]),
+    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_quote", "SPY", "*", "*", "both", "20250303", "60000"], True),
     # option_history_trade_quote::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_trade_quote", "SPY", "20250321", "570", "C", "20250303"]),
+    ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_trade_quote", "SPY", "20250321", "570", "C", "20250303"], False),
     # option_history_trade_quote::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_quote", "SPY", "20250321", "*", "both", "20250303"]),
+    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_quote", "SPY", "20250321", "*", "both", "20250303"], True),
     # option_history_trade_quote::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_quote", "SPY", "*", "570", "both", "20250303"]),
+    ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_quote", "SPY", "*", "570", "both", "20250303"], False),
     # option_history_trade_quote::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_quote", "SPY", "*", "*", "both", "20250303"]),
+    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_quote", "SPY", "*", "*", "both", "20250303"], True),
     # option_history_open_interest::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_open_interest", "SPY", "20250321", "570", "C", "20250303"]),
+    ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "history_open_interest", "SPY", "20250321", "570", "C", "20250303"], False),
     # option_history_open_interest::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_open_interest", "SPY", "20250321", "*", "both", "20250303"]),
+    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_open_interest", "SPY", "20250321", "*", "both", "20250303"], True),
     # option_history_open_interest::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_open_interest", "SPY", "*", "570", "both", "20250303"]),
+    ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_open_interest", "SPY", "*", "570", "both", "20250303"], False),
     # option_history_open_interest::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_open_interest", "SPY", "*", "*", "both", "20250303"]),
+    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_open_interest", "SPY", "*", "*", "both", "20250303"], True),
     # option_history_greeks_eod::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"]),
+    ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_eod", "SPY", "20250321", "570", "C", "20250303", "20250303"], False),
     # option_history_greeks_eod::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"]),
+    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_eod", "SPY", "20250321", "*", "both", "20250303", "20250303"], True),
     # option_history_greeks_eod::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_greeks_eod", "SPY", "*", "570", "both", "20250303", "20250303"]),
+    ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_greeks_eod", "SPY", "*", "570", "both", "20250303", "20250303"], False),
     # option_history_greeks_eod::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_greeks_eod", "SPY", "*", "*", "both", "20250303", "20250303"]),
+    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_greeks_eod", "SPY", "*", "*", "both", "20250303", "20250303"], True),
     # option_history_greeks_all::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_all", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_all", "SPY", "20250321", "570", "C", "20250303", "60000"], False),
     # option_history_greeks_all::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_all", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_all", "SPY", "20250321", "*", "both", "20250303", "60000"], True),
     # option_history_trade_greeks_all::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_all", "SPY", "20250321", "570", "C", "20250303"]),
+    ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_all", "SPY", "20250321", "570", "C", "20250303"], False),
     # option_history_trade_greeks_all::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_all", "SPY", "20250321", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_all", "SPY", "20250321", "*", "both", "20250303"], True),
     # option_history_trade_greeks_all::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_all", "SPY", "*", "570", "both", "20250303"]),
+    ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_all", "SPY", "*", "570", "both", "20250303"], False),
     # option_history_trade_greeks_all::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_all", "SPY", "*", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_all", "SPY", "*", "*", "both", "20250303"], True),
     # option_history_greeks_first_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_first_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_first_order", "SPY", "20250321", "570", "C", "20250303", "60000"], False),
     # option_history_greeks_first_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_first_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_first_order", "SPY", "20250321", "*", "both", "20250303", "60000"], True),
     # option_history_trade_greeks_first_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "570", "C", "20250303"]),
+    ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "570", "C", "20250303"], False),
     # option_history_trade_greeks_first_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_first_order", "SPY", "20250321", "*", "both", "20250303"], True),
     # option_history_trade_greeks_first_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_first_order", "SPY", "*", "570", "both", "20250303"]),
+    ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_first_order", "SPY", "*", "570", "both", "20250303"], False),
     # option_history_trade_greeks_first_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_first_order", "SPY", "*", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_first_order", "SPY", "*", "*", "both", "20250303"], True),
     # option_history_greeks_second_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_second_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_second_order", "SPY", "20250321", "570", "C", "20250303", "60000"], False),
     # option_history_greeks_second_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_second_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_second_order", "SPY", "20250321", "*", "both", "20250303", "60000"], True),
     # option_history_trade_greeks_second_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "570", "C", "20250303"]),
+    ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "570", "C", "20250303"], False),
     # option_history_trade_greeks_second_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_second_order", "SPY", "20250321", "*", "both", "20250303"], True),
     # option_history_trade_greeks_second_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_second_order", "SPY", "*", "570", "both", "20250303"]),
+    ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_second_order", "SPY", "*", "570", "both", "20250303"], False),
     # option_history_trade_greeks_second_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_second_order", "SPY", "*", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_second_order", "SPY", "*", "*", "both", "20250303"], True),
     # option_history_greeks_third_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_third_order", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_greeks_third_order", "SPY", "20250321", "570", "C", "20250303", "60000"], False),
     # option_history_greeks_third_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_third_order", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_third_order", "SPY", "20250321", "*", "both", "20250303", "60000"], True),
     # option_history_trade_greeks_third_order::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "570", "C", "20250303"]),
+    ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "570", "C", "20250303"], False),
     # option_history_trade_greeks_third_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_third_order", "SPY", "20250321", "*", "both", "20250303"], True),
     # option_history_trade_greeks_third_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_third_order", "SPY", "*", "570", "both", "20250303"]),
+    ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_third_order", "SPY", "*", "570", "both", "20250303"], False),
     # option_history_trade_greeks_third_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_third_order", "SPY", "*", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_third_order", "SPY", "*", "*", "both", "20250303"], True),
     # option_history_greeks_implied_volatility::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303", "60000"]),
+    ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303", "60000"], False),
     # option_history_greeks_implied_volatility::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303", "60000"]),
+    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303", "60000"], True),
     # option_history_trade_greeks_implied_volatility::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303"]),
+    ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "570", "C", "20250303"], False),
     # option_history_trade_greeks_implied_volatility::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "history_trade_greeks_implied_volatility", "SPY", "20250321", "*", "both", "20250303"], True),
     # option_history_trade_greeks_implied_volatility::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "570", "both", "20250303"]),
+    ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "570", "both", "20250303"], False),
     # option_history_trade_greeks_implied_volatility::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "*", "both", "20250303"]),
+    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "history_trade_greeks_implied_volatility", "SPY", "*", "*", "both", "20250303"], True),
     # option_at_time_trade::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "at_time_trade", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
+    ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", ["option", "at_time_trade", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"], False),
     # option_at_time_trade::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "at_time_trade", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "at_time_trade", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"], True),
     # option_at_time_trade::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "at_time_trade", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
+    ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "at_time_trade", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"], False),
     # option_at_time_trade::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "at_time_trade", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "at_time_trade", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"], True),
     # option_at_time_quote::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "at_time_quote", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"]),
+    ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", ["option", "at_time_quote", "SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000"], False),
     # option_at_time_quote::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "at_time_quote", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", ["option", "at_time_quote", "SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000"], True),
     # option_at_time_quote::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
-    ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "at_time_quote", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"]),
+    ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", ["option", "at_time_quote", "SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000"], False),
     # option_at_time_quote::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "at_time_quote", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"]),
+    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", ["option", "at_time_quote", "SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000"], True),
     # index_list_symbols::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("index_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["index", "list_symbols"]),
+    ("index_list_symbols", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["index", "list_symbols"], False),
     # index_list_dates::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("index_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["index", "list_dates", "SPX"]),
+    ("index_list_dates", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["index", "list_dates", "SPX"], False),
     # index_snapshot_ohlc::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("index_snapshot_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_ohlc", "SPX"]),
+    ("index_snapshot_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_ohlc", "SPX"], False),
     # index_snapshot_price::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("index_snapshot_price", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_price", "SPX"]),
+    ("index_snapshot_price", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_price", "SPX"], False),
     # index_snapshot_market_value::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("index_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_market_value", "SPX"]),
+    ("index_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "snapshot_market_value", "SPX"], False),
     # index_history_eod::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("index_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["index", "history_eod", "SPX", "20250303", "20250303"]),
+    ("index_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", ["index", "history_eod", "SPX", "20250303", "20250303"], False),
     # index_history_ohlc::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("index_history_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "history_ohlc", "SPX", "20250303", "20250303", "60000"]),
+    ("index_history_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", ["index", "history_ohlc", "SPX", "20250303", "20250303", "60000"], False),
     # index_history_price::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("index_history_price", "concrete", "value", "required params set, no optionals — baseline wire path", ["index", "history_price", "SPX", "20250303", "60000"]),
+    ("index_history_price", "concrete", "value", "required params set, no optionals — baseline wire path", ["index", "history_price", "SPX", "20250303", "60000"], False),
     # index_at_time_price::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("index_at_time_price", "concrete", "value", "required params set, no optionals — baseline wire path", ["index", "at_time_price", "SPX", "20250303", "20250303", "12:00:00.000"]),
+    ("index_at_time_price", "concrete", "value", "required params set, no optionals — baseline wire path", ["index", "at_time_price", "SPX", "20250303", "20250303", "12:00:00.000"], False),
     # calendar_open_today::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("calendar_open_today", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["calendar", "open_today"]),
+    ("calendar_open_today", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["calendar", "open_today"], False),
     # calendar_on_date::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("calendar_on_date", "basic", "value", "list/calendar/rate baseline call — no parameter variation", ["calendar", "on_date", "20250303"]),
+    ("calendar_on_date", "basic", "value", "list/calendar/rate baseline call — no parameter variation", ["calendar", "on_date", "20250303"], False),
     # calendar_year::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("calendar_year", "basic", "value", "list/calendar/rate baseline call — no parameter variation", ["calendar", "year", "2025"]),
+    ("calendar_year", "basic", "value", "list/calendar/rate baseline call — no parameter variation", ["calendar", "year", "2025"], False),
     # interest_rate_history_eod::basic
     #   rationale: list/calendar/rate baseline call — no parameter variation
-    ("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["rate", "history_eod", "SOFR", "20250303", "20250303"]),
+    ("interest_rate_history_eod", "basic", "free", "list/calendar/rate baseline call — no parameter variation", ["rate", "history_eod", "SOFR", "20250303", "20250303"], False),
     # stock_history_ohlc_range::concrete
     #   rationale: required params set, no optionals — baseline wire path
-    ("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_ohlc_range", "AAPL", "20250303", "20250303", "60000"]),
+    ("stock_history_ohlc_range", "concrete", "value", "required params set, no optionals — baseline wire path", ["stock", "history_ohlc_range", "AAPL", "20250303", "20250303", "60000"], False),
 ]
 
 if not TDX.exists():
@@ -530,9 +536,10 @@ def _extract_first_row(parsed):
         return _canonicalize(parsed)
     return None
 
-for endpoint, mode, min_tier, rationale, argv in CELLS:
+for endpoint, mode, min_tier, rationale, argv, slow in CELLS:
     label = f"{endpoint}::{mode}"
     t0 = time.monotonic()
+    cell_timeout_ms = SLOW_MODE_TIMEOUT_MS if slow else PER_CELL_TIMEOUT_MS
     try:
         proc = subprocess.run(
             # --format json-raw keeps dates as YYYYMMDD ints and ms_of_day as raw
@@ -543,7 +550,7 @@ for endpoint, mode, min_tier, rationale, argv in CELLS:
             # instead of being SIGKILLed by the subprocess kill-switch below.
             [
                 str(TDX), "--creds", creds,
-                "--timeout-ms", str(PER_CELL_TIMEOUT_MS),
+                "--timeout-ms", str(cell_timeout_ms),
                 *argv, "--format", "json-raw",
             ],
             cwd=REPO,

--- a/scripts/validate_python.py
+++ b/scripts/validate_python.py
@@ -11,11 +11,14 @@ and are classified `SKIP: tier-permission`. Real configuration bugs
 (invalid arguments, wire-format errors) surface as `FAIL`. See issue
 #287.
 
-Each cell carries a 60-second per-call deadline that the Rust SDK enforces
-via `tokio::time::timeout`. On expiry the in-flight gRPC stream is
-cancelled and a RuntimeError carrying "Request deadline exceeded" is
-raised. The `ThetaDataDx` handle stays usable for subsequent cells.
-See [docs/dev/w3-async-cancellation-design.md] (W3).
+Each cell carries a per-call deadline that the Rust SDK enforces via
+`tokio::time::timeout`. Concrete and list-style cells use the 60-second
+baseline; bulk cells (`all_strikes_one_exp`, `bulk_chain` on option
+history / at-time endpoints) use 180 seconds because a full-chain
+payload legitimately takes longer than a minute. On expiry the in-flight
+gRPC stream is cancelled and a RuntimeError carrying "Request deadline
+exceeded" is raised. The `ThetaDataDx` handle stays usable for
+subsequent cells. See [docs/dev/w3-async-cancellation-design.md] (W3).
 """
 import json
 import pathlib
@@ -25,6 +28,7 @@ import time
 from thetadatadx import Credentials, Config, ThetaDataDx
 
 PER_CELL_TIMEOUT_MS = 60_000
+SLOW_MODE_TIMEOUT_MS = 180_000
 ARTIFACT_PATH = pathlib.Path(__file__).resolve().parents[1] / "artifacts" / "validator_python.json"
 
 client = ThetaDataDx(Credentials.from_file(sys.argv[1]), Config.production())
@@ -150,13 +154,13 @@ CELLS = [
     ("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_ohlc::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_ohlc("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_ohlc("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_ohlc::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_ohlc("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_ohlc::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_ohlc("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_ohlc("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_ohlc::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_snapshot_ohlc", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_ohlc("SPY", "20250321", "570", "C", max_dte=30, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -174,7 +178,7 @@ CELLS = [
     ("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_trade::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_trade("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_trade("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_trade::with_strike_range
     #   rationale: strike_range=10 optional filter wiring
     ("option_snapshot_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", lambda: client.option_snapshot_trade("SPY", "20250321", "570", "C", strike_range=10, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -189,13 +193,13 @@ CELLS = [
     ("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_quote::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_quote("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_quote("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_quote::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_quote("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_quote::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_quote("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_quote("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_quote::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_snapshot_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_quote("SPY", "20250321", "570", "C", max_dte=30, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -213,13 +217,13 @@ CELLS = [
     ("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_open_interest::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_open_interest("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_open_interest("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_open_interest::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_open_interest("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_open_interest::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_open_interest("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_open_interest("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_open_interest::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_snapshot_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_open_interest("SPY", "20250321", "570", "C", max_dte=30, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -237,13 +241,13 @@ CELLS = [
     ("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_market_value::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_market_value("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_market_value("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_market_value::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_market_value("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_market_value::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_market_value("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_market_value("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_market_value::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_snapshot_market_value", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_snapshot_market_value("SPY", "20250321", "570", "C", max_dte=30, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -261,13 +265,13 @@ CELLS = [
     ("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_implied_volatility::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_implied_volatility::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_implied_volatility::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_implied_volatility::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", annual_dividend=0.015, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -303,13 +307,13 @@ CELLS = [
     ("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_all::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_all::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_all("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_all::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_all("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_all("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_all::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", annual_dividend=0.015, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -345,13 +349,13 @@ CELLS = [
     ("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_first_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_first_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_first_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_first_order("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_first_order::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", annual_dividend=0.015, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -387,13 +391,13 @@ CELLS = [
     ("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_second_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_second_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_second_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_second_order("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_second_order::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", annual_dividend=0.015, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -429,13 +433,13 @@ CELLS = [
     ("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_third_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_third_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "570", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_snapshot_greeks_third_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "*", "both", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_snapshot_greeks_third_order("SPY", "*", "*", "both", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_snapshot_greeks_third_order::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", annual_dividend=0.015, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -471,13 +475,13 @@ CELLS = [
     ("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_eod::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_eod::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_eod", "all_exps_one_strike", "free", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_eod::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_eod::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_history_eod", "with_max_dte", "free", "max_dte=30 optional filter wiring", lambda: client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", max_dte=30, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -492,7 +496,7 @@ CELLS = [
     ("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_ohlc::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_ohlc::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -510,13 +514,13 @@ CELLS = [
     ("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade("SPY", "20250321", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade("SPY", "20250321", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade("SPY", "*", "570", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade("SPY", "*", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade("SPY", "*", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -537,13 +541,13 @@ CELLS = [
     ("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_quote::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_quote::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_quote::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_quote::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -564,13 +568,13 @@ CELLS = [
     ("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_quote::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_quote::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_quote("SPY", "*", "570", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_quote::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_quote("SPY", "*", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_quote("SPY", "*", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_quote::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -594,13 +598,13 @@ CELLS = [
     ("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_open_interest::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_open_interest::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_open_interest("SPY", "*", "570", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_open_interest::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_open_interest("SPY", "*", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_open_interest("SPY", "*", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_open_interest::with_date_range
     #   rationale: start_date + end_date pair — date range optional wiring
     ("option_history_open_interest", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", lambda: client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", start_date="20250303", end_date="20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -618,13 +622,13 @@ CELLS = [
     ("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_greeks_eod::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_greeks_eod::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_greeks_eod::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_greeks_eod::with_annual_dividend
     #   rationale: annual_dividend=0.015 optional Greeks-input wiring
     ("option_history_greeks_eod", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", lambda: client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", annual_dividend=0.015, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -654,7 +658,7 @@ CELLS = [
     ("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_greeks_all::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_greeks_all::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -684,13 +688,13 @@ CELLS = [
     ("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_all::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_all::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_all::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_all::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -723,7 +727,7 @@ CELLS = [
     ("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_greeks_first_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_greeks_first_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_first_order", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -753,13 +757,13 @@ CELLS = [
     ("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_first_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_first_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_first_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_first_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_first_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -792,7 +796,7 @@ CELLS = [
     ("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_greeks_second_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_greeks_second_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -822,13 +826,13 @@ CELLS = [
     ("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_second_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_second_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_second_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_second_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -861,7 +865,7 @@ CELLS = [
     ("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_greeks_third_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_greeks_third_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -891,13 +895,13 @@ CELLS = [
     ("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_third_order::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_third_order::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_third_order::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_third_order::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -930,7 +934,7 @@ CELLS = [
     ("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_greeks_implied_volatility::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_greeks_implied_volatility::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_greeks_implied_volatility", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -960,13 +964,13 @@ CELLS = [
     ("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_implied_volatility::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_implied_volatility::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_history_trade_greeks_implied_volatility::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_history_trade_greeks_implied_volatility::with_intraday_window
     #   rationale: start_time + end_time pair — intraday window optional wiring
     ("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", lambda: client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", start_time="09:30:00", end_time="10:00:00", timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -999,13 +1003,13 @@ CELLS = [
     ("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_at_time_trade::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_at_time_trade::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_at_time_trade::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_at_time_trade::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_at_time_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", lambda: client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -1020,13 +1024,13 @@ CELLS = [
     ("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_at_time_quote::all_strikes_one_exp
     #   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", lambda: client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_at_time_quote::all_exps_one_strike
     #   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
     ("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", lambda: client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=PER_CELL_TIMEOUT_MS)),
     # option_at_time_quote::bulk_chain
     #   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=PER_CELL_TIMEOUT_MS)),
+    ("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", lambda: client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", timeout_ms=SLOW_MODE_TIMEOUT_MS)),
     # option_at_time_quote::with_max_dte
     #   rationale: max_dte=30 optional filter wiring
     ("option_at_time_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", lambda: client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", max_dte=30, timeout_ms=PER_CELL_TIMEOUT_MS)),
@@ -1141,13 +1145,13 @@ for endpoint, mode, min_tier, rationale, call in CELLS:
         # stream and raised RuntimeError carrying our timeout sentinel.
         # No daemon threads to clean up — the next cell runs immediately.
         if "request deadline exceeded" in msg:
-            print(f"  {label:60s} FAIL  timeout after {PER_CELL_TIMEOUT_MS//1000}s", flush=True)
+            print(f"  {label:60s} FAIL  timeout after {duration_ms//1000}s", flush=True)
             fail_count += 1
             records.append({
                 "endpoint": endpoint, "mode": mode, "rationale": rationale,
                 "status": "FAIL",
                 "row_count": 0, "duration_ms": duration_ms,
-                "detail": f"timeout after {PER_CELL_TIMEOUT_MS//1000}s",
+                "detail": f"timeout after {duration_ms//1000}s",
             })
             continue
         if "permission" in msg or "subscription" in msg:

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(thetadatadx-cpp VERSION 7.2.0 LANGUAGES CXX)
+project(thetadatadx-cpp VERSION 7.2.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/sdks/cpp/examples/validate.cpp
+++ b/sdks/cpp/examples/validate.cpp
@@ -5,13 +5,15 @@
 // live account tier come back as a permission error and are classified
 // SKIP: tier-permission. Real configuration bugs surface as FAIL.
 //
-// Per-cell deadline (W3): each cell sets
-// EndpointRequestOptions::timeout_ms = 60_000 so the Rust SDK enforces
-// the budget via tokio::time::timeout and cancels the in-flight gRPC
-// stream on expiry; the throw surfaces as a tdx::Error carrying
-// "Request deadline exceeded". RAII destructors run normally because
-// the SDK has already cleaned up its in-flight state. See issues #287,
-// #290 and [docs/dev/w3-async-cancellation-design.md].
+// Per-cell deadline (W3): concrete and list-style cells set
+// EndpointRequestOptions::timeout_ms = 60_000; bulk-chain / all-strike
+// cells use 180_000 because a full option chain payload legitimately
+// takes longer than a minute. The Rust SDK enforces the budget via
+// tokio::time::timeout and cancels the in-flight gRPC stream on expiry;
+// the throw surfaces as a tdx::Error carrying "Request deadline
+// exceeded". RAII destructors run normally because the SDK has already
+// cleaned up its in-flight state. See issues #287, #290 and
+// [docs/dev/w3-async-cancellation-design.md].
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -29,6 +31,7 @@
 namespace {
 
 constexpr uint64_t kPerCellTimeoutMs = 60'000;
+constexpr uint64_t kSlowModeTimeoutMs = 180'000;
 
 std::string lower(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
@@ -102,10 +105,11 @@ int main(int argc, char** argv) {
                 if (msg.find("request deadline exceeded") != std::string::npos) {
                     // SDK cancelled the in-flight gRPC stream on deadline elapse;
                     // the next cell runs normally on the same Client handle.
-                    std::cout << "  " << std::left << std::setw(60) << label << " FAIL  timeout after 60s" << std::endl;
+                    const long long elapsed_s = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - t0).count();
+                    std::cout << "  " << std::left << std::setw(60) << label << " FAIL  timeout after " << elapsed_s << "s" << std::endl;
                     ++fail;
                     rec.status = "FAIL";
-                    rec.detail = "timeout after 60s";
+                    rec.detail = "timeout after " + std::to_string(elapsed_s) + "s";
                 } else if (msg.find("permission") != std::string::npos || msg.find("subscription") != std::string::npos) {
                     std::cout << "  " << std::left << std::setw(60) << label << " SKIP: tier-permission (declared min_tier=" << declared_min_tier << ")" << std::endl;
                     ++skip;
@@ -247,13 +251,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_ohlc::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_ohlc::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_ohlc", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_ohlc("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_ohlc::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_ohlc("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_ohlc("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_ohlc::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_snapshot_ohlc", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_ohlc("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -271,7 +275,7 @@ int main(int argc, char** argv) {
         cell("option_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_trade::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_trade("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_trade("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_trade::with_strike_range
         //   rationale: strike_range=10 optional filter wiring
         cell("option_snapshot_trade", "with_strike_range", "standard", "strike_range=10 optional filter wiring", [&] { return client.option_snapshot_trade("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_strike_range(10).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -286,13 +290,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_quote::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_quote("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_quote("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_quote::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_quote("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_quote::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_quote("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_quote("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_quote::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_snapshot_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_quote("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -310,13 +314,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_open_interest::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_open_interest::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_open_interest("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_open_interest::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_open_interest("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_open_interest("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_open_interest::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_snapshot_open_interest", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_open_interest("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -334,13 +338,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_market_value::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_market_value("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_market_value("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_market_value::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_market_value", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_market_value("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_market_value::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_market_value("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_market_value("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_market_value::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_snapshot_market_value", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_snapshot_market_value("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_max_dte(30).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -358,13 +362,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_implied_volatility::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_implied_volatility::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_greeks_implied_volatility", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_implied_volatility::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_implied_volatility::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_implied_volatility", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_implied_volatility("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -400,13 +404,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_all::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_all::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_all("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_all::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_all("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_all("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_all::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_all", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_all("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -442,13 +446,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_first_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_first_order::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_greeks_first_order", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_first_order::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_first_order("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_first_order::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_first_order", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_first_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -484,13 +488,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_second_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_second_order::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_second_order::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_second_order("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_second_order::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_second_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_second_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -526,13 +530,13 @@ int main(int argc, char** argv) {
         cell("option_snapshot_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_third_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_third_order::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_snapshot_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "570", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_snapshot_greeks_third_order::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_snapshot_greeks_third_order("SPY", "*", "*", "both", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_snapshot_greeks_third_order::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_snapshot_greeks_third_order", "with_annual_dividend", "professional", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_snapshot_greeks_third_order("SPY", "20250321", "570", "C", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -568,13 +572,13 @@ int main(int argc, char** argv) {
         cell("option_history_eod", "concrete", "free", "required params set, no optionals — baseline wire path", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_eod::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_eod("SPY", "20250321", "*", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_eod::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_eod", "all_exps_one_strike", "free", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_eod("SPY", "*", "570", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_eod::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_eod("SPY", "*", "*", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_eod::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_history_eod", "with_max_dte", "free", "max_dte=30 optional filter wiring", [&] { return client.option_history_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_max_dte(30).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -589,7 +593,7 @@ int main(int argc, char** argv) {
         cell("option_history_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_ohlc::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_ohlc("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_ohlc::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_ohlc", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_ohlc("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -607,13 +611,13 @@ int main(int argc, char** argv) {
         cell("option_history_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade("SPY", "*", "570", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -634,13 +638,13 @@ int main(int argc, char** argv) {
         cell("option_history_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_quote::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_quote("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_quote::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_quote("SPY", "*", "570", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_quote::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_quote("SPY", "*", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_quote::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_quote", "with_intraday_window", "value", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_quote("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -661,13 +665,13 @@ int main(int argc, char** argv) {
         cell("option_history_trade_quote", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_quote::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_quote("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_quote::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_trade_quote", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_quote("SPY", "*", "570", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_quote::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_quote("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_quote("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_quote::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_quote", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_quote("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -691,13 +695,13 @@ int main(int argc, char** argv) {
         cell("option_history_open_interest", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_open_interest::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_open_interest("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_open_interest::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_open_interest", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_open_interest("SPY", "*", "570", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_open_interest::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_open_interest("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_open_interest("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_open_interest::with_date_range
         //   rationale: start_date + end_date pair — date range optional wiring
         cell("option_history_open_interest", "with_date_range", "value", "start_date + end_date pair — date range optional wiring", [&] { return client.option_history_open_interest("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_date("20250303").with_end_date("20250303").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -715,13 +719,13 @@ int main(int argc, char** argv) {
         cell("option_history_greeks_eod", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_greeks_eod::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_eod("SPY", "20250321", "*", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_greeks_eod::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_greeks_eod", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_greeks_eod("SPY", "*", "570", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_greeks_eod::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_greeks_eod("SPY", "*", "*", "both", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_greeks_eod::with_annual_dividend
         //   rationale: annual_dividend=0.015 optional Greeks-input wiring
         cell("option_history_greeks_eod", "with_annual_dividend", "standard", "annual_dividend=0.015 optional Greeks-input wiring", [&] { return client.option_history_greeks_eod("SPY", "20250321", "570", "C", "20250303", "20250303", tdx::EndpointRequestOptions{}.with_annual_dividend(0.015).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -751,7 +755,7 @@ int main(int argc, char** argv) {
         cell("option_history_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_greeks_all::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_all("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_greeks_all::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_all("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -781,13 +785,13 @@ int main(int argc, char** argv) {
         cell("option_history_trade_greeks_all", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_all::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_all::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_trade_greeks_all", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_all("SPY", "*", "570", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_all::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_all("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_all::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_all", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_all("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -820,7 +824,7 @@ int main(int argc, char** argv) {
         cell("option_history_greeks_first_order", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_greeks_first_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_greeks_first_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_first_order", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_first_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -850,13 +854,13 @@ int main(int argc, char** argv) {
         cell("option_history_trade_greeks_first_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_first_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_first_order::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_trade_greeks_first_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "570", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_first_order::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_first_order("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_first_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_first_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_first_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -889,7 +893,7 @@ int main(int argc, char** argv) {
         cell("option_history_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_greeks_second_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_greeks_second_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_second_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -919,13 +923,13 @@ int main(int argc, char** argv) {
         cell("option_history_trade_greeks_second_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_second_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_second_order::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_trade_greeks_second_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "570", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_second_order::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_second_order("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_second_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_second_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_second_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -958,7 +962,7 @@ int main(int argc, char** argv) {
         cell("option_history_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_greeks_third_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_greeks_third_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_third_order("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -988,13 +992,13 @@ int main(int argc, char** argv) {
         cell("option_history_trade_greeks_third_order", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_third_order::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_third_order::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_trade_greeks_third_order", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "570", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_third_order::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_third_order("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_third_order::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_third_order", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_third_order("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -1027,7 +1031,7 @@ int main(int argc, char** argv) {
         cell("option_history_greeks_implied_volatility", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_greeks_implied_volatility::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", "60000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_greeks_implied_volatility::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_greeks_implied_volatility", "with_intraday_window", "standard", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", "60000", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -1057,13 +1061,13 @@ int main(int argc, char** argv) {
         cell("option_history_trade_greeks_implied_volatility", "concrete", "professional", "required params set, no optionals — baseline wire path", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_implied_volatility::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_implied_volatility::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_history_trade_greeks_implied_volatility", "all_exps_one_strike", "professional", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "570", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_history_trade_greeks_implied_volatility::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "*", "*", "both", "20250303", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_history_trade_greeks_implied_volatility::with_intraday_window
         //   rationale: start_time + end_time pair — intraday window optional wiring
         cell("option_history_trade_greeks_implied_volatility", "with_intraday_window", "professional", "start_time + end_time pair — intraday window optional wiring", [&] { return client.option_history_trade_greeks_implied_volatility("SPY", "20250321", "570", "C", "20250303", tdx::EndpointRequestOptions{}.with_start_time("09:30:00").with_end_time("10:00:00").with_timeout_ms(kPerCellTimeoutMs)); });
@@ -1096,13 +1100,13 @@ int main(int argc, char** argv) {
         cell("option_at_time_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_at_time_trade::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_at_time_trade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_at_time_trade::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_at_time_trade", "all_exps_one_strike", "standard", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_at_time_trade("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_at_time_trade::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_at_time_trade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_at_time_trade::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_at_time_trade", "with_max_dte", "standard", "max_dte=30 optional filter wiring", [&] { return client.option_at_time_trade("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30).with_timeout_ms(kPerCellTimeoutMs)); });
@@ -1117,13 +1121,13 @@ int main(int argc, char** argv) {
         cell("option_at_time_quote", "concrete", "value", "required params set, no optionals — baseline wire path", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_at_time_quote::all_strikes_one_exp
         //   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
-        cell("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", [&] { return client.option_at_time_quote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_at_time_quote::all_exps_one_strike
         //   rationale: expiration=* — sent as literal `*` on the wire (server fan-out)
         cell("option_at_time_quote", "all_exps_one_strike", "value", "expiration=* — sent as literal `*` on the wire (server fan-out)", [&] { return client.option_at_time_quote("SPY", "*", "570", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
         // option_at_time_quote::bulk_chain
         //   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
-        cell("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kPerCellTimeoutMs)); });
+        cell("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", [&] { return client.option_at_time_quote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_timeout_ms(kSlowModeTimeoutMs)); });
         // option_at_time_quote::with_max_dte
         //   rationale: max_dte=30 optional filter wiring
         cell("option_at_time_quote", "with_max_dte", "value", "max_dte=30 optional filter wiring", [&] { return client.option_at_time_quote("SPY", "20250321", "570", "C", "20250303", "20250303", "12:00:00.000", tdx::EndpointRequestOptions{}.with_max_dte(30).with_timeout_ms(kPerCellTimeoutMs)); });

--- a/sdks/go/validate.go
+++ b/sdks/go/validate.go
@@ -9,11 +9,16 @@ import (
 	"time"
 )
 
-// perCellTimeoutMs caps each live cell at 60 seconds. The Rust SDK
+// perCellTimeoutMs caps each live cell at 60 seconds; slowModeTimeoutMs
+// applies to bulk-chain / all-strike cells whose full option chain
+// payload legitimately takes longer than a minute. The Rust SDK
 // enforces the deadline via tokio::time::timeout and cancels the
 // in-flight gRPC stream on expiry; the *Client handle stays usable.
 // See [docs/dev/w3-async-cancellation-design.md] (W3).
-const perCellTimeoutMs uint64 = 60_000
+const (
+	perCellTimeoutMs  uint64 = 60_000
+	slowModeTimeoutMs uint64 = 180_000
+)
 
 // CellRecord is one row of the validator's per-cell JSON artifact used
 // by the cross-language agreement check. `Status` is PASS|SKIP|FAIL.
@@ -340,7 +345,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotOHLC("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotOHLC("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_ohlc::all_exps_one_strike
@@ -354,7 +359,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotOHLC("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotOHLC("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_ohlc", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_ohlc::with_max_dte
@@ -397,7 +402,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotTrade("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotTrade("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_trade::with_strike_range
@@ -433,7 +438,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotQuote("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotQuote("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_quote::all_exps_one_strike
@@ -447,7 +452,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotQuote("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotQuote("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_quote::with_max_dte
@@ -490,7 +495,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotOpenInterest("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_open_interest::all_exps_one_strike
@@ -504,7 +509,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotOpenInterest("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotOpenInterest("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_open_interest::with_max_dte
@@ -547,7 +552,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotMarketValue("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_market_value", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_market_value::all_exps_one_strike
@@ -561,7 +566,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotMarketValue("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotMarketValue("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_market_value", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_market_value::with_max_dte
@@ -604,7 +609,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_implied_volatility::all_exps_one_strike
@@ -618,7 +623,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksImpliedVolatility("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_implied_volatility", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_implied_volatility::with_annual_dividend
@@ -703,7 +708,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksAll("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_all::all_exps_one_strike
@@ -717,7 +722,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksAll("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksAll("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_all::with_annual_dividend
@@ -802,7 +807,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_first_order::all_exps_one_strike
@@ -816,7 +821,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksFirstOrder("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_first_order", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_first_order::with_annual_dividend
@@ -901,7 +906,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_second_order::all_exps_one_strike
@@ -915,7 +920,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksSecondOrder("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_second_order::with_annual_dividend
@@ -1000,7 +1005,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "20250321", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_third_order::all_exps_one_strike
@@ -1014,7 +1019,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "*", "*", "both", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionSnapshotGreeksThirdOrder("SPY", "*", "*", "both", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_snapshot_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_snapshot_greeks_third_order::with_annual_dividend
@@ -1099,7 +1104,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryEOD("SPY", "20250321", "*", "both", "20250303", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryEOD("SPY", "20250321", "*", "both", "20250303", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_eod", "all_strikes_one_exp", "free", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_eod::all_exps_one_strike
@@ -1113,7 +1118,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryEOD("SPY", "*", "*", "both", "20250303", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryEOD("SPY", "*", "*", "both", "20250303", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_eod", "bulk_chain", "free", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_eod::with_max_dte
@@ -1149,7 +1154,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryOHLC("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryOHLC("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_ohlc", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_ohlc::with_intraday_window
@@ -1192,7 +1197,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTrade("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTrade("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade::all_exps_one_strike
@@ -1206,7 +1211,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTrade("SPY", "*", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTrade("SPY", "*", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade::with_intraday_window
@@ -1256,7 +1261,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryQuote("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryQuote("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_quote::all_exps_one_strike
@@ -1270,7 +1275,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryQuote("SPY", "*", "*", "both", "20250303", "60000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryQuote("SPY", "*", "*", "both", "20250303", "60000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_quote::with_intraday_window
@@ -1320,7 +1325,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeQuote("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_quote", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_quote::all_exps_one_strike
@@ -1334,7 +1339,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeQuote("SPY", "*", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeQuote("SPY", "*", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_quote", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_quote::with_intraday_window
@@ -1391,7 +1396,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryOpenInterest("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_open_interest", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_open_interest::all_exps_one_strike
@@ -1405,7 +1410,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryOpenInterest("SPY", "*", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryOpenInterest("SPY", "*", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_open_interest", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_open_interest::with_date_range
@@ -1448,7 +1453,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "*", "both", "20250303", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryGreeksEOD("SPY", "20250321", "*", "both", "20250303", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_greeks_eod", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_greeks_eod::all_exps_one_strike
@@ -1462,7 +1467,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryGreeksEOD("SPY", "*", "*", "both", "20250303", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryGreeksEOD("SPY", "*", "*", "both", "20250303", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_greeks_eod", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_greeks_eod::with_annual_dividend
@@ -1533,7 +1538,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryGreeksAll("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_greeks_all::with_intraday_window
@@ -1604,7 +1609,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksAll("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_all", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_all::all_exps_one_strike
@@ -1618,7 +1623,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksAll("SPY", "*", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksAll("SPY", "*", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_all", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_all::with_intraday_window
@@ -1696,7 +1701,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryGreeksFirstOrder("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_greeks_first_order", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_greeks_first_order::with_intraday_window
@@ -1767,7 +1772,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_first_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_first_order::all_exps_one_strike
@@ -1781,7 +1786,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "*", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksFirstOrder("SPY", "*", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_first_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_first_order::with_intraday_window
@@ -1859,7 +1864,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryGreeksSecondOrder("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_greeks_second_order::with_intraday_window
@@ -1930,7 +1935,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_second_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_second_order::all_exps_one_strike
@@ -1944,7 +1949,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "*", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksSecondOrder("SPY", "*", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_second_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_second_order::with_intraday_window
@@ -2022,7 +2027,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryGreeksThirdOrder("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_greeks_third_order::with_intraday_window
@@ -2093,7 +2098,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_third_order", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_third_order::all_exps_one_strike
@@ -2107,7 +2112,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "*", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksThirdOrder("SPY", "*", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_third_order", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_third_order::with_intraday_window
@@ -2185,7 +2190,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryGreeksImpliedVolatility("SPY", "20250321", "*", "both", "20250303", "60000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_greeks_implied_volatility", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_greeks_implied_volatility::with_intraday_window
@@ -2256,7 +2261,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20250321", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_implied_volatility", "all_strikes_one_exp", "professional", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_implied_volatility::all_exps_one_strike
@@ -2270,7 +2275,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "*", "*", "both", "20250303", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionHistoryTradeGreeksImpliedVolatility("SPY", "*", "*", "both", "20250303", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_history_trade_greeks_implied_volatility", "bulk_chain", "professional", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_history_trade_greeks_implied_volatility::with_intraday_window
@@ -2348,7 +2353,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionAtTimeTrade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionAtTimeTrade("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_at_time_trade", "all_strikes_one_exp", "standard", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_at_time_trade::all_exps_one_strike
@@ -2362,7 +2367,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionAtTimeTrade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionAtTimeTrade("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_at_time_trade", "bulk_chain", "standard", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_at_time_trade::with_max_dte
@@ -2398,7 +2403,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: strike=* — collapses to proto-unset ContractSpec.strike (server default)
 	{
 		t0 := time.Now()
-		v, e := c.OptionAtTimeQuote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionAtTimeQuote("SPY", "20250321", "*", "both", "20250303", "20250303", "12:00:00.000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_at_time_quote", "all_strikes_one_exp", "value", "strike=* — collapses to proto-unset ContractSpec.strike (server default)", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_at_time_quote::all_exps_one_strike
@@ -2412,7 +2417,7 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: expiration=* + strike=* + right=both — tests full-chain server mode
 	{
 		t0 := time.Now()
-		v, e := c.OptionAtTimeQuote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.OptionAtTimeQuote("SPY", "*", "*", "both", "20250303", "20250303", "12:00:00.000", WithTimeoutMs(slowModeTimeoutMs))
 		records = classify("option_at_time_quote", "bulk_chain", "value", "expiration=* + strike=* + right=both — tests full-chain server mode", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// option_at_time_quote::with_max_dte
@@ -2623,10 +2628,11 @@ func classify(endpoint, mode, declaredMinTier, rationale string, v interface{}, 
 	// Per-call deadline elapsed: SDK cancelled the in-flight gRPC stream
 	// (the next cell runs normally on the same *Client).
 	if strings.Contains(lowered, "request deadline exceeded") {
-		fmt.Printf("  %-60s FAIL  timeout after 60s\n", label)
+		secs := int(dur / time.Second)
+		fmt.Printf("  %-60s FAIL  timeout after %ds\n", label, secs)
 		*fail++
 		rec.Status = "FAIL"
-		rec.Detail = "timeout after 60s"
+		rec.Detail = fmt.Sprintf("timeout after %ds", secs)
 		rec.RowCount = 0
 		return append(records, rec)
 	}

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "pyo3",
  "tdbe",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "7.2.0"
+version = "7.2.1"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "GPL-3.0-or-later"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "7.2.0"
+version = "7.2.1"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "7.2.0"
+version = "7.2.1"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "7.2.0"
+version = "7.2.1"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "7.2.0"
+version = "7.2.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

Patch release fixing every FAIL reported by the live validation matrix (run 24520486541) against v7.2.0 on main.

- **Greek / IV decoders regressed by v7.2.0 strict decode (10 FAILs)** — `option_snapshot_greeks_*` and `option_history_greeks_*` endpoints returned `Decode failed: column N: expected Number, got Price` because the tightening in #325 / #326 routed every `f64` tick column through `row_float`, which accepts only `Number` cells. The v3 MDDS server legitimately sends Greeks and implied-volatility as `Price`-encoded cells, matching Java's `PojoMessageUtils.dataValue2Object` PRICE → BigDecimal arm. `f64` columns now decode through `row_price_f64` and accept both `Price` and `Number`. Pinned with two regression tests on `parse_greeks_ticks`.
- **Bulk option-chain validator cells timed out at 60s (7 FAILs)** — `all_strikes_one_exp` and `bulk_chain` cells on `option_history_ohlc`, `option_history_quote`, `option_history_trade_quote`, `option_history_greeks_first_order`, `option_history_greeks_implied_volatility`, and `option_at_time_quote` legitimately stream a full-chain payload that does not fit in the 60-second per-cell budget. The CLI / Python / Go / C++ validators now apply a 180-second deadline to bulk-chain / all-strike modes and keep the 60-second baseline elsewhere.
- **Release bookkeeping** — version bumps 7.2.0 → 7.2.1 across workspace crates and sibling lockfiles, CHANGELOG + docs-site mirror, `.github/release-notes/v7.2.1.md`. `tdbe` stays at 0.10.0 — the fix does not cross the tdbe crate boundary.

## Root cause

v7.2.0 tightened `row_number` / `row_float` to fail loud on non-Number cells, which is correct for the `i32` Number-only columns (trade sequence, condition codes, sizes, ...). It was over-tight for `f64` columns. Java dispatches on wire type — our generator now does the same for `f64`, routing through `row_price_f64`. The unused `row_float` helper and its test pinning the wrong invariant are removed.

## Changes per commit

1. `fix(decode): accept Price|Number on f64 columns (greeks, IV, rates)` — generator + decoder + regression tests.
2. `ci(validator): 180s deadline for bulk-chain / all-strike cells` — validator template + generator changes; regenerated CLI / Python / Go / C++ validators. Timeout messages now report actual elapsed seconds from the cell's duration counter so a 180s-budget failure doesn't print "60s".
3. `release: thetadatadx 7.2.1 — Greek decoder + bulk timeout` — version bumps, Cargo.lock updates, CHANGELOG, release notes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --locked -- -D warnings`
- [x] `cargo test --workspace --locked` (288 tests, including two new `parse_greeks_ticks` regression cases)
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces -- --check`
- [x] `go build ./...` on the regenerated Go SDK
- [x] `python3 -m py_compile scripts/validate_cli.py scripts/validate_python.py`
- [x] Manual CLI call against live production confirms Greek endpoints now decode:
      `target/release/tdx --creds creds.txt option history_greeks_first_order SPY 20250321 570 C 20250303 60000 --format json-raw`
- [ ] Full live validator run — verification running locally, CI live.yml will be re-triggered post-merge.

Closes: restores every cell failing on live run 24520486541.