### PR TITLE
docs: pre-release sync — align every doc with current code state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added (Python SDK)
+### Added
 
-- **`thetadatadx.to_arrow(ticks) -> pyarrow.Table`** — new public entry point that returns the Arrow table directly, for users wiring DuckDB / Arrow-Flight / cuDF / polars-arrow pipelines without a pandas or polars roundtrip. Requires `pip install thetadatadx[arrow]` (pyarrow only).
-- **Generated `#[new]` constructors on every tick pyclass** — `EodTick(ms_of_day=1, volume=1_000_000, ...)`, `OhlcTick(...)`, `TradeTick(...)`, etc. All fields are keyword-only with zero / empty-string defaults, so test fixtures and user-side data construction are possible from Python (previously pyclass instances could only be produced by Rust endpoints).
+- **`thetadatadx.to_arrow(ticks) -> pyarrow.Table`** (#379) — new public Python entry point that returns the Arrow table directly, for users wiring DuckDB / Arrow-Flight / cuDF / polars-arrow pipelines without a pandas or polars roundtrip. Requires `pip install thetadatadx[arrow]` (pyarrow only).
+- **`hint=` kwarg on `to_arrow` / `to_dataframe` / `to_polars`** (#380) — optional `hint: str` names the tick pyclass (e.g. `hint="EodTick"`) so the Arrow schema is materialised even when the input list is empty. Previous empty-list calls returned a zero-column table; downstream pipelines asserting a fixed schema now get the right columns on empty market-hours windows.
+- **Generated `#[new]` constructors on every tick pyclass** (#379) — `EodTick(ms_of_day=1, volume=1_000_000, ...)`, `OhlcTick(...)`, `TradeTick(...)`, etc. All fields are keyword-only with zero / empty-string defaults, so test fixtures and user-side data construction are possible from Python (previously pyclass instances could only be produced by Rust endpoints).
+- **`AllGreeks` pyclass** (#378) — `all_greeks(...)` now returns a frozen `AllGreeks` pyclass with 22 `#[pyo3(get)]` f64 fields (value / iv / delta / gamma / theta / vega / rho plus every second- and third-order Greek) and a `__repr__` showing the six most-referenced values. Replaces the untyped 22-key `PyDict` that was the sole remaining dict-typed public return in the Python SDK.
+- **`__repr__` on every FPSS event pyclass** (#380) — `Ohlcvc`, `Quote`, `Trade`, `OpenInterest`, `Simple`, `RawData` now render up to six live field values at the Jupyter / print boundary (matching the pattern already on tick pyclasses). Opaque `Vec<u8>` payloads and `received_at_ns` skipped as noise.
+- **`dropped_events()` counter on every streaming SDK** (#377) — `Arc<AtomicU64>` hoisted onto `ThetaDataDx` survives reconnect and is exposed as `tdx.dropped_events() -> int` (Python), `tdx.droppedEvents(): bigint` (TypeScript), `client.DroppedEvents() uint64` (Go), `client.dropped_events() -> uint64_t` (C++), `tdx_fpss_dropped_events(handle)` / `tdx_unified_dropped_events(handle)` (FFI). Previously silent `let _ = tx.send(buffered)` call-sites now bump the counter and emit `tracing::debug!` on target `thetadatadx::sdk::streaming`.
+- **`POST /v3/system/shutdown` endpoint on `thetadatadx-server`** (#377) — graceful shutdown over a privileged route gated by a per-startup random UUID `X-Shutdown-Token` header (constant-time compared via `subtle::ConstantTimeEq`). Prints the token to stderr at startup only; never into structured logs. Dedicated governor allows one attempt per hour, burst 3. Method is `POST` (not `GET`) so the action is neither cached nor prefetched.
 
 ### Changed — Performance (Python SDK)
 
-- **DataFrame adapter migrated to Apache Arrow columnar pipeline** — `to_dataframe` / `to_polars` / `to_arrow` and the `*_df` convenience wrappers on `ThetaDataDx` now build a single `arrow::RecordBatch` in Rust and hand it to pyarrow via the Arrow C Data Interface (zero-copy at the pyo3 boundary). pandas 2.x aliases the numeric columns in place; polars consumes via `polars.from_arrow`. At 100k x 20 EodTick rows wall-clock drops from ~300-500 ms (legacy dict-of-lists) to ~8 ms — roughly 40-60x. SSOT preserved: Arrow schema + converters are generated from `tick_schema.toml`; no hand-maintained Arrow code. Public `to_dataframe` / `to_polars` signatures are unchanged.
-- **Deleted** `sdks/python/src/tick_columnar.rs` (the old PyDict-based emission) — replaced end-to-end by the generator-emitted `sdks/python/src/tick_arrow.rs`. `pip install thetadatadx[pandas]` / `[polars]` now pull `pyarrow>=14.0` alongside the DataFrame library; `pip install thetadatadx[arrow]` is the pyarrow-only extras bundle.
+- **DataFrame adapter migrated to Apache Arrow columnar pipeline** (#379) — `to_dataframe(ticks)` / `to_polars(ticks)` / `to_arrow(ticks)` build a single `arrow::RecordBatch` in Rust and hand it to pyarrow via the Arrow C Data Interface (zero-copy at the pyo3 boundary). pandas 2.x aliases the numeric columns in place; polars consumes via `polars.from_arrow`. At 100k x 20 `EodTick` rows wall-clock drops from ~300-500 ms (legacy dict-of-lists) to ~8 ms — roughly 40-60x. SSOT preserved: Arrow schema + converters are generated from `tick_schema.toml`; no hand-maintained Arrow code.
+- **Per-endpoint DataFrame convenience wrappers removed** (#379) — the four per-endpoint `stock_history_{eod,ohlc,trade,quote}` Rust-tick-slice fast-path helpers on `ThetaDataDx` were deleted. The unified recipe is one extra line with identical performance:
+
+  ```python
+  ticks = client.stock_history_eod("AAPL", "20240101", "20240301")
+  df    = thetadatadx.to_dataframe(ticks)   # Arrow-backed, zero-copy on pandas 2.x
+  pdf   = thetadatadx.to_polars(ticks)      # Arrow-backed, zero-copy
+  table = thetadatadx.to_arrow(ticks)       # DuckDB / cuDF / Arrow-Flight
+  ```
+
+  Single code path, single generator, single test surface — 100% SSOT restored on the Python DataFrame surface.
+- **Deleted** `sdks/python/src/tick_columnar.rs` (the old PyDict-based emission) (#379) — replaced end-to-end by the generator-emitted `sdks/python/src/tick_arrow.rs`. `pip install thetadatadx[pandas]` / `[polars]` now pull `pyarrow>=14.0` alongside the DataFrame library; `pip install thetadatadx[arrow]` is the pyarrow-only extras bundle.
 
 ### Changed — BREAKING (Python SDK)
 
@@ -31,10 +46,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   close = ticks[i].close               # attribute access, typed
   ```
 
-  `to_dataframe(ticks)`, `to_polars(ticks)`, and the `*_df` convenience
-  wrappers (`stock_history_eod_df`, etc.) transparently pivot the new
-  shape into a pandas/polars frame — consumer code using those
-  helpers is unaffected.
+  `to_dataframe(ticks)`, `to_polars(ticks)`, and `to_arrow(ticks)` transparently pivot the new shape into a pandas / polars frame or a `pyarrow.Table`.
+
+### Changed — BREAKING (FFI / Go / C++)
+
+- **C++ `TdxFpssEvent` field order realigned with Rust + Go** (#376) — the hand-written `TdxFpssEvent` in `sdks/cpp/include/thetadx.h` declared `{ kind, quote, trade, open_interest, ohlcvc, control, raw_data }` while the Rust generator (and the Go C header) emits `{ kind, ohlcvc, open_interest, quote, trade, control, raw_data }`. Every `event->quote.*` / `event->trade.*` / `event->ohlcvc.*` access in existing C++ consumers was reading from the wrong offset — data corruption with no compile-time signal. `thetadx.h` now `#include`s the generator-emitted `fpss_event_structs.h.inc` (byte-identical to the Go C header) and `thetadx.hpp` gains `static_assert(offsetof / sizeof)` covering every field of every `TdxFpss*` struct. Any future drift is compile-fatal.
+- **Go `FpssControlData` renamed to `FpssControl`, `FpssOpenInterest*` → `FpssOpenInterest`** (#376) — Go-idiomatic naming on the mirror struct set. Callers referencing the old names will fail to compile; rename one-for-one. The nested field names on `FpssEvent` (`ev.RawData.Code`, `ev.RawData.Payload`) are unchanged.
+
+### Changed
+
+- **`thetadatadx-server`: governor layer is now outermost, rate-limited traffic short-circuits first** (#377) — axum `.layer(X).layer(Y)` makes Y the outer wrapper, so the previous `ConcurrencyLimit → BodyLimit → Governor` order had the per-IP limiter innermost. Every rate-limited request still consumed a concurrency permit and ran the body-length check before being rejected. Reordered so the governor runs first; body-limit and concurrency gates are only touched by allowed traffic.
+- **`thetadatadx-server`: `PeerIpKeyExtractor` on the REST + WS routers** (#377 / #378) — the per-IP rate limiter now keys on the real TCP socket source instead of the forwarded-header-trusting extractor used before. The server defaults to `127.0.0.1` without a trusted reverse proxy in front, so trusting `X-Forwarded-For` / `X-Real-IP` / `Forwarded` let a local attacker cycle fake IPs and bypass the per-IP rate limit. Module doc comment spells out the deployment policy.
+- **`thetadatadx-server`: `BoundedQuery<N>` extractor caps query-string params during parse** (#378) — the previous check ran after axum's `Query<HashMap<String, String>>` had already parsed the entire query string into a HashMap, so a `?a=1&b=2&...` flood still allocated MB+ before hitting the count check. `BoundedQuery<32>` counts `&`-delimited pairs on the raw URI before `serde_urlencoded::from_str`, rejects over-limit with 400, and caps HashMap capacity.
+- **`thetadatadx-server`: WS subscribe + every REST validator now run `ensure_no_control_chars` + per-field length caps** (#377) — symbol / root ≤ 16, expiration == 8 (YYYYMMDD), strike ≤ 10, right == 1, date == 8, venue ≤ 8. Returns 400 with a descriptive error, never 500. Unknown query-param names surface the real name in the error instead of an opaque `"parameter"` fallback.
+- **`thetadatadx-server`: REST global concurrency limit 256, per-IP governor 20 rps / burst 40, body limit 64 KiB, WS text-frame cap 4 KiB** (#377 / #378) — explicit layers on both routers. Legitimate subscribe commands are <200 B; 4 KiB is generous for pathological clients.
+- **`thetadatadx-server`: shutdown rate limit fixed — one token per hour, burst 3** (#377 follow-up) — `per_second(3600)` treats the argument as "requests per second", so the "3 attempts per hour" config was actually allowing ~3600 rps. Switched to `.period(Duration::from_secs(3600))`; constant renamed to `SHUTDOWN_REPLENISH_PERIOD`.
+- **`thetadatadx-server`: hot-path `String::clone` eliminated on FPSS TOCTOU contract map** (#378) — the broadcast path now holds `HashMap<i32, Arc<Contract>>` instead of `HashMap<i32, Contract>`; mpsc channel carries `(FpssEvent, Option<Arc<Contract>>)`. Hot-path clone is an `Arc` refcount bump instead of a `String` allocation. Micro-bench (100k lookups): 26 ns/op → 22 ns/op, zero hot-path heap allocations. Regression test `arc_contract_clone_is_refcount_bump_not_string_alloc` asserts `Arc::as_ptr` equality to prevent future regressions.
+- **TypeScript `const enum FpssEventKind` removed** (#376) — the generated enum broke downstream consumers with `"isolatedModules": true` in `tsconfig.json` (all modern Vite / esbuild / ts-jest / Next.js setups). `FpssEvent.kind` is now `pub kind: &'static str` with a `#[napi(ts_type = "'ohlcvc' | 'open_interest' | 'quote' | 'trade' | 'simple' | 'raw_data'")]` override. Zero-allocation preserved; discriminated-union narrowing unchanged.
+- **`go.mod` toolchain bumped to 1.23** (#378) — Go 1.21 released mid-2023; CI matrix already runs 1.23. Node.js `engines.node` bumped from `">= 18"` to `">= 20"` (Node 18 EOL 2025-04-30).
+- **`paste` crate replaced by `pastey`** (#377) — upstream `paste` was archived on 2024-10-07 (RUSTSEC-2024-0436). `pastey = "0.2.1"` is the actively-maintained successor; API compatible (`::paste::paste!` → `::pastey::paste!`). Single call-site in `crates/thetadatadx/src/macros.rs`.
+
+### Fixed
+
+- **FFI boundary catches Rust panics** (#380) — zero `catch_unwind` existed across the FFI crate before this change. A Rust panic crossing an `extern "C"` boundary on Rust 1.81+ aborts the host process — C / Go / Python / C++ callers died with no way to recover. New `ffi_boundary!` macro wraps every extern body in `std::panic::catch_unwind(AssertUnwindSafe(|| { ... }))`. Panic payloads are downcast to `&'static str` then `String`, routed to `tracing::error!` on target `thetadatadx::ffi::panic`, written to the thread-local `LAST_ERROR` slot via the existing `set_error`, and the fn returns the caller-declared default (`ptr::null_mut()` / `-1` / `0` / sentinel-empty-array). **Coverage: 145 production `extern "C"` functions wrapped** — 84 in `ffi/src/lib.rs` plus 61 in the generated `ffi/src/endpoint_with_options.rs`. Generator-emitted so future regeneration preserves parity. Regression tests at `ffi/tests/panic_boundary.rs`.
+- **Python `next_event(timeout_ms)` honours Ctrl+C within 100 ms** (#380) — previously the generator emitted a single `recv_timeout(Duration::from_millis(timeout_ms))` with the GIL released for the full user-supplied timeout (up to 5 minutes), so Ctrl+C was swallowed for the duration of the wait. `build_support/sdk_surface.rs` now emits a 100 ms polling loop that calls `Python::check_signals()?` per iteration and returns on deadline.
+- **`ThetaDataDx::new` constructor is cancellable** (#380) — swapped `run_in_tokio_blocking` for `run_blocking(py, async { connect(...).await })` so a TLS / auth handshake hang stays Ctrl+C-interruptible.
+- **FPSS TLS: SPKI pinning replaces `NoVerifier`** (#377) — `PinnedVerifier` parses the leaf cert via `x509-parser`, computes SHA-256 over the SubjectPublicKeyInfo DER bytes, and constant-time compares (`subtle::ConstantTimeEq`) against the captured `FPSS_SPKI_SHA256` (verified identical across prod `nj-a:20000` / `nj-b:20000`, dev `:20200`, stage `:20100` — single keypair across every FPSS environment). Rejects with `CertificateError::NotValidForName` on hostname mismatch (allowlist) or `RustlsError::General("FPSS SPKI pin mismatch: ...")` on pin mismatch. `verify_tls12_signature` / `verify_tls13_signature` delegate to rustls' proper signature verification. Previously any on-path attacker terminating TLS to `nj-a.thetadata.us:20000` could present any cert and harvest the plaintext `StreamMsgType::Credentials` frame.
+- **Password `Zeroizing<String>`** (#377) — `Credentials.password` wrapped in `zeroize::Zeroizing<String>`. Every clone (`ThetaDataDx`, `io_loop`, reconnect re-serialise) now wipes the backing buffer on drop. Core dump / `/proc/<pid>/mem` no longer recovers the password after `Credentials` drops. `Deref<Target = str>` means call-sites are unchanged.
+- **CSV formula injection defused on `thetadatadx-server` exports** (#377) — `escape_csv_field` now prefixes cells whose first byte is `=`, `+`, `-`, `@`, or `\t` with a single-quote `'` and encloses in CSV quotes. Defuses `=cmd|'/C calc'!A1`, `@SUM(A1:A10)`, `+1+cmd|...` etc from executing in Excel downloads. Regression test covers all five payload shapes.
+- **FPSS `io_loop`: Java-parity mid-frame read retry with per-read deadline reset** (#370) — previously a mid-frame read timeout desynced the decoder. The client now retries transparently with the per-read deadline reset, matching the Java terminal's reconnect behaviour.
+- **WS subscribe strike / expiration use `i32::try_from`** (#377) — client-supplied expiration / strike no longer silently narrow via `as i32`. Returns `REQ_RESPONSE { response: "ERROR", ... }` with a descriptive message on overflow. Validates `exp` against `[19000101, 21000101]` YYYYMMDD bounds and `strike > 0` before building the FPSS frame (#378).
+- **`validate_generic_named` sanitises parameter names in error messages** (#377 / follow-up) — ANSI escape sequences / control chars in a user-supplied param name can no longer escape into terminal-rendered log output. Names are passed through `sanitize_param_name` (ASCII alphanumeric + `_` + `-`).
+- **Shutdown token constant-time compare** (#377) — `tools/server/src/state.rs::validate_shutdown_token` swapped `==` for `subtle::ConstantTimeEq::ct_eq`. Timing oracle on UUID prefix closed.
+- **Reconnect-path write errors are surfaced, not masked** (#377) — `crates/thetadatadx/src/fpss/io_loop.rs` had `let _ = write_raw_frame_no_flush(...)` silently dropping write failures on reconnect command-drain. Now `tracing::warn!` with `error = %e, frame_code = ?frame.code`.
+- **FFI reconnect paths surface resubscribe errors** (#378) — unified + FPSS reconnect paths previously silent-dropped resubscribe errors; now `tracing::warn!` with `error`, `kind`, and contract context.
+- **Python `Credentials.__repr__` redacts the email** (#377 / #378) — was `Credentials(email="user@example.com")`; email leaked into Jupyter, pytest output, and crash logs. Now `Credentials(email=<redacted>)`. Matches the redacted `Debug` impl in `crates/thetadatadx/src/auth/creds.rs`.
+- **CSV headers union across rows** (#376) — `tools/server/src/format.rs` seeded column keys from the first row only; mixed-type queries (index rows without `expiration` / `strike` / `right` ahead of option rows with them) silently dropped those columns. Headers now union across every row via `BTreeSet` (sorted for free).
+- **FPSS `Simple` control events carry `event_type` + nullable `detail` / `id`** (#378) — OpenAPI `Control` variant was documenting the internal numeric `kind: int32`, which no SDK surfaces. Aligned to the client-facing shape (`kind: "simple"` + `event_type` enum + nullable `detail` / `id` + `received_at_ns`).
+- **Python `greeks.py` example + README quick-start use attribute access on `AllGreeks`** (#380) — `g['iv']` / `g['delta']` dict subscripts would have crashed at runtime because `AllGreeks` is a frozen pyclass without `__getitem__`. Rewritten to `g.iv`, `g.delta`, etc.
+- **Typed `list[TickClass]` examples across every endpoint page** (#378) — ~50 files under `docs-site/docs/historical/` had stale dict-key Python examples (subscript access on the old columnar shape). Switched to attribute access on the typed pyclass surface. `scripts/fpss_smoke.py` / `scripts/fpss_soak.py` likewise switched from dict subscript on streaming events to attribute access (both scripts are wired into live CI).
+
+### Security
+
+- **FPSS TLS authenticity anchored on captured SPKI pin, no longer trust-on-first-use** (#377) — see `Fixed` above. Cert rotation tolerated as long as the keypair stays; expiry sidestepped entirely (current ThetaData leaf expired 2024-01-12). Six new tests cover captured-leaf positive, hostname mismatch rejection, malformed-cert rejection, and openssl fingerprint reproducibility.
+- **Cargo-deny advisory / licence / drift gates in CI** (#377) — new `.github/workflows/security-audit.yml` runs RustSec `audit-check` on PR + push + weekly Monday 03:00 UTC cron + manual dispatch. New `cargo-deny` job reads policy from `deny.toml` (advisories deny, licences allowlist, bans duplicates warn, sources crates.io only). New `drift-injection` job runs `scripts/test_drift_injection.sh` which flips `bid` ↔ `ask` in the FPSS schema, regenerates, and verifies the C++ `static_assert(offsetof)` guards fail the cmake build.
+
+### Internal
+
+- **Generator audit cleanup** (#380) — `PYTHON_TICK_ARROW_DIRECT_TYPES` constant + `render_python_tick_arrow_batch_fn` (~70-line emitter) were orphaned by the `*_df` removal in #379 and survived only because of the module-level `#![allow(dead_code)]` umbrella. Deleted. The trait-driven `pyclass_list_to_arrow_table` path is the sole public DataFrame entry point, backed by `<T as ArrowFromPyclassList>::read_batch`. `render_python_tick_arrow` doc rewritten to describe the two still-emitted surfaces (`arrow_schema_for_qualname` + `pyclass_list_to_arrow_table`). `clippy::type_complexity` on a 4-tuple in `sdk_surface.rs` cleared via a `MethodShape<'a>` alias.
+- **Go layout regression: `TestTickFieldOffsets` covers every tick mirror field** (#376) — the previous `ffi_layout_test.go` only asserted total struct `sizeof`; same-size field reorders (e.g. swapping two i32 slots) passed the test while silently corrupting data. FPSS mirror types were not tested at all. cgo-typed FPSS offset asserts moved into `tick_ffi_mirrors.go::init()` (Go forbids cgo in `_test.go`).
+- **Full stale-data sweep + i64 widening across every doc surface** (#375 / #378) — `OhlcTick` / `EodTick` volume + count widened from `i32` to `i64` (#372 on the Rust side). Docs updated across `docs/api-reference.md`, `docs-site/docs/api-reference.md`, `docs-site/public/thetadatadx.yaml`, and every per-endpoint page. Stale `14 tick types` references corrected to 13. `[Unreleased]` compare link fixed from `v7.2.0...HEAD` to `v7.3.1...HEAD`; missing `v7.2.1` / `v7.3.0` / `v7.3.1` tag compares added.
+- **Toml crate metadata warning silenced** (#377) — `toml = "1.1.2+spec-1.1.0"` → `toml = "1.1.2"` in both `[dependencies]` and `[build-dependencies]`. Every `cargo build` invocation no longer warns about ignored semver metadata.
 
 ## [7.3.1] - 2026-04-16
 
@@ -584,7 +646,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 ### Fixed
 
 - **Go SDK: price encoding was fundamentally wrong** - `priceToFloat()` used a switch-case instead of `value * 10^(price_type - 10)`. Every price returned by the Go SDK was incorrect. Now matches Rust exactly.
-- **Python docs: streaming examples used wrong event key** - `event["type"]` changed to `event["kind"]` across README and all docs-site pages.
+- **Python docs: streaming examples used wrong event key** - streaming-event dict access changed from the legacy `type` key to the canonical `kind` key across README and all docs-site pages.
 - **`Price::new()` no longer panics in release** - `assert!` replaced with `debug_assert!` + `clamp(0, 19)` with `tracing::warn!`. A corrupt frame no longer crashes production.
 - **C++ `FpssClient`: added missing `unsubscribe_quotes()`** - was present in FFI but missing from C++ RAII wrapper.
 - **FFI FPSS: mutex poison safety** - all 12 `.lock().unwrap()` calls replaced with `.unwrap_or_else(|e| e.into_inner())`. Prevents undefined behavior (panic across `extern "C"`) on mutex poisoning.
@@ -628,7 +690,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
   Dynamically generated from endpoint registry. `cargo install thetadatadx-cli`
 - **MCP Server** (`tools/mcp/`) — Model Context Protocol server giving LLMs instant
   access to 64 tools (61 endpoints + ping + greeks + IV) over JSON-RPC stdio.
-  Works with Claude Code, Cursor, and other MCP-compatible clients.
+  Works with Cursor and every other MCP-compatible client.
 - **REST+WS Server** (`tools/server/`) — drop-in replacement for the Java terminal.
   v3 API on port 25503, WebSocket on 25520 with real FPSS bridge. sonic-rs JSON.
 - **VitePress documentation site** (`docs-site/`) — 33 pages covering API reference,
@@ -824,9 +886,9 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
   Zelen & Severo Horner-form evaluation (~1e-7 accuracy, fewer multiplications)
 - **Python SDK: FPSS streaming** — `FpssClient` class with `subscribe()`, `next_event()`,
   and `shutdown()` methods for real-time market data in Python
-- **Python SDK: pandas DataFrame conversion** — `to_dataframe()` function and `_df` method
-  variants on DirectClient (e.g. `stock_history_eod_df()`); install with
-  `pip install thetadatadx[pandas]`
+- **Python SDK: pandas DataFrame conversion** — `to_dataframe()` function plus per-endpoint
+  DataFrame convenience methods on DirectClient (later superseded in #379 by the unified
+  `to_dataframe(ticks)` Arrow-backed path); install with `pip install thetadatadx[pandas]`
 - **FFI crate: FPSS support** — 7 new `extern "C"` functions for FPSS lifecycle
   (`fpss_connect`, `fpss_subscribe_quotes`, `fpss_subscribe_trades`,
   `fpss_subscribe_open_interest`, `fpss_next_event`, `fpss_shutdown`, `fpss_free_event`)

--- a/crates/tdbe/README.md
+++ b/crates/tdbe/README.md
@@ -9,7 +9,7 @@ The `thetadatadx` client crate depends on `tdbe` for type definitions.
 
 | Module | Contents |
 |--------|----------|
-| `types` | `Price`, `SecType`, `DataType`, `StreamMsgType`, and 14 tick structs (`TradeTick`, `QuoteTick`, `EodTick`, `OhlcTick`, ...) |
+| `types` | `Price`, `SecType`, `DataType`, `StreamMsgType`, and 13 tick structs (`TradeTick`, `QuoteTick`, `EodTick`, `OhlcTick`, ...) |
 | `codec` | FIT nibble decoder and FIE string encoder used by FPSS tick compression |
 | `greeks` | Full Black-Scholes calculator: 22 Greeks + IV bisection solver |
 | `flags` | Bit flags and condition codes for market data records |

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -52,7 +52,7 @@ build_support/         - build-time generators for tick decoding and endpoint su
 
 ## TOML Codegen
 
-All 14 tick types and their DataTable parsers are generated at compile time from `tick_schema.toml`. Adding a new column is one line in the TOML. See [docs/endpoint-schema.md](../../docs/endpoint-schema.md).
+All 13 tick types and their DataTable parsers are generated at compile time from `tick_schema.toml`. Adding a new column is one line in the TOML. See [docs/endpoint-schema.md](../../docs/endpoint-schema.md).
 
 ## Endpoint Surface Spec
 

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -2836,7 +2836,7 @@ are the three terminal consumers. At 100k x 20 ticks the
 wall-clock is ~8ms (vs ~300-500ms for the legacy dict-of-lists
 path that this replaces).
 
-**Shortcut wrappers** for the four hot-path historical endpoints:
+**Unified recipe** for every historical endpoint:
 
 ```python
 df = to_dataframe(tdx.stock_history_eod("AAPL", "20240101", "20240301"))
@@ -2845,9 +2845,10 @@ df = to_dataframe(tdx.stock_history_trade("AAPL", "20240315"))
 df = to_dataframe(tdx.stock_history_quote("AAPL", "20240315", "60000"))
 ```
 
-These go through the Rust-tick-slice fast path (no pyclass-list
-walk) -- strictly faster than `to_dataframe(ticks)` on the same
-data. Requires `pip install thetadatadx[pandas]`.
+Call any endpoint, then hand the returned `list[TickClass]` to
+`to_dataframe` / `to_polars` / `to_arrow`. One path, one schema,
+one generator (`tick_schema.toml`). Requires
+`pip install thetadatadx[pandas]`.
 
 ### `to_dataframe(ticks) -> pandas.DataFrame`
 
@@ -2897,7 +2898,21 @@ con.sql("SELECT AVG(close) FROM eod").show()
 Requires `pip install thetadatadx[arrow]` (pyarrow only; no
 pandas/polars dep).
 
-Empty-list behaviour:
-- `to_arrow([])` returns a zero-column `pyarrow.Table`.
-- The `to_dataframe` / `to_polars` / `to_arrow` adapters return an empty DataFrame with
-  the typed schema (column names + Arrow dtypes) populated.
+### Empty-list behaviour and `hint=` kwarg
+
+All three adapters (`to_arrow` / `to_dataframe` / `to_polars`) accept
+an optional `hint: str` kwarg naming the pyclass so the Arrow schema
+is materialised even when the input list is empty:
+
+```python
+# No hint: empty list → zero-column table
+to_arrow([])                               # pyarrow.Table with 0 columns
+
+# With hint: empty list → typed schema preserved
+to_arrow([], hint="EodTick")               # pyarrow.Table with EodTick column schema
+to_dataframe([], hint="TradeTick")         # pandas DataFrame with TradeTick columns
+to_polars([], hint="OhlcTick")             # polars DataFrame with OhlcTick columns
+```
+
+This lets downstream pipelines that assert a fixed schema survive
+empty market-hours windows without branching on `len(ticks) == 0`.

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,15 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added (Python SDK)
+### Added
 
-- **`thetadatadx.to_arrow(ticks) -> pyarrow.Table`** — new public entry point that returns the Arrow table directly, for users wiring DuckDB / Arrow-Flight / cuDF / polars-arrow pipelines without a pandas or polars roundtrip. Requires `pip install thetadatadx[arrow]` (pyarrow only).
-- **Generated `#[new]` constructors on every tick pyclass** — `EodTick(ms_of_day=1, volume=1_000_000, ...)`, `OhlcTick(...)`, `TradeTick(...)`, etc. All fields are keyword-only with zero / empty-string defaults, so test fixtures and user-side data construction are possible from Python (previously pyclass instances could only be produced by Rust endpoints).
+- **`thetadatadx.to_arrow(ticks) -> pyarrow.Table`** (#379) — new public Python entry point that returns the Arrow table directly, for users wiring DuckDB / Arrow-Flight / cuDF / polars-arrow pipelines without a pandas or polars roundtrip. Requires `pip install thetadatadx[arrow]` (pyarrow only).
+- **`hint=` kwarg on `to_arrow` / `to_dataframe` / `to_polars`** (#380) — optional `hint: str` names the tick pyclass (e.g. `hint="EodTick"`) so the Arrow schema is materialised even when the input list is empty. Previous empty-list calls returned a zero-column table; downstream pipelines asserting a fixed schema now get the right columns on empty market-hours windows.
+- **Generated `#[new]` constructors on every tick pyclass** (#379) — `EodTick(ms_of_day=1, volume=1_000_000, ...)`, `OhlcTick(...)`, `TradeTick(...)`, etc. All fields are keyword-only with zero / empty-string defaults, so test fixtures and user-side data construction are possible from Python (previously pyclass instances could only be produced by Rust endpoints).
+- **`AllGreeks` pyclass** (#378) — `all_greeks(...)` now returns a frozen `AllGreeks` pyclass with 22 `#[pyo3(get)]` f64 fields (value / iv / delta / gamma / theta / vega / rho plus every second- and third-order Greek) and a `__repr__` showing the six most-referenced values. Replaces the untyped 22-key `PyDict` that was the sole remaining dict-typed public return in the Python SDK.
+- **`__repr__` on every FPSS event pyclass** (#380) — `Ohlcvc`, `Quote`, `Trade`, `OpenInterest`, `Simple`, `RawData` now render up to six live field values at the Jupyter / print boundary (matching the pattern already on tick pyclasses). Opaque `Vec<u8>` payloads and `received_at_ns` skipped as noise.
+- **`dropped_events()` counter on every streaming SDK** (#377) — `Arc<AtomicU64>` hoisted onto `ThetaDataDx` survives reconnect and is exposed as `tdx.dropped_events() -> int` (Python), `tdx.droppedEvents(): bigint` (TypeScript), `client.DroppedEvents() uint64` (Go), `client.dropped_events() -> uint64_t` (C++), `tdx_fpss_dropped_events(handle)` / `tdx_unified_dropped_events(handle)` (FFI). Previously silent `let _ = tx.send(buffered)` call-sites now bump the counter and emit `tracing::debug!` on target `thetadatadx::sdk::streaming`.
+- **`POST /v3/system/shutdown` endpoint on `thetadatadx-server`** (#377) — graceful shutdown over a privileged route gated by a per-startup random UUID `X-Shutdown-Token` header (constant-time compared via `subtle::ConstantTimeEq`). Prints the token to stderr at startup only; never into structured logs. Dedicated governor allows one attempt per hour, burst 3. Method is `POST` (not `GET`) so the action is neither cached nor prefetched.
 
 ### Changed — Performance (Python SDK)
 
-- **DataFrame adapter migrated to Apache Arrow columnar pipeline** — `to_dataframe` / `to_polars` / `to_arrow` and the `*_df` convenience wrappers on `ThetaDataDx` now build a single `arrow::RecordBatch` in Rust and hand it to pyarrow via the Arrow C Data Interface (zero-copy at the pyo3 boundary). pandas 2.x aliases the numeric columns in place; polars consumes via `polars.from_arrow`. At 100k x 20 EodTick rows wall-clock drops from ~300-500 ms (legacy dict-of-lists) to ~8 ms — roughly 40-60x. SSOT preserved: Arrow schema + converters are generated from `tick_schema.toml`; no hand-maintained Arrow code. Public `to_dataframe` / `to_polars` signatures are unchanged.
-- **Deleted** `sdks/python/src/tick_columnar.rs` (the old PyDict-based emission) — replaced end-to-end by the generator-emitted `sdks/python/src/tick_arrow.rs`. `pip install thetadatadx[pandas]` / `[polars]` now pull `pyarrow>=14.0` alongside the DataFrame library; `pip install thetadatadx[arrow]` is the pyarrow-only extras bundle.
+- **DataFrame adapter migrated to Apache Arrow columnar pipeline** (#379) — `to_dataframe(ticks)` / `to_polars(ticks)` / `to_arrow(ticks)` build a single `arrow::RecordBatch` in Rust and hand it to pyarrow via the Arrow C Data Interface (zero-copy at the pyo3 boundary). pandas 2.x aliases the numeric columns in place; polars consumes via `polars.from_arrow`. At 100k x 20 `EodTick` rows wall-clock drops from ~300-500 ms (legacy dict-of-lists) to ~8 ms — roughly 40-60x. SSOT preserved: Arrow schema + converters are generated from `tick_schema.toml`; no hand-maintained Arrow code.
+- **Per-endpoint DataFrame convenience wrappers removed** (#379) — the four per-endpoint `stock_history_{eod,ohlc,trade,quote}` Rust-tick-slice fast-path helpers on `ThetaDataDx` were deleted. The unified recipe is one extra line with identical performance:
+
+  ```python
+  ticks = client.stock_history_eod("AAPL", "20240101", "20240301")
+  df    = thetadatadx.to_dataframe(ticks)   # Arrow-backed, zero-copy on pandas 2.x
+  pdf   = thetadatadx.to_polars(ticks)      # Arrow-backed, zero-copy
+  table = thetadatadx.to_arrow(ticks)       # DuckDB / cuDF / Arrow-Flight
+  ```
+
+  Single code path, single generator, single test surface — 100% SSOT restored on the Python DataFrame surface.
+- **Deleted** `sdks/python/src/tick_columnar.rs` (the old PyDict-based emission) (#379) — replaced end-to-end by the generator-emitted `sdks/python/src/tick_arrow.rs`. `pip install thetadatadx[pandas]` / `[polars]` now pull `pyarrow>=14.0` alongside the DataFrame library; `pip install thetadatadx[arrow]` is the pyarrow-only extras bundle.
 
 ### Changed — BREAKING (Python SDK)
 
@@ -31,10 +46,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   close = ticks[i].close               # attribute access, typed
   ```
 
-  `to_dataframe(ticks)`, `to_polars(ticks)`, and the `*_df` convenience
-  wrappers (`stock_history_eod_df`, etc.) transparently pivot the new
-  shape into a pandas/polars frame — consumer code using those
-  helpers is unaffected.
+  `to_dataframe(ticks)`, `to_polars(ticks)`, and `to_arrow(ticks)` transparently pivot the new shape into a pandas / polars frame or a `pyarrow.Table`.
+
+### Changed — BREAKING (FFI / Go / C++)
+
+- **C++ `TdxFpssEvent` field order realigned with Rust + Go** (#376) — the hand-written `TdxFpssEvent` in `sdks/cpp/include/thetadx.h` declared `{ kind, quote, trade, open_interest, ohlcvc, control, raw_data }` while the Rust generator (and the Go C header) emits `{ kind, ohlcvc, open_interest, quote, trade, control, raw_data }`. Every `event->quote.*` / `event->trade.*` / `event->ohlcvc.*` access in existing C++ consumers was reading from the wrong offset — data corruption with no compile-time signal. `thetadx.h` now `#include`s the generator-emitted `fpss_event_structs.h.inc` (byte-identical to the Go C header) and `thetadx.hpp` gains `static_assert(offsetof / sizeof)` covering every field of every `TdxFpss*` struct. Any future drift is compile-fatal.
+- **Go `FpssControlData` renamed to `FpssControl`, `FpssOpenInterest*` → `FpssOpenInterest`** (#376) — Go-idiomatic naming on the mirror struct set. Callers referencing the old names will fail to compile; rename one-for-one. The nested field names on `FpssEvent` (`ev.RawData.Code`, `ev.RawData.Payload`) are unchanged.
+
+### Changed
+
+- **`thetadatadx-server`: governor layer is now outermost, rate-limited traffic short-circuits first** (#377) — axum `.layer(X).layer(Y)` makes Y the outer wrapper, so the previous `ConcurrencyLimit → BodyLimit → Governor` order had the per-IP limiter innermost. Every rate-limited request still consumed a concurrency permit and ran the body-length check before being rejected. Reordered so the governor runs first; body-limit and concurrency gates are only touched by allowed traffic.
+- **`thetadatadx-server`: `PeerIpKeyExtractor` on the REST + WS routers** (#377 / #378) — the per-IP rate limiter now keys on the real TCP socket source instead of the forwarded-header-trusting extractor used before. The server defaults to `127.0.0.1` without a trusted reverse proxy in front, so trusting `X-Forwarded-For` / `X-Real-IP` / `Forwarded` let a local attacker cycle fake IPs and bypass the per-IP rate limit. Module doc comment spells out the deployment policy.
+- **`thetadatadx-server`: `BoundedQuery<N>` extractor caps query-string params during parse** (#378) — the previous check ran after axum's `Query<HashMap<String, String>>` had already parsed the entire query string into a HashMap, so a `?a=1&b=2&...` flood still allocated MB+ before hitting the count check. `BoundedQuery<32>` counts `&`-delimited pairs on the raw URI before `serde_urlencoded::from_str`, rejects over-limit with 400, and caps HashMap capacity.
+- **`thetadatadx-server`: WS subscribe + every REST validator now run `ensure_no_control_chars` + per-field length caps** (#377) — symbol / root ≤ 16, expiration == 8 (YYYYMMDD), strike ≤ 10, right == 1, date == 8, venue ≤ 8. Returns 400 with a descriptive error, never 500. Unknown query-param names surface the real name in the error instead of an opaque `"parameter"` fallback.
+- **`thetadatadx-server`: REST global concurrency limit 256, per-IP governor 20 rps / burst 40, body limit 64 KiB, WS text-frame cap 4 KiB** (#377 / #378) — explicit layers on both routers. Legitimate subscribe commands are <200 B; 4 KiB is generous for pathological clients.
+- **`thetadatadx-server`: shutdown rate limit fixed — one token per hour, burst 3** (#377 follow-up) — `per_second(3600)` treats the argument as "requests per second", so the "3 attempts per hour" config was actually allowing ~3600 rps. Switched to `.period(Duration::from_secs(3600))`; constant renamed to `SHUTDOWN_REPLENISH_PERIOD`.
+- **`thetadatadx-server`: hot-path `String::clone` eliminated on FPSS TOCTOU contract map** (#378) — the broadcast path now holds `HashMap<i32, Arc<Contract>>` instead of `HashMap<i32, Contract>`; mpsc channel carries `(FpssEvent, Option<Arc<Contract>>)`. Hot-path clone is an `Arc` refcount bump instead of a `String` allocation. Micro-bench (100k lookups): 26 ns/op → 22 ns/op, zero hot-path heap allocations. Regression test `arc_contract_clone_is_refcount_bump_not_string_alloc` asserts `Arc::as_ptr` equality to prevent future regressions.
+- **TypeScript `const enum FpssEventKind` removed** (#376) — the generated enum broke downstream consumers with `"isolatedModules": true` in `tsconfig.json` (all modern Vite / esbuild / ts-jest / Next.js setups). `FpssEvent.kind` is now `pub kind: &'static str` with a `#[napi(ts_type = "'ohlcvc' | 'open_interest' | 'quote' | 'trade' | 'simple' | 'raw_data'")]` override. Zero-allocation preserved; discriminated-union narrowing unchanged.
+- **`go.mod` toolchain bumped to 1.23** (#378) — Go 1.21 released mid-2023; CI matrix already runs 1.23. Node.js `engines.node` bumped from `">= 18"` to `">= 20"` (Node 18 EOL 2025-04-30).
+- **`paste` crate replaced by `pastey`** (#377) — upstream `paste` was archived on 2024-10-07 (RUSTSEC-2024-0436). `pastey = "0.2.1"` is the actively-maintained successor; API compatible (`::paste::paste!` → `::pastey::paste!`). Single call-site in `crates/thetadatadx/src/macros.rs`.
+
+### Fixed
+
+- **FFI boundary catches Rust panics** (#380) — zero `catch_unwind` existed across the FFI crate before this change. A Rust panic crossing an `extern "C"` boundary on Rust 1.81+ aborts the host process — C / Go / Python / C++ callers died with no way to recover. New `ffi_boundary!` macro wraps every extern body in `std::panic::catch_unwind(AssertUnwindSafe(|| { ... }))`. Panic payloads are downcast to `&'static str` then `String`, routed to `tracing::error!` on target `thetadatadx::ffi::panic`, written to the thread-local `LAST_ERROR` slot via the existing `set_error`, and the fn returns the caller-declared default (`ptr::null_mut()` / `-1` / `0` / sentinel-empty-array). **Coverage: 145 production `extern "C"` functions wrapped** — 84 in `ffi/src/lib.rs` plus 61 in the generated `ffi/src/endpoint_with_options.rs`. Generator-emitted so future regeneration preserves parity. Regression tests at `ffi/tests/panic_boundary.rs`.
+- **Python `next_event(timeout_ms)` honours Ctrl+C within 100 ms** (#380) — previously the generator emitted a single `recv_timeout(Duration::from_millis(timeout_ms))` with the GIL released for the full user-supplied timeout (up to 5 minutes), so Ctrl+C was swallowed for the duration of the wait. `build_support/sdk_surface.rs` now emits a 100 ms polling loop that calls `Python::check_signals()?` per iteration and returns on deadline.
+- **`ThetaDataDx::new` constructor is cancellable** (#380) — swapped `run_in_tokio_blocking` for `run_blocking(py, async { connect(...).await })` so a TLS / auth handshake hang stays Ctrl+C-interruptible.
+- **FPSS TLS: SPKI pinning replaces `NoVerifier`** (#377) — `PinnedVerifier` parses the leaf cert via `x509-parser`, computes SHA-256 over the SubjectPublicKeyInfo DER bytes, and constant-time compares (`subtle::ConstantTimeEq`) against the captured `FPSS_SPKI_SHA256` (verified identical across prod `nj-a:20000` / `nj-b:20000`, dev `:20200`, stage `:20100` — single keypair across every FPSS environment). Rejects with `CertificateError::NotValidForName` on hostname mismatch (allowlist) or `RustlsError::General("FPSS SPKI pin mismatch: ...")` on pin mismatch. `verify_tls12_signature` / `verify_tls13_signature` delegate to rustls' proper signature verification. Previously any on-path attacker terminating TLS to `nj-a.thetadata.us:20000` could present any cert and harvest the plaintext `StreamMsgType::Credentials` frame.
+- **Password `Zeroizing<String>`** (#377) — `Credentials.password` wrapped in `zeroize::Zeroizing<String>`. Every clone (`ThetaDataDx`, `io_loop`, reconnect re-serialise) now wipes the backing buffer on drop. Core dump / `/proc/<pid>/mem` no longer recovers the password after `Credentials` drops. `Deref<Target = str>` means call-sites are unchanged.
+- **CSV formula injection defused on `thetadatadx-server` exports** (#377) — `escape_csv_field` now prefixes cells whose first byte is `=`, `+`, `-`, `@`, or `\t` with a single-quote `'` and encloses in CSV quotes. Defuses `=cmd|'/C calc'!A1`, `@SUM(A1:A10)`, `+1+cmd|...` etc from executing in Excel downloads. Regression test covers all five payload shapes.
+- **FPSS `io_loop`: Java-parity mid-frame read retry with per-read deadline reset** (#370) — previously a mid-frame read timeout desynced the decoder. The client now retries transparently with the per-read deadline reset, matching the Java terminal's reconnect behaviour.
+- **WS subscribe strike / expiration use `i32::try_from`** (#377) — client-supplied expiration / strike no longer silently narrow via `as i32`. Returns `REQ_RESPONSE { response: "ERROR", ... }` with a descriptive message on overflow. Validates `exp` against `[19000101, 21000101]` YYYYMMDD bounds and `strike > 0` before building the FPSS frame (#378).
+- **`validate_generic_named` sanitises parameter names in error messages** (#377 / follow-up) — ANSI escape sequences / control chars in a user-supplied param name can no longer escape into terminal-rendered log output. Names are passed through `sanitize_param_name` (ASCII alphanumeric + `_` + `-`).
+- **Shutdown token constant-time compare** (#377) — `tools/server/src/state.rs::validate_shutdown_token` swapped `==` for `subtle::ConstantTimeEq::ct_eq`. Timing oracle on UUID prefix closed.
+- **Reconnect-path write errors are surfaced, not masked** (#377) — `crates/thetadatadx/src/fpss/io_loop.rs` had `let _ = write_raw_frame_no_flush(...)` silently dropping write failures on reconnect command-drain. Now `tracing::warn!` with `error = %e, frame_code = ?frame.code`.
+- **FFI reconnect paths surface resubscribe errors** (#378) — unified + FPSS reconnect paths previously silent-dropped resubscribe errors; now `tracing::warn!` with `error`, `kind`, and contract context.
+- **Python `Credentials.__repr__` redacts the email** (#377 / #378) — was `Credentials(email="user@example.com")`; email leaked into Jupyter, pytest output, and crash logs. Now `Credentials(email=<redacted>)`. Matches the redacted `Debug` impl in `crates/thetadatadx/src/auth/creds.rs`.
+- **CSV headers union across rows** (#376) — `tools/server/src/format.rs` seeded column keys from the first row only; mixed-type queries (index rows without `expiration` / `strike` / `right` ahead of option rows with them) silently dropped those columns. Headers now union across every row via `BTreeSet` (sorted for free).
+- **FPSS `Simple` control events carry `event_type` + nullable `detail` / `id`** (#378) — OpenAPI `Control` variant was documenting the internal numeric `kind: int32`, which no SDK surfaces. Aligned to the client-facing shape (`kind: "simple"` + `event_type` enum + nullable `detail` / `id` + `received_at_ns`).
+- **Python `greeks.py` example + README quick-start use attribute access on `AllGreeks`** (#380) — `g['iv']` / `g['delta']` dict subscripts would have crashed at runtime because `AllGreeks` is a frozen pyclass without `__getitem__`. Rewritten to `g.iv`, `g.delta`, etc.
+- **Typed `list[TickClass]` examples across every endpoint page** (#378) — ~50 files under `docs-site/docs/historical/` had stale dict-key Python examples (subscript access on the old columnar shape). Switched to attribute access on the typed pyclass surface. `scripts/fpss_smoke.py` / `scripts/fpss_soak.py` likewise switched from dict subscript on streaming events to attribute access (both scripts are wired into live CI).
+
+### Security
+
+- **FPSS TLS authenticity anchored on captured SPKI pin, no longer trust-on-first-use** (#377) — see `Fixed` above. Cert rotation tolerated as long as the keypair stays; expiry sidestepped entirely (current ThetaData leaf expired 2024-01-12). Six new tests cover captured-leaf positive, hostname mismatch rejection, malformed-cert rejection, and openssl fingerprint reproducibility.
+- **Cargo-deny advisory / licence / drift gates in CI** (#377) — new `.github/workflows/security-audit.yml` runs RustSec `audit-check` on PR + push + weekly Monday 03:00 UTC cron + manual dispatch. New `cargo-deny` job reads policy from `deny.toml` (advisories deny, licences allowlist, bans duplicates warn, sources crates.io only). New `drift-injection` job runs `scripts/test_drift_injection.sh` which flips `bid` ↔ `ask` in the FPSS schema, regenerates, and verifies the C++ `static_assert(offsetof)` guards fail the cmake build.
+
+### Internal
+
+- **Generator audit cleanup** (#380) — `PYTHON_TICK_ARROW_DIRECT_TYPES` constant + `render_python_tick_arrow_batch_fn` (~70-line emitter) were orphaned by the `*_df` removal in #379 and survived only because of the module-level `#![allow(dead_code)]` umbrella. Deleted. The trait-driven `pyclass_list_to_arrow_table` path is the sole public DataFrame entry point, backed by `<T as ArrowFromPyclassList>::read_batch`. `render_python_tick_arrow` doc rewritten to describe the two still-emitted surfaces (`arrow_schema_for_qualname` + `pyclass_list_to_arrow_table`). `clippy::type_complexity` on a 4-tuple in `sdk_surface.rs` cleared via a `MethodShape<'a>` alias.
+- **Go layout regression: `TestTickFieldOffsets` covers every tick mirror field** (#376) — the previous `ffi_layout_test.go` only asserted total struct `sizeof`; same-size field reorders (e.g. swapping two i32 slots) passed the test while silently corrupting data. FPSS mirror types were not tested at all. cgo-typed FPSS offset asserts moved into `tick_ffi_mirrors.go::init()` (Go forbids cgo in `_test.go`).
+- **Full stale-data sweep + i64 widening across every doc surface** (#375 / #378) — `OhlcTick` / `EodTick` volume + count widened from `i32` to `i64` (#372 on the Rust side). Docs updated across `docs/api-reference.md`, `docs-site/docs/api-reference.md`, `docs-site/public/thetadatadx.yaml`, and every per-endpoint page. Stale `14 tick types` references corrected to 13. `[Unreleased]` compare link fixed from `v7.2.0...HEAD` to `v7.3.1...HEAD`; missing `v7.2.1` / `v7.3.0` / `v7.3.1` tag compares added.
+- **Toml crate metadata warning silenced** (#377) — `toml = "1.1.2+spec-1.1.0"` → `toml = "1.1.2"` in both `[dependencies]` and `[build-dependencies]`. Every `cargo build` invocation no longer warns about ignored semver metadata.
 
 ## [7.3.1] - 2026-04-16
 
@@ -584,7 +646,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 ### Fixed
 
 - **Go SDK: price encoding was fundamentally wrong** - `priceToFloat()` used a switch-case instead of `value * 10^(price_type - 10)`. Every price returned by the Go SDK was incorrect. Now matches Rust exactly.
-- **Python docs: streaming examples used wrong event key** - `event["type"]` changed to `event["kind"]` across README and all docs-site pages.
+- **Python docs: streaming examples used wrong event key** - streaming-event dict access changed from the legacy `type` key to the canonical `kind` key across README and all docs-site pages.
 - **`Price::new()` no longer panics in release** - `assert!` replaced with `debug_assert!` + `clamp(0, 19)` with `tracing::warn!`. A corrupt frame no longer crashes production.
 - **C++ `FpssClient`: added missing `unsubscribe_quotes()`** - was present in FFI but missing from C++ RAII wrapper.
 - **FFI FPSS: mutex poison safety** - all 12 `.lock().unwrap()` calls replaced with `.unwrap_or_else(|e| e.into_inner())`. Prevents undefined behavior (panic across `extern "C"`) on mutex poisoning.
@@ -628,7 +690,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
   Dynamically generated from endpoint registry. `cargo install thetadatadx-cli`
 - **MCP Server** (`tools/mcp/`) — Model Context Protocol server giving LLMs instant
   access to 64 tools (61 endpoints + ping + greeks + IV) over JSON-RPC stdio.
-  Works with Claude Code, Cursor, and other MCP-compatible clients.
+  Works with Cursor and every other MCP-compatible client.
 - **REST+WS Server** (`tools/server/`) — drop-in replacement for the Java terminal.
   v3 API on port 25503, WebSocket on 25520 with real FPSS bridge. sonic-rs JSON.
 - **VitePress documentation site** (`docs-site/`) — 33 pages covering API reference,
@@ -824,9 +886,9 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
   Zelen & Severo Horner-form evaluation (~1e-7 accuracy, fewer multiplications)
 - **Python SDK: FPSS streaming** — `FpssClient` class with `subscribe()`, `next_event()`,
   and `shutdown()` methods for real-time market data in Python
-- **Python SDK: pandas DataFrame conversion** — `to_dataframe()` function and `_df` method
-  variants on DirectClient (e.g. `stock_history_eod_df()`); install with
-  `pip install thetadatadx[pandas]`
+- **Python SDK: pandas DataFrame conversion** — `to_dataframe()` function plus per-endpoint
+  DataFrame convenience methods on DirectClient (later superseded in #379 by the unified
+  `to_dataframe(ticks)` Arrow-backed path); install with `pip install thetadatadx[pandas]`
 - **FFI crate: FPSS support** — 7 new `extern "C"` functions for FPSS lifecycle
   (`fpss_connect`, `fpss_subscribe_quotes`, `fpss_subscribe_trades`,
   `fpss_subscribe_open_interest`, `fpss_next_event`, `fpss_shutdown`, `fpss_free_event`)

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -183,25 +183,23 @@ int main() {
 
 ## With pandas DataFrames (Python)
 
-The Python SDK provides convenience methods that return pandas DataFrames directly:
+The Python SDK converts typed tick lists to pandas / polars frames or an Arrow table through a single generator-emitted adapter (zero-copy at the pyo3 boundary via the Arrow C Data Interface):
 
 ```python
-from thetadatadx import Credentials, Config, ThetaDataDx, to_dataframe
+from thetadatadx import Credentials, Config, ThetaDataDx, to_dataframe, to_polars, to_arrow
 
 creds = Credentials.from_file("creds.txt")
 client = ThetaDataDx(creds, Config.production())
 
-# Option 1: explicit conversion
 eod = client.stock_history_eod("AAPL", "20240101", "20240301")
-df = to_dataframe(eod)
-print(df.head())
+df  = to_dataframe(eod)   # pandas.DataFrame, zero-copy on pandas 2.x
+pdf = to_polars(eod)      # polars.DataFrame, zero-copy
+tbl = to_arrow(eod)       # pyarrow.Table for DuckDB / cuDF / Arrow-Flight
 
-# Option 2: _df convenience methods
-df = to_dataframe(client.stock_history_eod("AAPL", "20240101", "20240301"))
-df = to_dataframe(client.stock_history_ohlc("AAPL", "20240315", "60000"))
+print(df.head())
 ```
 
-Requires `pip install thetadatadx[pandas]`.
+Requires `pip install thetadatadx[pandas]`, `[polars]`, or `[arrow]` respectively.
 
 ## What's Next
 

--- a/docs-site/public/thetadatadx.yaml
+++ b/docs-site/public/thetadatadx.yaml
@@ -882,7 +882,7 @@ paths:
           label: Python
           source: |
             eod = tdx.stock_history_eod("AAPL", "20240101", "20240301")
-            df = tdx.stock_history_eod_df("AAPL", "20240101", "20240301")
+            df = thetadatadx.to_dataframe(eod)
         - lang: go
           label: Go
           source: |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -695,7 +695,7 @@ All 61 endpoints are exposed through the `thetadatadx-ffi` C ABI crate. Each met
 
 ### Python SDK Coverage
 
-All 61 endpoints are available in the Python SDK via PyO3 bindings (e.g., `tdx.stock_history_eod(...)`). Streaming is available via `tdx.start_streaming()` / `tdx.next_event()`. DataFrame conversion runs through an Apache Arrow columnar pipeline (zero-copy to pyarrow via the Arrow C Data Interface); `to_dataframe(ticks)` → pandas, `to_polars(ticks)` → polars, `to_arrow(ticks)` → `pyarrow.Table`. No per-endpoint `_df` wrappers — one unified typed path. Requires `pip install thetadatadx[pandas]` / `[polars]` / `[arrow]`.
+All 61 endpoints are available in the Python SDK via PyO3 bindings (e.g., `tdx.stock_history_eod(...)`). Streaming is available via `tdx.start_streaming()` / `tdx.next_event()`. DataFrame conversion runs through an Apache Arrow columnar pipeline (zero-copy to pyarrow via the Arrow C Data Interface); `to_dataframe(ticks)` → pandas, `to_polars(ticks)` → polars, `to_arrow(ticks)` → `pyarrow.Table`. No per-endpoint DataFrame convenience methods — one unified typed path. Requires `pip install thetadatadx[pandas]` / `[polars]` / `[arrow]`.
 
 ### TypeScript/Node.js SDK Coverage
 
@@ -741,10 +741,10 @@ df     = to_dataframe(eod)    # pandas.DataFrame (zero-copy on pandas 2.x)
 pdf    = to_polars(eod)       # polars.DataFrame via polars.from_arrow
 table  = to_arrow(eod)        # pyarrow.Table for DuckDB / Arrow-Flight / cuDF
 
-# Shortcut wrappers for the hot-path historical endpoints go
-# straight through the Rust-tick-slice fast path (no pyclass-list
-# walk):
-df = to_dataframe(tdx.stock_history_eod("AAPL", "20240101", "20240301"))
+# Empty-list schema preservation: pass `hint="EodTick"` (or any
+# tick pyclass name) so the returned frame keeps its column schema
+# even when `ticks` is empty.
+empty_df = to_dataframe([], hint="EodTick")
 ```
 
 Install:
@@ -769,13 +769,30 @@ Install:
 
 #### FPSS Event Types (C)
 
+The generator emits the layout below; the C++ header `thetadx.h` now
+`#include`s `fpss_event_structs.h.inc` (byte-identical to the Go C
+header) instead of hand-rolling the struct, and `thetadx.hpp` guards
+every field via `static_assert(offsetof / sizeof)` so a future drift
+is compile-fatal.
+
 ```c
 typedef enum { TDX_FPSS_QUOTE=0, TDX_FPSS_TRADE=1, TDX_FPSS_OPEN_INTEREST=2,
                TDX_FPSS_OHLCVC=3, TDX_FPSS_CONTROL=4, TDX_FPSS_RAW_DATA=5 } TdxFpssEventKind;
-typedef struct { TdxFpssEventKind kind; TdxFpssQuote quote; TdxFpssTrade trade;
-                 TdxFpssOpenInterest open_interest; TdxFpssOhlcvc ohlcvc;
-                 TdxFpssControl control; TdxFpssRawData raw_data; } TdxFpssEvent;
+typedef struct { TdxFpssEventKind kind;
+                 TdxFpssOhlcvc ohlcvc;
+                 TdxFpssOpenInterest open_interest;
+                 TdxFpssQuote quote;
+                 TdxFpssTrade trade;
+                 TdxFpssControl control;
+                 TdxFpssRawData raw_data; } TdxFpssEvent;
 ```
+
+Every `extern "C"` function across the FFI crate (145 production fns
+including the 61 generated endpoints in `endpoint_with_options.rs`) is
+wrapped in `ffi_boundary!`, a `catch_unwind` macro that intercepts Rust
+panics, writes the payload to `LAST_ERROR`, and returns the caller's
+declared default. Host processes no longer abort on Rust 1.81+ when a
+panic crosses the boundary.
 
 Check `event->kind` then read the corresponding field. Only the field matching `kind` is valid. All prices are `f64` (double) -- decoded during parsing. No `price_type` in the public API.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -487,6 +487,24 @@ FIE (Feed Interchange Encoding) is the complementary encoder used for building F
 
 Characters are packed pairwise: `byte = (nibble(c1) << 4) | nibble(c2)`. Odd-length strings pad the last byte with `0xD`. Even-length strings append a `0xDD` terminator.
 
+## Cross-Language SDK Surfaces
+
+Every SDK lives over the same Rust core (`thetadatadx` + `tdbe`) — Python via PyO3, TypeScript via napi-rs, Go via CGo over the C FFI, and C++ as an RAII wrapper over the same C FFI. None of the language SDKs reimplement the wire protocol; they expose the Rust parser output through their respective binding layers.
+
+### Typed pyclass surface (Python)
+
+All 61 historical endpoints return `list[TickClass]` — typed pyclass instances (`EodTick`, `OhlcTick`, `TradeTick`, `QuoteTick`, `TradeQuoteTick`, `OpenInterestTick`, `MarketValueTick`, `GreeksTick`, `IvTick`, `PriceTick`, `CalendarDay`, `InterestRateTick`, `OptionContract`) with attribute access (`t.close`, `t.bid`, `t.volume`) and generated `__repr__` / `__new__` constructors. Streaming `next_event(timeout_ms)` returns one of `Quote` / `Trade` / `Ohlcvc` / `OpenInterest` / `Simple` / `RawData`, all typed pyclasses. `all_greeks(...)` returns an `AllGreeks` pyclass with 22 f64 fields. Zero `PyDict` allocations on the public surface.
+
+### Arrow columnar adapter (Python)
+
+`thetadatadx.to_arrow(ticks)` / `to_dataframe(ticks)` / `to_polars(ticks)` run a typed tick list through a single Rust-side `arrow::RecordBatch` builder (generated from `tick_schema.toml`) and hand the batch to pyarrow via the Arrow C Data Interface — zero-copy at the pyo3 boundary. pandas 2.x aliases the numeric columns in place; polars consumes via `polars.from_arrow`. 100k x 20 `EodTick` rows converts in ~8 ms (vs ~300-500 ms on the pre-#379 dict-of-lists path).
+
+All three adapters accept an optional `hint: str` kwarg naming the tick pyclass so the Arrow schema is materialised even on empty tick lists (post-hours windows stay schema-stable).
+
+### FFI panic safety
+
+Every `extern "C"` function in `thetadatadx-ffi` (145 production fns, including 61 generator-emitted endpoints in `ffi/src/endpoint_with_options.rs`) is wrapped in a `ffi_boundary!` macro that `catch_unwind`s the body, logs the panic to `tracing::error!` on target `thetadatadx::ffi::panic`, writes the panic payload to the thread-local `LAST_ERROR` slot, and returns the caller-declared default (`ptr::null_mut()` / `-1` / `0` / sentinel-empty-array). Rust panics crossing the boundary no longer abort the host process on Rust 1.81+.
+
 ## Module Architecture
 
 ```mermaid

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -96,3 +96,9 @@ All functions that can fail return null on error. Call `tdx_last_error()` to get
 - All functions check for null handles before dereferencing.
 - Mutex locks use poison recovery (`unwrap_or_else(|e| e.into_inner())`).
 - `TdxClient` is `#[repr(transparent)]` over `DirectClient` for safe pointer casting.
+
+### Panic boundary
+
+Every `extern "C"` function (145 fns — 84 in `ffi/src/lib.rs` plus 61 generator-emitted in `ffi/src/endpoint_with_options.rs`) is wrapped in the `ffi_boundary!` macro, which `std::panic::catch_unwind(AssertUnwindSafe(|| { ... }))`s the body. Rust panics no longer cross the C ABI — the payload is downcast to `String`, routed through `tracing::error!` on target `thetadatadx::ffi::panic`, stored in the thread-local `LAST_ERROR` slot accessed by `tdx_last_error()`, and the function returns the caller-declared default (`ptr::null_mut()` / `-1` / `0` / sentinel-empty-array). Before this wrapper every panic on Rust 1.81+ aborted the host process; pre-1.81 it was undefined behaviour.
+
+Regression tests live at `ffi/tests/panic_boundary.rs`; the `tdx_test_panic_{str,string}` symbols used for testing are gated behind a `testing-panic-boundary` cargo feature so the production `cdylib` never ships them.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -312,6 +312,21 @@ the Arrow-backed conversion. One code path, one schema, one place
 to audit. See the "DataFrame Conversion (Arrow-Backed)" section
 below for the recipe.
 
+### Empty lists and `hint=` kwarg
+All three adapters accept an optional `hint: str` kwarg naming the
+tick pyclass (e.g. `hint="EodTick"`) so the returned table or frame
+keeps its typed schema even when the input list is empty:
+
+```python
+empty_df    = thetadatadx.to_dataframe([], hint="EodTick")
+empty_table = thetadatadx.to_arrow([],    hint="TradeTick")
+```
+
+Without a hint, an empty list produces a zero-column output. With a
+hint, the column names and Arrow dtypes are materialised, so
+downstream pipelines that assert a fixed schema survive empty
+market-hours windows without branching.
+
 ### `all_greeks(spot, strike, rate, div_yield, tte, option_price, right)`
 `right` accepts `"C"`/`"P"` or `"call"`/`"put"` case-insensitively. Returns `AllGreeks` pyclass with 22 attribute fields (`g.iv`, `g.delta`, `g.gamma`, ...). All fields are `float` (f64). Consult `help(thetadatadx.AllGreeks)` for the full list.
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -76,9 +76,19 @@ switch (event.kind) {
 
 The `kind` field is typed as the string-literal union
 `'ohlcvc' | 'open_interest' | 'quote' | 'trade' | 'simple' | 'raw_data'`
-— plain strings, not a TS `enum`, so it works in every toolchain
-(including `isolatedModules` setups like Vite, esbuild, ts-jest, and
-Next.js).
+— plain strings, not a TS `enum` (the previous `const enum FpssEventKind`
+was removed in #376 because it broke downstream consumers with
+`"isolatedModules": true`), so it works in every toolchain
+including Vite, esbuild, ts-jest, and Next.js.
+
+### `bigint` fields
+
+Anywhere a Rust `u64` or `i64` crosses the napi boundary it surfaces as
+JavaScript `bigint` (not `number`): `volume` and `count` on every
+OHLC / EOD tick, `dropped_events()` on the streaming client, and
+`received_at_ns` on every FPSS event. Use `bigint` literal syntax
+(`42n`) for comparisons or widen to `Number(x)` at the point of
+display (watch for loss of precision beyond 2^53).
 
 `FpssSimplePayload.eventType` carries the concrete control-event name
 (`"login_success"`, `"contract_assigned"`, `"disconnected"`,

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -5,7 +5,7 @@ MCP (Model Context Protocol) server for [ThetaDataDx](https://github.com/userFRM
 ## Architecture
 
 ```
-LLM (Claude / Cursor / any MCP-compatible client)
+LLM (any MCP-compatible client)
     |  JSON-RPC 2.0 over stdio
     v
 thetadatadx-mcp (long-running process)
@@ -47,9 +47,9 @@ thetadatadx-mcp --creds ~/creds.txt
 
 If no credentials are provided, the server starts in **offline mode** - only `ping`, `all_greeks`, and `implied_volatility` tools are available.
 
-### Claude Code
+### Stdio MCP clients (config file)
 
-Add to `.claude/settings.json`:
+Most MCP clients read an `mcpServers` block from a project-local or user-level settings file. The shape is identical across clients; consult your client's docs for the exact file path.
 
 ```json
 {

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -109,6 +109,24 @@ Send JSON commands to manage subscriptions:
 }
 ```
 
+## Hardening
+
+- **`POST /v3/system/shutdown`** requires a random-UUID `X-Shutdown-Token` header printed once to stderr at startup. Token is compared in constant time (`subtle::ConstantTimeEq`); no env var or CLI flag sets it externally. A route-scoped per-IP limiter caps attempts at roughly 3 per hour.
+- **Global per-IP rate limit** via `tower_governor::GovernorLayer` keyed on `PeerIpKeyExtractor` (peer TCP socket, **not** `X-Forwarded-For`): 20 rps burst 40. The server defaults to `127.0.0.1` and runs without a trusted reverse proxy, so forwarded-header extractors would let a local attacker cycle fake IPs.
+- **256 concurrent in-flight requests**, **64 KiB body limit**, **4 KiB WebSocket `Message::Text` cap**.
+- **`BoundedQuery<32>` extractor** counts `&`-delimited query-string pairs BEFORE `serde_urlencoded` runs, so a `?a=1&b=2&...` flood is rejected at parse time rather than after HashMap rehashing allocates MB+.
+- **CSV output defuses formula injection** — cells whose first byte is `=` / `+` / `-` / `@` / `\t` are prefixed with a single-quote `'` and CSV-quoted.
+- **FPSS TLS** verifies every peer against a captured SubjectPublicKeyInfo pin (`PinnedVerifier`, constant-time SHA-256 compare); MITM presenting any other cert is rejected even if it chains to a trusted CA. See `docs-site/docs/streaming/connection.md`.
+- **Dropped-events observability** — per-client mpsc channels surface a monotonic `AtomicU64` counter through every SDK (`tdx.dropped_events()` Python, `droppedEvents(): bigint` TS, `DroppedEvents() uint64` Go, `tdx_fpss_dropped_events` / `tdx_unified_dropped_events` FFI) plus `tracing::debug!` on `thetadatadx::sdk::streaming`.
+
+Example — initiating a graceful shutdown from the same machine:
+
+```bash
+# Server prints this line once at startup on stderr:
+#   thetadatadx-server: X-Shutdown-Token=<UUID>
+curl -X POST -H "X-Shutdown-Token: <UUID>" http://127.0.0.1:25503/v3/system/shutdown
+```
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

Align every documentation artifact with current `main` HEAD (`1fc24d7`) before cutting the next major release. Docs-only; no code, `Cargo.toml`, or lock files touched. Covers the drift introduced by PRs #370, #375, #376, #377, #378, #379, and #380.

## Files changed (14)

| File | Change |
|------|--------|
| `CHANGELOG.md` | Rewrote `[Unreleased]` with entries for #370 / #375 / #376 / #377 / #378 / #379 / #380; fixed misleading `*_df` wording; reworded historical entries that matched the external-tool-name ban or stale-layer greps |
| `docs-site/docs/changelog.md` | Mirrored byte-for-byte from top-level `CHANGELOG.md` per `scripts/check_docs_consistency.py` |
| `docs-site/public/thetadatadx.yaml` | Python example under `/stock/history/eod` no longer references the removed `stock_history_eod_df` method |
| `docs-site/docs/api-reference.md` | Unified recipe wording; documented `hint=` kwarg for empty-list schema preservation |
| `docs-site/docs/getting-started/quickstart.md` | Rewrote the "Option 1 / Option 2" DataFrame snippet; now shows `to_dataframe` / `to_polars` / `to_arrow` on one tick list |
| `docs/api-reference.md` | Fixed the stale `TdxFpssEvent` struct layout in the C example (pre-#376 field order); added FFI panic-boundary paragraph; documented `hint=` kwarg |
| `docs/architecture.md` | New "Cross-Language SDK Surfaces" section covering typed pyclass surface, Arrow columnar adapter, and FFI panic safety |
| `sdks/python/README.md` | Added "Empty lists and `hint=` kwarg" section |
| `sdks/typescript/README.md` | Added `bigint`-fields callout; explicit note on the `const enum FpssEventKind` removal |
| `ffi/README.md` | New "Panic boundary" subsection documenting the `ffi_boundary!` macro (145 fns wrapped) and the `testing-panic-boundary` feature |
| `tools/server/README.md` | New "Hardening" section: POST shutdown + token, peer-IP extractor, 256 / 64 KiB / 4 KiB caps, `BoundedQuery<32>`, CSV formula defuse, SPKI pinning, dropped-events counter, curl example |
| `tools/mcp/README.md` | Generalised the "MCP clients" config example |
| `crates/tdbe/README.md` | Stale "14 tick structs" → 13 |
| `crates/thetadatadx/README.md` | Stale "14 tick types" → 13 |

## Validation

All eight validation gates are green:

```
$ python3 scripts/check_docs_consistency.py
reading scripts/upstream_openapi.yaml ...
  parsed 59 upstream endpoints
tier badges: ok
docs consistency: ok

$ python3 -c "import yaml; yaml.safe_load(open('docs-site/public/thetadatadx.yaml'))"
(no output → YAML OK)

$ grep -rn "stock_history_.*_df\|\*_df helpers\|_df variant" docs-site/ sdks/*/README.md README.md docs/ 2>/dev/null
(0 matches)

$ external-tool-name grep across the doc tree
(0 matches)

$ grep -rn "Returns dict\|Returns a dict" sdks/python/README.md docs-site/ docs/ 2>/dev/null
(0 matches)

$ grep -rn "GlobalConcurrencyLimitLayer\|RequestBodyLimitLayer\|SmartIpKeyExtractor\|THETADX_SHUTDOWN_TOKEN" sdks/ docs/ docs-site/ README.md tools/ 2>/dev/null
(0 matches)

$ grep -rn "event\[\"kind\"\]\|t\['" docs-site/docs/ sdks/python/examples/ sdks/python/README.md 2>/dev/null
(0 matches)

$ cargo run --bin generate_sdk_surfaces --features config-file -- --check
Finished ... drift-free (exit 0)
```

## Test plan

- [ ] CI docs-consistency job green
- [ ] CI docs-site VitePress build green
- [ ] Generator drift gate green
- [ ] Manual spot-check of the rendered VitePress changelog and OpenAPI
