### PR TITLE
release: 8.0.1 — bump tdbe to 0.11.0, all crates to 8.0.1

### DIFF
--- a/.github/release-notes/v8.0.1.md
+++ b/.github/release-notes/v8.0.1.md
@@ -1,0 +1,10 @@
+## Fixed
+
+- **`tdbe` 0.10.0 → 0.11.0** so `SecType::Unknown` (added in 8.0.0 as the empty-contract sentinel) is actually published to crates.io. `cargo publish --verify` for `thetadatadx 8.0.0` pulled `tdbe 0.10.0` from the registry — the still-old version without the new variant — and failed with `E0599`. crates.io never materialized `thetadatadx 8.0.0`; npm and PyPI had already published successfully and stay at 8.0.0 alongside this 8.0.1 bump for all three ecosystems.
+
+Everything else in this release is identical to 8.0.0 — see the [v8.0.0 notes](https://github.com/userFRM/ThetaDataDx/releases/tag/v8.0.0) for the full feature set (parsed `Contract` on every FPSS data event, `FromStr` + OCC-21 parser, twelve subscribe shortcuts, four new FPSS control code variants).
+
+## Changed
+
+- Every Rust crate version bumps `8.0.0 → 8.0.1`: `thetadatadx`, `thetadatadx-ffi`, `thetadatadx-cli`, `thetadatadx-server`, `thetadatadx-mcp`, `thetadatadx-py`, `thetadatadx-napi`.
+- `sdks/typescript/package.json` + every platform subpackage under `sdks/typescript/npm/` bumps to `8.0.1` so the npm dependency graph stays coherent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.1] - 2026-04-21
+
 ### Fixed
 
+- **`tdbe` bumped to 0.11.0 to publish the new `SecType::Unknown` variant to crates.io** — the 8.0.0 release added `SecType::Unknown` (empty-contract sentinel) but kept `tdbe` at `0.10.0`. `cargo publish --verify` for `thetadatadx 8.0.0` pulled `tdbe = 0.10.0` from the registry, which does not contain `Unknown`, and failed with `E0599`. The `thetadatadx`, `ffi`, `cli`, `mcp`, `server`, `py`, and `napi` crates bump to `8.0.1` so all three ecosystems (crates.io, PyPI, npm) end up on matching, publishable versions. npm and PyPI had already published 8.0.0 successfully; crates.io 8.0.0 was never materialized.
 - **FPSS handshake surfaces every typed control frame** — `wait_for_login` collects `Connected` (code 4), `Ping` (code 10), `ReconnectedServer` (code 13), and `Restart` (code 31) frames that arrive before `METADATA` into an ordered buffer; the I/O loop drains the buffer onto the event bus before emitting `LoginSuccess` so user callbacks see the exact wire order. Previously all typed control frames except `Connected` were silently dropped by the handshake's trace-and-continue branch. Applies to the initial login AND the reconnect-path login.
 - **Reconnect-path login short-circuits on permanent rejection** — `LoginResult::Disconnected(reason)` during the reconnect handshake now consults `reconnect_delay(reason)` as the single source of truth for "no retry will fix this" and exits the I/O loop with `shutdown = true` + a `FpssControl::Disconnected` event. Previously bad credentials burned `MAX_RECONNECT_ATTEMPTS` (5) cycles of `Reconnecting` / `Disconnected` noise before giving up.
 - **Mid-frame reader yields to the command drain on a bounded budget** — `FrameReadState` threads partial-frame progress across `read_frame_into` calls. A new `MID_FRAME_DRAIN_WINDOW_MS = 200` (4× the 50 ms drain cadence) caps the total wall time spent retrying a partial frame before the reader yields control to the I/O loop, which drains outbound commands and re-enters the reader with the preserved state. Previously a trickling sender could block heartbeats / user writes for up to `READ_TIMEOUT_MS` (10 s) because the per-stall deadline reset on every successful byte.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "criterion",
  "disruptor",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "clap",
  "comfy-table",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.0"
+version = "8.0.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -26,7 +26,7 @@ default = []
 config-file = ["dep:toml"]
 
 [dependencies]
-tdbe = { version = "0.10.0", path = "../tdbe" }
+tdbe = { version = "0.11.0", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }
@@ -95,7 +95,7 @@ prost-build = "=0.14.3"
 regex = "1.12.3"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
-tdbe = { version = "0.10.0", path = "../tdbe" }
+tdbe = { version = "0.11.0", path = "../tdbe" }
 
 [[bench]]
 name = "bench_decode"

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.1] - 2026-04-21
+
 ### Fixed
 
