### PR TITLE
docs(release): v8.0.0 release notes

### DIFF
--- a/.github/release-notes/v8.0.0.md
+++ b/.github/release-notes/v8.0.0.md
@@ -1,0 +1,59 @@
+## Highlights
+
+Every FPSS data event now carries a fully-parsed `Arc<Contract>` — no more looking up contract IDs or splitting ticker strings in user code. Four previously-opaque FPSS control codes (`Connected`, `Ping`, `ReconnectedServer`, `Restart`) decode into typed variants. A complete workspace cleanup series landed along the way: DRY manifests, module splits (`mdds/`, `ws/`, `ffi/`, generator trees), proto rename (`external.proto` → `mdds.proto`), 50 inline generator templates extracted to `.tmpl` files, and a byte-identical regeneration harness that guards every generated surface.
+
+### Breaking changes
+
+- **`FpssData::{Quote,Trade,OpenInterest,Ohlcvc}::symbol: Arc<str>`** → **`contract: Arc<Contract>`**. Access the root ticker via `event.contract.root`. Option events now expose `event.contract.exp_date`, `event.contract.strike`, `event.contract.is_call` directly — no second map lookup required.
+- **`FpssControl::ContractAssigned { contract: Contract }`** → **`{ contract: Arc<Contract> }`** so every consumer shares the same allocation.
+- **`FpssClient::contract_map()` / `contract_lookup()`** now return `HashMap<i32, Arc<Contract>>` / `Option<Arc<Contract>>` instead of by-value.
+- **`DirectClient` → `MddsClient`** (already announced in the `[Unreleased]` cycle, shipping in v8.0.0). The `DirectConfig` associated config type keeps its name.
+- **`SecType::Unknown`** variant added to `tdbe::types::enums::SecType`. Use it as the canonical check for the empty-contract sentinel that surfaces when a data frame arrives before its `ContractAssigned`. Exhaustive matches must add a branch.
+- **`Restart` (code 31) + `Connected` (code 4)** wire frames no longer arrive as `FpssControl::UnknownFrame { code, payload }`. Handlers matching on `UnknownFrame` by those codes need the new typed arms.
+
+### Added
+
+- **Typed `Contract` on every FPSS data event** — exposed in every language SDK (Rust, Python pyclass, TypeScript napi object, Go struct with nullable pointers, C++ struct with `has_*` flags, C FFI struct with CString-backed root pointer). Schema v2 → v3 in `fpss_event_schema.toml`; generator-emitted end-to-end.
+- **`impl FromStr for Contract`** — `"AAPL".parse::<Contract>()?` returns a stock contract; `"SPY   260417C00550000".parse::<Contract>()?` parses the OCC 21-character institutional option identifier format. Trim-tolerant for single-space-padded 20-char inputs. Scope: 2000-2099. Root validation widened to 1..=16 ASCII uppercase characters + single `.` (matches the wire codec's `to_bytes` / `from_bytes` range).
+- **Six subscribe shortcuts** on `FpssClient` and `ThetaDataDx`:
+  - `subscribe_{quotes,trades,open_interest}_stock(symbol)`
+  - `subscribe_{quotes,trades,open_interest}_option(root, exp, strike, right)`
+  - Unsubscribe counterparts with the same shape.
+- **Four FPSS control code variants** decoded:
+  - `FpssControl::Connected` (wire code 4) — server connection ack
+  - `FpssControl::Ping { payload }` (wire code 10) — server heartbeat
+  - `FpssControl::ReconnectedServer` (wire code 13) — server-side reconnect ack, distinct from the existing `Reconnected` which is emitted by the client-side auto-reconnect state machine
+  - `FpssControl::Restart` (wire code 31) — server stream restart
+
+### Changed
+
+- **`crates/thetadatadx/src/direct.rs` split into `src/mdds/`** module with six concern-separated files (`client`, `endpoints`, `endpoint_arg_ext`, `normalize`, `validate`, `mod`). Pure move; wire behavior unchanged.
+- **`crates/thetadatadx/proto/external.proto` renamed to `mdds.proto`**. The proto `package BetaEndpoints;` declaration is unchanged, so `tonic::include_proto!("beta_endpoints")` and every downstream Rust import resolve without edits. 17 files / 51 reference-site updates.
+- **`tools/server/src/ws.rs` (1044 LoC) → `ws/` module** — seven concern-separated files (`upgrade`, `session`, `subscribe`, `broadcast`, `contract_map`, `format`, `mod`). Visibility tightened to `pub(super)` where external visibility wasn't needed.
+- **`ffi/src/lib.rs` (4054 LoC) → seven topic modules** — `types`, `auth`, `historical`, `streaming`, `utility`, `error`, `panic`. **ABI byte-for-byte identical**: the same 211 `tdx_*` symbols are exposed on both `cdylib` and `staticlib` before and after the split.
+- **Three largest code generators split by render target**:
+  - `build_support/endpoints/sdk_surface.rs` (2905 LoC) → `sdk_surface/{python,typescript,go,cpp,mcp,cli,common,spec}.rs`
+  - `ticks.rs` (2094 LoC) → `ticks/{schema,parser,cli_headers,python_arrow,python_classes,typescript,go}.rs`
+  - `fpss_events.rs` (1551 LoC) → `fpss_events/{schema,common,buffered,python,typescript,ffi_rust,ffi_c,go_structs}.rs`
+- **50 multi-line `format!(r#"..."#)` code templates externalized** into `.tmpl` files loaded via `include_str!`. No new runtime dependency. LoC reductions on the offender files: `sdk_surface/cpp.rs` -35%, `fpss_events/ffi_rust.rs` -33%, `fpss_events/buffered.rs` -38%, `ticks/parser.rs` -33%. `.gitattributes` pins every `*.tmpl` to `eol=lf` so Windows checkouts cannot leak CRLF into `include_str!` output.
+- **Workspace manifest DRY** — duplicate `edition` / `license` / `authors` / `repository` / `homepage` / `rust-version` hoisted to `[workspace.package]`; every member inherits via `x.workspace = true`. `[workspace.lints.rust]` + `[workspace.lints.clippy]` added at the root (`warnings = "deny"`, `unsafe_op_in_unsafe_fn = "deny"`, `clippy::all = deny`). Each `[workspace.exclude]`'d crate (`sdks/python`, `sdks/typescript`, `tools/mcp`, `tools/server`) gets a local `[lints.*]` mirror.
+- **`regen_byte_identical.sh` harness** — CI-friendly script under `crates/thetadatadx/tests/` that hashes every generated artifact before + after a clean rebuild and fails on any drift. Guards the cross-SDK generator against silent behavior changes on future refactors. Currently verifies 485 files.
+
+### Fixed
+
+- **FPSS handshake now surfaces typed control frames during login / reconnect**. `wait_for_login_generic()` threads a buffer through; any `Connected`, `Ping`, `ReconnectedServer`, or `Restart` frame arriving before `METADATA` is replayed onto the main event channel. Previously silently dropped.
+- **Reconnect login rejection short-circuits on permanent errors**. `InvalidCredentials` / `InvalidLoginValues` / `AccountAlreadyConnected` now set `shutdown` and exit the reconnect loop immediately instead of burning `MAX_RECONNECT_ATTEMPTS` cycles of `Disconnected` / `Reconnecting` noise.
+- **Mid-frame read retries can no longer starve the command drain**. Total retry window capped at `MID_FRAME_DRAIN_WINDOW_MS = 200`; the I/O loop yields back to drain pings / subscribes / user writes between reads, preserving the documented 50ms command-drain cadence.
+- **`Credentials` email + password redacted consistently**. `AuthResponse::Debug` and `AuthUser::Debug` emit `<redacted>`; `authenticate()` tracing swapped to an `email_prefix` field that leaks at most the first three characters. `Credentials::from_file` wraps the full file contents in `Zeroizing<String>` and `parse()` / `new()` zeroize transient plain `String` copies before they drop.
+- **`clippy::too_many_arguments` allowed on PyO3 + napi-rs binding crates**. Generated endpoint methods expose every optional query parameter as a separate `Option<T>` kwarg — routinely hitting 10-27 params — which is the language-native contract for those bindings. Allow is scoped to the two binding crates; main library stays strict.
+- **WS subscribe validates option `right` before contract construction**. Missing / garbage / `"P"` alone no longer silently coerce to PUT. Returns a `REQ_RESPONSE` ERROR with a descriptive message naming the offending input.
+- **`ffi/src/historical.rs` double `ffi_boundary!` wrapper dropped** — outer was dead.
+- **C++ + Go offset asserts updated** for the embedded `TdxContract` field on every `TdxFpss*` data struct (32-byte LP64 footprint).
+
+### Internal
+
+- **Workspace split into three PR series before this one**: MDDS refactor (#383), workspace DRY + module splits (#384), proto rename (#385), template extraction (#386), post-merge audit cleanup (#388).
+- **Byte-identical generator regen** across every SDK surface (485 files) is now a CI gate.
+- **Full cross-reference sweep** replaced every stale `direct.rs` / `ticks.rs` / `sdk_surface.rs` / `fpss_events.rs` path in docs and in-code comments with the post-split directory paths.
+
+See `CHANGELOG.md` for the full per-PR breakdown.


### PR DESCRIPTION
Adds v8.0.0 release notes file under .github/release-notes/. Picked up by softprops/action-gh-release when the v8.0.0 tag is pushed — matches the pattern used for v7.3.1 and earlier.