### PR TITLE
fix(fpss): re-subscribe all active contracts on auto-reconnect

### DIFF
--- a/crates/thetadatadx/src/fpss/io_loop.rs
+++ b/crates/thetadatadx/src/fpss/io_loop.rs
@@ -7,7 +7,7 @@
 //! login handshake in-place according to [`ReconnectPolicy`].
 
 use std::collections::HashMap;
-use std::io::BufReader;
+use std::io::{BufReader, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
@@ -36,6 +36,16 @@ use super::protocol::{
 };
 use super::reconnect_delay;
 use super::ring::{self, AdaptiveWaitStrategy, RingEvent};
+
+type ActiveSubs = Arc<Mutex<Vec<(super::protocol::SubscriptionKind, Contract)>>>;
+type ActiveFullSubs = Arc<
+    Mutex<
+        Vec<(
+            super::protocol::SubscriptionKind,
+            tdbe::types::enums::SecType,
+        )>,
+    >,
+>;
 
 // ---------------------------------------------------------------------------
 // Login result (internal)
@@ -124,15 +134,8 @@ pub(super) fn io_loop<F>(
     policy: ReconnectPolicy,
     creds: Credentials,
     hosts: Vec<(String, u16)>,
-    active_subs: Arc<Mutex<Vec<(super::protocol::SubscriptionKind, Contract)>>>,
-    active_full_subs: Arc<
-        Mutex<
-            Vec<(
-                super::protocol::SubscriptionKind,
-                tdbe::types::enums::SecType,
-            )>,
-        >,
-    >,
+    active_subs: ActiveSubs,
+    active_full_subs: ActiveFullSubs,
 ) where
     F: FnMut(&FpssEvent) + Send + 'static,
 {
@@ -450,34 +453,40 @@ pub(super) fn io_loop<F>(
         // Source: FPSSClient.java METADATA handler iterates activeQuotes +
         // activeTrades and re-sends each. Without this, the server accepts
         // the login but receives no subscribe commands → data stops flowing.
-        {
-            let subs = active_subs
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            for (kind, contract) in subs.iter() {
-                let payload = protocol::build_subscribe_payload(-1, contract);
-                let code = kind.subscribe_code();
-                let writer = reader.get_mut();
-                if let Err(e) = write_raw_frame(writer, code, &payload) {
-                    tracing::warn!(error = %e, contract = %contract, "failed to re-subscribe on reconnect");
-                } else {
-                    tracing::debug!(kind = ?kind, contract = %contract, "re-subscribed on auto-reconnect");
-                }
+        //
+        // Snapshot + drop lock before writing: holding the mutex during
+        // network I/O would stall concurrent subscribe/unsubscribe calls.
+        let subs_snapshot = active_subs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let full_subs_snapshot = active_full_subs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+
+        let writer = reader.get_mut();
+        for (kind, contract) in &subs_snapshot {
+            let payload = protocol::build_subscribe_payload(-1, contract);
+            let code = kind.subscribe_code();
+            if let Err(e) = write_raw_frame_no_flush(writer, code, &payload) {
+                tracing::warn!(error = %e, contract = %contract, "failed to re-subscribe on reconnect");
+            } else {
+                tracing::debug!(kind = ?kind, contract = %contract, "re-subscribed on auto-reconnect");
             }
         }
-        {
-            let full_subs = active_full_subs
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            for (kind, sec_type) in full_subs.iter() {
-                let payload = protocol::build_full_type_subscribe_payload(-1, *sec_type);
-                let code = kind.subscribe_code();
-                let writer = reader.get_mut();
-                if let Err(e) = write_raw_frame(writer, code, &payload) {
-                    tracing::warn!(error = %e, sec_type = ?sec_type, "failed to re-subscribe full-type on reconnect");
-                } else {
-                    tracing::debug!(kind = ?kind, sec_type = ?sec_type, "re-subscribed full-type on auto-reconnect");
-                }
+        for (kind, sec_type) in &full_subs_snapshot {
+            let payload = protocol::build_full_type_subscribe_payload(-1, *sec_type);
+            let code = kind.subscribe_code();
+            if let Err(e) = write_raw_frame_no_flush(writer, code, &payload) {
+                tracing::warn!(error = %e, sec_type = ?sec_type, "failed to re-subscribe full-type on reconnect");
+            } else {
+                tracing::debug!(kind = ?kind, sec_type = ?sec_type, "re-subscribed full-type on auto-reconnect");
+            }
+        }
+        if !subs_snapshot.is_empty() || !full_subs_snapshot.is_empty() {
+            if let Err(e) = writer.flush() {
+                tracing::warn!(error = %e, "failed to flush re-subscribe batch on reconnect");
             }
         }
 

--- a/crates/thetadatadx/src/fpss/io_loop.rs
+++ b/crates/thetadatadx/src/fpss/io_loop.rs
@@ -124,6 +124,15 @@ pub(super) fn io_loop<F>(
     policy: ReconnectPolicy,
     creds: Credentials,
     hosts: Vec<(String, u16)>,
+    active_subs: Arc<Mutex<Vec<(super::protocol::SubscriptionKind, Contract)>>>,
+    active_full_subs: Arc<
+        Mutex<
+            Vec<(
+                super::protocol::SubscriptionKind,
+                tdbe::types::enums::SecType,
+            )>,
+        >,
+    >,
 ) where
     F: FnMut(&FpssEvent) + Send + 'static,
 {
@@ -437,8 +446,43 @@ pub(super) fn io_loop<F>(
         // Replace the reader with the new stream.
         reader = BufReader::new(new_stream);
 
+        // Re-subscribe all active subscriptions on the new connection.
+        // Source: FPSSClient.java METADATA handler iterates activeQuotes +
+        // activeTrades and re-sends each. Without this, the server accepts
+        // the login but receives no subscribe commands → data stops flowing.
+        {
+            let subs = active_subs
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for (kind, contract) in subs.iter() {
+                let payload = protocol::build_subscribe_payload(-1, contract);
+                let code = kind.subscribe_code();
+                let writer = reader.get_mut();
+                if let Err(e) = write_raw_frame(writer, code, &payload) {
+                    tracing::warn!(error = %e, contract = %contract, "failed to re-subscribe on reconnect");
+                } else {
+                    tracing::debug!(kind = ?kind, contract = %contract, "re-subscribed on auto-reconnect");
+                }
+            }
+        }
+        {
+            let full_subs = active_full_subs
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            for (kind, sec_type) in full_subs.iter() {
+                let payload = protocol::build_full_type_subscribe_payload(-1, *sec_type);
+                let code = kind.subscribe_code();
+                let writer = reader.get_mut();
+                if let Err(e) = write_raw_frame(writer, code, &payload) {
+                    tracing::warn!(error = %e, sec_type = ?sec_type, "failed to re-subscribe full-type on reconnect");
+                } else {
+                    tracing::debug!(kind = ?kind, sec_type = ?sec_type, "re-subscribed full-type on auto-reconnect");
+                }
+            }
+        }
+
         // Drain any commands that queued up during reconnection (subscribe, ping, etc.)
-        // and send them over the new connection to re-establish subscriptions.
+        // and send them over the new connection.
         loop {
             match cmd_rx.try_recv() {
                 Ok(IoCommand::WriteFrame { code, payload }) => {

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -151,10 +151,10 @@ pub struct FpssClient {
     /// Monotonically increasing request ID counter.
     next_req_id: AtomicI32,
     /// Active per-contract subscriptions for reconnection.
-    pub(in crate::fpss) active_subs: Mutex<Vec<(SubscriptionKind, Contract)>>,
+    pub(in crate::fpss) active_subs: Arc<Mutex<Vec<(SubscriptionKind, Contract)>>>,
     /// Active full-type (firehose) subscriptions for reconnection.
     pub(in crate::fpss) active_full_subs:
-        Mutex<Vec<(SubscriptionKind, tdbe::types::enums::SecType)>>,
+        Arc<Mutex<Vec<(SubscriptionKind, tdbe::types::enums::SecType)>>>,
     /// Server-assigned contract ID mapping.
     contract_map: Arc<Mutex<HashMap<i32, Contract>>>,
     /// The server address we connected to.
@@ -295,6 +295,11 @@ impl FpssClient {
         let shutdown = Arc::new(AtomicBool::new(false));
         let authenticated = Arc::new(AtomicBool::new(true));
         let contract_map = Arc::new(Mutex::new(HashMap::new()));
+        let active_subs: Arc<Mutex<Vec<(protocol::SubscriptionKind, protocol::Contract)>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let active_full_subs: Arc<
+            Mutex<Vec<(protocol::SubscriptionKind, tdbe::types::enums::SecType)>>,
+        > = Arc::new(Mutex::new(Vec::new()));
 
         // Command channel: FpssClient -> I/O thread
         let (cmd_tx, cmd_rx) = std_mpsc::channel::<IoCommand>();
@@ -309,6 +314,8 @@ impl FpssClient {
         let io_server_addr = server_addr.clone();
         let io_creds = creds.clone();
         let io_hosts = hosts.to_vec();
+        let io_active_subs = Arc::clone(&active_subs);
+        let io_active_full_subs = Arc::clone(&active_full_subs);
 
         let io_handle = thread::Builder::new()
             .name("fpss-io".to_owned())
@@ -328,6 +335,8 @@ impl FpssClient {
                     policy,
                     io_creds,
                     io_hosts,
+                    io_active_subs,
+                    io_active_full_subs,
                 );
             })
             .map_err(|e| Error::Fpss {
@@ -356,8 +365,8 @@ impl FpssClient {
             shutdown,
             authenticated,
             next_req_id: AtomicI32::new(1),
-            active_subs: Mutex::new(Vec::new()),
-            active_full_subs: Mutex::new(Vec::new()),
+            active_subs,
+            active_full_subs,
             contract_map,
             server_addr,
         })


### PR DESCRIPTION
## What
io_loop auto-reconnect now re-subscribes all active contracts after login, matching Java terminal behavior.

## Why
After a disconnect + auto-reconnect, the server accepted login but the io_loop never re-sent subscription frames. Data stopped flowing. The explicit `reconnect()` (session.rs) and the Java terminal both re-iterate active subscriptions — the io_loop didn't.

Discovered via dev-server soak test: 2.7M events, one disconnect at event 2175, auto-reconnect authenticated but zero data afterward.

## How
- `active_subs` + `active_full_subs` promoted to `Arc<Mutex<Vec<...>>>` (shared between `FpssClient` + io_loop thread)
- After reconnect login success in io_loop, read both lists and re-send every subscribe frame with `req_id=-1`
- Then drain queued commands as before

## Test plan
- [x] `cargo fmt / clippy / test` green
- [ ] Dev-server soak: disconnect + auto-reconnect should resume data flow