+- **`tdbe` bumped to 0.11.0 to publish the new `SecType::Unknown` variant to crates.io** — the 8.0.0 release added `SecType::Unknown` (empty-contract sentinel) but kept `tdbe` at `0.10.0`. `cargo publish --verify` for `thetadatadx 8.0.0` pulled `tdbe = 0.10.0` from the registry, which does not contain `Unknown`, and failed with `E0599`. The `thetadatadx`, `ffi`, `cli`, `mcp`, `server`, `py`, and `napi` crates bump to `8.0.1` so all three ecosystems (crates.io, PyPI, npm) end up on matching, publishable versions. npm and PyPI had already published 8.0.0 successfully; crates.io 8.0.0 was never materialized.
 - **FPSS handshake surfaces every typed control frame** — `wait_for_login` collects `Connected` (code 4), `Ping` (code 10), `ReconnectedServer` (code 13), and `Restart` (code 31) frames that arrive before `METADATA` into an ordered buffer; the I/O loop drains the buffer onto the event bus before emitting `LoginSuccess` so user callbacks see the exact wire order. Previously all typed control frames except `Connected` were silently dropped by the handshake's trace-and-continue branch. Applies to the initial login AND the reconnect-path login.
 - **Reconnect-path login short-circuits on permanent rejection** — `LoginResult::Disconnected(reason)` during the reconnect handshake now consults `reconnect_delay(reason)` as the single source of truth for "no retry will fix this" and exits the I/O loop with `shutdown = true` + a `FpssControl::Disconnected` event. Previously bad credentials burned `MAX_RECONNECT_ATTEMPTS` (5) cycles of `Reconnecting` / `Disconnected` noise before giving up.
 - **Mid-frame reader yields to the command drain on a bounded budget** — `FrameReadState` threads partial-frame progress across `read_frame_into` calls. A new `MID_FRAME_DRAIN_WINDOW_MS = 200` (4× the 50 ms drain cadence) caps the total wall time spent retrying a partial frame before the reader yields control to the I/O loop, which drains outbound commands and re-enters the reader with the preserved state. Previously a trickling sender could block heartbeats / user writes for up to `READ_TIMEOUT_MS` (10 s) because the per-stall deadline reset on every successful byte.

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.0"
+version = "8.0.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -31,7 +31,7 @@ testing-panic-boundary = []
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.10.0", path = "../crates/tdbe" }
+tdbe = { version = "0.11.0", path = "../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 # Used by the FPSS streaming callback silent-drop observability path
 # (see `tdx_fpss_dropped_events` / `tdx_unified_dropped_events`). Keep

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2254,7 +2254,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2307,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.0"
+version = "8.0.1"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.10.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.11.0", path = "../../crates/tdbe" }
 
 # PyO3 bindings. We target the stable ABI so one wheel per platform supports
 # every Python version from 3.9 upward.

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.0"
+version = "8.0.1"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.10.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.11.0", path = "../../crates/tdbe" }
 
 napi = { version = "3.8.5", features = ["async", "tokio_rt", "serde-json", "napi6"] }
 napi-derive = "3.5.4"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.0",
-    "thetadatadx-darwin-arm64": "8.0.0",
-    "thetadatadx-win32-x64-msvc": "8.0.0"
+    "thetadatadx-linux-x64-gnu": "8.0.1",
+    "thetadatadx-darwin-arm64": "8.0.1",
+    "thetadatadx-win32-x64-msvc": "8.0.1"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.0"
+version = "8.0.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.10.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.11.0", path = "../../crates/tdbe" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.5.8"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.0"
+version = "8.0.1"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.10.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.11.0", path = "../../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 sonic-rs = "0.5.8"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.0"
+version = "8.0.1"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23.38", features = ["ring"] }
-tdbe = { version = "0.10.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.11.0", path = "../../crates/tdbe" }
 axum = { version = "0.8.9", features = ["ws"] }
 tokio = { version = "1.52.1", features = ["full"] }
 sonic-rs = "0.5.8"


### PR DESCRIPTION
## Summary

Hotfix release. The 8.0.0 release added `SecType::Unknown` to `tdbe` without bumping `tdbe`'s published version, so `cargo publish --verify` for `thetadatadx 8.0.0` pulled the old `tdbe 0.10.0` from crates.io and failed to compile. npm + PyPI published 8.0.0 successfully (neither goes through crates.io verification). crates.io never materialized `thetadatadx 8.0.0`.

## What

- `tdbe` 0.10.0 → 0.11.0 (enum variant addition is breaking even on 0.x)
- `thetadatadx`, `thetadatadx-ffi`, `thetadatadx-cli`, `thetadatadx-server`, `thetadatadx-mcp`, `thetadatadx-py`, `thetadatadx-napi`: 8.0.0 → 8.0.1
- `sdks/typescript/package.json` + every platform subpackage: 8.0.0 → 8.0.1
- CHANGELOG `[Unreleased]` cut over to `[8.0.1] - 2026-04-21`
- `docs-site/docs/changelog.md` synced
- Cargo.lock × 5 (root + 4 excluded workspaces) refreshed
- `.github/release-notes/v8.0.1.md` added

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` green
- `python3 scripts/check_docs_consistency.py` ok

## Test plan

- [ ] CI green
- [ ] Merge, tag `v8.0.1`, workflows fire
- [ ] `cargo search thetadatadx` shows 8.0.1 on crates.io
- [ ] `npm view thetadatadx versions` shows 8.0.1 alongside 8.0.0
- [ ] `pip index versions thetadatadx` shows 8.0.1
- [ ] GitHub Release page for v8.0.1 exists with the notes file body