### PR TITLE
fix(ci): drop --provenance on new platform packages

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -99,7 +99,7 @@ jobs:
               if npm view "${pkg_name}@${pkg_version}" version 2>/dev/null; then
                 echo "⏭ ${pkg_name}@${pkg_version} already published"
               else
-                npm publish "$dir" --provenance --access public
+                npm publish "$dir" --access public
               fi
             fi
           done


### PR DESCRIPTION
EOTP even with bypass-2FA token. --provenance + new package (no TP) = OIDC path = 2FA required. Drop flag for platform packages only.