### PR TITLE
ci(typescript): npm token auth + idempotent publish

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -89,12 +89,28 @@ jobs:
         run: ls -lR npm/
       - name: Publish platform packages
         working-directory: sdks/typescript
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for dir in npm/*/; do
             if ls "$dir"/*.node 1>/dev/null 2>&1; then
-              npm publish "$dir" --provenance --access public
+              pkg_name=$(node -p "require('./${dir}package.json').name")
+              pkg_version=$(node -p "require('./${dir}package.json').version")
+              if npm view "${pkg_name}@${pkg_version}" version 2>/dev/null; then
+                echo "⏭ ${pkg_name}@${pkg_version} already published"
+              else
+                npm publish "$dir" --provenance --access public
+              fi
             fi
           done
       - name: Publish root package
         working-directory: sdks/typescript
-        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          pkg_version=$(node -p "require('./package.json').version")
+          if npm view "thetadatadx@${pkg_version}" version 2>/dev/null; then
+            echo "⏭ thetadatadx@${pkg_version} already published"
+          else
+            npm publish --provenance --access public
+          fi


### PR DESCRIPTION
## Summary

- Use `NPM_TOKEN` secret (Automation token) for npm auth instead of relying solely on OIDC Trusted Publishers, which cannot create new packages
- Add version-exists checks before each `npm publish` so the workflow is idempotent — safe to re-trigger via `workflow_dispatch` without failing on already-published versions
- Platform packages (`thetadatadx-linux-x64-gnu`, `thetadatadx-darwin-arm64`, `thetadatadx-win32-x64-msvc`) can now be created on npm for the first time by CI

Closes #336

## Test plan

- [ ] User creates npm Automation token at npmjs.com → Settings → Access Tokens → Generate → type: Automation
- [ ] User adds token as `NPM_TOKEN` secret in GitHub repo settings
- [ ] Trigger `workflow_dispatch` on main → builds on 3 platforms → publishes all 4 packages
- [ ] Verify `npm install thetadatadx` works on Linux x64, macOS arm64, Windows x64

🤖 Generated with [Claude Code](https://claude.com/claude-code)