### PR TITLE
thetadatadx: re-export tdbe tick types at crate root

### DIFF
--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -166,3 +166,7 @@ pub use tdbe::types::enums::{
     StreamResponseType, Venue, Version,
 };
 pub use tdbe::types::price::Price;
+
+pub mod utils {
+    pub use tdbe::{conditions, exchange, sequences};
+}

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -154,3 +154,14 @@ pub use tdbe::types::tick::{
     CalendarDay, EodTick, GreeksTick, InterestRateTick, IvTick, MarketValueTick, OhlcTick,
     OpenInterestTick, OptionContract, PriceTick, QuoteTick, TradeQuoteTick, TradeTick,
 };
+
+// Enums + the `Price` wrapper appear on SDK method signatures and inside
+// every tick struct, so consumers naming method parameters or unpacking
+// tick fields need them in scope. Re-exported here for the same single-
+// dep reason as the tick types above. `tdbe::Error` is intentionally
+// NOT re-exported to avoid colliding with [`crate::Error`]; the SDK's
+// own `Error` transparently wraps codec failures from `tdbe`.
+pub use tdbe::types::enums::{
+    DataType, Interval, RateType, RequestType, Right, SecType, Venue, Version,
+};
+pub use tdbe::types::price::Price;

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -162,6 +162,7 @@ pub use tdbe::types::tick::{
 // NOT re-exported to avoid colliding with [`crate::Error`]; the SDK's
 // own `Error` transparently wraps codec failures from `tdbe`.
 pub use tdbe::types::enums::{
-    DataType, Interval, RateType, RequestType, Right, SecType, Venue, Version,
+    DataType, Interval, RateType, RemoveReason, RequestType, Right, SecType, StreamMsgType,
+    StreamResponseType, Venue, Version,
 };
 pub use tdbe::types::price::Price;

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -138,3 +138,19 @@ pub use unified::{ConnectionStatus, SubscriptionInfo, ThetaDataDx};
 // path. See [`tdbe::greeks`] for the full surface (per-Greek helpers,
 // `GreeksResult` struct, etc.).
 pub use tdbe::greeks::{all_greeks, implied_volatility, GreeksResult};
+
+// Re-export every tick / row type returned by the SDK's network methods.
+// These all live in `tdbe::types::tick`, but consumers of the high-level
+// `ThetaDataDx` / `MddsClient` surface should not need a second crate in
+// their `Cargo.toml` just to name a return type. `tdbe` remains a
+// standalone crate for offline use cases (Greeks math, format primitives,
+// no network); customers consuming the SDK get every type they need
+// at the `thetadatadx` crate root, fronting the same structs.
+//
+// Adding a new tick type? Mirror the addition here so `thetadatadx`
+// consumers stay on a single dep. The companion items above
+// (`ParsedRight`, `GreeksResult`, …) follow the same policy.
+pub use tdbe::types::tick::{
+    CalendarDay, EodTick, GreeksTick, InterestRateTick, IvTick, MarketValueTick, OhlcTick,
+    OpenInterestTick, OptionContract, PriceTick, QuoteTick, TradeQuoteTick, TradeTick,
+};


### PR DESCRIPTION
Closes #422.

## Summary

Adds 13 `pub use tdbe::types::tick::*` re-exports at the `thetadatadx` crate root so SDK consumers can name every return type without adding `tdbe` to their own `Cargo.toml`.

## Why

Methods on `ThetaDataDx` and `MddsClient` return types defined in `tdbe` (`GreeksTick`, `OhlcTick`, `EodTick`, `TradeQuoteTick`, etc.). `thetadatadx::lib.rs` already re-exports `tdbe::right::*` and `tdbe::greeks::*` — tick types were the missing third group. Every SDK user that names a return type in a function signature, struct field, or variable annotation has been forced to depend on `tdbe` directly, even though they only consume the SDK.

This punishes the standard SDK use case with a two-crate dep when one suffices. Downstream wrappers (e.g. `kairos-thetadata`) currently re-export `tdbe::types::tick::*` themselves to hide the awkwardness — a workaround for an upstream gap.

## Change

| File | Lines | Change |
|---|---|---|
| `crates/thetadatadx/src/lib.rs` | +16 / -0 | New `pub use tdbe::types::tick::{...}` block + module-level doc |

## Why this is non-breaking

- Pure addition to the public surface. No removal, no renaming.
- `tdbe` continues to exist as a standalone crate. Existing consumers that depend on `tdbe` directly keep working unchanged.
- Same shape as the existing re-exports for `tdbe::right::*` and `tdbe::greeks::*` already in `lib.rs`.

## Version impact

Minor bump (`8.0.15` → `8.1.0`) per semver: additive public API.

## Single-dep contract

After this PR, the policy is: **consumers of `thetadatadx` never need `tdbe` in their `Cargo.toml`.** `tdbe` remains a separate published crate for offline-only use cases (Greeks math, format primitives, no network surface). The SDK fronts every return type at its own crate root.

## CI

`cargo fmt --all -- --check` ✓
`cargo clippy --workspace -- -D warnings` ✓
`cargo test --workspace --lib` ✓ (256 passed)

## Follow-ups

- Bump version to `8.1.0` after merge.
- `kairos-thetadata` (separate repo) drops `tdbe` from its `Cargo.toml` once pinned to the new minor; re-exports through `thetadatadx` instead.