### PR TITLE
fix(ts): drop prepublishOnly script

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -23,7 +23,6 @@
   "scripts": {
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
-    "prepublishOnly": "napi prepublish",
     "test": "node --test __tests__/basic.test.mjs",
     "version": "napi version"
   },


### PR DESCRIPTION
napi prepublish needs release commit metadata; our CI handles the whole publish flow explicitly. Remove hook.