### PR TITLE
fix(ci): napi artifacts --output-dir

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -83,7 +83,7 @@ jobs:
           path: sdks/typescript/artifacts
       - name: Move binaries into platform packages
         working-directory: sdks/typescript
-        run: npx napi artifacts --dir artifacts
+        run: npx napi artifacts --output-dir artifacts
       - name: List platform packages
         working-directory: sdks/typescript
         run: ls -lR npm/


### PR DESCRIPTION
Closes #340. cli v3 renamed `--dir` → `--output-dir`.