### PR TITLE
release: thetadatadx 7.3.0

### DIFF
--- a/.github/release-notes/v7.3.0.md
+++ b/.github/release-notes/v7.3.0.md
@@ -1,0 +1,17 @@
+## Added
+
+- **TypeScript/Node.js SDK via napi-rs** (#332) -- native Node.js addon exposing all 61 historical endpoints, 20+ streaming methods, and 13 tick types, SSOT-generated from the same TOML surface that drives the Python, Go, and C++ SDKs. TypeScript type definitions included. CI builds and smoke-tests on every PR. TypeScript SDK available from source; npm publish workflow coming in a follow-up.
+
+## Fixed
+
+- **FPSS auto-reconnect now re-subscribes all active contracts** (#333) -- the `io_loop` reconnect path authenticated but never re-sent subscription frames after an involuntary disconnect, causing data to stop flowing. Subscription tables are now shared via `Arc<Mutex<...>>` between the client and the I/O thread; all active subscriptions are re-sent after reconnect login.
+- **Unrecognized FPSS frame codes now emitted as `UnknownFrame` with raw bytes** -- previously silently dropped. Now surfaced as `FpssControl::UnknownFrame { code, payload }` with hex-encoded wire bytes across all four SDKs (Python, TypeScript, Go, C++). FFI maps to kind 11 with hex payload in the detail field; Go adds the `FpssCtrlUnknownFrame` constant and a complete control-kind enum.
+- **Python and TypeScript SDKs explicitly map `Reconnecting`, `Reconnected`, and `MarketClose` control events** -- previously fell through to the catch-all `"unknown_control"` label.
+
+## Changed
+
+- `active_subs` / `active_full_subs` promoted to `Arc<Mutex<...>>` for `io_loop` thread sharing (#333).
+- TypeScript/Node.js added to all SDK documentation (82 files).
+- 7 Jupyter notebooks with executed outputs.
+
+Full changelog: https://github.com/userFRM/ThetaDataDx/blob/main/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.0] - 2026-04-16
+
+### Added
+
+- **TypeScript/Node.js SDK via napi-rs** (#332) -- native addon exposing all 61 historical endpoints, 20+ streaming methods, and 13 tick types to Node.js 18+. Every method, type, and streaming dispatch is SSOT-generated from the same TOML surface that drives Python, Go, and C++. TypeScript type definitions included. CI builds and smoke-tests on every PR. npm publish workflow coming in a follow-up.
+
+### Fixed
+
+- **FPSS auto-reconnect now re-subscribes all active contracts** (#333) -- the `io_loop` reconnect path authenticated successfully but never re-sent subscription frames, so data stopped flowing after an involuntary disconnect. `active_subs` and `active_full_subs` are now shared via `Arc<Mutex<...>>` between the client and the I/O thread; after reconnect login, every active subscription is re-sent before draining the command channel.
+- **Unrecognized FPSS frame codes now emitted as `UnknownFrame` with raw bytes** -- previously logged at trace level and silently dropped, so users had no visibility into unexpected server frames. Now surfaced as `FpssControl::UnknownFrame { code, payload }` with hex-encoded wire bytes in the Python and TypeScript SDKs.
+- **Python and TypeScript SDKs explicitly map `Reconnecting`, `Reconnected`, and `MarketClose` control events** -- these previously fell through to the catch-all `"unknown_control"` label, which was confusing in soak-test logs.
+- **FFI + Go SDK now expose `UnknownFrame` with raw payload bytes** -- the C FFI bridge maps `UnknownFrame` to kind 11 with the hex-encoded payload in the detail field (was kind 99 with no detail). Go SDK adds the `FpssCtrlUnknownFrame` constant and a complete control-kind enum for all 11 event types. All four SDKs (Python, TypeScript, Go, C++) now surface unrecognized server frames consistently.
+
+### Changed
+
+- **`active_subs` / `active_full_subs` promoted to `Arc<Mutex<...>>`** (#333) -- subscription tables are now shared between the `FpssClient` and the `io_loop` thread so the reconnect path can read them without a command-channel round-trip. Snapshots are cloned before writing frames to avoid holding the lock during I/O.
+
 ## [7.2.1] - 2026-04-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "7.2.1"
+version = "7.3.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.0] - 2026-04-16
+
+### Added
+
+- **TypeScript/Node.js SDK via napi-rs** (#332) -- native addon exposing all 61 historical endpoints, 20+ streaming methods, and 13 tick types to Node.js 18+. Every method, type, and streaming dispatch is SSOT-generated from the same TOML surface that drives Python, Go, and C++. TypeScript type definitions included. CI builds and smoke-tests on every PR. npm publish workflow coming in a follow-up.
+
+### Fixed
+
+- **FPSS auto-reconnect now re-subscribes all active contracts** (#333) -- the `io_loop` reconnect path authenticated successfully but never re-sent subscription frames, so data stopped flowing after an involuntary disconnect. `active_subs` and `active_full_subs` are now shared via `Arc<Mutex<...>>` between the client and the I/O thread; after reconnect login, every active subscription is re-sent before draining the command channel.
+- **Unrecognized FPSS frame codes now emitted as `UnknownFrame` with raw bytes** -- previously logged at trace level and silently dropped, so users had no visibility into unexpected server frames. Now surfaced as `FpssControl::UnknownFrame { code, payload }` with hex-encoded wire bytes in the Python and TypeScript SDKs.
+- **Python and TypeScript SDKs explicitly map `Reconnecting`, `Reconnected`, and `MarketClose` control events** -- these previously fell through to the catch-all `"unknown_control"` label, which was confusing in soak-test logs.
+- **FFI + Go SDK now expose `UnknownFrame` with raw payload bytes** -- the C FFI bridge maps `UnknownFrame` to kind 11 with the hex-encoded payload in the detail field (was kind 99 with no detail). Go SDK adds the `FpssCtrlUnknownFrame` constant and a complete control-kind enum for all 11 event types. All four SDKs (Python, TypeScript, Go, C++) now surface unrecognized server frames consistently.
+
+### Changed
+
+- **`active_subs` / `active_full_subs` promoted to `Arc<Mutex<...>>`** (#333) -- subscription tables are now shared between the `FpssClient` and the `io_loop` thread so the reconnect path can read them without a command-channel round-trip. Snapshots are cloned before writing frames to avoid holding the lock during I/O.
+
 ## [7.2.1] - 2026-04-16
 
 ### Fixed

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ description: Install ThetaDataDx for Rust, Python, TypeScript/Node.js, Go, or C+
 ```toml [Rust]
 # Add to your Cargo.toml
 [dependencies]
-thetadatadx = "7.2"
+thetadatadx = "7.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 ```bash [Python]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "7.2.1"
+version = "7.3.0"
 edition = "2021"
 description = "C FFI layer for thetadatadx — used by Go and C++ SDKs"
 license = "GPL-3.0-or-later"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -585,6 +585,16 @@ fn fpss_event_to_ffi(event: &thetadatadx::fpss::FpssEvent) -> FfiBufferedEvent {
                 ),
                 FpssControl::Reconnected => (9, 0, None),
                 FpssControl::Error { message } => (10, 0, Some(message.clone())),
+                FpssControl::UnknownFrame { code, payload } => (
+                    11,
+                    *code as i32,
+                    Some(
+                        payload
+                            .iter()
+                            .map(|b| format!("{b:02x}"))
+                            .collect::<String>(),
+                    ),
+                ),
                 _ => (99, 0, None), // unknown control
             };
             let cstring = detail_str.and_then(|s| CString::new(s).ok());

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -119,7 +119,7 @@ def check_static_docs() -> None:
     # Version strings in getting-started docs must match the workspace version.
     expect_contains(
         ROOT / "docs-site/docs/getting-started/installation.md",
-        'thetadatadx = "7.2"',
+        'thetadatadx = "7.3"',
     )
     expect_contains(
         ROOT / "docs-site/docs/tools/mcp.md",

--- a/sdks/go/fpss.go
+++ b/sdks/go/fpss.go
@@ -23,6 +23,24 @@ const (
 	FpssRawDataEvent      FpssEventKind = 5
 )
 
+// FpssControlKind identifies the sub-type of a control event.
+// Use with FpssControlData.Kind.
+type FpssControlKind = int32
+
+const (
+	FpssCtrlLoginSuccess      FpssControlKind = 0
+	FpssCtrlContractAssigned  FpssControlKind = 1
+	FpssCtrlReqResponse       FpssControlKind = 2
+	FpssCtrlMarketOpen        FpssControlKind = 3
+	FpssCtrlMarketClose       FpssControlKind = 4
+	FpssCtrlServerError       FpssControlKind = 5
+	FpssCtrlDisconnected      FpssControlKind = 6
+	FpssCtrlReconnecting      FpssControlKind = 8
+	FpssCtrlReconnected       FpssControlKind = 9
+	FpssCtrlError             FpssControlKind = 10
+	FpssCtrlUnknownFrame      FpssControlKind = 11 // ID = frame code, Detail = hex payload
+)
+
 // FpssQuote is a real-time quote event from FPSS.
 // Bid and Ask are pre-decoded to float64 at parse time.
 type FpssQuote struct {

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "pyo3",
  "tdbe",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "7.2.1"
+version = "7.3.0"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "GPL-3.0-or-later"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1645,7 +1645,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "7.2.1"
+version = "7.3.0"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "GPL-3.0-or-later"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "GPL-3.0-or-later",
   "repository": {

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "7.2.1"
+version = "7.3.0"
 edition = "2021"
 description = "CLI for ThetaDataDx — query ThetaData from your terminal"
 license = "GPL-3.0-or-later"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "7.2.1"
+version = "7.3.0"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "GPL-3.0-or-later"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "7.2.1"
+version = "7.3.0"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "7.2.1"
+version = "7.3.0"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

- TypeScript/Node.js SDK via napi-rs (#332) — 61 endpoints, 20+ streaming methods, 13 tick types, all SSOT-generated from TOML
- FPSS auto-reconnect now re-subscribes all active contracts (#333) — data no longer stops flowing after involuntary disconnect
- Unrecognized FPSS frame codes emitted as `UnknownFrame` with raw bytes across all four SDKs (Python, TypeScript, Go, C++)
- Version bump: 7.2.1 → 7.3.0 (all crates except tdbe which stays at 0.10.0)

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `generate_sdk_surfaces --check`
- [x] `check_docs_consistency.py`
- [x] MCP clippy + test
- [x] Server clippy + test
- [x] Python `cargo check`
- [x] TypeScript `cargo check`
- [x] CHANGELOG.md updated
- [x] docs-site changelog mirrored
- [x] Release notes at `.github/release-notes/v7.3.0.md`
- [x] Installation docs updated to `"7.3"`

## Note

npm publish workflow is not in CI yet — TypeScript SDK available from source. Follow-up planned.