### PR TITLE
fix(server): deterministic CSV header key order

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,31 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/sdks/typescript"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/docs-site"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/sdks/python"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -403,10 +403,11 @@ pub fn json_to_csv(response: &[sonic_rs::Value]) -> Option<String> {
 
     if let Some(obj) = first.as_object() {
         let null_val = sonic_rs::Value::default();
-        let keys: Vec<&str> = obj.iter().map(|(k, _)| k).collect();
+        let mut keys: Vec<&str> = obj.iter().map(|(k, _)| k).collect();
         if keys.is_empty() {
             return None;
         }
+        keys.sort_unstable();
 
         for (i, key) in keys.iter().enumerate() {
             if i > 0 {
@@ -488,7 +489,7 @@ mod tests {
         ])
         .expect("object rows should format as CSV");
 
-        assert_eq!(csv, "symbol,count\nAAPL,1\nMSFT,2\n");
+        assert_eq!(csv, "count,symbol\n1,AAPL\n2,MSFT\n");
     }
 
     #[test]


### PR DESCRIPTION
Pre-existing flaky test. sonic_rs Object iteration is hash-order dependent. Sort keys to fix.