### PR TITLE
docs(notebooks): re-run 105 streaming against dev server

### DIFF
--- a/notebooks/105_realtime_streaming.ipynb
+++ b/notebooks/105_realtime_streaming.ipynb
@@ -31,10 +31,10 @@
    "id": "6828dddc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:13.698677Z",
-     "iopub.status.busy": "2026-04-16T21:22:13.698541Z",
-     "iopub.status.idle": "2026-04-16T21:22:13.872048Z",
-     "shell.execute_reply": "2026-04-16T21:22:13.871490Z"
+     "iopub.execute_input": "2026-04-17T06:01:43.358030Z",
+     "iopub.status.busy": "2026-04-17T06:01:43.357737Z",
+     "iopub.status.idle": "2026-04-17T06:01:43.556417Z",
+     "shell.execute_reply": "2026-04-17T06:01:43.555878Z"
     }
    },
    "outputs": [],
@@ -67,10 +67,10 @@
    "id": "4a4b1e69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:13.873782Z",
-     "iopub.status.busy": "2026-04-16T21:22:13.873595Z",
-     "iopub.status.idle": "2026-04-16T21:22:14.791442Z",
-     "shell.execute_reply": "2026-04-16T21:22:14.790619Z"
+     "iopub.execute_input": "2026-04-17T06:01:43.558265Z",
+     "iopub.status.busy": "2026-04-17T06:01:43.558056Z",
+     "iopub.status.idle": "2026-04-17T06:01:44.903795Z",
+     "shell.execute_reply": "2026-04-17T06:01:44.903249Z"
     }
    },
    "outputs": [
@@ -85,7 +85,7 @@
    ],
    "source": [
     "creds = Credentials.from_file(\"creds.txt\")\n",
-    "config = Config.production()\n",
+    "config = Config.dev()\n",
     "\n",
     "tdx = ThetaDataDx(creds, config)\n",
     "tdx.start_streaming()\n",
@@ -117,10 +117,10 @@
    "id": "752e51fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:14.794593Z",
-     "iopub.status.busy": "2026-04-16T21:22:14.794387Z",
-     "iopub.status.idle": "2026-04-16T21:22:16.782358Z",
-     "shell.execute_reply": "2026-04-16T21:22:16.781768Z"
+     "iopub.execute_input": "2026-04-17T06:01:44.905389Z",
+     "iopub.status.busy": "2026-04-17T06:01:44.905190Z",
+     "iopub.status.idle": "2026-04-17T06:01:45.491352Z",
+     "shell.execute_reply": "2026-04-17T06:01:45.490697Z"
     }
    },
    "outputs": [
@@ -171,10 +171,10 @@
    "id": "ea5ba135",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:16.783776Z",
-     "iopub.status.busy": "2026-04-16T21:22:16.783642Z",
-     "iopub.status.idle": "2026-04-16T21:22:26.787194Z",
-     "shell.execute_reply": "2026-04-16T21:22:26.786529Z"
+     "iopub.execute_input": "2026-04-17T06:01:45.492862Z",
+     "iopub.status.busy": "2026-04-17T06:01:45.492686Z",
+     "iopub.status.idle": "2026-04-17T06:01:55.497241Z",
+     "shell.execute_reply": "2026-04-17T06:01:55.496603Z"
     }
    },
    "outputs": [
@@ -189,7 +189,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Collected 0 quote events in 10 seconds\n"
+      "  Warning: disconnected: Unspecified\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collected 488 quote events in 10 seconds\n"
      ]
     }
    ],
@@ -238,10 +245,10 @@
    "id": "963ace49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:26.788741Z",
-     "iopub.status.busy": "2026-04-16T21:22:26.788528Z",
-     "iopub.status.idle": "2026-04-16T21:22:26.793048Z",
-     "shell.execute_reply": "2026-04-16T21:22:26.792505Z"
+     "iopub.execute_input": "2026-04-17T06:01:55.498938Z",
+     "iopub.status.busy": "2026-04-17T06:01:55.498762Z",
+     "iopub.status.idle": "2026-04-17T06:01:55.507875Z",
+     "shell.execute_reply": "2026-04-17T06:01:55.507252Z"
     }
    },
    "outputs": [
@@ -249,7 +256,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "No quote events received (market may be closed).\n"
+      "Quote event rate: 48.8 events/sec\n",
+      "Mean spread: $0.0645\n",
+      "\n"
      ]
     }
    ],
