### PR TITLE
fix(go): bump TdxEndpointRequestOptions expected size to 192

### DIFF
--- a/sdks/go/tick_ffi_mirrors.go
+++ b/sdks/go/tick_ffi_mirrors.go
@@ -320,10 +320,11 @@ func init() {
 		{"cGreeksTick", unsafe.Sizeof(cGreeksTick{}), 256},
 		{"cTradeQuoteTick", unsafe.Sizeof(cTradeQuoteTick{}), 192},
 		{"cOptionContract", unsafe.Sizeof(cOptionContract{}), 32},
-		// TdxEndpointRequestOptions: 27 builder-param fields + cross-cutting
-		// timeout_ms (uint64) + has_timeout_ms (int32) + tail-padding to align
-		// to the uint64 = 168 bytes on x86_64 / aarch64.
-		{"TdxEndpointRequestOptions", unsafe.Sizeof(C.TdxEndpointRequestOptions{}), 168},
+		// TdxEndpointRequestOptions: 29 builder-param fields (strike + right
+		// joined the builder-bound set in v8.0.10 alongside the existing 27)
+		// plus cross-cutting timeout_ms (uint64) + has_timeout_ms (int32) +
+		// tail-padding to align to uint64 = 192 bytes on x86_64 / aarch64.
+		{"TdxEndpointRequestOptions", unsafe.Sizeof(C.TdxEndpointRequestOptions{}), 192},
 		// FPSS cgo structs — schema-driven from fpss_event_schema.toml,
 		// same layout as ffi/src/fpss_event_structs.rs. Every data variant
 		// carries an embedded TdxContract (32 bytes on LP64) immediately


### PR DESCRIPTION
## Summary
v8.0.10 moved `strike`/`right` from method-positional to builder-bound, growing `TdxEndpointRequestOptions` from 27 to 29 pointer/int fields = 168 -> 192 bytes on x86_64/aarch64. The Go drift-detector in `tick_ffi_mirrors.go` still expected 168, panicking every Go init(). Updated to 192.

Root cause: hand-maintained assertion didn't track SSOT struct growth. Considered automating the expected-size extraction from Rust `size_of` but keeping the hardcoded value preserves the drift-detector's original intent (catch accidental layout changes).

## Test plan
- [x] cargo clippy workspace
- [x] go build ./...