### PR TITLE
release: 8.0.8 — v8.0.7 audit fixes

### DIFF
--- a/.github/release-notes/v8.0.8.md
+++ b/.github/release-notes/v8.0.8.md
@@ -1,0 +1,29 @@
+Follow-up patch to v8.0.7. Addresses the audit findings surfaced against the code-strip release: rustdoc breakage inside `tdbe`, TypeScript loader and subpackage versions drifting from the root package, a `[8.0.7]` changelog section that accidentally absorbed v8.0.6 content, dead references to modules that v8.0.7 removed, and a handful of doc inaccuracies around DataFrame terminals and SDK parameter names. No behaviour changes; every item is documentation, packaging metadata, or tooling hygiene.
+
+See the [v8.0.8 entry in the structured changelog](https://github.com/userFRM/ThetaDataDx/blob/v8.0.8/CHANGELOG.md#808---2026-04-23) for the full detail.
+
+## Fixed
+
+- `crates/tdbe/src/codec/fit.rs` — broken intra-doc link on `FitReader`'s module-level docstring now resolves via `[FitReader::read_changes]`.
+- `crates/tdbe/src/right.rs` — five redundant explicit link targets on `[Error::Config]` references dropped; rustdoc resolves the bare path against the in-scope `use crate::error::Error`.
+- `sdks/typescript/index.js` — native-binding version guard now compares against `'8.0.8'` (was stale sentinel `'8.0.0'`). Mismatched binaries are caught when `NAPI_RS_ENFORCE_VERSION_CHECK` is set.
+- `sdks/typescript/package.json` — `optionalDependencies` pin each platform subpackage to `8.0.8` (was `8.0.4`). The three published subpackages (`thetadatadx-linux-x64-gnu`, `thetadatadx-darwin-arm64`, `thetadatadx-win32-x64-msvc`) bump from `8.0.7` to `8.0.8` in lockstep.
+- `CHANGELOG.md` / `docs-site/docs/changelog.md` — v8.0.6 content (snapshot fast-path, Rust `frames` module) split back out of the v8.0.7 section into a standalone `[8.0.6]` entry; the `### Internal` bucket on v8.0.6 was renamed `### Changed` to stay within the Keep a Changelog vocabulary.
+- `docs/api-reference.md` — two references to `tdbe::errors` (removed in v8.0.7) repointed to `tdbe::error`.
+- `docs/java-parity-checklist.md` — stale `mdds/normalize.rs` path updated to `mdds/endpoints.rs`, the current home of `normalize_interval` after the v8.0.7 fold.
+- `crates/thetadatadx/src/wire_semantics.rs` — stale "(via `mdds/normalize.rs`)" parenthetical removed from the module docstring.
+- `docs-site/docs/api-reference.md` — DataFrame-terminals section narrowed: `.to_pandas()` / `.to_polars()` / `.to_arrow()` are available on the `<TickName>List` list-wrapper return types; snapshot-fast-path endpoints return a plain `list[TickClass]` and do not carry the chainable terminals.
+- `sdks/python/README.md`, `sdks/go/README.md`, `sdks/cpp/README.md` — parameter-name tables now use the canonical SSOT names (`expiration`, `start_date` / `startDate`, `end_date` / `endDate`) instead of the `exp`, `start`, `end` shorthand.
+
+## Changed
+
+- `docs-site/docs/.vitepress/config.ts` — `vite.build.chunkSizeWarningLimit` raised to `1500` kB. The docs site vendors Mermaid and Vue chunks that exceed the default 500 kB threshold; the warning was non-actionable.
+- `deny.toml` — unused license allowances pruned from `[licenses].allow`; remaining entries carry a short comment explaining why each is there. Upstream-rooted duplicate-version entries for `disruptor`, `ring`, and `petgraph` listed under `[bans].skip-tree`. `cargo deny check` now produces zero warnings.
+
+## Release notes
+
+- Every Rust crate version bumps `8.0.7 → 8.0.8`: `thetadatadx`, `thetadatadx-ffi`, `thetadatadx-cli`, `thetadatadx-server`, `thetadatadx-mcp`, `thetadatadx-py`, `thetadatadx-napi`.
+- `sdks/typescript/package.json` + every platform subpackage under `sdks/typescript/npm/` bumps to `8.0.8` so the npm dependency graph stays coherent.
+- `tdbe` stays at `0.12.0`; the rustdoc fixes are non-breaking.
+- Five `Cargo.lock`s refreshed (workspace root + `sdks/python`, `sdks/typescript`, `tools/mcp`, `tools/server`).
+- Verification: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy --workspace --all-targets --features "polars,arrow" -- -D warnings`, `cargo test --workspace`, `cargo doc --workspace --no-deps --all-features` (zero warnings), `cargo deny check` (zero warnings), `scripts/check_docs_consistency.py`, `scripts/check_tier_badges.py`, `docs-site npm run build`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.8] - 2026-04-23
+
+Follow-up patch to v8.0.7. Addresses the audit findings surfaced against
+the code-strip release: rustdoc breakage inside `tdbe`, TypeScript loader
+and subpackage versions drifting from the root package, a `[8.0.7]`
+changelog section that accidentally absorbed v8.0.6 content, dead
+references to modules that v8.0.7 removed, and a handful of doc
+inaccuracies around DataFrame terminals and SDK parameter names. No
+behaviour changes; every item is documentation, packaging metadata, or
+tooling hygiene.
+
+### Fixed
+
+- `crates/tdbe/src/codec/fit.rs` — broken intra-doc link on
+  `FitReader`'s module-level docstring now resolves via
+  `[FitReader::read_changes]`.
+- `crates/tdbe/src/right.rs` — five redundant explicit link targets on
+  `[Error::Config]` references dropped; rustdoc resolves the bare path
+  against the in-scope `use crate::error::Error`.
+- `sdks/typescript/index.js` — native-binding version guard now compares
+  against `'8.0.8'` (was stale sentinel `'8.0.0'`). Mismatched binaries
+  are caught when `NAPI_RS_ENFORCE_VERSION_CHECK` is set.
+- `sdks/typescript/package.json` — `optionalDependencies` pin each
+  platform subpackage to `8.0.8` (was `8.0.4`). The three published
+  subpackages (`thetadatadx-linux-x64-gnu`, `thetadatadx-darwin-arm64`,
+  `thetadatadx-win32-x64-msvc`) bump from `8.0.7` to `8.0.8` in lockstep.
+- `CHANGELOG.md` / `docs-site/docs/changelog.md` — v8.0.6 content
+  (snapshot fast-path, Rust `frames` module) split back out of the
+  v8.0.7 section into a standalone `[8.0.6]` entry; the `### Internal`
+  bucket on v8.0.6 was renamed `### Changed` to stay within the Keep a
+  Changelog vocabulary.
+- `docs/api-reference.md` — two references to `tdbe::errors` (removed
+  in v8.0.7) repointed to `tdbe::error`.
+- `docs/java-parity-checklist.md` — stale `mdds/normalize.rs` path
+  updated to `mdds/endpoints.rs`, the current home of
+  `normalize_interval` after the v8.0.7 fold.
+- `crates/thetadatadx/src/wire_semantics.rs` — stale
+  "(via `mdds/normalize.rs`)" parenthetical removed from the module
+  docstring.
+- `docs-site/docs/api-reference.md` — DataFrame-terminals section
+  narrowed: `.to_pandas()` / `.to_polars()` / `.to_arrow()` are
+  available on the `<TickName>List` list-wrapper return types;
+  snapshot-fast-path endpoints return a plain `list[TickClass]` and do
+  not carry the chainable terminals.
+- `sdks/python/README.md`, `sdks/go/README.md`, `sdks/cpp/README.md` —
+  parameter-name tables now use the canonical SSOT names
+  (`expiration`, `start_date`, `end_date`) instead of the `exp`,
+  `start`, `end` shorthand.
+
+### Changed
+
+- `docs-site/docs/.vitepress/config.ts` — `vite.build.chunkSizeWarningLimit`
+  raised to `1500` kB. The docs site vendors Mermaid and Vue chunks that
+  exceed the default 500 kB threshold; the warning was non-actionable.
+- `deny.toml` — unused license allowances pruned from `[licenses].allow`;
+  remaining entries carry a short comment explaining why each is there.
+  `cargo deny check` now produces zero warnings.
+
 ## [8.0.7] - 2026-04-23
 
 Code-strip release. No new features. Every item removes dead or
@@ -76,6 +134,8 @@ FFI surfaces. `tdbe` bumps to `0.12.0` (public module removed).
   TypeScript — now calls the `tdx_<endpoint>_with_options` entry
   points. The plain-name FFI entry points are no longer exported.
 
+## [8.0.6] - 2026-04-23
+
 Snapshot-endpoint latency fast-path on the Python binding and new opt-in
 Rust `frames` module. Closes the residual 3-7 ms per-call gap vs. the
 vendor's v3 Python client on the 5 flagged snapshot / calendar
@@ -95,9 +155,6 @@ out of the default dep graph.
 - **Snapshot pymethods now dispatch via a new `run_blocking_snapshot` helper — bounded `tokio::time::timeout` instead of the 100 ms signal-check ticker.** `run_blocking`'s `tokio::select!` poll loop taxed every sub-100 ms call with 1-5 ms of first-tick jitter in the worst case. `run_blocking_snapshot` drops the ticker entirely: `py.detach { runtime().block_on(tokio::time::timeout(5s, fut)) }`. The 5-second upper bound is a liveness safeguard — every observed production snapshot call completes in <200 ms, so the bound adds zero steady-state cost. Ctrl+C is still honoured after the future resolves or the timeout fires. Emitted by the generator only when `is_snapshot_endpoint` is true; parsed / list / streaming endpoints keep the existing `run_blocking` path unchanged.
 - **`run_blocking` signal-check poll cadence reduced from 100 ms to 20 ms.** Drops the worst-case select-wait on short parsed-kind calls from ~100 ms to ~20 ms. `Python::check_signals()` is ~1 µs per call so driving the ticker 5× as often has negligible steady-state cost. Long-running endpoints see no behavioural change beyond a slightly finer-grained Ctrl+C cancellation window. One-line constant edit in `sdks/python/src/lib.rs`; the matching doc-comment is updated.
 - **`README.md` / `sdks/python/README.md` — positioning refreshed.** Dropped the "Small snapshot / calendar calls run within ±5% of the vendor" caveat now that the fast-path closes the gap on every measured endpoint. Added a feature-gated Rust DataFrame quickstart example showing `thetadatadx = { version = "8", features = ["polars"] }` plus the chained `ticks.as_slice().to_polars()?` call site.
-
-### Internal
-
 - **Generator-emitted snapshot fast-path converters (`<tick>_vec_to_pylist`) in `sdks/python/src/tick_classes.rs`.** One helper per snapshot-return tick type (9 total: `calendar_days_vec_to_pylist`, `ohlc_ticks_vec_to_pylist`, `quote_ticks_vec_to_pylist`, `trade_ticks_vec_to_pylist`, `market_value_ticks_vec_to_pylist`, `open_interest_ticks_vec_to_pylist`, `iv_ticks_vec_to_pylist`, `greeks_ticks_vec_to_pylist`, `price_ticks_vec_to_pylist`); one helper per tick type that is NOT reached by any snapshot endpoint is suppressed at generation time to avoid dead-code. Emission is gated on a TOML-derived set computed by the new `endpoints::snapshot_return_types` helper — adding a snapshot endpoint of a new tick type to `endpoint_surface.toml` automatically opts its converter into emission on the next generator run. Row-building body reuses `pyclass_from_tick_expr` from the `<TickName>List.to_list()` path so both surfaces emit byte-identical pylist contents.
 
 ## [8.0.5] - 2026-04-22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/tdbe/src/codec/fit.rs
+++ b/crates/tdbe/src/codec/fit.rs
@@ -134,7 +134,7 @@ pub fn decode_fit_buffer_bulk(buf: &[u8], fields_per_row: usize) -> FitRows {
 /// Stateful FIT stream reader.
 ///
 /// Holds a position cursor into a byte buffer and decodes one row at a time
-/// via [`read_changes`]. The caller is responsible for delta-accumulation
+/// via [`FitReader::read_changes`]. The caller is responsible for delta-accumulation
 /// across rows (see module-level docs).
 pub struct FitReader<'a> {
     buf: &'a [u8],

--- a/crates/tdbe/src/right.rs
+++ b/crates/tdbe/src/right.rs
@@ -21,7 +21,7 @@
 //! - `"both"`, `"BOTH"`, `"*"` — wildcard; only valid where the endpoint
 //!   supports it (e.g. snapshot / history endpoints taking `strike="0"`)
 //!
-//! Anything else returns [`Error::Config`](crate::error::Error::Config) with
+//! Anything else returns [`Error::Config`] with
 //! a descriptive message. No silent defaults.
 //!
 //! # Upstream vs ours
@@ -102,11 +102,11 @@ impl ParsedRight {
 /// Parse a user-supplied `right` string.
 ///
 /// Accepts `call`/`put`/`both`/`C`/`P`/`*` in any case. Returns
-/// [`Error::Config`](crate::error::Error::Config) for anything else.
+/// [`Error::Config`] for anything else.
 ///
 /// # Errors
 ///
-/// Returns [`Error::Config`](crate::error::Error::Config) if the input does
+/// Returns [`Error::Config`] if the input does
 /// not match any of the accepted forms.
 ///
 /// # Examples
@@ -139,13 +139,13 @@ pub fn parse_right(input: &str) -> Result<ParsedRight, Error> {
 
 /// Parse a `right` that must resolve to a single side (call or put).
 ///
-/// Returns [`Error::Config`](crate::error::Error::Config) if the input parses
+/// Returns [`Error::Config`] if the input parses
 /// to [`ParsedRight::Both`]. Use this for endpoints where the wildcard is not
 /// meaningful (e.g. FPSS per-contract subscriptions, Greeks utilities).
 ///
 /// # Errors
 ///
-/// Returns [`Error::Config`](crate::error::Error::Config) for invalid inputs
+/// Returns [`Error::Config`] for invalid inputs
 /// and for the `both` / `*` wildcards.
 pub fn parse_right_strict(input: &str) -> Result<ParsedRight, Error> {
     let parsed = parse_right(input)?;

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.7"
+version = "8.0.8"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/build_support/endpoints/modes.rs
+++ b/crates/thetadatadx/build_support/endpoints/modes.rs
@@ -123,7 +123,7 @@ fn with_optional_rationale(param_name: &str, literal: &str) -> String {
 /// Minimum subscription tier each endpoint requires.
 ///
 /// Derived at generator-run-time from the pinned upstream OpenAPI snapshot at
-/// `scripts/upstream_openapi.yaml` (see [`super::upstream_openapi`]), keyed
+/// `scripts/upstream_openapi.yaml` (parsed by the `upstream_openapi` helper), keyed
 /// on the endpoint's `operationId`. Upstream is the sole source of truth for
 /// `x-min-subscription`, so docs-site `<TierBadge>` and this function agree
 /// as long as the snapshot is fresh.
@@ -288,7 +288,7 @@ pub(super) fn has_full_contract_spec(endpoint: &GeneratedEndpoint) -> bool {
 /// wildcards to its `expiration_no_star` component parameter (they return
 /// `InvalidArgument -- Cannot specify '*' for the date` if we send `*`),
 /// and wildcard-accepting endpoints to `expiration`. See
-/// [`super::upstream_openapi::UpstreamEndpoint::supports_expiration_wildcard`].
+/// the `UpstreamEndpoint::supports_expiration_wildcard` helper.
 ///
 /// Endpoints absent from upstream (streaming, SDK-only clones) fall back to
 /// `true` — they don't participate in the wildcard matrix anyway (streaming

--- a/crates/thetadatadx/build_support/endpoints/render/build_out.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/build_out.rs
@@ -2,7 +2,7 @@
 //!
 //! These feed the crate's `include!()` sites for the endpoint registry, the
 //! shared endpoint dispatch runtime, and the three per-kind MDDS
-//! [`MddsClient`] extension impls (list, parsed, streaming), consumed by
+//! `MddsClient` extension impls (list, parsed, streaming), consumed by
 //! `crates/thetadatadx/src/mdds/endpoints.rs`. The [`generate_all`] entry
 //! point is wired from `build_support::run()`.
 

--- a/crates/thetadatadx/build_support/endpoints/render/mdds.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/mdds.rs
@@ -1,4 +1,4 @@
-//! Rust emitters for the MDDS gRPC [`MddsClient`] surface.
+//! Rust emitters for the MDDS gRPC `MddsClient` surface.
 //!
 //! Emits per-endpoint `list_endpoint!`, `parsed_endpoint!`, and streaming
 //! builder macro invocations into the `OUT_DIR`. Shared naming/type helpers

--- a/crates/thetadatadx/build_support/endpoints/render/python.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/python.rs
@@ -1,4 +1,4 @@
-//! Python SDK #[pymethods] emitter.
+//! Python SDK `#[pymethods]` emitter.
 //!
 //! Renders `sdks/python/src/historical_methods.rs` — the `ThetaDataDx` impl
 //! block that PyO3 compiles into the Python extension.
@@ -636,7 +636,7 @@ fn render_python_endpoint_async(endpoint: &GeneratedEndpoint) -> String {
     out
 }
 
-/// Async variants take owned `String` / Option<String> so the future owns
+/// Async variants take owned `String` / `Option<String>` so the future owns
 /// its captures (future_into_py requires `'static + Send`). This mirrors
 /// `python_optional_type` but substitutes String for &str on the owned
 /// path.
@@ -668,7 +668,7 @@ fn async_setter_arg(param: &GeneratedParam) -> &'static str {
 // configuration. State captured at builder construction time: required
 // args + accumulated optional kwargs + timeout_ms.
 
-/// The name of the #[pyclass] builder emitted for this endpoint.
+/// The name of the `#[pyclass]` builder emitted for this endpoint.
 fn endpoint_builder_struct(name: &str) -> String {
     format!("{}Builder", to_pascal_case(name))
 }

--- a/crates/thetadatadx/src/config.rs
+++ b/crates/thetadatadx/src/config.rs
@@ -125,8 +125,8 @@ pub enum FpssFlushMode {
 ///
 /// Only wired on status codes `Unavailable`, `DeadlineExceeded`, and
 /// `ResourceExhausted`. Permission / credential failures route through
-/// the separate auto-refresh path (see [`MddsClient`] wrappers) and are
-/// never retried by this policy.
+/// the separate auto-refresh path (see the in-crate `MddsClient` wrappers)
+/// and are never retried by this policy.
 ///
 /// # Jitter
 ///

--- a/crates/thetadatadx/src/fpss/framing.rs
+++ b/crates/thetadatadx/src/fpss/framing.rs
@@ -417,8 +417,8 @@ pub(crate) fn is_binary_payload(payload: &[u8]) -> bool {
 /// # Unknown message codes
 ///
 /// Frames with unrecognized codes are silently skipped (payload consumed
-/// to keep the stream aligned). After [`MAX_CONSECUTIVE_UNKNOWN_CODES`]
-/// consecutive unknown codes, returns an error to trigger reconnection.
+/// to keep the stream aligned). After 5 consecutive unknown codes, returns
+/// an error to trigger reconnection.
 /// # Errors
 ///
 /// Returns an error on network, authentication, or parsing failure.

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -190,7 +190,7 @@ impl FpssClient {
     /// Source: `FPSSClient.connect()` and `FPSSClient.sendCredentials()`.
     /// Connect to FPSS streaming servers.
     ///
-    /// `hosts` is the FPSS server list from [`DirectConfig::fpss_hosts`].
+    /// `hosts` is the FPSS server list from [`crate::config::DirectConfig::fpss_hosts`].
     /// Servers are tried in order until one connects.
     ///
     /// `policy` controls auto-reconnect behavior after involuntary disconnect.
@@ -457,7 +457,7 @@ impl FpssClient {
     ///
     /// If OHLCVC derivation is enabled (default), you will also
     /// receive locally-derived [`FpssData::Ohlcvc`] after each trade. Pass
-    /// `derive_ohlcvc: false` to [`connect`] to disable this and reduce throughput overhead.
+    /// `derive_ohlcvc: false` to [`FpssClient::connect`] to disable this and reduce throughput overhead.
     ///
     /// # Wire protocol (from `PacketStream.java`)
     ///
@@ -496,7 +496,7 @@ impl FpssClient {
 
     /// Subscribe to all open interest data for a security type (full OI stream).
     ///
-    /// Same pattern as [`subscribe_full_trades`] but for open interest.
+    /// Same pattern as [`FpssClient::subscribe_full_trades`] but for open interest.
     ///
     /// # Wire protocol
     ///
@@ -538,7 +538,7 @@ impl FpssClient {
     /// # Wire protocol
     ///
     /// Sends code 52 (`REMOVE_TRADE`) with 5-byte payload `[req_id: i32 BE] [sec_type: u8]`.
-    /// Same format as [`subscribe_full_trades`] but with the REMOVE code.
+    /// Same format as [`FpssClient::subscribe_full_trades`] but with the REMOVE code.
     /// # Errors
     ///
     /// Returns an error on network, authentication, or parsing failure.
@@ -574,7 +574,7 @@ impl FpssClient {
     /// # Wire protocol
     ///
     /// Sends code 53 (`REMOVE_OPEN_INTEREST`) with 5-byte payload `[req_id: i32 BE] [sec_type: u8]`.
-    /// Same format as [`subscribe_full_open_interest`] but with the REMOVE code.
+    /// Same format as [`FpssClient::subscribe_full_open_interest`] but with the REMOVE code.
     /// # Errors
     ///
     /// Returns an error on network, authentication, or parsing failure.

--- a/crates/thetadatadx/src/mdds/mod.rs
+++ b/crates/thetadatadx/src/mdds/mod.rs
@@ -3,8 +3,8 @@
 //! [`MddsClient`] authenticates against the Nexus HTTP API, opens a gRPC
 //! channel to the MDDS server, and exposes typed methods for every historical
 //! data endpoint. Macro-driven builder patterns (`list_endpoint!`,
-//! `parsed_endpoint!`) live in [`crate::macros`] and are applied here via
-//! generated code (`include!`) from `endpoint_surface.toml`.
+//! `parsed_endpoint!`) live in the in-crate `macros` module and are applied
+//! here via generated code (`include!`) from `endpoint_surface.toml`.
 //!
 //! # Architecture
 //!
@@ -27,14 +27,14 @@
 //! This module mirrors the [`crate::fpss`] layout for symmetry between the two
 //! upstream services:
 //!
-//! - [`client`] — `MddsClient` struct, `connect`, transport/session state
-//! - [`stream`] — gRPC response stream helpers (`collect_stream`, `for_each_chunk`)
-//! - [`validate`] — runtime parameter validators invoked by generated macros
-//! - [`endpoints`] — generated endpoint method bodies (`include!` sites);
+//! - `client` — [`MddsClient`] struct, `connect`, transport/session state
+//! - `stream` — gRPC response stream helpers (`collect_stream`, `for_each_chunk`)
+//! - `validate` — runtime parameter validators invoked by generated macros
+//! - `endpoints` — generated endpoint method bodies (`include!` sites);
 //!   wire-format canonicalizers (`normalize_interval`, `normalize_time_of_day`,
 //!   `contract_spec!`) live at the top of that file. The cross-cutting wire
 //!   helpers (`normalize_expiration`, `wire_strike_opt`, `wire_right_opt`)
-//!   live in [`crate::wire_semantics`].
+//!   live in the in-crate `wire_semantics` module.
 
 mod client;
 mod endpoints;

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -88,7 +88,7 @@ pub struct ThetaDataDx {
 impl ThetaDataDx {
     /// Connect to `ThetaData`. Authenticates once, opens gRPC channel.
     ///
-    /// FPSS streaming is NOT connected yet -- call [`start_streaming`]
+    /// FPSS streaming is NOT connected yet -- call [`ThetaDataDx::start_streaming`]
     /// when you need real-time data.
     /// # Errors
     ///

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,11 @@ allow = [
     # data-sharing license); used only for the static Mozilla CA bundle
     # bundled into rustls.
     "CDLA-Permissive-2.0",
+    # Reason: xxhash-rust is BSL-1.0 (Boost Software License). Permissive,
+    # OSI-approved, no copyleft on derivative works -- effectively identical
+    # to MIT for SDK consumers. Pulled in transitively by polars through
+    # polars-schema; only reachable with the `polars` feature flag enabled.
+    "BSL-1.0",
 ]
 confidence-threshold = 0.8
 exceptions = []

--- a/deny.toml
+++ b/deny.toml
@@ -45,29 +45,37 @@ ignore = []
 [licenses]
 # Workspace crates (tdbe, thetadatadx, FFI shim, SDK shims, tools) are
 # Apache-2.0. The allowlist below determines which *dependency* licenses
-# we accept in the tree. Anything unlisted fails.
+# we accept in the tree. Anything unlisted fails. Every entry below is
+# present in the current lock file's license surface; unused allowances
+# are deleted so the list stays an accurate record of what we actually
+# ship.
 allow = [
+    # Reason: the dominant permissive license across the Rust ecosystem.
     "MIT",
+    # Reason: the project's own license; also widely reused by deps.
     "Apache-2.0",
+    # Reason: the LLVM-exception variant covers rustc-internal crates we
+    # pick up transitively (e.g. via the compiler-builtins path).
     "Apache-2.0 WITH LLVM-exception",
+    # Reason: permissive BSD family; pulled in by several small utility
+    # crates (pkg-config, libloading, etc.).
     "BSD-2-Clause",
     "BSD-3-Clause",
+    # Reason: permissive, no attribution clause quirks; appears on
+    # hashbrown and a few networking primitives.
     "ISC",
+    # Reason: zlib-style permissive; required by miniz_oxide / adler.
     "Zlib",
+    # Reason: public-domain-equivalent dedication on tiny-keccak and a
+    # handful of hash-family crates.
     "CC0-1.0",
-    "Unicode-DFS-2016",
+    # Reason: unicode-ident (required by syn / proc-macro2 / every
+    # derive-macro consumer) moved to Unicode-3.0 in recent releases.
     "Unicode-3.0",
-    "MPL-2.0",
-    # Reason: webpki-roots 1.x is CDLA-Permissive-2.0. The Community
-    # Data License Agreement - Permissive 2.0 is a data-sharing license
-    # (Linux Foundation) with effectively no copyleft on output; rustls
-    # uses it only for the static Mozilla CA bundle.
+    # Reason: webpki-roots 1.x is CDLA-Permissive-2.0 (Linux Foundation
+    # data-sharing license); used only for the static Mozilla CA bundle
+    # bundled into rustls.
     "CDLA-Permissive-2.0",
-    # Reason: xxhash-rust is BSL-1.0 (Boost Software License). Permissive,
-    # OSI-approved, no copyleft on derivative works — effectively identical
-    # to MIT for SDK consumers. Pulled in transitively by polars through
-    # polars-schema; only reachable with the `polars` feature flag enabled.
-    "BSL-1.0",
 ]
 confidence-threshold = 0.8
 exceptions = []
@@ -84,7 +92,22 @@ highlight = "all"
 # Allow cargo-deny to skip duplicate-version noise rooted at these
 # trees when it is unavoidable (e.g. `syn 1.x` vs `syn 2.x`). Add
 # entries here only after confirming the duplication is upstream.
-skip-tree = []
+skip-tree = [
+    # Reason: disruptor v4 still depends on thiserror 1.x while the rest
+    # of the tree is on thiserror 2.x. The duplicate is rooted upstream
+    # in the disruptor crate and clears itself once disruptor updates.
+    { name = "disruptor", version = "4" },
+    # Reason: ring pins getrandom 0.2 while the ahash / jobserver side
+    # of the tree is on getrandom 0.3 (and the uuid side on 0.4). The
+    # duplicates are forced by upstream version-choice decisions in the
+    # TLS stack and clear themselves once ring releases against a
+    # unified getrandom line.
+    { name = "ring", version = "0.17" },
+    # Reason: petgraph (pulled in by prost-build at build time only) is
+    # still on hashbrown 0.15 while the rest of the tree is on 0.17.
+    # Duplicate is upstream-rooted and resolves once petgraph updates.
+    { name = "petgraph", version = "0.8" },
+]
 
 [sources]
 unknown-registry = "warn"

--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -7,6 +7,17 @@ export default withMermaid(defineConfig({
   base: '/ThetaDataDx/',
   cleanUrls: true,
 
+  // The docs site vendors Mermaid and Vue chunks that legitimately
+  // exceed Vite's 500 kB default threshold. Raise the warning limit so
+  // the build output stays free of non-actionable chunk-size warnings;
+  // real regressions (e.g. a new dep inflating the bundle further)
+  // still trip the bumped threshold.
+  vite: {
+    build: {
+      chunkSizeWarningLimit: 1500,
+    },
+  },
+
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
     ['meta', { name: 'theme-color', content: '#3b82f6' }],

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -2848,11 +2848,18 @@ df = tdx.stock_history_trade("AAPL", "20240315").to_pandas()
 df = tdx.stock_history_quote("AAPL", "20240315", "60000").to_pandas()
 ```
 
-Call any endpoint, chain `.to_pandas()` / `.to_polars()` /
-`.to_arrow()` / `.to_list()` on the returned list wrapper. One
-path, one schema, one generator (`tick_schema.toml`). Requires
-`pip install thetadatadx[pandas]` / `[polars]` / `[arrow]` for
-the matching terminal.
+Historical / list-returning endpoints wrap their result in a
+typed `<TickName>List` (e.g. `EodTickList`, `QuoteTickList`);
+chain `.to_pandas()` / `.to_polars()` / `.to_arrow()` / `.to_list()`
+on that wrapper. One path, one schema, one generator
+(`tick_schema.toml`). Requires `pip install thetadatadx[pandas]` /
+`[polars]` / `[arrow]` for the matching terminal.
+
+Snapshot-kind endpoints (`*_snapshot_*`) and calendar endpoints
+take the fast path and return a plain `list[TickClass]` rather
+than a list wrapper, so the chainable DataFrame terminals are not
+available on those return values. Build a DataFrame from the raw
+list directly if needed (e.g. `pandas.DataFrame([vars(t) for t in rows])`).
 
 ### `<TickName>List.to_pandas() -> pandas.DataFrame`
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.8] - 2026-04-23
+
+Follow-up patch to v8.0.7. Addresses the audit findings surfaced against
+the code-strip release: rustdoc breakage inside `tdbe`, TypeScript loader
+and subpackage versions drifting from the root package, a `[8.0.7]`
+changelog section that accidentally absorbed v8.0.6 content, dead
+references to modules that v8.0.7 removed, and a handful of doc
+inaccuracies around DataFrame terminals and SDK parameter names. No
+behaviour changes; every item is documentation, packaging metadata, or
+tooling hygiene.
+
+### Fixed
+
+- `crates/tdbe/src/codec/fit.rs` — broken intra-doc link on
+  `FitReader`'s module-level docstring now resolves via
+  `[FitReader::read_changes]`.
+- `crates/tdbe/src/right.rs` — five redundant explicit link targets on
+  `[Error::Config]` references dropped; rustdoc resolves the bare path
+  against the in-scope `use crate::error::Error`.
+- `sdks/typescript/index.js` — native-binding version guard now compares
+  against `'8.0.8'` (was stale sentinel `'8.0.0'`). Mismatched binaries
+  are caught when `NAPI_RS_ENFORCE_VERSION_CHECK` is set.
+- `sdks/typescript/package.json` — `optionalDependencies` pin each
+  platform subpackage to `8.0.8` (was `8.0.4`). The three published
+  subpackages (`thetadatadx-linux-x64-gnu`, `thetadatadx-darwin-arm64`,
+  `thetadatadx-win32-x64-msvc`) bump from `8.0.7` to `8.0.8` in lockstep.
+- `CHANGELOG.md` / `docs-site/docs/changelog.md` — v8.0.6 content
+  (snapshot fast-path, Rust `frames` module) split back out of the
+  v8.0.7 section into a standalone `[8.0.6]` entry; the `### Internal`
+  bucket on v8.0.6 was renamed `### Changed` to stay within the Keep a
+  Changelog vocabulary.
+- `docs/api-reference.md` — two references to `tdbe::errors` (removed
+  in v8.0.7) repointed to `tdbe::error`.
+- `docs/java-parity-checklist.md` — stale `mdds/normalize.rs` path
+  updated to `mdds/endpoints.rs`, the current home of
+  `normalize_interval` after the v8.0.7 fold.
+- `crates/thetadatadx/src/wire_semantics.rs` — stale
+  "(via `mdds/normalize.rs`)" parenthetical removed from the module
+  docstring.
+- `docs-site/docs/api-reference.md` — DataFrame-terminals section
+  narrowed: `.to_pandas()` / `.to_polars()` / `.to_arrow()` are
+  available on the `<TickName>List` list-wrapper return types;
+  snapshot-fast-path endpoints return a plain `list[TickClass]` and do
+  not carry the chainable terminals.
+- `sdks/python/README.md`, `sdks/go/README.md`, `sdks/cpp/README.md` —
+  parameter-name tables now use the canonical SSOT names
+  (`expiration`, `start_date`, `end_date`) instead of the `exp`,
+  `start`, `end` shorthand.
+
+### Changed
+
+- `docs-site/docs/.vitepress/config.ts` — `vite.build.chunkSizeWarningLimit`
+  raised to `1500` kB. The docs site vendors Mermaid and Vue chunks that
+  exceed the default 500 kB threshold; the warning was non-actionable.
+- `deny.toml` — unused license allowances pruned from `[licenses].allow`;
+  remaining entries carry a short comment explaining why each is there.
+  `cargo deny check` now produces zero warnings.
+
 ## [8.0.7] - 2026-04-23
 
 Code-strip release. No new features. Every item removes dead or
@@ -76,6 +134,8 @@ FFI surfaces. `tdbe` bumps to `0.12.0` (public module removed).
   TypeScript — now calls the `tdx_<endpoint>_with_options` entry
   points. The plain-name FFI entry points are no longer exported.
 
+## [8.0.6] - 2026-04-23
+
 Snapshot-endpoint latency fast-path on the Python binding and new opt-in
 Rust `frames` module. Closes the residual 3-7 ms per-call gap vs. the
 vendor's v3 Python client on the 5 flagged snapshot / calendar
@@ -95,9 +155,6 @@ out of the default dep graph.
 - **Snapshot pymethods now dispatch via a new `run_blocking_snapshot` helper — bounded `tokio::time::timeout` instead of the 100 ms signal-check ticker.** `run_blocking`'s `tokio::select!` poll loop taxed every sub-100 ms call with 1-5 ms of first-tick jitter in the worst case. `run_blocking_snapshot` drops the ticker entirely: `py.detach { runtime().block_on(tokio::time::timeout(5s, fut)) }`. The 5-second upper bound is a liveness safeguard — every observed production snapshot call completes in <200 ms, so the bound adds zero steady-state cost. Ctrl+C is still honoured after the future resolves or the timeout fires. Emitted by the generator only when `is_snapshot_endpoint` is true; parsed / list / streaming endpoints keep the existing `run_blocking` path unchanged.
 - **`run_blocking` signal-check poll cadence reduced from 100 ms to 20 ms.** Drops the worst-case select-wait on short parsed-kind calls from ~100 ms to ~20 ms. `Python::check_signals()` is ~1 µs per call so driving the ticker 5× as often has negligible steady-state cost. Long-running endpoints see no behavioural change beyond a slightly finer-grained Ctrl+C cancellation window. One-line constant edit in `sdks/python/src/lib.rs`; the matching doc-comment is updated.
 - **`README.md` / `sdks/python/README.md` — positioning refreshed.** Dropped the "Small snapshot / calendar calls run within ±5% of the vendor" caveat now that the fast-path closes the gap on every measured endpoint. Added a feature-gated Rust DataFrame quickstart example showing `thetadatadx = { version = "8", features = ["polars"] }` plus the chained `ticks.as_slice().to_polars()?` call site.
-
-### Internal
-
 - **Generator-emitted snapshot fast-path converters (`<tick>_vec_to_pylist`) in `sdks/python/src/tick_classes.rs`.** One helper per snapshot-return tick type (9 total: `calendar_days_vec_to_pylist`, `ohlc_ticks_vec_to_pylist`, `quote_ticks_vec_to_pylist`, `trade_ticks_vec_to_pylist`, `market_value_ticks_vec_to_pylist`, `open_interest_ticks_vec_to_pylist`, `iv_ticks_vec_to_pylist`, `greeks_ticks_vec_to_pylist`, `price_ticks_vec_to_pylist`); one helper per tick type that is NOT reached by any snapshot endpoint is suppressed at generation time to avoid dead-code. Emission is gated on a TOML-derived set computed by the new `endpoints::snapshot_return_types` helper — adding a snapshot endpoint of a new tick type to `endpoint_surface.toml` automatically opts its converter into emission on the next generator run. Row-building body reuses `pyclass_from_tick_expr` from the `<TickName>List.to_list()` path so both surfaces emit byte-identical pylist contents.
 
 ## [8.0.5] - 2026-04-22

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1756,7 +1756,7 @@ All variants implement `Display` and `std::error::Error`. Automatic conversions 
 
 ### ThetaData Server Error Codes
 
-The `tdbe::errors` module defines 14 server error codes (`ThetaDataError`) extracted from gRPC response metadata (`http_status_code`). When a gRPC `Status` carries a known code, the `Error::Status` variant is enriched with the ThetaData error name and description.
+The `tdbe::error` module defines 14 server error codes (`ThetaDataError`) extracted from gRPC response metadata (`http_status_code`). When a gRPC `Status` carries a known code, the `Error::Status` variant is enriched with the ThetaData error name and description.
 
 | Code | Name | Description |
 |------|------|-------------|
@@ -1784,7 +1784,7 @@ The `tdbe` crate provides lookup tables for the following enumerated code sets:
 | Exchange codes | 78 (0..77) | `tdbe::exchange` | `exchange_name(code)`, `exchange_symbol(code)` |
 | Trade conditions | 149 | `tdbe::conditions` | `trade_condition_name(code)` |
 | Quote conditions | 75 | `tdbe::conditions` | `quote_condition_name(code)` |
-| ThetaData server errors | 14 | `tdbe::errors` | `error_from_http_code(code)` |
+| ThetaData server errors | 14 | `tdbe::error` | `error_from_http_code(code)` |
 
 ---
 

--- a/docs/java-parity-checklist.md
+++ b/docs/java-parity-checklist.md
@@ -184,7 +184,7 @@ empty forms.
 |---------|:------:|-------|
 | `start_time="09:30:00"` / `end_time="16:00:00"` on interval endpoints | [✓] | Matches Java (added v4.2.0). |
 | `venue="nqb"` on stock snapshot + intraday history endpoints | [✓] | NASDAQ Basic / UTP SIP — matches Java (added v4.2.0). |
-| Interval shorthand normalization (`"60000"` -> `"1m"`) | [✗] | Server accepts both; wire value differs (`normalize_interval()` in `mdds/normalize.rs`). |
+| Interval shorthand normalization (`"60000"` -> `"1m"`) | [✗] | Server accepts both; wire value differs (`normalize_interval()` in `mdds/endpoints.rs`). |
 
 ## Response streaming
 
@@ -224,10 +224,10 @@ either v2-style or v3-style parameter values.
 
 | v2 (ms) | v3 | Where |
 |---------|----|-------|
-| `"60000"` | `"1m"` | `normalize_interval()` in `mdds/normalize.rs` |
-| `"1000"` | `"1s"` | `normalize_interval()` in `mdds/normalize.rs` |
-| `"300000"` | `"5m"` | `normalize_interval()` in `mdds/normalize.rs` |
-| already shorthand | pass-through | `normalize_interval()` in `mdds/normalize.rs` |
+| `"60000"` | `"1m"` | `normalize_interval()` in `mdds/endpoints.rs` |
+| `"1000"` | `"1s"` | `normalize_interval()` in `mdds/endpoints.rs` |
+| `"300000"` | `"5m"` | `normalize_interval()` in `mdds/endpoints.rs` |
+| already shorthand | pass-through | `normalize_interval()` in `mdds/endpoints.rs` |
 
 ### Symbol field
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.7"
+version = "8.0.8"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -111,9 +111,9 @@ auto client = tdx::Client::connect(creds, tdx::Config::production());
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `stock_history_eod(sym, start, end)` | `vector<EodTick>` | EOD data |
+| `stock_history_eod(sym, start_date, end_date)` | `vector<EodTick>` | EOD data |
 | `stock_history_ohlc(sym, date, interval)` | `vector<OhlcTick>` | Intraday OHLC bars. `interval` accepts ms (`"60000"`) or shorthand (`"1m"`). |
-| `stock_history_ohlc_range(sym, start, end, interval)` | `vector<OhlcTick>` | OHLC bars across date range. `interval` accepts ms or shorthand. |
+| `stock_history_ohlc_range(sym, start_date, end_date, interval)` | `vector<OhlcTick>` | OHLC bars across date range. `interval` accepts ms or shorthand. |
 | `stock_history_trade(sym, date)` | `vector<TradeTick>` | All trades on a date |
 | `stock_history_quote(sym, date, interval)` | `vector<QuoteTick>` | NBBO quotes. `interval` accepts ms or shorthand. |
 | `stock_history_trade_quote(sym, date)` | `vector<TradeQuoteTick>` | Combined trade + quote ticks |
@@ -122,67 +122,67 @@ auto client = tdx::Client::connect(creds, tdx::Config::production());
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `stock_at_time_trade(sym, start, end, time)` | `vector<TradeTick>` | Trade at a specific time across date range |
-| `stock_at_time_quote(sym, start, end, time)` | `vector<QuoteTick>` | Quote at a specific time across date range |
+| `stock_at_time_trade(sym, start_date, end_date, time)` | `vector<TradeTick>` | Trade at a specific time across date range |
+| `stock_at_time_quote(sym, start_date, end_date, time)` | `vector<QuoteTick>` | Quote at a specific time across date range |
 
 #### Option - List (5)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `option_list_symbols()` | `vector<string>` | All option underlyings |
-| `option_list_dates(req, sym, exp, strike, right)` | `vector<string>` | Available dates for an option contract |
+| `option_list_dates(req, sym, expiration, strike, right)` | `vector<string>` | Available dates for an option contract |
 | `option_list_expirations(sym)` | `vector<string>` | Expiration dates |
-| `option_list_strikes(sym, exp)` | `vector<string>` | Strike prices |
+| `option_list_strikes(sym, expiration)` | `vector<string>` | Strike prices |
 | `option_list_contracts(req, sym, date)` | `vector<OptionContract>` | All option contracts on a date |
 
 #### Option - Snapshot (10)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `option_snapshot_ohlc(sym, exp, strike, right)` | `vector<OhlcTick>` | Latest OHLC snapshot |
-| `option_snapshot_trade(sym, exp, strike, right)` | `vector<TradeTick>` | Latest trade snapshot |
-| `option_snapshot_quote(sym, exp, strike, right)` | `vector<QuoteTick>` | Latest quote snapshot |
-| `option_snapshot_open_interest(sym, exp, strike, right)` | `vector<OpenInterestTick>` | Latest open interest snapshot |
-| `option_snapshot_market_value(sym, exp, strike, right)` | `vector<MarketValueTick>` | Latest market value snapshot |
-| `option_snapshot_greeks_implied_volatility(sym, exp, strike, right)` | `vector<IvTick>` | IV snapshot |
-| `option_snapshot_greeks_all(sym, exp, strike, right)` | `vector<GreeksTick>` | All Greeks snapshot |
-| `option_snapshot_greeks_first_order(sym, exp, strike, right)` | `vector<GreeksTick>` | First-order Greeks snapshot |
-| `option_snapshot_greeks_second_order(sym, exp, strike, right)` | `vector<GreeksTick>` | Second-order Greeks snapshot |
-| `option_snapshot_greeks_third_order(sym, exp, strike, right)` | `vector<GreeksTick>` | Third-order Greeks snapshot |
+| `option_snapshot_ohlc(sym, expiration, strike, right)` | `vector<OhlcTick>` | Latest OHLC snapshot |
+| `option_snapshot_trade(sym, expiration, strike, right)` | `vector<TradeTick>` | Latest trade snapshot |
+| `option_snapshot_quote(sym, expiration, strike, right)` | `vector<QuoteTick>` | Latest quote snapshot |
+| `option_snapshot_open_interest(sym, expiration, strike, right)` | `vector<OpenInterestTick>` | Latest open interest snapshot |
+| `option_snapshot_market_value(sym, expiration, strike, right)` | `vector<MarketValueTick>` | Latest market value snapshot |
+| `option_snapshot_greeks_implied_volatility(sym, expiration, strike, right)` | `vector<IvTick>` | IV snapshot |
+| `option_snapshot_greeks_all(sym, expiration, strike, right)` | `vector<GreeksTick>` | All Greeks snapshot |
+| `option_snapshot_greeks_first_order(sym, expiration, strike, right)` | `vector<GreeksTick>` | First-order Greeks snapshot |
+| `option_snapshot_greeks_second_order(sym, expiration, strike, right)` | `vector<GreeksTick>` | Second-order Greeks snapshot |
+| `option_snapshot_greeks_third_order(sym, expiration, strike, right)` | `vector<GreeksTick>` | Third-order Greeks snapshot |
 
 #### Option - History (6)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `option_history_eod(sym, exp, strike, right, start, end)` | `vector<EodTick>` | EOD option data |
-| `option_history_ohlc(sym, exp, strike, right, date, interval)` | `vector<OhlcTick>` | Intraday OHLC for options |
-| `option_history_trade(sym, exp, strike, right, date)` | `vector<TradeTick>` | All trades for an option |
-| `option_history_quote(sym, exp, strike, right, date, interval)` | `vector<QuoteTick>` | Quotes for an option |
-| `option_history_trade_quote(sym, exp, strike, right, date)` | `vector<TradeQuoteTick>` | Combined trade + quote for an option |
-| `option_history_open_interest(sym, exp, strike, right, date)` | `vector<OpenInterestTick>` | Open interest history |
+| `option_history_eod(sym, expiration, strike, right, start_date, end_date)` | `vector<EodTick>` | EOD option data |
+| `option_history_ohlc(sym, expiration, strike, right, date, interval)` | `vector<OhlcTick>` | Intraday OHLC for options |
+| `option_history_trade(sym, expiration, strike, right, date)` | `vector<TradeTick>` | All trades for an option |
+| `option_history_quote(sym, expiration, strike, right, date, interval)` | `vector<QuoteTick>` | Quotes for an option |
+| `option_history_trade_quote(sym, expiration, strike, right, date)` | `vector<TradeQuoteTick>` | Combined trade + quote for an option |
+| `option_history_open_interest(sym, expiration, strike, right, date)` | `vector<OpenInterestTick>` | Open interest history |
 
 #### Option - History Greeks (11)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `option_history_greeks_eod(sym, exp, strike, right, start, end[, options])` | `vector<GreeksTick>` | EOD Greeks history. Optional `EndpointRequestOptions` exposes filters such as `strike_range`. |
-| `option_history_greeks_all(sym, exp, strike, right, date, interval)` | `vector<GreeksTick>` | All Greeks history (intraday) |
-| `option_history_trade_greeks_all(sym, exp, strike, right, date)` | `vector<GreeksTick>` | All Greeks on each trade |
-| `option_history_greeks_first_order(sym, exp, strike, right, date, interval)` | `vector<GreeksTick>` | First-order Greeks history |
-| `option_history_trade_greeks_first_order(sym, exp, strike, right, date)` | `vector<GreeksTick>` | First-order Greeks on each trade |
-| `option_history_greeks_second_order(sym, exp, strike, right, date, interval)` | `vector<GreeksTick>` | Second-order Greeks history |
-| `option_history_trade_greeks_second_order(sym, exp, strike, right, date)` | `vector<GreeksTick>` | Second-order Greeks on each trade |
-| `option_history_greeks_third_order(sym, exp, strike, right, date, interval)` | `vector<GreeksTick>` | Third-order Greeks history |
-| `option_history_trade_greeks_third_order(sym, exp, strike, right, date)` | `vector<GreeksTick>` | Third-order Greeks on each trade |
-| `option_history_greeks_implied_volatility(sym, exp, strike, right, date, interval)` | `vector<IvTick>` | IV history (intraday) |
-| `option_history_trade_greeks_implied_volatility(sym, exp, strike, right, date)` | `vector<IvTick>` | IV on each trade |
+| `option_history_greeks_eod(sym, expiration, strike, right, start_date, end_date[, options])` | `vector<GreeksTick>` | EOD Greeks history. Optional `EndpointRequestOptions` exposes filters such as `strike_range`. |
+| `option_history_greeks_all(sym, expiration, strike, right, date, interval)` | `vector<GreeksTick>` | All Greeks history (intraday) |
+| `option_history_trade_greeks_all(sym, expiration, strike, right, date)` | `vector<GreeksTick>` | All Greeks on each trade |
+| `option_history_greeks_first_order(sym, expiration, strike, right, date, interval)` | `vector<GreeksTick>` | First-order Greeks history |
+| `option_history_trade_greeks_first_order(sym, expiration, strike, right, date)` | `vector<GreeksTick>` | First-order Greeks on each trade |
+| `option_history_greeks_second_order(sym, expiration, strike, right, date, interval)` | `vector<GreeksTick>` | Second-order Greeks history |
+| `option_history_trade_greeks_second_order(sym, expiration, strike, right, date)` | `vector<GreeksTick>` | Second-order Greeks on each trade |
+| `option_history_greeks_third_order(sym, expiration, strike, right, date, interval)` | `vector<GreeksTick>` | Third-order Greeks history |
+| `option_history_trade_greeks_third_order(sym, expiration, strike, right, date)` | `vector<GreeksTick>` | Third-order Greeks on each trade |
+| `option_history_greeks_implied_volatility(sym, expiration, strike, right, date, interval)` | `vector<IvTick>` | IV history (intraday) |
+| `option_history_trade_greeks_implied_volatility(sym, expiration, strike, right, date)` | `vector<IvTick>` | IV on each trade |
 
 #### Option - At-Time (2)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `option_at_time_trade(sym, exp, strike, right, start, end, time)` | `vector<TradeTick>` | Trade at a specific time for an option |
-| `option_at_time_quote(sym, exp, strike, right, start, end, time)` | `vector<QuoteTick>` | Quote at a specific time for an option |
+| `option_at_time_trade(sym, expiration, strike, right, start_date, end_date, time)` | `vector<TradeTick>` | Trade at a specific time for an option |
+| `option_at_time_quote(sym, expiration, strike, right, start_date, end_date, time)` | `vector<QuoteTick>` | Quote at a specific time for an option |
 
 #### Index - List (2)
 
@@ -203,15 +203,15 @@ auto client = tdx::Client::connect(creds, tdx::Config::production());
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `index_history_eod(sym, start, end)` | `vector<EodTick>` | EOD index data |
-| `index_history_ohlc(sym, start, end, interval)` | `vector<OhlcTick>` | Intraday OHLC for an index |
+| `index_history_eod(sym, start_date, end_date)` | `vector<EodTick>` | EOD index data |
+| `index_history_ohlc(sym, start_date, end_date, interval)` | `vector<OhlcTick>` | Intraday OHLC for an index |
 | `index_history_price(sym, date, interval)` | `vector<PriceTick>` | Intraday price history |
 
 #### Index - At-Time (1)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `index_at_time_price(sym, start, end, time)` | `vector<PriceTick>` | Index price at a specific time |
+| `index_at_time_price(sym, start_date, end_date, time)` | `vector<PriceTick>` | Index price at a specific time |
 
 #### Calendar (3)
 
@@ -225,7 +225,7 @@ auto client = tdx::Client::connect(creds, tdx::Config::production());
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `interest_rate_history_eod(sym, start, end)` | `vector<InterestRateTick>` | EOD interest rate history |
+| `interest_rate_history_eod(sym, start_date, end_date)` | `vector<InterestRateTick>` | EOD interest rate history |
 
 ### Standalone Functions
 

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -124,9 +124,9 @@ defer client.Close()
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `StockHistoryEOD(symbol, start, end)` | `([]EodTick, error)` | EOD data |
+| `StockHistoryEOD(symbol, startDate, endDate)` | `([]EodTick, error)` | EOD data |
 | `StockHistoryOHLC(symbol, date, interval)` | `([]OhlcTick, error)` | Intraday OHLC. `interval` accepts ms (`"60000"`) or shorthand (`"1m"`). |
-| `StockHistoryOHLCRange(symbol, start, end, interval)` | `([]OhlcTick, error)` | OHLC over date range. `interval` accepts ms or shorthand. |
+| `StockHistoryOHLCRange(symbol, startDate, endDate, interval)` | `([]OhlcTick, error)` | OHLC over date range. `interval` accepts ms or shorthand. |
 | `StockHistoryTrade(symbol, date)` | `([]TradeTick, error)` | All trades |
 | `StockHistoryQuote(symbol, date, interval)` | `([]QuoteTick, error)` | NBBO quotes. `interval` accepts ms or shorthand. |
 | `StockHistoryTradeQuote(symbol, date)` | `([]TradeQuoteTick, error)` | Trade+quote combined |
@@ -135,68 +135,68 @@ defer client.Close()
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `StockAtTimeTrade(symbol, start, end, time)` | `([]TradeTick, error)` | Trade at specific time across dates |
-| `StockAtTimeQuote(symbol, start, end, time)` | `([]QuoteTick, error)` | Quote at specific time across dates |
+| `StockAtTimeTrade(symbol, startDate, endDate, time)` | `([]TradeTick, error)` | Trade at specific time across dates |
+| `StockAtTimeQuote(symbol, startDate, endDate, time)` | `([]QuoteTick, error)` | Quote at specific time across dates |
 
 #### Option - List (5)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `OptionListSymbols()` | `([]string, error)` | Option underlyings |
-| `OptionListDates(reqType, sym, exp, strike, right)` | `([]string, error)` | Available dates |
+| `OptionListDates(reqType, sym, expiration, strike, right)` | `([]string, error)` | Available dates |
 | `OptionListExpirations(symbol)` | `([]string, error)` | Expiration dates |
-| `OptionListStrikes(symbol, exp)` | `([]string, error)` | Strike prices |
+| `OptionListStrikes(symbol, expiration)` | `([]string, error)` | Strike prices |
 | `OptionListContracts(reqType, symbol, date)` | `([]Contract, error)` | All contracts |
 
 #### Option - Snapshot (10)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `OptionSnapshotOHLC(sym, exp, strike, right)` | `([]OhlcTick, error)` | Latest OHLC |
-| `OptionSnapshotTrade(sym, exp, strike, right)` | `([]TradeTick, error)` | Latest trade |
-| `OptionSnapshotQuote(sym, exp, strike, right)` | `([]QuoteTick, error)` | Latest quote |
-| `OptionSnapshotOpenInterest(sym, exp, strike, right)` | `([]OpenInterestTick, error)` | Latest OI |
-| `OptionSnapshotMarketValue(sym, exp, strike, right)` | `([]MarketValueTick, error)` | Latest market value |
-| `OptionSnapshotGreeksImpliedVolatility(sym, exp, strike, right)` | `([]IVTick, error)` | IV snapshot |
-| `OptionSnapshotGreeksAll(sym, exp, strike, right)` | `([]GreeksTick, error)` | All Greeks snapshot |
-| `OptionSnapshotGreeksFirstOrder(sym, exp, strike, right)` | `([]GreeksTick, error)` | First-order Greeks |
-| `OptionSnapshotGreeksSecondOrder(sym, exp, strike, right)` | `([]GreeksTick, error)` | Second-order Greeks |
-| `OptionSnapshotGreeksThirdOrder(sym, exp, strike, right)` | `([]GreeksTick, error)` | Third-order Greeks |
+| `OptionSnapshotOHLC(sym, expiration, strike, right)` | `([]OhlcTick, error)` | Latest OHLC |
+| `OptionSnapshotTrade(sym, expiration, strike, right)` | `([]TradeTick, error)` | Latest trade |
+| `OptionSnapshotQuote(sym, expiration, strike, right)` | `([]QuoteTick, error)` | Latest quote |
+| `OptionSnapshotOpenInterest(sym, expiration, strike, right)` | `([]OpenInterestTick, error)` | Latest OI |
+| `OptionSnapshotMarketValue(sym, expiration, strike, right)` | `([]MarketValueTick, error)` | Latest market value |
+| `OptionSnapshotGreeksImpliedVolatility(sym, expiration, strike, right)` | `([]IVTick, error)` | IV snapshot |
+| `OptionSnapshotGreeksAll(sym, expiration, strike, right)` | `([]GreeksTick, error)` | All Greeks snapshot |
+| `OptionSnapshotGreeksFirstOrder(sym, expiration, strike, right)` | `([]GreeksTick, error)` | First-order Greeks |
+| `OptionSnapshotGreeksSecondOrder(sym, expiration, strike, right)` | `([]GreeksTick, error)` | Second-order Greeks |
+| `OptionSnapshotGreeksThirdOrder(sym, expiration, strike, right)` | `([]GreeksTick, error)` | Third-order Greeks |
 
 #### Option - History (6)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `OptionHistoryEOD(sym, exp, strike, right, start, end)` | `([]EodTick, error)` | EOD data |
-| `OptionHistoryOHLC(sym, exp, strike, right, date, interval)` | `([]OhlcTick, error)` | OHLC bars |
-| `OptionHistoryTrade(sym, exp, strike, right, date)` | `([]TradeTick, error)` | Trades |
-| `OptionHistoryQuote(sym, exp, strike, right, date, interval)` | `([]QuoteTick, error)` | Quotes |
-| `OptionHistoryTradeQuote(sym, exp, strike, right, date)` | `([]TradeQuoteTick, error)` | Trade+quote combined |
-| `OptionHistoryOpenInterest(sym, exp, strike, right, date)` | `([]OpenInterestTick, error)` | Open interest history |
+| `OptionHistoryEOD(sym, expiration, strike, right, startDate, endDate)` | `([]EodTick, error)` | EOD data |
+| `OptionHistoryOHLC(sym, expiration, strike, right, date, interval)` | `([]OhlcTick, error)` | OHLC bars |
+| `OptionHistoryTrade(sym, expiration, strike, right, date)` | `([]TradeTick, error)` | Trades |
+| `OptionHistoryQuote(sym, expiration, strike, right, date, interval)` | `([]QuoteTick, error)` | Quotes |
+| `OptionHistoryTradeQuote(sym, expiration, strike, right, date)` | `([]TradeQuoteTick, error)` | Trade+quote combined |
+| `OptionHistoryOpenInterest(sym, expiration, strike, right, date)` | `([]OpenInterestTick, error)` | Open interest history |
 
 #### Option - History Greeks (11)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `OptionHistoryGreeksEOD(sym, exp, strike, right, start, end)` | `([]GreeksTick, error)` | EOD Greeks |
-| `OptionHistoryGreeksEODWithOptions(sym, exp, strike, right, start, end, opts)` | `([]GreeksTick, error)` | EOD Greeks with `EndpointRequestOptions`, including builder parameters such as `StrikeRange` |
-| `OptionHistoryGreeksAll(sym, exp, strike, right, date, interval)` | `([]GreeksTick, error)` | All Greeks history |
-| `OptionHistoryTradeGreeksAll(sym, exp, strike, right, date)` | `([]GreeksTick, error)` | Greeks on each trade |
-| `OptionHistoryGreeksFirstOrder(sym, exp, strike, right, date, interval)` | `([]GreeksTick, error)` | First-order Greeks history |
-| `OptionHistoryTradeGreeksFirstOrder(sym, exp, strike, right, date)` | `([]GreeksTick, error)` | First-order on each trade |
-| `OptionHistoryGreeksSecondOrder(sym, exp, strike, right, date, interval)` | `([]GreeksTick, error)` | Second-order Greeks history |
-| `OptionHistoryTradeGreeksSecondOrder(sym, exp, strike, right, date)` | `([]GreeksTick, error)` | Second-order on each trade |
-| `OptionHistoryGreeksThirdOrder(sym, exp, strike, right, date, interval)` | `([]GreeksTick, error)` | Third-order Greeks history |
-| `OptionHistoryTradeGreeksThirdOrder(sym, exp, strike, right, date)` | `([]GreeksTick, error)` | Third-order on each trade |
-| `OptionHistoryGreeksImpliedVolatility(sym, exp, strike, right, date, interval)` | `([]IVTick, error)` | IV history |
-| `OptionHistoryTradeGreeksImpliedVolatility(sym, exp, strike, right, date)` | `([]IVTick, error)` | IV on each trade |
+| `OptionHistoryGreeksEOD(sym, expiration, strike, right, startDate, endDate)` | `([]GreeksTick, error)` | EOD Greeks |
+| `OptionHistoryGreeksEODWithOptions(sym, expiration, strike, right, startDate, endDate, opts)` | `([]GreeksTick, error)` | EOD Greeks with `EndpointRequestOptions`, including builder parameters such as `StrikeRange` |
+| `OptionHistoryGreeksAll(sym, expiration, strike, right, date, interval)` | `([]GreeksTick, error)` | All Greeks history |
+| `OptionHistoryTradeGreeksAll(sym, expiration, strike, right, date)` | `([]GreeksTick, error)` | Greeks on each trade |
+| `OptionHistoryGreeksFirstOrder(sym, expiration, strike, right, date, interval)` | `([]GreeksTick, error)` | First-order Greeks history |
+| `OptionHistoryTradeGreeksFirstOrder(sym, expiration, strike, right, date)` | `([]GreeksTick, error)` | First-order on each trade |
+| `OptionHistoryGreeksSecondOrder(sym, expiration, strike, right, date, interval)` | `([]GreeksTick, error)` | Second-order Greeks history |
+| `OptionHistoryTradeGreeksSecondOrder(sym, expiration, strike, right, date)` | `([]GreeksTick, error)` | Second-order on each trade |
+| `OptionHistoryGreeksThirdOrder(sym, expiration, strike, right, date, interval)` | `([]GreeksTick, error)` | Third-order Greeks history |
+| `OptionHistoryTradeGreeksThirdOrder(sym, expiration, strike, right, date)` | `([]GreeksTick, error)` | Third-order on each trade |
+| `OptionHistoryGreeksImpliedVolatility(sym, expiration, strike, right, date, interval)` | `([]IVTick, error)` | IV history |
+| `OptionHistoryTradeGreeksImpliedVolatility(sym, expiration, strike, right, date)` | `([]IVTick, error)` | IV on each trade |
 
 #### Option - At-Time (2)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `OptionAtTimeTrade(sym, exp, strike, right, start, end, time)` | `([]TradeTick, error)` | Trade at specific time across dates |
-| `OptionAtTimeQuote(sym, exp, strike, right, start, end, time)` | `([]QuoteTick, error)` | Quote at specific time across dates |
+| `OptionAtTimeTrade(sym, expiration, strike, right, startDate, endDate, time)` | `([]TradeTick, error)` | Trade at specific time across dates |
+| `OptionAtTimeQuote(sym, expiration, strike, right, startDate, endDate, time)` | `([]QuoteTick, error)` | Quote at specific time across dates |
 
 #### Index - List (2)
 
@@ -217,15 +217,15 @@ defer client.Close()
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `IndexHistoryEOD(symbol, start, end)` | `([]EodTick, error)` | EOD data |
-| `IndexHistoryOHLC(symbol, start, end, interval)` | `([]OhlcTick, error)` | OHLC bars |
+| `IndexHistoryEOD(symbol, startDate, endDate)` | `([]EodTick, error)` | EOD data |
+| `IndexHistoryOHLC(symbol, startDate, endDate, interval)` | `([]OhlcTick, error)` | OHLC bars |
 | `IndexHistoryPrice(symbol, date, interval)` | `([]PriceTick, error)` | Price history |
 
 #### Index - At-Time (1)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `IndexAtTimePrice(symbol, start, end, time)` | `([]PriceTick, error)` | Price at specific time across dates |
+| `IndexAtTimePrice(symbol, startDate, endDate, time)` | `([]PriceTick, error)` | Price at specific time across dates |
 
 #### Calendar (3)
 
@@ -239,7 +239,7 @@ defer client.Close()
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `InterestRateHistoryEOD(symbol, start, end)` | `([]InterestRate, error)` | Interest rate EOD history |
+| `InterestRateHistoryEOD(symbol, startDate, endDate)` | `([]InterestRate, error)` | Interest rate EOD history |
 
 ### Greeks (Standalone Functions)
 - `AllGreeks(spot, strike, rate, divYield, tte, price, right)` - returns `(*Greeks, error)` with 22 fields. `right` accepts `"C"`/`"P"` or `"call"`/`"put"` case-insensitively.

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.7"
+version = "8.0.8"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -112,53 +112,53 @@ return a `CalendarDayList`.
 | `stock_snapshot_trade(symbols)` | Latest trade snapshot |
 | `stock_snapshot_quote(symbols)` | Latest NBBO quote snapshot |
 | `stock_snapshot_market_value(symbols)` | Latest market value snapshot |
-| `stock_history_eod(symbol, start, end)` | End-of-day data |
+| `stock_history_eod(symbol, start_date, end_date)` | End-of-day data |
 | `stock_history_ohlc(symbol, date, interval)` | Intraday OHLC bars. `interval` accepts ms (`"60000"`) or shorthand (`"1m"`). |
-| `stock_history_ohlc_range(symbol, start, end, interval)` | OHLC bars across date range. `interval` accepts ms or shorthand. |
+| `stock_history_ohlc_range(symbol, start_date, end_date, interval)` | OHLC bars across date range. `interval` accepts ms or shorthand. |
 | `stock_history_trade(symbol, date)` | All trades for a date |
 | `stock_history_quote(symbol, date, interval)` | NBBO quotes. `interval` accepts ms or shorthand. |
 | `stock_history_trade_quote(symbol, date)` | Combined trade+quote ticks |
-| `stock_at_time_trade(symbol, start, end, time)` | Trade at specific time across dates |
-| `stock_at_time_quote(symbol, start, end, time)` | Quote at specific time across dates |
+| `stock_at_time_trade(symbol, start_date, end_date, time)` | Trade at specific time across dates |
+| `stock_at_time_quote(symbol, start_date, end_date, time)` | Quote at specific time across dates |
 
 #### Option Methods (34)
 
 | Method | Description |
 |--------|-------------|
 | `option_list_symbols()` | Option underlying symbols |
-| `option_list_dates(request_type, symbol, exp, strike, right)` | Available dates for a contract |
+| `option_list_dates(request_type, symbol, expiration, strike, right)` | Available dates for a contract |
 | `option_list_expirations(symbol)` | Expiration dates |
-| `option_list_strikes(symbol, exp)` | Strike prices |
+| `option_list_strikes(symbol, expiration)` | Strike prices |
 | `option_list_contracts(request_type, symbol, date)` | All contracts for a date |
-| `option_snapshot_ohlc(symbol, exp, strike, right)` | Latest OHLC snapshot |
-| `option_snapshot_trade(symbol, exp, strike, right)` | Latest trade snapshot |
-| `option_snapshot_quote(symbol, exp, strike, right)` | Latest quote snapshot |
-| `option_snapshot_open_interest(symbol, exp, strike, right)` | Latest open interest |
-| `option_snapshot_market_value(symbol, exp, strike, right)` | Latest market value |
-| `option_snapshot_greeks_implied_volatility(symbol, exp, strike, right)` | IV snapshot |
-| `option_snapshot_greeks_all(symbol, exp, strike, right)` | All Greeks snapshot |
-| `option_snapshot_greeks_first_order(symbol, exp, strike, right)` | First-order Greeks |
-| `option_snapshot_greeks_second_order(symbol, exp, strike, right)` | Second-order Greeks |
-| `option_snapshot_greeks_third_order(symbol, exp, strike, right)` | Third-order Greeks |
-| `option_history_eod(symbol, exp, strike, right, start, end)` | EOD option data |
-| `option_history_ohlc(symbol, exp, strike, right, date, interval)` | Intraday OHLC bars |
-| `option_history_trade(symbol, exp, strike, right, date)` | All trades |
-| `option_history_quote(symbol, exp, strike, right, date, interval)` | NBBO quotes |
-| `option_history_trade_quote(symbol, exp, strike, right, date)` | Combined trade+quote |
-| `option_history_open_interest(symbol, exp, strike, right, date)` | Open interest history |
-| `option_history_greeks_eod(symbol, exp, strike, right, start, end, *, annual_dividend=None, rate_type=None, rate_value=None, version=None, underlyer_use_nbbo=None, max_dte=None, strike_range=None)` | EOD Greeks |
-| `option_history_greeks_all(symbol, exp, strike, right, date, interval)` | All Greeks history |
-| `option_history_trade_greeks_all(symbol, exp, strike, right, date)` | Greeks on each trade |
-| `option_history_greeks_first_order(symbol, exp, strike, right, date, interval)` | First-order Greeks history |
-| `option_history_trade_greeks_first_order(symbol, exp, strike, right, date)` | First-order on each trade |
-| `option_history_greeks_second_order(symbol, exp, strike, right, date, interval)` | Second-order Greeks history |
-| `option_history_trade_greeks_second_order(symbol, exp, strike, right, date)` | Second-order on each trade |
-| `option_history_greeks_third_order(symbol, exp, strike, right, date, interval)` | Third-order Greeks history |
-| `option_history_trade_greeks_third_order(symbol, exp, strike, right, date)` | Third-order on each trade |
-| `option_history_greeks_implied_volatility(symbol, exp, strike, right, date, interval)` | IV history |
-| `option_history_trade_greeks_implied_volatility(symbol, exp, strike, right, date)` | IV on each trade |
-| `option_at_time_trade(symbol, exp, strike, right, start, end, time)` | Trade at specific time |
-| `option_at_time_quote(symbol, exp, strike, right, start, end, time)` | Quote at specific time |
+| `option_snapshot_ohlc(symbol, expiration, strike, right)` | Latest OHLC snapshot |
+| `option_snapshot_trade(symbol, expiration, strike, right)` | Latest trade snapshot |
+| `option_snapshot_quote(symbol, expiration, strike, right)` | Latest quote snapshot |
+| `option_snapshot_open_interest(symbol, expiration, strike, right)` | Latest open interest |
+| `option_snapshot_market_value(symbol, expiration, strike, right)` | Latest market value |
+| `option_snapshot_greeks_implied_volatility(symbol, expiration, strike, right)` | IV snapshot |
+| `option_snapshot_greeks_all(symbol, expiration, strike, right)` | All Greeks snapshot |
+| `option_snapshot_greeks_first_order(symbol, expiration, strike, right)` | First-order Greeks |
+| `option_snapshot_greeks_second_order(symbol, expiration, strike, right)` | Second-order Greeks |
+| `option_snapshot_greeks_third_order(symbol, expiration, strike, right)` | Third-order Greeks |
+| `option_history_eod(symbol, expiration, strike, right, start_date, end_date)` | EOD option data |
+| `option_history_ohlc(symbol, expiration, strike, right, date, interval)` | Intraday OHLC bars |
+| `option_history_trade(symbol, expiration, strike, right, date)` | All trades |
+| `option_history_quote(symbol, expiration, strike, right, date, interval)` | NBBO quotes |
+| `option_history_trade_quote(symbol, expiration, strike, right, date)` | Combined trade+quote |
+| `option_history_open_interest(symbol, expiration, strike, right, date)` | Open interest history |
+| `option_history_greeks_eod(symbol, expiration, strike, right, start_date, end_date, *, annual_dividend=None, rate_type=None, rate_value=None, version=None, underlyer_use_nbbo=None, max_dte=None, strike_range=None)` | EOD Greeks |
+| `option_history_greeks_all(symbol, expiration, strike, right, date, interval)` | All Greeks history |
+| `option_history_trade_greeks_all(symbol, expiration, strike, right, date)` | Greeks on each trade |
+| `option_history_greeks_first_order(symbol, expiration, strike, right, date, interval)` | First-order Greeks history |
+| `option_history_trade_greeks_first_order(symbol, expiration, strike, right, date)` | First-order on each trade |
+| `option_history_greeks_second_order(symbol, expiration, strike, right, date, interval)` | Second-order Greeks history |
+| `option_history_trade_greeks_second_order(symbol, expiration, strike, right, date)` | Second-order on each trade |
+| `option_history_greeks_third_order(symbol, expiration, strike, right, date, interval)` | Third-order Greeks history |
+| `option_history_trade_greeks_third_order(symbol, expiration, strike, right, date)` | Third-order on each trade |
+| `option_history_greeks_implied_volatility(symbol, expiration, strike, right, date, interval)` | IV history |
+| `option_history_trade_greeks_implied_volatility(symbol, expiration, strike, right, date)` | IV on each trade |
+| `option_at_time_trade(symbol, expiration, strike, right, start_date, end_date, time)` | Trade at specific time |
+| `option_at_time_quote(symbol, expiration, strike, right, start_date, end_date, time)` | Quote at specific time |
 
 #### Index Methods (9)
 
@@ -169,10 +169,10 @@ return a `CalendarDayList`.
 | `index_snapshot_ohlc(symbols)` | Latest OHLC snapshot |
 | `index_snapshot_price(symbols)` | Latest price snapshot |
 | `index_snapshot_market_value(symbols)` | Latest market value snapshot |
-| `index_history_eod(symbol, start, end)` | End-of-day index data |
-| `index_history_ohlc(symbol, start, end, interval)` | Intraday OHLC bars |
+| `index_history_eod(symbol, start_date, end_date)` | End-of-day index data |
+| `index_history_ohlc(symbol, start_date, end_date, interval)` | Intraday OHLC bars |
 | `index_history_price(symbol, date, interval)` | Intraday price history |
-| `index_at_time_price(symbol, start, end, time)` | Price at specific time |
+| `index_at_time_price(symbol, start_date, end_date, time)` | Price at specific time |
 
 #### Calendar Methods (3)
 
@@ -186,7 +186,7 @@ return a `CalendarDayList`.
 
 | Method | Description |
 |--------|-------------|
-| `interest_rate_history_eod(symbol, start, end)` | Interest rate EOD history |
+| `interest_rate_history_eod(symbol, start_date, end_date)` | Interest rate EOD history |
 
 ### Streaming (via `ThetaDataDx`)
 Real-time streaming is accessed through the same `ThetaDataDx` instance.

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "napi",
  "napi-build",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.7"
+version = "8.0.8"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm64')
         const bindingPackageVersion = require('thetadatadx-android-arm64/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm-eabi')
         const bindingPackageVersion = require('thetadatadx-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-gnu')
         const bindingPackageVersion = require('thetadatadx-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-ia32-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-arm64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('thetadatadx-darwin-universal')
       const bindingPackageVersion = require('thetadatadx-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-x64')
         const bindingPackageVersion = require('thetadatadx-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-arm64')
         const bindingPackageVersion = require('thetadatadx-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-x64')
         const bindingPackageVersion = require('thetadatadx-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-arm64')
         const bindingPackageVersion = require('thetadatadx-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-musleabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-gnueabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-ppc64-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-s390x-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm64')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-x64')
         const bindingPackageVersion = require('thetadatadx-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '8.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.4",
-    "thetadatadx-darwin-arm64": "8.0.4",
-    "thetadatadx-win32-x64-msvc": "8.0.4"
+    "thetadatadx-linux-x64-gnu": "8.0.8",
+    "thetadatadx-darwin-arm64": "8.0.8",
+    "thetadatadx-win32-x64-msvc": "8.0.8"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.7"
+version = "8.0.8"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.7"
+version = "8.0.8"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.7"
+version = "8.0.8"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.7"
+version = "8.0.8"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary
Follow-up patch to v8.0.7. Addresses all 17 audit findings surfaced against the code-strip release. No behaviour changes; every item is documentation, packaging metadata, or tooling hygiene.

- 2 rustdoc broken/redundant intra-doc links in `tdbe` (plus a cascade of pre-existing rustdoc breakage in `thetadatadx` that was previously masked by the `tdbe` failures — now resolved end to end).
- TypeScript loader + root package optionalDependencies brought coherent at `8.0.8`; every platform subpackage under `sdks/typescript/npm/` bumped in lockstep.
- `CHANGELOG.md` + `docs-site/docs/changelog.md` restructured: v8.0.6 content (snapshot fast-path, Rust `frames` module) split back out of the `[8.0.7]` section into a standalone `[8.0.6]` entry. `### Internal` renamed to `### Changed` to stay within Keep a Changelog vocabulary.
- Dead refs to `mdds/normalize.rs`, `tdbe::errors`, and other v8.0.7-removed modules purged from `docs/`, `docs-site/docs/`, and in-crate docstrings.
- DataFrame-terminals section in `docs-site/docs/api-reference.md` narrowed: terminals attach to `<TickName>List` list-wrapper types only; snapshot-fast-path endpoints return plain `list[TickClass]`.
- Python / Go / C++ SDK README parameter-name tables aligned with SSOT (`expiration`, `start_date` / `startDate`, `end_date` / `endDate`).
- `deny.toml`: unused license allowances pruned; upstream-rooted duplicate-version warnings (disruptor, ring, petgraph) listed under `[bans].skip-tree`. `cargo deny check` is now zero-warning.
- `docs-site/docs/.vitepress/config.ts`: `vite.build.chunkSizeWarningLimit` raised to 1500 kB to silence the non-actionable Mermaid/Vue vendored-chunk warning.

## Version bumps
- Every Rust crate `8.0.7 → 8.0.8`: `thetadatadx`, `thetadatadx-ffi`, `thetadatadx-cli`, `thetadatadx-server`, `thetadatadx-mcp`, `thetadatadx-py`, `thetadatadx-napi`.
- `sdks/typescript/package.json` root and three `npm/*/package.json` subpackages to `8.0.8`.
- `tdbe` stays at `0.12.0` (rustdoc fixes are non-breaking).
- All five `Cargo.lock` files refreshed.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features "polars,arrow" -- -D warnings`
- [x] `cargo clippy` on each of `sdks/python`, `sdks/typescript`, `tools/mcp`, `tools/server`
- [x] `cargo test --workspace --no-fail-fast`
- [x] `cargo doc --workspace --no-deps --all-features` — zero warnings/errors
- [x] `cargo deny check` — zero warnings
- [x] `regen_byte_identical.sh` — 584 files byte-identical
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces -- --check`
- [x] `scripts/check_docs_consistency.py`, `scripts/check_tier_badges.py`
- [x] `docs-site` vitepress build — no chunk warnings
- [x] `PYO3_PYTHON=/usr/bin/python3 cargo test --manifest-path sdks/python/Cargo.toml --lib`
- [x] Banned-phrase greps on non-changelog files: 0 hits