### PR TITLE
release: 8.0.14 — republish v8.0.13 chain after changelog mirror race

### DIFF
--- a/.github/release-notes/v8.0.14.md
+++ b/.github/release-notes/v8.0.14.md
@@ -1,0 +1,27 @@
+v8.0.14 re-publishes the v8.0.13 release chain to crates.io and
+GitHub Releases. The v8.0.13 tag CI failed on the `Extended Surfaces`
+docs-consistency gate because the squash merge of #412 captured an
+intermediate branch state where the top-level `CHANGELOG.md` had the
+final wording but the mirrored `docs-site/docs/changelog.md` still
+had the pre-cp wording. PyPI and npm published v8.0.13 successfully;
+crates.io and the GitHub Release did not.
+
+v8.0.14 carries the same code as v8.0.13 plus the synced changelog
+mirror. No behavior change vs v8.0.13. `tdbe` remains at `0.12.0`.
+
+## Fixed
+
+- Re-publish v8.0.13 chain from a clean main tip so crates.io and the
+  GitHub Release catch up with the Python and npm wheels already out
+  at 8.0.13.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --workspace --all-targets --features "polars,arrow" -- -D warnings`
+- `cargo test --workspace --no-fail-fast`
+- `scripts/check_docs_consistency.py`
+- `scripts/regen_byte_identical.sh`
+- `cargo deny check`
+- `(cd docs-site && npm run build)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.14] - 2026-04-23
+
+### Fixed
+
+- Re-publish the v8.0.13 chain to crates.io and GitHub Releases. The
+  v8.0.13 tag CI failed on the `Extended Surfaces` docs-consistency
+  gate because the squash merge of #412 captured an intermediate
+  branch state (top-level `CHANGELOG.md` had the final wording while
+  the mirrored `docs-site/docs/changelog.md` still had the pre-cp
+  wording). PyPI and npm published v8.0.13 successfully; crates.io
+  and the GitHub Release did not. v8.0.14 re-publishes everything
+  from the synced main tip. No behavior change vs v8.0.13.
+
 ## [8.0.13] - 2026-04-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.13"
+version = "8.0.14"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.14] - 2026-04-23
+
+### Fixed
+
+- Re-publish the v8.0.13 chain to crates.io and GitHub Releases. The
+  v8.0.13 tag CI failed on the `Extended Surfaces` docs-consistency
+  gate because the squash merge of #412 captured an intermediate
+  branch state (top-level `CHANGELOG.md` had the final wording while
+  the mirrored `docs-site/docs/changelog.md` still had the pre-cp
+  wording). PyPI and npm published v8.0.13 successfully; crates.io
+  and the GitHub Release did not. v8.0.14 re-publishes everything
+  from the synced main tip. No behavior change vs v8.0.13.
+
 ## [8.0.13] - 2026-04-23
 
 ### Fixed

--- a/docs-site/public/thetadatadx.yaml
+++ b/docs-site/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 8.0.13
+  version: 8.0.14
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.13"
+version = "8.0.14"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.13"
+version = "8.0.14"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.13"
+version = "8.0.14"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.13",
+  "version": "8.0.14",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.13",
+  "version": "8.0.14",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.13",
+  "version": "8.0.14",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.13",
+  "version": "8.0.14",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.13",
-    "thetadatadx-darwin-arm64": "8.0.13",
-    "thetadatadx-win32-x64-msvc": "8.0.13"
+    "thetadatadx-linux-x64-gnu": "8.0.14",
+    "thetadatadx-darwin-arm64": "8.0.14",
+    "thetadatadx-win32-x64-msvc": "8.0.14"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.13"
+version = "8.0.14"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.13"
+version = "8.0.14"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.13"
+version = "8.0.14"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.13"
+version = "8.0.14"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary
v8.0.13 published to PyPI + npm but its tag CI failed on Extended Surfaces docs-consistency, blocking crates.io publish + GitHub Release. #412 auto-merge captured an intermediate branch state where the top-level CHANGELOG.md had the final wording but `docs-site/docs/changelog.md` still had the hand-typed pre-cp wording.

v8.0.14 carries the same code + synced mirror. No behavior change vs v8.0.13.

## Test plan
- [x] cargo fmt / clippy / clippy+features
- [x] scripts/check_docs_consistency.py
- [x] scripts/regen_byte_identical.sh (803 files)
- [x] cargo deny check