### PR TITLE
fix(go): scalar symbol literal in validator + finish v8.0.10 docstring defaults

### DIFF
--- a/crates/thetadatadx/build_support/endpoints/helpers.rs
+++ b/crates/thetadatadx/build_support/endpoints/helpers.rs
@@ -933,11 +933,14 @@ pub(super) fn python_arg_literal(param: &GeneratedParam, value: &str) -> String 
 }
 
 /// Render a single arg string as a Go literal expression.
-pub(super) fn go_arg_literal(param: &GeneratedParam, value: &str) -> String {
-    match param.param_type.as_str() {
-        "Symbols" => format!("[]string{{\"{value}\"}}"),
-        _ => format!("\"{value}\""),
-    }
+pub(super) fn go_arg_literal(_param: &GeneratedParam, value: &str) -> String {
+    // The Go SDK keeps scalar signatures (`StockSnapshotOHLC(symbol string, ...)`)
+    // and exposes bulk variants via a `*Bulk` suffix (`StockSnapshotOHLCBulk(
+    // symbols []string, ...)`). Generated validator cells use single-value
+    // fixtures and therefore must target the scalar form — passing a
+    // `[]string{...}` literal tripwires the Go type checker on every
+    // `Symbols`-param endpoint and turns SDK Bindings CI red.
+    format!("\"{value}\"")
 }
 
 /// Render a single arg string as a C++ literal expression.

--- a/crates/thetadatadx/build_support/endpoints/helpers.rs
+++ b/crates/thetadatadx/build_support/endpoints/helpers.rs
@@ -139,12 +139,49 @@ pub(super) fn optional_getter_name(param_type: &str) -> &'static str {
 /// Compose the full doc body for an endpoint: native description first,
 /// vendor block (if any) appended with a blank separator line.
 pub(super) fn compose_endpoint_doc(endpoint: &GeneratedEndpoint) -> String {
-    match endpoint.vendor_docstring.as_deref() {
+    let mut body = match endpoint.vendor_docstring.as_deref() {
         Some(vendor) if !vendor.is_empty() => {
             format!("{}\n\n{vendor}", endpoint.description)
         }
         _ => endpoint.description.clone(),
+    };
+    let defaults_block = render_param_defaults_block(endpoint);
+    if !defaults_block.is_empty() {
+        if !body.ends_with('\n') {
+            body.push('\n');
+        }
+        body.push('\n');
+        body.push_str(&defaults_block);
     }
+    body
+}
+
+/// Render the "Defaults (upstream)" block surfacing every param whose
+/// `default` is set in `endpoint_surface.toml`. Single SSOT origin so
+/// `help()` (Python), JSDoc hover (TypeScript), and `cargo doc` (Rust)
+/// all agree. String defaults render with quotes; numeric / bool
+/// defaults render bare. Empty output when no param has a default.
+fn render_param_defaults_block(endpoint: &GeneratedEndpoint) -> String {
+    use std::fmt::Write as _;
+    let mut rows: Vec<(String, String)> = Vec::new();
+    for param in &endpoint.params {
+        let Some(default) = param.default.as_deref() else {
+            continue;
+        };
+        let value = match param.param_type.as_str() {
+            "Bool" | "Int" | "Float" => default.to_string(),
+            _ => format!("\"{default}\""),
+        };
+        rows.push((param.name.clone(), value));
+    }
+    if rows.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("Defaults (upstream):\n");
+    for (name, value) in rows {
+        writeln!(out, "- `{name}`: `{value}`").unwrap();
+    }
+    out
 }
 
 /// Format an endpoint doc body as a sequence of Rust `///` lines with the

--- a/crates/thetadatadx/build_support/endpoints/render/mdds.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/mdds.rs
@@ -9,6 +9,7 @@
 
 use std::fmt::Write as _;
 
+use super::super::helpers::compose_endpoint_doc;
 use super::super::helpers::{
     direct_date_arg_name, direct_method_arg_name, direct_optional_kind_and_default,
     direct_optional_rust_type, direct_optional_setter_arg_type, direct_optional_setter_assign_expr,
@@ -20,7 +21,7 @@ use super::super::model::{GeneratedEndpoint, ProtoField};
 
 pub(super) fn generate_mdds_list_endpoint(out: &mut String, endpoint: &GeneratedEndpoint) {
     writeln!(out, "list_endpoint! {{").unwrap();
-    writeln!(out, "    #[doc = {:?}]", endpoint.description).unwrap();
+    writeln!(out, "    #[doc = {:?}]", compose_endpoint_doc(endpoint)).unwrap();
     writeln!(
         out,
         "    #[doc = {:?}]",
@@ -79,7 +80,7 @@ pub(super) fn generate_mdds_list_endpoint(out: &mut String, endpoint: &Generated
 
 pub(super) fn generate_mdds_parsed_endpoint(out: &mut String, endpoint: &GeneratedEndpoint) {
     writeln!(out, "parsed_endpoint! {{").unwrap();
-    writeln!(out, "    #[doc = {:?}]", endpoint.description).unwrap();
+    writeln!(out, "    #[doc = {:?}]", compose_endpoint_doc(endpoint)).unwrap();
     writeln!(
         out,
         "    #[doc = {:?}]",

--- a/crates/thetadatadx/build_support/endpoints/render/typescript.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/typescript.rs
@@ -47,7 +47,10 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
     let camel_name = to_camel_case(&endpoint.name);
     let mut out = String::new();
 
-    out.push_str(&render_rust_doc_block("    ", &compose_endpoint_doc(endpoint)));
+    out.push_str(&render_rust_doc_block(
+        "    ",
+        &compose_endpoint_doc(endpoint),
+    ));
     writeln!(out, "    #[napi(js_name = \"{camel_name}\")]").unwrap();
     writeln!(out, "    pub fn {name}(", name = endpoint.name).unwrap();
     out.push_str("        &self,\n");

--- a/crates/thetadatadx/build_support/endpoints/render/typescript.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/typescript.rs
@@ -9,6 +9,8 @@
 
 use std::fmt::Write as _;
 
+use super::super::helpers::compose_endpoint_doc;
+use super::super::helpers::render_rust_doc_block;
 use super::super::helpers::{
     builder_params, is_streaming_endpoint, is_time_arg, method_params, sdk_method_arg_name,
     to_camel_case, ts_class_name, ts_class_vec_converter,
@@ -45,7 +47,7 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
     let camel_name = to_camel_case(&endpoint.name);
     let mut out = String::new();
 
-    writeln!(out, "    /// {}", endpoint.description).unwrap();
+    out.push_str(&render_rust_doc_block("    ", &compose_endpoint_doc(endpoint)));
     writeln!(out, "    #[napi(js_name = \"{camel_name}\")]").unwrap();
     writeln!(out, "    pub fn {name}(", name = endpoint.name).unwrap();
     out.push_str("        &self,\n");

--- a/sdks/go/validate.go
+++ b/sdks/go/validate.go
@@ -84,14 +84,14 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: required params set, no optionals — baseline wire path
 	{
 		t0 := time.Now()
-		v, e := c.StockSnapshotOHLC([]string{"AAPL"}, WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.StockSnapshotOHLC("AAPL", WithTimeoutMs(perCellTimeoutMs))
 		records = classify("stock_snapshot_ohlc", "concrete", "value", "required params set, no optionals — baseline wire path", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// stock_snapshot_ohlc::with_min_time
 	//   rationale: min_time=09:45:00 optional filter wiring
 	{
 		t0 := time.Now()
-		v, e := c.StockSnapshotOHLC([]string{"AAPL"}, WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.StockSnapshotOHLC("AAPL", WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
 		records = classify("stock_snapshot_ohlc", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 
@@ -99,14 +99,14 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: required params set, no optionals — baseline wire path
 	{
 		t0 := time.Now()
-		v, e := c.StockSnapshotTrade([]string{"AAPL"}, WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.StockSnapshotTrade("AAPL", WithTimeoutMs(perCellTimeoutMs))
 		records = classify("stock_snapshot_trade", "concrete", "standard", "required params set, no optionals — baseline wire path", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// stock_snapshot_trade::with_min_time
 	//   rationale: min_time=09:45:00 optional filter wiring
 	{
 		t0 := time.Now()
-		v, e := c.StockSnapshotTrade([]string{"AAPL"}, WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.StockSnapshotTrade("AAPL", WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
 		records = classify("stock_snapshot_trade", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 
@@ -114,14 +114,14 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: required params set, no optionals — baseline wire path
 	{
 		t0 := time.Now()
-		v, e := c.StockSnapshotQuote([]string{"AAPL"}, WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.StockSnapshotQuote("AAPL", WithTimeoutMs(perCellTimeoutMs))
 		records = classify("stock_snapshot_quote", "concrete", "value", "required params set, no optionals — baseline wire path", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// stock_snapshot_quote::with_min_time
 	//   rationale: min_time=09:45:00 optional filter wiring
 	{
 		t0 := time.Now()
-		v, e := c.StockSnapshotQuote([]string{"AAPL"}, WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.StockSnapshotQuote("AAPL", WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
 		records = classify("stock_snapshot_quote", "with_min_time", "value", "min_time=09:45:00 optional filter wiring", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 
@@ -129,14 +129,14 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: required params set, no optionals — baseline wire path
 	{
 		t0 := time.Now()
-		v, e := c.StockSnapshotMarketValue([]string{"AAPL"}, WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.StockSnapshotMarketValue("AAPL", WithTimeoutMs(perCellTimeoutMs))
 		records = classify("stock_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// stock_snapshot_market_value::with_min_time
 	//   rationale: min_time=09:45:00 optional filter wiring
 	{
 		t0 := time.Now()
-		v, e := c.StockSnapshotMarketValue([]string{"AAPL"}, WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.StockSnapshotMarketValue("AAPL", WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
 		records = classify("stock_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 
@@ -2469,14 +2469,14 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: required params set, no optionals — baseline wire path
 	{
 		t0 := time.Now()
-		v, e := c.IndexSnapshotOHLC([]string{"SPX"}, WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.IndexSnapshotOHLC("SPX", WithTimeoutMs(perCellTimeoutMs))
 		records = classify("index_snapshot_ohlc", "concrete", "standard", "required params set, no optionals — baseline wire path", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// index_snapshot_ohlc::with_min_time
 	//   rationale: min_time=09:45:00 optional filter wiring
 	{
 		t0 := time.Now()
-		v, e := c.IndexSnapshotOHLC([]string{"SPX"}, WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.IndexSnapshotOHLC("SPX", WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
 		records = classify("index_snapshot_ohlc", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 
@@ -2484,14 +2484,14 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: required params set, no optionals — baseline wire path
 	{
 		t0 := time.Now()
-		v, e := c.IndexSnapshotPrice([]string{"SPX"}, WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.IndexSnapshotPrice("SPX", WithTimeoutMs(perCellTimeoutMs))
 		records = classify("index_snapshot_price", "concrete", "standard", "required params set, no optionals — baseline wire path", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// index_snapshot_price::with_min_time
 	//   rationale: min_time=09:45:00 optional filter wiring
 	{
 		t0 := time.Now()
-		v, e := c.IndexSnapshotPrice([]string{"SPX"}, WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.IndexSnapshotPrice("SPX", WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
 		records = classify("index_snapshot_price", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 
@@ -2499,14 +2499,14 @@ func ValidateAllEndpoints(c *Client) (int, int, int, []CellRecord) {
 	//   rationale: required params set, no optionals — baseline wire path
 	{
 		t0 := time.Now()
-		v, e := c.IndexSnapshotMarketValue([]string{"SPX"}, WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.IndexSnapshotMarketValue("SPX", WithTimeoutMs(perCellTimeoutMs))
 		records = classify("index_snapshot_market_value", "concrete", "standard", "required params set, no optionals — baseline wire path", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 	// index_snapshot_market_value::with_min_time
 	//   rationale: min_time=09:45:00 optional filter wiring
 	{
 		t0 := time.Now()
-		v, e := c.IndexSnapshotMarketValue([]string{"SPX"}, WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
+		v, e := c.IndexSnapshotMarketValue("SPX", WithMinTime("09:45:00"), WithTimeoutMs(perCellTimeoutMs))
 		records = classify("index_snapshot_market_value", "with_min_time", "standard", "min_time=09:45:00 optional filter wiring", v, e, time.Since(t0), &pass, &skip, &fail, records)
 	}
 

--- a/sdks/python/src/historical_methods.rs
+++ b/sdks/python/src/historical_methods.rs
@@ -136,6 +136,9 @@ impl StockListDatesBuilder {
 /// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
 /// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
 /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+///
+/// Defaults (upstream):
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockSnapshotOhlcBuilder")]
 pub struct StockSnapshotOhlcBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -227,6 +230,9 @@ impl StockSnapshotOhlcBuilder {
 /// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
 ///
 /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+///
+/// Defaults (upstream):
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockSnapshotTradeBuilder")]
 pub struct StockSnapshotTradeBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -318,6 +324,9 @@ impl StockSnapshotTradeBuilder {
 /// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
 /// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
 /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+///
+/// Defaults (upstream):
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockSnapshotQuoteBuilder")]
 pub struct StockSnapshotQuoteBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -409,6 +418,9 @@ impl StockSnapshotQuoteBuilder {
 /// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
 /// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
 /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+///
+/// Defaults (upstream):
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockSnapshotMarketValueBuilder")]
 pub struct StockSnapshotMarketValueBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -575,6 +587,12 @@ impl StockHistoryEodBuilder {
 /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
 /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockHistoryOhlcBuilder")]
 pub struct StockHistoryOhlcBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -732,6 +750,11 @@ impl StockHistoryOhlcBuilder {
 ///
 /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockHistoryTradeBuilder")]
 pub struct StockHistoryTradeBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -876,6 +899,12 @@ impl StockHistoryTradeBuilder {
 /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
 /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockHistoryQuoteBuilder")]
 pub struct StockHistoryQuoteBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -1033,6 +1062,12 @@ impl StockHistoryQuoteBuilder {
 ///
 /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `exclusive`: `true`
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockHistoryTradeQuoteBuilder")]
 pub struct StockHistoryTradeQuoteBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -1195,6 +1230,9 @@ impl StockHistoryTradeQuoteBuilder {
 /// #### Historical request:
 /// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
 /// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+///
+/// Defaults (upstream):
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockAtTimeTradeBuilder")]
 pub struct StockAtTimeTradeBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -1300,6 +1338,9 @@ impl StockAtTimeTradeBuilder {
 ///
 /// #### Historical request:
 ///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+///
+/// Defaults (upstream):
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockAtTimeQuoteBuilder")]
 pub struct StockAtTimeQuoteBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -1456,6 +1497,10 @@ impl OptionListSymbolsBuilder {
 ///
 /// Lists all dates of data that are available for an option with a given symbol, request type, and expiration.
 /// This endpoint is updated overnight.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionListDatesBuilder")]
 pub struct OptionListDatesBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -1775,6 +1820,10 @@ impl OptionListContractsBuilder {
 ///
 /// - Retrieve a real-time last ohlc of an option contract for the trading day.
 /// - You might need to change the default expiration date to a different date if it is past the current date.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotOhlcBuilder")]
 pub struct OptionSnapshotOhlcBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -1918,6 +1967,10 @@ impl OptionSnapshotOhlcBuilder {
 /// - Retrieve the real-time last trade of an option contract.
 /// - You might need to change the default expiration date to a different date if it is past the current date.
 /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotTradeBuilder")]
 pub struct OptionSnapshotTradeBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -2046,6 +2099,10 @@ impl OptionSnapshotTradeBuilder {
 /// - Retrieve a real-time last NBBO quote of an option contract.
 /// - You might need to change the default expiration date to a different date if it is past the current date.
 /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotQuoteBuilder")]
 pub struct OptionSnapshotQuoteBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -2190,6 +2247,10 @@ impl OptionSnapshotQuoteBuilder {
 /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the of the previous trading day. 
 /// - You might need to change the default expiration date to a different date if it is past the current date.
 /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotOpenInterestBuilder")]
 pub struct OptionSnapshotOpenInterestBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -2331,6 +2392,10 @@ impl OptionSnapshotOpenInterestBuilder {
 /// Get the latest market value snapshot for an option contract.
 ///
 /// * Returns a real-time market value derived from the last NBBO quote of an option contract.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotMarketValueBuilder")]
 pub struct OptionSnapshotMarketValueBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -2475,6 +2540,13 @@ impl OptionSnapshotMarketValueBuilder {
 /// of the option respectively. The underlying price represents whatever the last underlying price was at the
 /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
 /// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
+/// - `use_market_value`: `false`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotGreeksImpliedVolatilityBuilder")]
 pub struct OptionSnapshotGreeksImpliedVolatilityBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -2709,6 +2781,13 @@ impl OptionSnapshotGreeksImpliedVolatilityBuilder {
 /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
 /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
+/// - `use_market_value`: `false`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotGreeksAllBuilder")]
 pub struct OptionSnapshotGreeksAllBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -2943,6 +3022,13 @@ impl OptionSnapshotGreeksAllBuilder {
 /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
 /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
+/// - `use_market_value`: `false`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotGreeksFirstOrderBuilder")]
 pub struct OptionSnapshotGreeksFirstOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -3177,6 +3263,13 @@ impl OptionSnapshotGreeksFirstOrderBuilder {
 /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
 /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
+/// - `use_market_value`: `false`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotGreeksSecondOrderBuilder")]
 pub struct OptionSnapshotGreeksSecondOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -3411,6 +3504,13 @@ impl OptionSnapshotGreeksSecondOrderBuilder {
 /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
 /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
+/// - `use_market_value`: `false`
 #[pyclass(module = "thetadatadx", name = "OptionSnapshotGreeksThirdOrderBuilder")]
 pub struct OptionSnapshotGreeksThirdOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -3645,6 +3745,10 @@ impl OptionSnapshotGreeksThirdOrderBuilder {
 /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
 /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
 /// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryEodBuilder")]
 pub struct OptionHistoryEodBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -3791,6 +3895,13 @@ impl OptionHistoryEodBuilder {
 /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
 /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryOhlcBuilder")]
 pub struct OptionHistoryOhlcBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -3989,6 +4100,12 @@ impl OptionHistoryOhlcBuilder {
 /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
 /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryTradeBuilder")]
 pub struct OptionHistoryTradeBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -4186,6 +4303,13 @@ impl OptionHistoryTradeBuilder {
 /// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
 /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryQuoteBuilder")]
 pub struct OptionHistoryQuoteBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -4399,6 +4523,13 @@ impl OptionHistoryQuoteBuilder {
 /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
 /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `exclusive`: `true`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryTradeQuoteBuilder")]
 pub struct OptionHistoryTradeQuoteBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -4611,6 +4742,10 @@ impl OptionHistoryTradeQuoteBuilder {
 /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
 /// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
 /// - The reported open interest represents the open interest at the end of the previous trading day.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryOpenInterestBuilder")]
 pub struct OptionHistoryOpenInterestBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -4778,6 +4913,13 @@ impl OptionHistoryOpenInterestBuilder {
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
 /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
 /// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
+/// - `underlyer_use_nbbo`: `false`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryGreeksEodBuilder")]
 pub struct OptionHistoryGreeksEodBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -5000,6 +5142,15 @@ impl OptionHistoryGreeksEodBuilder {
 /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryGreeksAllBuilder")]
 pub struct OptionHistoryGreeksAllBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -5258,6 +5409,14 @@ impl OptionHistoryGreeksAllBuilder {
 /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryTradeGreeksAllBuilder")]
 pub struct OptionHistoryTradeGreeksAllBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -5516,6 +5675,15 @@ impl OptionHistoryTradeGreeksAllBuilder {
 /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryGreeksFirstOrderBuilder")]
 pub struct OptionHistoryGreeksFirstOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -5774,6 +5942,14 @@ impl OptionHistoryGreeksFirstOrderBuilder {
 /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryTradeGreeksFirstOrderBuilder")]
 pub struct OptionHistoryTradeGreeksFirstOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -6032,6 +6208,15 @@ impl OptionHistoryTradeGreeksFirstOrderBuilder {
 /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryGreeksSecondOrderBuilder")]
 pub struct OptionHistoryGreeksSecondOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -6290,6 +6475,14 @@ impl OptionHistoryGreeksSecondOrderBuilder {
 /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryTradeGreeksSecondOrderBuilder")]
 pub struct OptionHistoryTradeGreeksSecondOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -6548,6 +6741,15 @@ impl OptionHistoryTradeGreeksSecondOrderBuilder {
 /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryGreeksThirdOrderBuilder")]
 pub struct OptionHistoryGreeksThirdOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -6806,6 +7008,14 @@ impl OptionHistoryGreeksThirdOrderBuilder {
 /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryTradeGreeksThirdOrderBuilder")]
 pub struct OptionHistoryTradeGreeksThirdOrderBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -7063,6 +7273,15 @@ impl OptionHistoryTradeGreeksThirdOrderBuilder {
 /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryGreeksImpliedVolatilityBuilder")]
 pub struct OptionHistoryGreeksImpliedVolatilityBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -7320,6 +7539,14 @@ impl OptionHistoryGreeksImpliedVolatilityBuilder {
 /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
 /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `rate_type`: `"sofr"`
+/// - `version`: `"latest"`
 #[pyclass(module = "thetadatadx", name = "OptionHistoryTradeGreeksImpliedVolatilityBuilder")]
 pub struct OptionHistoryTradeGreeksImpliedVolatilityBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -7578,6 +7805,10 @@ impl OptionHistoryTradeGreeksImpliedVolatilityBuilder {
 /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
 /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
 /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionAtTimeTradeBuilder")]
 pub struct OptionAtTimeTradeBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -7732,6 +7963,10 @@ impl OptionAtTimeTradeBuilder {
 ///
 /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
 /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
+///
+/// Defaults (upstream):
+/// - `strike`: `"*"`
+/// - `right`: `"both"`
 #[pyclass(module = "thetadatadx", name = "OptionAtTimeQuoteBuilder")]
 pub struct OptionAtTimeQuoteBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -8308,6 +8543,11 @@ impl IndexHistoryEodBuilder {
 /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
 /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
 /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+///
+/// Defaults (upstream):
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
 #[pyclass(module = "thetadatadx", name = "IndexHistoryOhlcBuilder")]
 pub struct IndexHistoryOhlcBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -8431,6 +8671,11 @@ impl IndexHistoryOhlcBuilder {
 /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
 /// - A price update from the exchange is omitted if the price remained the same from the previous update.
 /// - Multi-day requests are limited to 1 month of data.
+///
+/// Defaults (upstream):
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
 #[pyclass(module = "thetadatadx", name = "IndexHistoryPriceBuilder")]
 pub struct IndexHistoryPriceBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -8900,6 +9145,12 @@ impl InterestRateHistoryEodBuilder {
 }
 
 /// Fetch intraday OHLC bars across a date range.
+///
+/// Defaults (upstream):
+/// - `interval`: `"1s"`
+/// - `start_time`: `"09:30:00"`
+/// - `end_time`: `"16:00:00"`
+/// - `venue`: `"nqb"`
 #[pyclass(module = "thetadatadx", name = "StockHistoryOhlcRangeBuilder")]
 pub struct StockHistoryOhlcRangeBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDx>,
@@ -9247,6 +9498,9 @@ impl ThetaDataDx {
     /// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
     /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbols, *, venue=None, min_time=None, timeout_ms=None))]
     fn stock_snapshot_ohlc(
         &self,
@@ -9277,6 +9531,9 @@ impl ThetaDataDx {
     /// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
     /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -9333,6 +9590,9 @@ impl ThetaDataDx {
     /// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     ///
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbols, *, venue=None, min_time=None, timeout_ms=None))]
     fn stock_snapshot_trade(
         &self,
@@ -9362,6 +9622,9 @@ impl ThetaDataDx {
     /// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     ///
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -9418,6 +9681,9 @@ impl ThetaDataDx {
     /// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbols, *, venue=None, min_time=None, timeout_ms=None))]
     fn stock_snapshot_quote(
         &self,
@@ -9447,6 +9713,9 @@ impl ThetaDataDx {
     /// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -9503,6 +9772,9 @@ impl ThetaDataDx {
     /// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbols, *, venue=None, min_time=None, timeout_ms=None))]
     fn stock_snapshot_market_value(
         &self,
@@ -9532,6 +9804,9 @@ impl ThetaDataDx {
     /// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -9657,6 +9932,12 @@ impl ThetaDataDx {
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
     /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbol, date, *, interval=None, start_time=None, end_time=None, venue=None, start_date=None, end_date=None, timeout_ms=None))]
     fn stock_history_ohlc(
         &self,
@@ -9702,6 +9983,12 @@ impl ThetaDataDx {
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
     /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -9779,6 +10066,11 @@ impl ThetaDataDx {
     ///
     /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbol, date, *, start_time=None, end_time=None, venue=None, start_date=None, end_date=None, timeout_ms=None))]
     fn stock_history_trade(
         &self,
@@ -9819,6 +10111,11 @@ impl ThetaDataDx {
     ///
     /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -9893,6 +10190,12 @@ impl ThetaDataDx {
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
     /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbol, date, *, interval=None, start_time=None, end_time=None, venue=None, start_date=None, end_date=None, timeout_ms=None))]
     fn stock_history_quote(
         &self,
@@ -9939,6 +10242,12 @@ impl ThetaDataDx {
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
     /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -10016,6 +10325,12 @@ impl ThetaDataDx {
     ///
     /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `exclusive`: `true`
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbol, date, *, start_time=None, end_time=None, exclusive=true, venue=None, start_date=None, end_date=None, timeout_ms=None))]
     fn stock_history_trade_quote(
         &self,
@@ -10060,6 +10375,12 @@ impl ThetaDataDx {
     ///
     /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `exclusive`: `true`
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -10142,6 +10463,9 @@ impl ThetaDataDx {
     /// #### Historical request:
     /// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
     /// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbol, start_date, end_date, time_of_day, *, venue=None, timeout_ms=None))]
     fn stock_at_time_trade(
         &self,
@@ -10173,6 +10497,9 @@ impl ThetaDataDx {
     /// #### Historical request:
     /// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
     /// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -10236,6 +10563,9 @@ impl ThetaDataDx {
     ///
     /// #### Historical request:
     ///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbol, start_date, end_date, time_of_day, *, venue=None, timeout_ms=None))]
     fn stock_at_time_quote(
         &self,
@@ -10267,6 +10597,9 @@ impl ThetaDataDx {
     ///
     /// #### Historical request:
     ///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -10392,6 +10725,10 @@ impl ThetaDataDx {
     ///
     /// Lists all dates of data that are available for an option with a given symbol, request type, and expiration.
     /// This endpoint is updated overnight.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (request_type, symbol, expiration, *, timeout_ms=None))]
     fn option_list_dates(
         &self,
@@ -10419,6 +10756,10 @@ impl ThetaDataDx {
     ///
     /// Lists all dates of data that are available for an option with a given symbol, request type, and expiration.
     /// This endpoint is updated overnight.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -10709,6 +11050,10 @@ impl ThetaDataDx {
     ///
     /// - Retrieve a real-time last ohlc of an option contract for the trading day.
     /// - You might need to change the default expiration date to a different date if it is past the current date.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, max_dte=None, strike_range=None, min_time=None, timeout_ms=None))]
     fn option_snapshot_ohlc(
         &self,
@@ -10749,6 +11094,10 @@ impl ThetaDataDx {
     ///
     /// - Retrieve a real-time last ohlc of an option contract for the trading day.
     /// - You might need to change the default expiration date to a different date if it is past the current date.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -10822,6 +11171,10 @@ impl ThetaDataDx {
     /// - Retrieve the real-time last trade of an option contract.
     /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, strike_range=None, min_time=None, timeout_ms=None))]
     fn option_snapshot_trade(
         &self,
@@ -10859,6 +11212,10 @@ impl ThetaDataDx {
     /// - Retrieve the real-time last trade of an option contract.
     /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -10927,6 +11284,10 @@ impl ThetaDataDx {
     /// - Retrieve a real-time last NBBO quote of an option contract.
     /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, max_dte=None, strike_range=None, min_time=None, timeout_ms=None))]
     fn option_snapshot_quote(
         &self,
@@ -10968,6 +11329,10 @@ impl ThetaDataDx {
     /// - Retrieve a real-time last NBBO quote of an option contract.
     /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -11042,6 +11407,10 @@ impl ThetaDataDx {
     /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the of the previous trading day. 
     /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, max_dte=None, strike_range=None, min_time=None, timeout_ms=None))]
     fn option_snapshot_open_interest(
         &self,
@@ -11084,6 +11453,10 @@ impl ThetaDataDx {
     /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the of the previous trading day. 
     /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -11155,6 +11528,10 @@ impl ThetaDataDx {
     /// Get the latest market value snapshot for an option contract.
     ///
     /// * Returns a real-time market value derived from the last NBBO quote of an option contract.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, max_dte=None, strike_range=None, min_time=None, timeout_ms=None))]
     fn option_snapshot_market_value(
         &self,
@@ -11194,6 +11571,10 @@ impl ThetaDataDx {
     /// Get the latest market value snapshot for an option contract.
     ///
     /// * Returns a real-time market value derived from the last NBBO quote of an option contract.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -11268,6 +11649,13 @@ impl ThetaDataDx {
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
     /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
     /// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, annual_dividend=None, rate_type=None, rate_value=None, stock_price=None, version=None, max_dte=None, strike_range=None, min_time=None, use_market_value=false, timeout_ms=None))]
     fn option_snapshot_greeks_implied_volatility(
         &self,
@@ -11334,6 +11722,13 @@ impl ThetaDataDx {
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
     /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
     /// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -11438,6 +11833,13 @@ impl ThetaDataDx {
     /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
     /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, annual_dividend=None, rate_type=None, rate_value=None, stock_price=None, version=None, max_dte=None, strike_range=None, min_time=None, use_market_value=false, timeout_ms=None))]
     fn option_snapshot_greeks_all(
         &self,
@@ -11504,6 +11906,13 @@ impl ThetaDataDx {
     /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
     /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -11608,6 +12017,13 @@ impl ThetaDataDx {
     /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
     /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, annual_dividend=None, rate_type=None, rate_value=None, stock_price=None, version=None, max_dte=None, strike_range=None, min_time=None, use_market_value=false, timeout_ms=None))]
     fn option_snapshot_greeks_first_order(
         &self,
@@ -11674,6 +12090,13 @@ impl ThetaDataDx {
     /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
     /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -11778,6 +12201,13 @@ impl ThetaDataDx {
     /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
     /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, annual_dividend=None, rate_type=None, rate_value=None, stock_price=None, version=None, max_dte=None, strike_range=None, min_time=None, use_market_value=false, timeout_ms=None))]
     fn option_snapshot_greeks_second_order(
         &self,
@@ -11844,6 +12274,13 @@ impl ThetaDataDx {
     /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
     /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -11948,6 +12385,13 @@ impl ThetaDataDx {
     /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
     /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[pyo3(signature = (symbol, expiration, *, strike=None, right=None, annual_dividend=None, rate_type=None, rate_value=None, stock_price=None, version=None, max_dte=None, strike_range=None, min_time=None, use_market_value=false, timeout_ms=None))]
     fn option_snapshot_greeks_third_order(
         &self,
@@ -12014,6 +12458,13 @@ impl ThetaDataDx {
     /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
     /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -12118,6 +12569,10 @@ impl ThetaDataDx {
     /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
     /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
     /// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, start_date, end_date, *, strike=None, right=None, max_dte=None, strike_range=None, timeout_ms=None))]
     fn option_history_eod(
         &self,
@@ -12158,6 +12613,10 @@ impl ThetaDataDx {
     /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
     /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
     /// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -12232,6 +12691,13 @@ impl ThetaDataDx {
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, interval=None, start_time=None, end_time=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_ohlc(
         &self,
@@ -12286,6 +12752,13 @@ impl ThetaDataDx {
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -12378,6 +12851,12 @@ impl ThetaDataDx {
     /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
     /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, start_time=None, end_time=None, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_trade(
         &self,
@@ -12433,6 +12912,12 @@ impl ThetaDataDx {
     /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
     /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -12524,6 +13009,13 @@ impl ThetaDataDx {
     /// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, interval=None, start_time=None, end_time=None, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_quote(
         &self,
@@ -12582,6 +13074,13 @@ impl ThetaDataDx {
     /// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -12679,6 +13178,13 @@ impl ThetaDataDx {
     /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
     /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `exclusive`: `true`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, start_time=None, end_time=None, exclusive=true, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_trade_quote(
         &self,
@@ -12738,6 +13244,13 @@ impl ThetaDataDx {
     /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
     /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `exclusive`: `true`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -12834,6 +13347,10 @@ impl ThetaDataDx {
     /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
     /// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
     /// - The reported open interest represents the open interest at the end of the previous trading day.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_open_interest(
         &self,
@@ -12880,6 +13397,10 @@ impl ThetaDataDx {
     /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
     /// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
     /// - The reported open interest represents the open interest at the end of the previous trading day.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -12961,6 +13482,13 @@ impl ThetaDataDx {
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
     /// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `underlyer_use_nbbo`: `false`
     #[pyo3(signature = (symbol, expiration, start_date, end_date, *, strike=None, right=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, underlyer_use_nbbo=false, max_dte=None, strike_range=None, timeout_ms=None))]
     fn option_history_greeks_eod(
         &self,
@@ -13020,6 +13548,13 @@ impl ThetaDataDx {
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
     /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
     /// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `underlyer_use_nbbo`: `false`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -13120,6 +13655,15 @@ impl ThetaDataDx {
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, interval=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_greeks_all(
         &self,
@@ -13191,6 +13735,15 @@ impl ThetaDataDx {
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -13303,6 +13856,14 @@ impl ThetaDataDx {
     /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_trade_greeks_all(
         &self,
@@ -13374,6 +13935,14 @@ impl ThetaDataDx {
     /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -13486,6 +14055,15 @@ impl ThetaDataDx {
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, interval=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_greeks_first_order(
         &self,
@@ -13557,6 +14135,15 @@ impl ThetaDataDx {
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -13669,6 +14256,14 @@ impl ThetaDataDx {
     /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_trade_greeks_first_order(
         &self,
@@ -13740,6 +14335,14 @@ impl ThetaDataDx {
     /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -13852,6 +14455,15 @@ impl ThetaDataDx {
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, interval=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_greeks_second_order(
         &self,
@@ -13923,6 +14535,15 @@ impl ThetaDataDx {
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -14035,6 +14656,14 @@ impl ThetaDataDx {
     /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_trade_greeks_second_order(
         &self,
@@ -14106,6 +14735,14 @@ impl ThetaDataDx {
     /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -14218,6 +14855,15 @@ impl ThetaDataDx {
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, interval=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_greeks_third_order(
         &self,
@@ -14289,6 +14935,15 @@ impl ThetaDataDx {
     /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -14401,6 +15056,14 @@ impl ThetaDataDx {
     /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_trade_greeks_third_order(
         &self,
@@ -14472,6 +15135,14 @@ impl ThetaDataDx {
     /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -14583,6 +15254,15 @@ impl ThetaDataDx {
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, interval=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_greeks_implied_volatility(
         &self,
@@ -14653,6 +15333,15 @@ impl ThetaDataDx {
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -14764,6 +15453,14 @@ impl ThetaDataDx {
     /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[pyo3(signature = (symbol, expiration, date, *, strike=None, right=None, start_time=None, end_time=None, annual_dividend=None, rate_type=None, rate_value=None, version=None, max_dte=None, strike_range=None, start_date=None, end_date=None, timeout_ms=None))]
     fn option_history_trade_greeks_implied_volatility(
         &self,
@@ -14834,6 +15531,14 @@ impl ThetaDataDx {
     /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
     /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -14946,6 +15651,10 @@ impl ThetaDataDx {
     /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
     /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, start_date, end_date, time_of_day, *, strike=None, right=None, max_dte=None, strike_range=None, timeout_ms=None))]
     fn option_at_time_trade(
         &self,
@@ -14987,6 +15696,10 @@ impl ThetaDataDx {
     /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
     /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -15063,6 +15776,10 @@ impl ThetaDataDx {
     ///
     /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[pyo3(signature = (symbol, expiration, start_date, end_date, time_of_day, *, strike=None, right=None, max_dte=None, strike_range=None, timeout_ms=None))]
     fn option_at_time_quote(
         &self,
@@ -15102,6 +15819,10 @@ impl ThetaDataDx {
     ///
     /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -15608,6 +16329,11 @@ impl ThetaDataDx {
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
     /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[pyo3(signature = (symbol, start_date, end_date, *, interval=None, start_time=None, end_time=None, timeout_ms=None))]
     fn index_history_ohlc(
         &self,
@@ -15642,6 +16368,11 @@ impl ThetaDataDx {
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
     /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -15709,6 +16440,11 @@ impl ThetaDataDx {
     /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
     /// - A price update from the exchange is omitted if the price remained the same from the previous update.
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[pyo3(signature = (symbol, date, *, interval=None, start_time=None, end_time=None, start_date=None, end_date=None, timeout_ms=None))]
     fn index_history_price(
         &self,
@@ -15751,6 +16487,11 @@ impl ThetaDataDx {
     /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
     /// - A price update from the exchange is omitted if the price remained the same from the previous update.
     /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -16159,6 +16900,12 @@ impl ThetaDataDx {
     }
 
     /// Fetch intraday OHLC bars across a date range.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     #[pyo3(signature = (symbol, start_date, end_date, *, interval=None, start_time=None, end_time=None, venue=None, timeout_ms=None))]
     fn stock_history_ohlc_range(
         &self,
@@ -16193,6 +16940,13 @@ impl ThetaDataDx {
     }
 
     /// Fetch intraday OHLC bars across a date range.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
+    ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
     /// Shares the same shared tokio runtime as the sync variant; no

--- a/sdks/typescript/src/historical_methods.rs
+++ b/sdks/typescript/src/historical_methods.rs
@@ -3,6 +3,8 @@
 #[napi]
 impl ThetaDataDx {
     /// List all available stock ticker symbols.
+    ///
+    /// A symbol can be defined as a unique identifier for a stock / underlying asset. Common terms also include: root, ticker, and underlying. This endpoint returns all traded symbols for stocks. This endpoint is updated overnight.
     #[napi(js_name = "stockListSymbols")]
     pub fn stock_list_symbols(
         &self,
@@ -22,6 +24,8 @@ impl ThetaDataDx {
     }
 
     /// List available dates for a stock by request type (EOD, TRADE, QUOTE, etc.).
+    ///
+    /// Lists all dates of data that are available for a stock with a given request type and symbol. This endpoint is updated overnight.
     #[napi(js_name = "stockListDates")]
     pub fn stock_list_dates(
         &self,
@@ -43,6 +47,14 @@ impl ThetaDataDx {
     }
 
     /// Get the latest OHLC snapshot for one or more stocks.
+    ///
+    /// Provides a real-time Open, High, Low, Close for the current day.
+    /// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+    /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockSnapshotOHLC")]
     pub fn stock_snapshot_ohlc(
         &self,
@@ -69,6 +81,13 @@ impl ThetaDataDx {
     }
 
     /// Get the latest trade snapshot for one or more stocks.
+    ///
+    /// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    ///
+    /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockSnapshotTrade")]
     pub fn stock_snapshot_trade(
         &self,
@@ -95,6 +114,13 @@ impl ThetaDataDx {
     }
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
+    ///
+    /// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockSnapshotQuote")]
     pub fn stock_snapshot_quote(
         &self,
@@ -121,6 +147,13 @@ impl ThetaDataDx {
     }
 
     /// Get the latest market value snapshot for one or more stocks.
+    ///
+    /// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockSnapshotMarketValue")]
     pub fn stock_snapshot_market_value(
         &self,
@@ -147,6 +180,8 @@ impl ThetaDataDx {
     }
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
+    ///
+    /// Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
     #[napi(js_name = "stockHistoryEOD")]
     pub fn stock_history_eod(
         &self,
@@ -166,6 +201,16 @@ impl ThetaDataDx {
     }
 
     /// Fetch intraday OHLC bars for a stock on a single date.
+    ///
+    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockHistoryOHLC")]
     pub fn stock_history_ohlc(
         &self,
@@ -211,6 +256,14 @@ impl ThetaDataDx {
     }
 
     /// Fetch all trades for a stock on a given date.
+    ///
+    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockHistoryTrade")]
     pub fn stock_history_trade(
         &self,
@@ -252,6 +305,17 @@ impl ThetaDataDx {
     }
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
+    ///
+    /// - Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs). 
+    /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockHistoryQuote")]
     pub fn stock_history_quote(
         &self,
@@ -297,6 +361,15 @@ impl ThetaDataDx {
     }
 
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
+    ///
+    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `exclusive`: `true`
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockHistoryTradeQuote")]
     pub fn stock_history_trade_quote(
         &self,
@@ -342,6 +415,17 @@ impl ThetaDataDx {
     }
 
     /// Fetch the trade at a specific time of day across a date range.
+    ///
+    /// #### Real-time request:
+    /// - Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    ///
+    /// #### Historical request:
+    /// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+    /// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockAtTimeTrade")]
     pub fn stock_at_time_trade(
         &self,
@@ -367,6 +451,17 @@ impl ThetaDataDx {
     }
 
     /// Fetch the quote at a specific time of day across a date range.
+    ///
+    /// #### Real-time request:
+    ///   - Subscription tier standard or higher will default to NQB.
+    ///   - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    ///
+    /// #### Historical request:
+    ///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+    ///
+    /// Defaults (upstream):
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockAtTimeQuote")]
     pub fn stock_at_time_quote(
         &self,
@@ -392,6 +487,8 @@ impl ThetaDataDx {
     }
 
     /// List all available option underlying symbols.
+    ///
+    /// A symbol can be defined as a unique identifier for a stock / underlying asset. Common terms also include: root, ticker, and underlying. This endpoint returns all traded symbols for options. This endpoint is updated overnight.
     #[napi(js_name = "optionListSymbols")]
     pub fn option_list_symbols(
         &self,
@@ -411,6 +508,13 @@ impl ThetaDataDx {
     }
 
     /// List available dates for an option contract by request type.
+    ///
+    /// Lists all dates of data that are available for an option with a given symbol, request type, and expiration.
+    /// This endpoint is updated overnight.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionListDates")]
     pub fn option_list_dates(
         &self,
@@ -434,6 +538,9 @@ impl ThetaDataDx {
     }
 
     /// List available expiration dates for an option underlying.
+    ///
+    /// Lists all dates of expirations that are available for an option with a given symbol.
+    /// This endpoint is updated overnight.
     #[napi(js_name = "optionListExpirations")]
     pub fn option_list_expirations(
         &self,
@@ -454,6 +561,9 @@ impl ThetaDataDx {
     }
 
     /// List available strike prices for an option at a given expiration.
+    ///
+    /// Lists all strikes that are available for an option with a given symbol and expiration date.
+    /// This endpoint is updated overnight.
     #[napi(js_name = "optionListStrikes")]
     pub fn option_list_strikes(
         &self,
@@ -476,6 +586,12 @@ impl ThetaDataDx {
     }
 
     /// List all option contracts for a symbol on a given date.
+    ///
+    /// Lists all contracts that were traded or quoted on a particular date.
+    ///
+    /// If the ``symbol`` parameter is specified, the returned contracts will be filtered to match the symbol.
+    /// Multiple symbols can be specified by separating them with commas such as ``symbol=AAPL,SPY,AMD``
+    /// This endpoint is updated real-time.
     #[napi(js_name = "optionListContracts")]
     pub fn option_list_contracts(
         &self,
@@ -498,6 +614,13 @@ impl ThetaDataDx {
     }
 
     /// Get the latest OHLC snapshot for an option contract.
+    ///
+    /// - Retrieve a real-time last ohlc of an option contract for the trading day.
+    /// - You might need to change the default expiration date to a different date if it is past the current date.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionSnapshotOHLC")]
     pub fn option_snapshot_ohlc(
         &self,
@@ -536,6 +659,14 @@ impl ThetaDataDx {
     }
 
     /// Get the latest trade snapshot for an option contract.
+    ///
+    /// - Retrieve the real-time last trade of an option contract.
+    /// - You might need to change the default expiration date to a different date if it is past the current date.
+    /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionSnapshotTrade")]
     pub fn option_snapshot_trade(
         &self,
@@ -570,6 +701,14 @@ impl ThetaDataDx {
     }
 
     /// Get the latest NBBO quote snapshot for an option contract.
+    ///
+    /// - Retrieve a real-time last NBBO quote of an option contract.
+    /// - You might need to change the default expiration date to a different date if it is past the current date.
+    /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionSnapshotQuote")]
     pub fn option_snapshot_quote(
         &self,
@@ -608,6 +747,15 @@ impl ThetaDataDx {
     }
 
     /// Get the latest open interest snapshot for an option contract.
+    ///
+    /// - Retrieve the last open interest message of an option contract.
+    /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the of the previous trading day. 
+    /// - You might need to change the default expiration date to a different date if it is past the current date.
+    /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionSnapshotOpenInterest")]
     pub fn option_snapshot_open_interest(
         &self,
@@ -646,6 +794,12 @@ impl ThetaDataDx {
     }
 
     /// Get the latest market value snapshot for an option contract.
+    ///
+    /// * Returns a real-time market value derived from the last NBBO quote of an option contract.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionSnapshotMarketValue")]
     pub fn option_snapshot_market_value(
         &self,
@@ -684,6 +838,18 @@ impl ThetaDataDx {
     }
 
     /// Get implied volatility snapshot for an option contract (from ThetaData server).
+    ///
+    /// Returns implied volatilies calculated using the national best bid, mid, and ask price
+    /// of the option respectively. The underlying price represents whatever the last underlying price was at the
+    /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
+    /// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[napi(js_name = "optionSnapshotGreeksImpliedVolatility")]
     pub fn option_snapshot_greeks_implied_volatility(
         &self,
@@ -746,6 +912,18 @@ impl ThetaDataDx {
     }
 
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
+    ///
+    /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
+    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
+    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[napi(js_name = "optionSnapshotGreeksAll")]
     pub fn option_snapshot_greeks_all(
         &self,
@@ -808,6 +986,18 @@ impl ThetaDataDx {
     }
 
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
+    ///
+    /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
+    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
+    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[napi(js_name = "optionSnapshotGreeksFirstOrder")]
     pub fn option_snapshot_greeks_first_order(
         &self,
@@ -870,6 +1060,18 @@ impl ThetaDataDx {
     }
 
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
+    ///
+    /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
+    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
+    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[napi(js_name = "optionSnapshotGreeksSecondOrder")]
     pub fn option_snapshot_greeks_second_order(
         &self,
@@ -932,6 +1134,18 @@ impl ThetaDataDx {
     }
 
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
+    ///
+    /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
+    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
+    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `use_market_value`: `false`
     #[napi(js_name = "optionSnapshotGreeksThirdOrder")]
     pub fn option_snapshot_greeks_third_order(
         &self,
@@ -994,6 +1208,15 @@ impl ThetaDataDx {
     }
 
     /// Fetch end-of-day option data for a contract over a date range.
+    ///
+    /// - Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+    /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
+    /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
+    /// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionHistoryEOD")]
     pub fn option_history_eod(
         &self,
@@ -1031,6 +1254,17 @@ impl ThetaDataDx {
     }
 
     /// Fetch intraday OHLC bars for an option contract.
+    ///
+    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
+    /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[napi(js_name = "optionHistoryOHLC")]
     pub fn option_history_ohlc(
         &self,
@@ -1086,6 +1320,17 @@ impl ThetaDataDx {
     }
 
     /// Fetch all trades for an option contract on a given date.
+    ///
+    /// - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[napi(js_name = "optionHistoryTrade")]
     pub fn option_history_trade(
         &self,
@@ -1141,6 +1386,17 @@ impl ThetaDataDx {
     }
 
     /// Fetch NBBO quotes for an option contract on a given date.
+    ///
+    /// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+    /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
+    /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[napi(js_name = "optionHistoryQuote")]
     pub fn option_history_quote(
         &self,
@@ -1200,6 +1456,18 @@ impl ThetaDataDx {
     }
 
     /// Fetch combined trade + quote ticks for an option contract.
+    ///
+    /// - Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+    /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
+    /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
+    /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `exclusive`: `true`
     #[napi(js_name = "optionHistoryTradeQuote")]
     pub fn option_history_trade_quote(
         &self,
@@ -1259,6 +1527,14 @@ impl ThetaDataDx {
     }
 
     /// Fetch open interest history for an option contract.
+    ///
+    /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
+    /// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+    /// - The reported open interest represents the open interest at the end of the previous trading day.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionHistoryOpenInterest")]
     pub fn option_history_open_interest(
         &self,
@@ -1304,6 +1580,17 @@ impl ThetaDataDx {
     }
 
     /// Fetch end-of-day Greeks history for an option contract.
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration. 
+    /// - Uses Theta Data's EOD reports that get generated at 17:15 ET each day. The closing option price and closing underlying price are used for the greeks calculation.
+    /// - **Set `expiration` to ``*`` if you want to retrieve data for every option that shares the same ``symbol``. (note: Any ``expiration=*`` must be requested day by day)**
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
+    /// - `underlyer_use_nbbo`: `false`
     #[napi(js_name = "optionHistoryGreeksEOD")]
     pub fn option_history_greeks_eod(
         &self,
@@ -1361,6 +1648,20 @@ impl ThetaDataDx {
     }
 
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration. 
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryGreeksAll")]
     pub fn option_history_greeks_all(
         &self,
@@ -1432,6 +1733,19 @@ impl ThetaDataDx {
     }
 
     /// Fetch all Greeks on each trade for an option contract.
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration. 
+    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryTradeGreeksAll")]
     pub fn option_history_trade_greeks_all(
         &self,
@@ -1503,6 +1817,20 @@ impl ThetaDataDx {
     }
 
     /// Fetch first-order Greeks history (intraday, sampled by interval).
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration. 
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryGreeksFirstOrder")]
     pub fn option_history_greeks_first_order(
         &self,
@@ -1574,6 +1902,19 @@ impl ThetaDataDx {
     }
 
     /// Fetch first-order Greeks on each trade for an option contract.
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration.
+    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryTradeGreeksFirstOrder")]
     pub fn option_history_trade_greeks_first_order(
         &self,
@@ -1645,6 +1986,20 @@ impl ThetaDataDx {
     }
 
     /// Fetch second-order Greeks history (intraday, sampled by interval).
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration. 
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryGreeksSecondOrder")]
     pub fn option_history_greeks_second_order(
         &self,
@@ -1716,6 +2071,19 @@ impl ThetaDataDx {
     }
 
     /// Fetch second-order Greeks on each trade for an option contract.
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration.
+    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryTradeGreeksSecondOrder")]
     pub fn option_history_trade_greeks_second_order(
         &self,
@@ -1787,6 +2155,20 @@ impl ThetaDataDx {
     }
 
     /// Fetch third-order Greeks history (intraday, sampled by interval).
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration. 
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryGreeksThirdOrder")]
     pub fn option_history_greeks_third_order(
         &self,
@@ -1858,6 +2240,19 @@ impl ThetaDataDx {
     }
 
     /// Fetch third-order Greeks on each trade for an option contract.
+    ///
+    /// - Returns the data for all contracts that share the same provided symbol and expiration.
+    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryTradeGreeksThirdOrder")]
     pub fn option_history_trade_greeks_third_order(
         &self,
@@ -1929,6 +2324,19 @@ impl ThetaDataDx {
     }
 
     /// Fetch implied volatility history (intraday, sampled by interval).
+    ///
+    /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryGreeksImpliedVolatility")]
     pub fn option_history_greeks_implied_volatility(
         &self,
@@ -2000,6 +2408,18 @@ impl ThetaDataDx {
     }
 
     /// Fetch implied volatility on each trade for an option contract.
+    ///
+    /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `rate_type`: `"sofr"`
+    /// - `version`: `"latest"`
     #[napi(js_name = "optionHistoryTradeGreeksImpliedVolatility")]
     pub fn option_history_trade_greeks_implied_volatility(
         &self,
@@ -2071,6 +2491,15 @@ impl ThetaDataDx {
     }
 
     /// Fetch the trade at a specific time of day across a date range for an option.
+    ///
+    /// - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionAtTimeTrade")]
     pub fn option_at_time_trade(
         &self,
@@ -2110,6 +2539,13 @@ impl ThetaDataDx {
     }
 
     /// Fetch the quote at a specific time of day across a date range for an option.
+    ///
+    /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+    /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
+    ///
+    /// Defaults (upstream):
+    /// - `strike`: `"*"`
+    /// - `right`: `"both"`
     #[napi(js_name = "optionAtTimeQuote")]
     pub fn option_at_time_quote(
         &self,
@@ -2149,6 +2585,8 @@ impl ThetaDataDx {
     }
 
     /// List all available index symbols.
+    ///
+    /// A symbol can be defined as a unique identifier for a stock / underlying asset. Common terms also include: root, ticker, and underlying. This endpoint returns all traded symbols for options. This endpoint is updated overnight.
     #[napi(js_name = "indexListSymbols")]
     pub fn index_list_symbols(
         &self,
@@ -2168,6 +2606,8 @@ impl ThetaDataDx {
     }
 
     /// List available dates for an index symbol.
+    ///
+    /// Lists all dates of data that are available for a index with a given request type and symbol. This endpoint is updated overnight.
     #[napi(js_name = "indexListDates")]
     pub fn index_list_dates(
         &self,
@@ -2188,6 +2628,9 @@ impl ThetaDataDx {
     }
 
     /// Get the latest OHLC snapshot for one or more indices.
+    ///
+    /// - Retrieves the real-time current day OHLC.
+    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotOHLC")]
     pub fn index_snapshot_ohlc(
         &self,
@@ -2210,6 +2653,9 @@ impl ThetaDataDx {
     }
 
     /// Get the latest price snapshot for one or more indices.
+    ///
+    /// - Retrieves a real-time last index price.
+    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotPrice")]
     pub fn index_snapshot_price(
         &self,
@@ -2232,6 +2678,9 @@ impl ThetaDataDx {
     }
 
     /// Get the latest market value snapshot for one or more indices.
+    ///
+    /// - Retrieves a real-time last index market value.
+    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotMarketValue")]
     pub fn index_snapshot_market_value(
         &self,
@@ -2254,6 +2703,8 @@ impl ThetaDataDx {
     }
 
     /// Fetch end-of-day index data for a date range.
+    ///
+    /// - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
     #[napi(js_name = "indexHistoryEOD")]
     pub fn index_history_eod(
         &self,
@@ -2273,6 +2724,15 @@ impl ThetaDataDx {
     }
 
     /// Fetch intraday OHLC bars for an index.
+    ///
+    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+    /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
+    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[napi(js_name = "indexHistoryOHLC")]
     pub fn index_history_ohlc(
         &self,
@@ -2306,6 +2766,16 @@ impl ThetaDataDx {
     }
 
     /// Fetch intraday price history for an index.
+    ///
+    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
+    /// - A price update from the exchange is omitted if the price remained the same from the previous update.
+    /// - Multi-day requests are limited to 1 month of data.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
     #[napi(js_name = "indexHistoryPrice")]
     pub fn index_history_price(
         &self,
@@ -2347,6 +2817,9 @@ impl ThetaDataDx {
     }
 
     /// Fetch the index price at a specific time of day across a date range.
+    ///
+    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
     #[napi(js_name = "indexAtTimePrice")]
     pub fn index_at_time_price(
         &self,
@@ -2368,6 +2841,10 @@ impl ThetaDataDx {
     }
 
     /// Check whether the market is open today.
+    ///
+    /// - Retrieves current day equity market schedule
+    /// - *On days when the market closes early at 1:00 PM ET; eligible options will trade until 1:15 PM.
+    /// - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
     #[napi(js_name = "calendarOpenToday")]
     pub fn calendar_open_today(
         &self,
@@ -2382,6 +2859,11 @@ impl ThetaDataDx {
     }
 
     /// Get calendar information for a specific date.
+    ///
+    /// - Retrieves equity market schedule for a given date
+    /// - Note: Holiday data is available 01/01/2012 through the end of the calendar year that immediately follows the current year
+    /// - *On days when the market closes early at 1:00 PM ET; eligible options will trade until 1:15 PM.
+    /// - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
     #[napi(js_name = "calendarOnDate")]
     pub fn calendar_on_date(
         &self,
@@ -2398,6 +2880,11 @@ impl ThetaDataDx {
     }
 
     /// Get calendar information for an entire year.
+    ///
+    /// - Retrieves equity market holidays for a given year
+    /// - Note: Holiday data is available 01/01/2012 through the end of the calendar year that immediately follows the current year
+    /// - *On days when the market closes early at 1:00 PM ET; eligible options will trade until 1:15 PM.
+    /// - **Some NYSE exchanges will continue late trading until 5:00 PM ET on early close days.
     #[napi(js_name = "calendarYear")]
     pub fn calendar_year(
         &self,
@@ -2413,6 +2900,8 @@ impl ThetaDataDx {
     }
 
     /// Fetch end-of-day interest rate history.
+    ///
+    /// - Returns the interest rate reported. Depending on the rate, reports can occur in the morning or the afternoon.
     #[napi(js_name = "interestRateHistoryEOD")]
     pub fn interest_rate_history_eod(
         &self,
@@ -2432,6 +2921,12 @@ impl ThetaDataDx {
     }
 
     /// Fetch intraday OHLC bars across a date range.
+    ///
+    /// Defaults (upstream):
+    /// - `interval`: `"1s"`
+    /// - `start_time`: `"09:30:00"`
+    /// - `end_time`: `"16:00:00"`
+    /// - `venue`: `"nqb"`
     #[napi(js_name = "stockHistoryOHLCRange")]
     pub fn stock_history_ohlc_range(
         &self,


### PR DESCRIPTION
## Summary

Main went red after v8.0.10 (#406) merged: SDK Bindings CI failed on all 3 platforms because the generated Go validator passes `[]string{"AAPL"}` to scalar `c.StockSnapshotOHLC(symbol string, ...)`. Codex added bulk `*Bulk` variants but the validator wasn't wired through them.

Also includes the `Defaults (upstream):` docstring block that was in flight when #406 squash-merged — those commits were pushed after auto-merge armed and didn't land.

## Changes
1. `helpers.rs::go_arg_literal` — always emit `"AAPL"`, never `[]string{...}`. Validator cells exercise scalar path; bulk exercised by users.
2. `compose_endpoint_doc` now appends `Defaults (upstream):` listing every param with a `default` field in SSOT. Routed through Python pymethods, Rust mdds `#[doc]`, and TS napi-src doc.

## Test plan
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] scripts/regen_byte_identical.sh
- [x] cd sdks/go && go build ./...