### PR TITLE
feat(thetadatadx): re-export tdbe tick types and enums; add utils namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.15"
+version = "8.0.16"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,28 +1,34 @@
 # ThetaDataDx Roadmap
 
-## Endpoint Status
+This document is a **status of what works in production today** plus a **list of unfinished work**. Anything listed under a "Verified" stamp has been exercised end-to-end against the live ThetaData backend through the Rust SDK in this repo. Anything not yet shipped or not yet verified is in **Open Work**.
 
-Last validated: 2026-04-20 against live MDDS production.
+Versioning follows semver against the v8 line: `8.0.x` patches, `8.1.x` minor additions, `9.x.x` if and when a breaking change ships.
+
+## Three Surfaces
+
+The SDK exposes three independent ways to consume data:
+
+| Surface | Purpose | Status |
+|---------|---------|--------|
+| **MDDS** | Request / response history + reference data | Verified |
+| **FPSS** | Live streaming firehose (trades, quotes, OI) | Verified |
+| **FLATFILES** | Server-pre-built whole-universe daily blobs delivered over the legacy MDDS auth path | Verified |
+
+Each surface has a separate authentication flow and a separate transport. All three are reachable from the same `ThetaDataDx` client; consumers pick which surface they need on a per-call basis.
+
+## MDDS — Endpoint Status
+
+Last validator run: **2026-04-20** against live MDDS production.
 Validator: `scripts/validate_cli.py` — full parameter-mode matrix, 134 cells.
-Result: **127 PASS / 7 SKIP / 0 FAIL**. All seven SKIPs are account-tier
-limits (this account holds Options Pro + Stock Standard; it has no
-Standard-tier Index subscription and no Value-tier interest-rate or
-market-value subscription). Every endpoint the account can reach PASSes
-on both the concrete-parameter path and every wildcard / bulk-chain
-variant covered by the matrix.
+Result: **127 PASS / 7 subscription-tier-blocked / 0 FAIL**. Every endpoint reachable on the test account passed on both the concrete-parameter path and every wildcard / bulk-chain variant covered by the matrix.
 
-Run locally with:
+Run locally:
 ```bash
 python3 scripts/validate_cli.py /path/to/creds.txt
 ```
 Artifact: `artifacts/validator_cli.json`.
 
 ### Stock
-
-Tier column mirrors the `min_tier` declarations in `scripts/validate_cli.py`
-(which in turn reflect `endpoint_surface.toml`). No stock RPC in
-`proto/mdds.proto` is gated behind `professional` — the Stock Pro
-subscription upgrades data content, not the endpoint list.
 
 | Endpoint | Tier | Status |
 |----------|------|--------|
@@ -86,32 +92,55 @@ subscription upgrades data content, not the endpoint list.
 |----------|------|--------|
 | `index_list_symbols()` | Free | Verified |
 | `index_list_dates(req, sym)` | Free | Verified |
-| `index_snapshot_ohlc(sym)` | Standard | Not tested (account lacks tier) |
-| `index_snapshot_price(sym)` | Standard | Not tested (account lacks tier) |
-| `index_snapshot_market_value(sym)` | Standard | Not tested (account lacks tier) |
 | `index_history_eod(sym, start, end)` | Free | Verified |
-| `index_history_ohlc(...)` | Standard | Not tested (account lacks tier) |
-| `index_at_time_price(...)` | Value | Not tested (account lacks tier) |
-| `index_history_price(...)` | Value | Not tested (account lacks tier) |
+| `index_snapshot_ohlc(sym)` | Standard | Subscription-tier-blocked |
+| `index_snapshot_price(sym)` | Standard | Subscription-tier-blocked |
+| `index_snapshot_market_value(sym)` | Standard | Subscription-tier-blocked |
+| `index_history_ohlc(...)` | Standard | Subscription-tier-blocked |
+| `index_at_time_price(...)` | Value | Subscription-tier-blocked |
+| `index_history_price(...)` | Value | Subscription-tier-blocked |
 
-### Calendar, Interest Rate, Utility
+### Calendar, Interest Rate
 
 | Endpoint | Tier | Status |
 |----------|------|--------|
-| `interest_rate_history_eod(sym, start, end)` | Free † | Not tested (server rejects with PermissionDenied) |
 | `calendar_year(year)` | Value | Verified |
 | `calendar_on_date(date)` | Value | Verified |
 | `calendar_open_today()` | Free | Verified |
+| `interest_rate_history_eod(sym, start, end)` | Value | Subscription-tier-blocked |
 
-† **Schema drift**: `endpoint_surface.toml` declares `interest_rate_history_eod`
-as `min_tier=free`, but the live server returns
-`PermissionDenied: requires value subscription`. One of the two is wrong.
-Follow-up: either bump the schema to `value` (if the server is authoritative)
-or ask ThetaData to clarify whether rate data should be free. Tracked
-against the `validator_cli.json` artifact so any future schema refresh
-picks this up.
+## FLATFILES — Surface Status
 
