### PR TITLE
release: 8.0.13 — close P13 chunk header drift gap

### DIFF
--- a/.github/release-notes/v8.0.13.md
+++ b/.github/release-notes/v8.0.13.md
@@ -1,0 +1,43 @@
+v8.0.13 closes the mid-stream chunk header drift gap flagged as P13 in
+the external bench handoff. `MddsClient::collect_stream` and
+`MddsClient::for_each_chunk` used to silently keep the first chunk's
+header set and pile subsequent chunks' rows underneath it; a mid-
+response schema change therefore surfaced as silent data corruption.
+Both paths now compare each non-empty chunk header set against the
+saved first-chunk schema and raise a new
+`DecodeError::ChunkHeaderDrift` on mismatch.
+
+`tdbe` remains at `0.12.0`.
+
+## Fixed
+
+- `MddsClient::collect_stream` and `MddsClient::for_each_chunk` now
+  surface mid-stream chunk header drift instead of silently
+  accumulating rows under the first-chunk schema.
+
+## Added
+
+- `decode::DecodeError::ChunkHeaderDrift { chunk_index, first, chunk }`
+  variant covering the new error path.
+
+## Known
+
+- `option_at_time_quote` 0.67× vs vendor: needs bench-validated
+  per-endpoint override in `endpoint_surface.toml`. Deferred to
+  avoid regressing the other option endpoints that benefit from
+  the uniform v8.0.5 `mdds_query_field_expr` rule.
+- `option_history_greeks_eod` 0.704× vs vendor: persistent since
+  v8.0.0; likely server-side per-contract aggregation path, not a
+  wire-shape issue. Needs proto-level diff against the other
+  `option_history_greeks_*` endpoints.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --workspace --all-targets --features "polars,arrow" -- -D warnings`
+- `cargo test --workspace --no-fail-fast`
+- `scripts/regen_byte_identical.sh`
+- `cargo deny check`
+- `(cd docs-site && npm run build)`
+- `PYO3_PYTHON=/usr/bin/python3 cargo test --manifest-path sdks/python/Cargo.toml --lib`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.13] - 2026-04-23
+
+### Fixed
+
+- Mid-stream chunk header drift in the MDDS response accumulator was
+  silently masked: `MddsClient::collect_stream` / `for_each_chunk` would
+  keep the first chunk's `headers` and pile subsequent chunks' rows
+  underneath, even if a later chunk carried a different non-empty
+  header set. A server-side schema change mid-response would therefore
+  surface as silent data corruption instead of an error. Both paths
+  now compare the saved first-chunk schema against every non-empty
+  chunk header set and raise a new `DecodeError::ChunkHeaderDrift`
+  on mismatch (P13 from the external bench handoff).
+
+### Added
+
+- `decode::DecodeError::ChunkHeaderDrift { chunk_index, first, chunk }`
+  variant.
+
+### Known
+
+- **`option_at_time_quote` 0.67× vs vendor** (bench handoff §8 #1).
+  The v8.0.5 uniform `mdds_query_field_expr` rule that empties the
+  top-level `expiration` field on any option query carrying a
+  `ContractSpec` may have flipped this specific endpoint into a
+  slower server-side path. Needs a bench-validated per-endpoint
+  override in `endpoint_surface.toml`. Not fixed in this release
+  because a speculative generator carve-out without bench
+  re-validation would risk regressing the other option endpoints
+  that benefit from the current rule.
+- **`option_history_greeks_eod` 0.704× vs vendor** (bench handoff §8
+  #2). Persistent across v8.0.0 / v8.0.4 / v8.0.10. Likely server-
+  side per-contract aggregation path rather than a wire-shape
+  issue; needs proto-level diff against the other
+  `option_history_greeks_*` endpoints (which are DX wins at
+  4-6× faster).
+
 ## [8.0.12] - 2026-04-23
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.12"
+version = "8.0.13"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -41,6 +41,21 @@ pub enum DecodeError {
         rows: usize,
         available: String,
     },
+    /// A mid-stream gRPC chunk carries a header set that does not match the
+    /// header set established by the first chunk. The stream accumulator
+    /// used to silently retain the first header set and accumulate rows
+    /// from every chunk underneath it, which would transparently corrupt
+    /// a row set if the server's wire schema changed mid-response. This
+    /// variant surfaces the drift instead of hiding it.
+    #[error(
+        "chunk {chunk_index} headers drifted from first-chunk schema; \
+         first: [{first}]; chunk: [{chunk}]"
+    )]
+    ChunkHeaderDrift {
+        chunk_index: usize,
+        first: String,
+        chunk: String,
+    },
 }
 
 /// Name the `DataType` variant for error messages. `None` is treated as a

--- a/crates/thetadatadx/src/mdds/stream.rs
+++ b/crates/thetadatadx/src/mdds/stream.rs
@@ -39,7 +39,8 @@ impl MddsClient {
         mut stream: tonic::Streaming<proto::ResponseData>,
     ) -> Result<proto::DataTable, Error> {
         let mut all_rows = Vec::new();
-        let mut headers = Vec::new();
+        let mut headers: Vec<String> = Vec::new();
+        let mut chunk_index: usize = 0;
 
         while let Some(response) = stream.next().await {
             let response = response?;
@@ -54,8 +55,20 @@ impl MddsClient {
             let table = decode::decode_data_table(&response)?;
             if headers.is_empty() {
                 headers = table.headers;
+            } else if !table.headers.is_empty() && table.headers != headers {
+                // Mid-stream schema drift. The old accumulator silently kept
+                // the first chunk's headers and piled rows under them; surface
+                // the mismatch instead so downstream decoders do not read
+                // columns under the wrong names.
+                return Err(decode::DecodeError::ChunkHeaderDrift {
+                    chunk_index,
+                    first: headers.join(","),
+                    chunk: table.headers.join(","),
+                }
+                .into());
             }
             all_rows.extend(table.data_table);
+            chunk_index += 1;
         }
 
         // An empty stream is valid (e.g. no trades on a holiday) — return an
@@ -97,13 +110,27 @@ impl MddsClient {
     where
         F: FnMut(&[String], &[proto::DataValueList]),
     {
-        // Preserve first-chunk headers across all chunks, matching collect_stream behavior.
+        // Preserve first-chunk headers across all chunks, matching
+        // collect_stream behavior. Reject any mid-stream chunk whose
+        // non-empty headers disagree with the first-chunk schema: accepting
+        // them silently would let the callback read columns under the wrong
+        // names, which is the exact failure mode P13 asked to close.
         let mut saved_headers: Option<Vec<String>> = None;
+        let mut chunk_index: usize = 0;
         while let Some(response) = stream.next().await {
             let response = response?;
             let table = decode::decode_data_table(&response)?;
             if saved_headers.is_none() && !table.headers.is_empty() {
                 saved_headers = Some(table.headers.clone());
+            } else if let Some(first) = saved_headers.as_deref() {
+                if !table.headers.is_empty() && table.headers.as_slice() != first {
+                    return Err(decode::DecodeError::ChunkHeaderDrift {
+                        chunk_index,
+                        first: first.join(","),
+                        chunk: table.headers.join(","),
+                    }
+                    .into());
+                }
             }
             let headers = if table.headers.is_empty() {
                 saved_headers.as_deref().unwrap_or(&[])
@@ -111,6 +138,7 @@ impl MddsClient {
                 &table.headers
             };
             f(headers, &table.data_table);
+            chunk_index += 1;
         }
         Ok(())
     }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.13] - 2026-04-23
+
+### Fixed
+
+- Mid-stream chunk header drift in the MDDS response accumulator was
+  silently masked: `MddsClient::collect_stream` / `for_each_chunk` kept
+  the first chunk's `headers` and accumulated subsequent chunks'
+  rows underneath even if a later chunk carried a different
+  non-empty header set. Both paths now raise
+  `DecodeError::ChunkHeaderDrift` on mismatch (P13 from the external
+  bench handoff).
+
+### Added
+
+- `decode::DecodeError::ChunkHeaderDrift { chunk_index, first, chunk }`
+  variant.
+
+### Known
+
+- **`option_at_time_quote` 0.67× vs vendor.** The v8.0.5
+  `mdds_query_field_expr` rule may have flipped this endpoint to a
+  slower server path. Needs bench-validated per-endpoint override;
+  not speculatively fixed to avoid regressing the other option
+  endpoints that currently benefit from the uniform rule.
+- **`option_history_greeks_eod` 0.704× vs vendor.** Persistent across
+  v8.0.0 / v8.0.4 / v8.0.10. Likely server-side per-contract
+  aggregation; needs proto-level diff against the other
+  `option_history_greeks_*` endpoints.
+
 ## [8.0.12] - 2026-04-23
 
 ### Removed

--- a/docs-site/public/thetadatadx.yaml
+++ b/docs-site/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 8.0.12
+  version: 8.0.13
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.12"
+version = "8.0.13"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.12"
+version = "8.0.13"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.12"
+version = "8.0.13"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.12",
+  "version": "8.0.13",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.12",
+  "version": "8.0.13",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.12",
+  "version": "8.0.13",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.12",
+  "version": "8.0.13",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.12",
-    "thetadatadx-darwin-arm64": "8.0.12",
-    "thetadatadx-win32-x64-msvc": "8.0.12"
+    "thetadatadx-linux-x64-gnu": "8.0.13",
+    "thetadatadx-darwin-arm64": "8.0.13",
+    "thetadatadx-win32-x64-msvc": "8.0.13"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.12"
+version = "8.0.13"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.12"
+version = "8.0.13"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.12"
+version = "8.0.13"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.12"
+version = "8.0.13"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary
Closes the mid-stream chunk header drift gap flagged as P13 in the external bench handoff.

## Fixed
- `MddsClient::collect_stream` and `MddsClient::for_each_chunk` now raise `DecodeError::ChunkHeaderDrift` on mid-stream schema change instead of silently accumulating rows under the first-chunk header set.

## Added
- `decode::DecodeError::ChunkHeaderDrift { chunk_index, first, chunk }` variant.

## Known / deferred
- `option_at_time_quote` 0.67× vs vendor — needs bench-validated per-endpoint generator carve-out, not applied here to avoid regressing the other option endpoints that benefit from the uniform v8.0.5 rule.
- `option_history_greeks_eod` 0.704× vs vendor — persistent since v8.0.0; needs proto-level diff against other `option_history_greeks_*` endpoints.
- `__init__.pyi` type stub emission — deferred (requires maturin include wiring + wheel-build validation).

## Test plan
- [x] cargo fmt / clippy / clippy+features / manifest-scoped clippy (py, ts, mcp, server)
- [x] cargo test --workspace --no-fail-fast
- [x] scripts/regen_byte_identical.sh
- [x] cargo deny check
- [x] docs-site npm run build