### PR TITLE
release: 8.0.15 — fix Linux wheel manylinux tag (Colab / RHEL 8 / Ubuntu 22.04)

### DIFF
--- a/.github/release-notes/v8.0.15.md
+++ b/.github/release-notes/v8.0.15.md
@@ -1,0 +1,35 @@
+v8.0.15 fixes a Linux wheel tag regression that silently broke
+`pip install thetadatadx` on every glibc 2.17+ / glibc < 2.38 runtime
+— Google Colab, Databricks, CentOS 7 / RHEL 7 / RHEL 8, Ubuntu 18.04
+through 22.04, Debian 10+. The v8.0.14 wheel was produced on
+`ubuntu-latest` (now Ubuntu 24.04, glibc 2.38), which caused maturin
+to tag the artifact `manylinux_2_38`; pip on those older hosts
+rejected the wheel, fell through to the sdist, and failed the
+source-build step because Rust is not preinstalled on most hosted
+Python runtimes.
+
+The wheel now builds inside the PyPA `manylinux2014` Docker image
+(glibc 2.17) via `PyO3/maturin-action@v1`. No code changes. `tdbe`
+remains at `0.12.0`.
+
+## Fixed
+
+- Linux wheel tag moved from `manylinux_2_38` to `manylinux_2_17` so
+  `pip install thetadatadx` now resolves to the prebuilt wheel on
+  every supported host instead of falling through to the sdist.
+
+## Changed
+
+- `.github/workflows/python.yml` Linux wheel step swapped to
+  `PyO3/maturin-action@v1` with `manylinux: '2014'`. macOS and
+  Windows continue to build natively on their matrix runners.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --workspace --all-targets --features "polars,arrow" -- -D warnings`
+- `cargo test --workspace --no-fail-fast`
+- `scripts/regen_byte_identical.sh`
+- `scripts/check_docs_consistency.py`
+- After release: `pip download thetadatadx==8.0.15 --platform manylinux_2_17_x86_64 --python-version 3.11 --only-binary=:all: -d /tmp/wheel-check` should succeed against the published wheel.

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -55,7 +55,22 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings -A clippy::too_many_arguments
       - shell: bash
         run: python -m pip install --upgrade pip "maturin>=1.9.4,<2.0"
-      - name: Build wheel
+      # Linux wheel uses the manylinux2014 (glibc 2.17) Docker toolchain so
+      # the published wheel is installable on every supported platform —
+      # Ubuntu 22.04 / RHEL 8 / Google Colab / Databricks / CentOS 7 all
+      # pin glibc at or below 2.34. Building on `ubuntu-latest` directly
+      # tags the wheel with the host glibc floor (currently 2.38), which
+      # silently breaks every older runtime.
+      - name: Build wheel (Linux, manylinux2014)
+        if: matrix.os == 'ubuntu-latest'
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release -m sdks/python/Cargo.toml -o dist/ --interpreter python
+          manylinux: '2014'
+          target: x86_64
+      - name: Build wheel (macOS / Windows)
+        if: matrix.os != 'ubuntu-latest'
         shell: bash
         run: python -m maturin build --release -m sdks/python/Cargo.toml -o dist/ --interpreter python
       - name: Install wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.15] - 2026-04-24
+
+### Fixed
+
+- Linux wheel tag moved from `manylinux_2_38` to `manylinux_2_17` so
+  the published `thetadatadx-*-manylinux_2_17_x86_64.whl` installs on
+  every glibc 2.17+ runtime (CentOS 7 / RHEL 7+ / Ubuntu 18.04+ /
+  Debian 10+ / Google Colab / Databricks). The v8.0.14 wheel was
+  built on `ubuntu-latest` (now Ubuntu 24.04 / glibc 2.38), which
+  silently gated every older environment — `pip install thetadatadx`
+  would fall through to the sdist and fail the source build because
+  Rust is not available on most hosted Python runtimes.
+
+### Changed
+
+- `.github/workflows/python.yml` Linux wheel step now uses
+  `PyO3/maturin-action@v1` with `manylinux: '2014'` (glibc 2.17
+  toolchain inside a Docker container). macOS and Windows continue
+  to build natively on their matrix runners.
+
 ## [8.0.14] - 2026-04-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.14"
+version = "8.0.15"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.15] - 2026-04-24
+
+### Fixed
+
+- Linux wheel tag moved from `manylinux_2_38` to `manylinux_2_17` so
+  the published `thetadatadx-*-manylinux_2_17_x86_64.whl` installs on
+  every glibc 2.17+ runtime (CentOS 7 / RHEL 7+ / Ubuntu 18.04+ /
+  Debian 10+ / Google Colab / Databricks). The v8.0.14 wheel was
+  built on `ubuntu-latest` (now Ubuntu 24.04 / glibc 2.38), which
+  silently gated every older environment — `pip install thetadatadx`
+  would fall through to the sdist and fail the source build because
+  Rust is not available on most hosted Python runtimes.
+
+### Changed
+
+- `.github/workflows/python.yml` Linux wheel step now uses
+  `PyO3/maturin-action@v1` with `manylinux: '2014'` (glibc 2.17
+  toolchain inside a Docker container). macOS and Windows continue
+  to build natively on their matrix runners.
+
 ## [8.0.14] - 2026-04-23
 
 ### Fixed

--- a/docs-site/public/thetadatadx.yaml
+++ b/docs-site/public/thetadatadx.yaml
@@ -13,7 +13,7 @@ info:
     All dates use YYYYMMDD format. Times use milliseconds since midnight ET.
     Intervals accept milliseconds ("60000") or shorthand ("1m"). Valid presets: 100ms, 500ms, 1s, 5s, 10s, 15s, 30s, 1m, 5m, 10m, 15m, 30m, 1h.
     All prices are f64 (double) -- decoded during parsing.
-  version: 8.0.14
+  version: 8.0.15
   contact:
     name: ThetaDataDx
     url: https://github.com/userFRM/ThetaDataDx

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.14"
+version = "8.0.15"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.14"
+version = "8.0.15"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.14"
+version = "8.0.15"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.14",
+  "version": "8.0.15",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.14",
+  "version": "8.0.15",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.14",
+  "version": "8.0.15",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.14",
+  "version": "8.0.15",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.14",
-    "thetadatadx-darwin-arm64": "8.0.14",
-    "thetadatadx-win32-x64-msvc": "8.0.14"
+    "thetadatadx-linux-x64-gnu": "8.0.15",
+    "thetadatadx-darwin-arm64": "8.0.15",
+    "thetadatadx-win32-x64-msvc": "8.0.15"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.14"
+version = "8.0.15"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.14"
+version = "8.0.15"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.14"
+version = "8.0.15"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.14"
+version = "8.0.15"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary
v8.0.14 Linux wheel tagged `manylinux_2_38` because `ubuntu-latest` moved to Ubuntu 24.04 (glibc 2.38). Every glibc 2.17+ / glibc < 2.38 runtime rejected the wheel (Colab, Databricks, CentOS 7, RHEL 7/8, Ubuntu 18.04-22.04, Debian 10+), pip fell through to the sdist and failed because Rust isn't preinstalled on hosted Python runtimes.

Linux wheel now builds inside the PyPA manylinux2014 Docker image via `PyO3/maturin-action@v1`. macOS + Windows keep their native builds. No code changes.

## Test plan
- [x] cargo fmt / clippy (+features)
- [x] scripts/regen_byte_identical.sh (833 files identical)
- [x] scripts/check_docs_consistency.py
- [x] cargo deny check
- [ ] After release workflow completes: verify the published wheel is tagged `manylinux_2_17_x86_64`