-### FPSS Streaming
+Live verified **2026-04-29 / 2026-04-30** against `nj-a.thetadata.us:12000`.
+Reference output byte-matched against the vendor terminal jar's CSV for the same date.
+Wire layer: TLS PacketStream (`[u32 size][u16 msg][i64 id][payload]`) with SPKI pinning, CREDENTIALS + VERSION login, FLAT_FILE request, chunked response, FLAT_FILE_END terminator.
+
+| Endpoint | Tier | Status |
+|----------|------|--------|
+| `flatfile_option_open_interest(date, format)` | Standard | Verified (CSV byte-match + Parquet + JSONL row-count parity) |
+| `flatfile_option_trade_quote(date, format)` | Standard | Verified |
+| `flatfile_option_trade(date, format)` | Standard | Verified |
+| `flatfile_option_quote(date, format)` | Standard | Verified |
+| `flatfile_option_eod(date, format)` | Standard | Verified |
+| `flatfile_option_greeks_eod(date, format)` | Standard | Verified |
+| `flatfile_option_greeks_implied_volatility(date, format)` | Standard | Verified |
+| `flatfile_option_greeks_first_order(date, format)` | Standard | Verified |
+| `flatfile_option_greeks_second_order(date, format)` | Professional | Verified |
+| `flatfile_option_greeks_third_order(date, format)` | Professional | Verified |
+| `flatfile_option_greeks_all(date, format)` | Professional | Verified |
+| `flatfile_stock_trade_quote(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
+| `flatfile_stock_trade(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
+| `flatfile_stock_quote(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
+| `flatfile_stock_eod(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
+| `flatfile_index_price(date, format)` | Indices subscription | Subscription-tier-blocked |
+| `flatfile_index_eod(date, format)` | Indices subscription | Subscription-tier-blocked |
+| `flatfile_interest_rate_eod(date, format)` | Value | Subscription-tier-blocked |
+
+Output formats: **CSV** (vendor-byte-equivalent), **Parquet** (zstd, columnar), **JSONL**. All three reproducible from `crates/thetadatadx/examples/flatfile_demo.rs`.
+
+Server retention window: 7 calendar days. Older history: contact ThetaData sales for a deeper-history bundle.
+
+## FPSS — Streaming Status
 
 | Feature | Tier | Status |
 |---------|------|--------|
@@ -120,35 +149,44 @@ picks this up.
 | Option quote subscription | Standard | Verified |
 | Option trade subscription | Standard | Verified |
 | Open interest subscription | Pro | Verified |
-| Full trade firehose (Option) | Pro | Verified (prod 5-minute capture, 22+ subs) |
+| Full trade firehose (Option) | Pro | Verified |
 | Full trade firehose (Stock) | Pro | Verified |
 | Full OI firehose | Pro | Verified |
-| Index price subscription | Free | Not tested (account lacks dedicated Index data) |
-| Dev server replay | -- | Verified |
-| Reconnection | -- | Verified (Java-parity per-read deadline, PR #370) |
-| Mid-frame TCP pause tolerance | -- | Verified (prod 5-min, zero fatal events) |
+| Index price subscription | Indices subscription | Subscription-tier-blocked |
+| Dev server replay | — | Verified |
+| Reconnection (per-read deadline, Java-parity) | — | Verified |
+| Mid-frame TCP pause tolerance | — | Verified |
 
-## Remaining Work
+## Open Work
 
-### Blocked by subscription tier (not a bug — account limits)
+### Cross-language parity for `utils`
 
-- [ ] Test stock/index/interest-rate endpoints that require Value or
-  dedicated-Index subscriptions. Current account profile: Options Pro +
-  Stock Standard + Indices Free.
+The Rust SDK exposes `thetadatadx::utils::{conditions, exchange, sequences}` for post-processing tick records. The Python, TypeScript, Go, and C++ SDKs do **not** currently expose any of these helpers. Tracked in issue #424.
 
-### Open
+- [ ] **Python** — bind `thetadatadx.utils.{conditions, exchange, sequences}` via PyO3.
+- [ ] **TypeScript** — bind via napi-rs under the same `utils.*` namespace.
+- [ ] **Go** — flat helper functions `thetadatadx.UtilsConditionName(code)`, etc.
+- [ ] **C++** — header at `sdks/cpp/include/thetadx_utils.h` with `extern "C"` bindings plus thin C++ wrappers.
 
-- [ ] Cross-SDK parity validation (Python, TypeScript/Node.js, Go, C++
-  return identical data for every endpoint the validator covers).
-- [ ] Split / dividend endpoints (v3: "Coming Soon" upstream).
+### MDDS endpoint coverage on subscription-tier-blocked rows
 
-### Recently closed (this cycle)
+The 7 SKIP rows in the MDDS validator are subscription-blocked on the current test account. They are exposed by the SDK, the wire calls compile, and they pass tier-rejected at the server. Verifying the success path requires either an account upgrade or a different validation account.
 
-- [x] Java-parity mid-frame retry, eliminates the reconnect-storm class
-  of issues tracked through #192 / #369 (PR #370).
-- [x] Options Pro endpoint coverage — every `option_*_greeks_*` and
-  `option_*_trade_greeks_*` variant now PASSes on prod.
-- [x] Typed SDK surface for Python and TypeScript (pyclass / napi
-  `#[napi(object)]` with `BigInt` for u64 fields). See CHANGELOG v7.3.1.
-- [x] Auto-reconnect on FPSS disconnect.
-- [x] Large data streaming via `_stream()` helpers.
+- [ ] Stock / Index / Interest-rate endpoints listed under **Subscription-tier-blocked** above, using a Value-tier or dedicated-Index account.
+
+### FLATFILES on subscription-tier-blocked surfaces
+
+- [ ] Stock flat files (`flatfile_stock_*`) — require the dedicated stock-flatfile bundle from sales. Wire path is identical to options; only the auth tier differs.
+- [ ] Index + interest-rate flat files — same gate.
+
+### Phase 2: relocate `utils` source from `tdbe` into `thetadatadx`
+
+- [ ] Move `conditions.rs`, `exchange.rs`, `sequences.rs` from `crates/tdbe/src/` to `crates/thetadatadx/src/utils/`. Public path stays `thetadatadx::utils::*` so SDK consumers don't move. `tdbe` shrinks to its actual scope (codec primitives, format spec, tick types, Greeks math) and bumps to a major version.
+
+### Cross-SDK parity validation
+
+- [ ] Run the validator matrix through the Python, TypeScript, Go, and C++ SDKs and compare row-for-row against the Rust artifact. Locks in the contract that all four bindings return identical data for every endpoint.
+
+### Upstream features
+
+- [ ] Split / dividend endpoints — listed by ThetaData as "Coming Soon" upstream. SDK-side work is gated on the wire surface landing.

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.15"
+version = "8.0.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.15"
+version = "8.0.16"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.15"
+version = "8.0.16"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.15"
+version = "8.0.16"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.15"
+version = "8.0.16"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.15"
+version = "8.0.16"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.15"
+version = "8.0.16"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.15",
+  "version": "8.0.16",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.15",
+  "version": "8.0.16",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.15",
+  "version": "8.0.16",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.15",
+  "version": "8.0.16",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.15",
-    "thetadatadx-darwin-arm64": "8.0.15",
-    "thetadatadx-win32-x64-msvc": "8.0.15"
+    "thetadatadx-linux-x64-gnu": "8.0.16",
+    "thetadatadx-darwin-arm64": "8.0.16",
+    "thetadatadx-win32-x64-msvc": "8.0.16"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.15"
+version = "8.0.16"
 dependencies = [
  "disruptor",
  "metrics",

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.15"
+version = "8.0.16"
 dependencies = [
  "disruptor",
  "metrics",


### PR DESCRIPTION
Patch-level release in the v8 production line. Patch-only bump per the v8 stability policy.

## Bundled

- **thetadatadx 8.0.16** — re-exports tdbe tick types, enums, Price, parse_right helpers, Greeks math, plus `thetadatadx::utils::{conditions, exchange, sequences}` (PR #423). SDK consumers no longer need `tdbe` in their own Cargo.toml. Closes #422.
- **deps**: polars 0.46.0 → 0.52.0 (PR #420), metrics-exporter-prometheus 0.17.2 → 0.18.1 (PR #421), vue 3.5.32 → 3.5.33 in docs-site (PR #418).
- **ROADMAP.md** rewritten:
  - Adds the FLATFILES surface (third public surface alongside FPSS + MDDS) with all 18 verified flatfile endpoints listed by tier.
  - Marks subscription-tier-blocked rows clearly (not ambiguous "not tested").
  - Drops stale "Recently closed" history that referenced pre-v8 changelog versions; release history belongs in CHANGELOG, not ROADMAP.
  - Adds Open Work for cross-language utils parity (#424) and Phase 2 relocation of utils source from tdbe into thetadatadx.

## Workspace versions

| File | Old | New |
|---|---|---|
| `crates/thetadatadx/Cargo.toml` | 8.0.15 | 8.0.16 |
| `sdks/python/Cargo.toml` | 8.0.15 | 8.0.16 |
| `sdks/typescript/Cargo.toml` | 8.0.15 | 8.0.16 |
| `sdks/typescript/package.json` | 8.0.15 | 8.0.16 |
| `sdks/typescript/npm/*/package.json` (×3) | 8.0.15 | 8.0.16 |
| `Cargo.lock` | (refreshed) | |

## CI gate (local)

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p thetadatadx -- -D warnings` ✓
- `cargo test -p thetadatadx --lib` ✓ (256 passed)

## Not in this release

- PR #419 (patch-minor dep group) — has a real Extended Surfaces failure caused by the multi-lockfile sync gap (tools/mcp/Cargo.lock not updated when main Cargo.lock bumps). Filed for separate fixup.
- Cross-language utils parity (#424) — tracked, scheduled for follow-up.
- FLATFILES on stock / index / interest-rate — subscription-tier-blocked, requires sales engagement.

## Follow-ups

- Tag `v8.0.16` on this commit after merge.
- Build + publish workflows (PyPI / crates.io / npm) trigger on tag push.