### PR TITLE
docs: housekeeping sweep — README / deny.toml / check_docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ flowchart TB
 | [Java Parity Checklist](docs/java-parity-checklist.md) | Feature-by-feature comparison with the Java terminal |
 | [Endpoint Schema](docs/endpoint-schema.md) | TOML codegen format for adding new types/columns |
 | [Proto Maintenance](crates/thetadatadx/proto/MAINTENANCE.md) | Guide for updating proto files |
+| [Changelog](CHANGELOG.md) | Release notes with breaking changes, features, and fixes |
 
 ## Contributing
 

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,12 @@
 #
 # Every `ignore` entry requires a `# Reason:` comment explaining why the
 # advisory does not apply to our use. No silent pins.
+#
+# CI runs the same command on every PR plus a weekly Monday 03:00 UTC cron
+# (`.github/workflows/security-audit.yml`). A newly-published advisory on a
+# transitive dependency is surfaced by the cron job before it reaches a
+# release; do not downgrade the `yanked = "deny"` bar without a matching
+# `# Reason:` entry below.
 
 [graph]
 # Check every target triple we actually build against -- the FFI and SDK

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -8,6 +8,12 @@ surface by checking a few high-signal invariants:
 - REST/OpenAPI path + operationId parity with `endpoint_surface.toml`
 - docs-site API reference coverage for every endpoint
 - current server docs staying on the v3 path scheme and current defaults
+- `CHANGELOG.md` and `docs-site/docs/changelog.md` staying byte-identical
+  (the docs-site build re-publishes whatever is on `main`, so any drift
+  is a release-note bug the moment it lands)
+
+Exits non-zero on any mismatch. Run from repo root; the script resolves
+the workspace root from its own path so `cd` is not required.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Three small doc-layer touches that sat in the no-go-back backlog.

## What

- **`README.md`** — add `CHANGELOG.md` to the Documentation table. First-time readers no longer have to dig through GitHub releases to find release notes.
- **`deny.toml`** — expand the header comment to name the weekly Monday 03:00 UTC cron in `.github/workflows/security-audit.yml` and restate the policy that the `yanked = "deny"` bar is not downgradeable without a documented `# Reason:`. No rule change.
- **`scripts/check_docs_consistency.py`** — extend the module docstring to mention the `CHANGELOG.md` ↔ `docs-site/docs/changelog.md` sync invariant the script enforces and note that the script resolves the repo root from its own path. No behavior change.

## Verification

- `python3 scripts/check_docs_consistency.py` — ok
- `cargo deny check` still passes (no rule edits)

## Test plan

- [ ] CI green (doc-only + config-comment changes)