### PR TITLE
perf(server): drop contract-map lock before WS JSON encoding

### DIFF
--- a/tools/server/src/ws.rs
+++ b/tools/server/src/ws.rs
@@ -271,11 +271,31 @@ async fn handle_client_message(state: &AppState, text: &str, socket: &mut WebSoc
 //  FPSS -> WebSocket bridge
 // ---------------------------------------------------------------------------
 
-/// Convert an `FpssEvent` to the Java terminal's WebSocket JSON format.
-fn fpss_event_to_ws_json(
+/// Peek the contract for an event's `contract_id`, if any, while briefly
+/// holding the shared contract-map lock. Returns a cloned `Contract` so the
+/// lock can be released before the (O(fields)) JSON serialization runs.
+fn lookup_event_contract(
     event: &FpssEvent,
-    contract_map: &HashMap<i32, Contract>,
-) -> Option<String> {
+    contract_map: &Mutex<HashMap<i32, Contract>>,
+) -> Option<Contract> {
+    let cid = match event {
+        FpssEvent::Data(FpssData::Quote { contract_id, .. })
+        | FpssEvent::Data(FpssData::Trade { contract_id, .. })
+        | FpssEvent::Data(FpssData::OpenInterest { contract_id, .. })
+        | FpssEvent::Data(FpssData::Ohlcvc { contract_id, .. }) => *contract_id,
+        _ => return None,
+    };
+    let map = contract_map.lock().unwrap_or_else(|e| e.into_inner());
+    map.get(&cid).cloned()
+}
+
+/// Convert an `FpssEvent` to the Java terminal's WebSocket JSON format.
+///
+/// `peeked_contract` should be the contract already looked up from the shared
+/// map (see [`lookup_event_contract`]). Passing it in lets the caller release
+/// the map lock before serialization, so the FPSS callback thread and the
+/// broadcast task never contend on the lock during JSON encoding.
+fn fpss_event_to_ws_json(event: &FpssEvent, peeked_contract: Option<&Contract>) -> Option<String> {
     match event {
         FpssEvent::Data(data) => {
             let (event_type, contract_id, body) = match data {
@@ -382,8 +402,7 @@ fn fpss_event_to_ws_json(
                 _ => return None,
             };
 
-            let contract_json = contract_map
-                .get(&contract_id)
+            let contract_json = peeked_contract
                 .map(contract_to_json)
                 .unwrap_or_else(|| sonic_rs::json!({"id": contract_id}));
 
@@ -485,14 +504,21 @@ pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
     // Unbounded mpsc keeps the Disruptor callback non-blocking even if the
     // broadcast task is briefly slow. Memory is bounded by channel drain
     // rate; clients get bounded per-client backpressure inside broadcast_ws.
+    //
+    // Per-tick clone is intentionally cheap: `FpssData::{Quote,Trade,Ohlcvc,
+    // OpenInterest}` carry only primitives plus `Arc<str>` for symbol, so
+    // `event.clone()` is a field copy + refcount bump — not a heap allocation
+    // on the hot path.
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<FpssEvent>();
 
     tokio::spawn(async move {
         while let Some(event) = rx.recv().await {
-            let json = {
-                let map = map_for_task.lock().unwrap_or_else(|e| e.into_inner());
-                fpss_event_to_ws_json(&event, &map)
-            };
+            // Fetch the event's contract (if any) under the map lock, then
+            // drop the lock BEFORE running the O(fields) JSON serialization.
+            // This stops the broadcast task and the FPSS callback from
+            // contending on the same Mutex during encoding.
+            let peeked = lookup_event_contract(&event, &map_for_task);
+            let json = fpss_event_to_ws_json(&event, peeked.as_ref());
             if let Some(ws_json) = json {
                 let msg: Arc<str> = Arc::from(ws_json);
                 state_for_task.broadcast_ws(msg);


### PR DESCRIPTION
## Summary

Closes #360. The broadcast task held the shared `Mutex<HashMap<i32, Contract>>` for the full duration of `fpss_event_to_ws_json()` — including the `sonic_rs::json!()` macros and field-by-field encoding. The FPSS callback thread needs the same lock to register new contracts, so under reconnects or Contract storms the two threads contended on the same critical section for the length of each JSON encode (O(fields)) instead of an O(1) map lookup.

Refactored to look up the single contract the event references, clone it out of the map, drop the lock, then serialize. Lock-held critical section is now a single `HashMap::get + clone`.

Also addresses the per-tick clone concern in #359: documented in-code that `FpssData` variants carry only primitives + `Arc<str>` for symbol, so `event.clone()` on the callback path is a field copy + refcount bump, not a heap allocation. No code change needed there.

## Changes

- `tools/server/src/ws.rs`
  - New `lookup_event_contract` helper that locks the map, pulls a single contract by id, clones it, drops the lock.
  - `fpss_event_to_ws_json` now takes `Option<&Contract>` instead of the whole map.
  - Broadcast task: peek contract, drop lock, then serialize.
  - Inline comment explaining why per-tick `event.clone()` is cheap.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (server tests green)
- [ ] Updated `CHANGELOG.md` (n/a until release cut)
- [x] Updated documentation (inline docstring on new helper + signature change note)
- [ ] FFI/SDK bindings updated (n/a — server-local change)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test` (server-local unit tests)
- Ran `thetadatadx-server` locally against dev option-full stream; WS client received unchanged JSON payloads.

## Related Issues

Closes #360
Addresses #359 (documented in-code, no code change required)