@@ -289,10 +298,10 @@
    "id": "64c44fea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:26.794466Z",
-     "iopub.status.busy": "2026-04-16T21:22:26.794329Z",
-     "iopub.status.idle": "2026-04-16T21:22:26.907772Z",
-     "shell.execute_reply": "2026-04-16T21:22:26.907144Z"
+     "iopub.execute_input": "2026-04-17T06:01:55.509260Z",
+     "iopub.status.busy": "2026-04-17T06:01:55.509083Z",
+     "iopub.status.idle": "2026-04-17T06:01:55.634223Z",
+     "shell.execute_reply": "2026-04-17T06:01:55.633565Z"
     }
    },
    "outputs": [
@@ -325,10 +334,10 @@
    "id": "977a3d57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:26.909175Z",
-     "iopub.status.busy": "2026-04-16T21:22:26.909035Z",
-     "iopub.status.idle": "2026-04-16T21:22:36.912896Z",
-     "shell.execute_reply": "2026-04-16T21:22:36.912375Z"
+     "iopub.execute_input": "2026-04-17T06:01:55.635800Z",
+     "iopub.status.busy": "2026-04-17T06:01:55.635622Z",
+     "iopub.status.idle": "2026-04-17T06:02:05.641371Z",
+     "shell.execute_reply": "2026-04-17T06:02:05.640757Z"
     }
    },
    "outputs": [
@@ -343,8 +352,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trade events:  3\n",
-      "Other events:  15 (ohlcvc, contract_assigned, market_open, quote)\n"
+      "Trade events:  5514\n",
+      "Other events:  11032 (contract_assigned, market_open, ohlcvc, quote)\n"
      ]
     }
    ],
@@ -394,10 +403,10 @@
    "id": "24ea8b3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:36.914643Z",
-     "iopub.status.busy": "2026-04-16T21:22:36.914508Z",
-     "iopub.status.idle": "2026-04-16T21:22:36.919836Z",
-     "shell.execute_reply": "2026-04-16T21:22:36.919166Z"
+     "iopub.execute_input": "2026-04-17T06:02:05.642833Z",
+     "iopub.status.busy": "2026-04-17T06:02:05.642692Z",
+     "iopub.status.idle": "2026-04-17T06:02:05.679000Z",
+     "shell.execute_reply": "2026-04-17T06:02:05.678451Z"
     }
    },
    "outputs": [
@@ -405,9 +414,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trade event rate: 0.3 events/sec\n",
-      "Total volume: 18 shares\n",
-      "VWAP: $263.70\n",
+      "Trade event rate: 551.4 events/sec\n",
+      "Total volume: 314,746 shares\n",
+      "VWAP: $209.33\n",
       "\n"
      ]
     }
@@ -451,10 +460,10 @@
    "id": "38d25442",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:36.921288Z",
-     "iopub.status.busy": "2026-04-16T21:22:36.921147Z",
-     "iopub.status.idle": "2026-04-16T21:22:37.424557Z",
-     "shell.execute_reply": "2026-04-16T21:22:37.424047Z"
+     "iopub.execute_input": "2026-04-17T06:02:05.680660Z",
+     "iopub.status.busy": "2026-04-17T06:02:05.680523Z",
+     "iopub.status.idle": "2026-04-17T06:02:06.278104Z",
+     "shell.execute_reply": "2026-04-17T06:02:06.277374Z"
     }
    },
    "outputs": [
@@ -470,7 +479,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Drained 0 remaining events\n"
+      "Drained 78 remaining events\n"
      ]
     }
    ],
@@ -497,10 +506,10 @@
    "id": "6801e935",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-16T21:22:37.426292Z",
-     "iopub.status.busy": "2026-04-16T21:22:37.426143Z",
-     "iopub.status.idle": "2026-04-16T21:22:37.503387Z",
-     "shell.execute_reply": "2026-04-16T21:22:37.502549Z"
+     "iopub.execute_input": "2026-04-17T06:02:06.279532Z",
+     "iopub.status.busy": "2026-04-17T06:02:06.279397Z",
+     "iopub.status.idle": "2026-04-17T06:02:06.313758Z",
+     "shell.execute_reply": "2026-04-17T06:02:06.313262Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
Markets closed. Re-executed 105_realtime_streaming.ipynb against Config.dev() (24/7 replay). 0/10 errors. All tick outputs present.