### PR TITLE
feat(thetadatadx): add FLATFILES surface for whole-universe daily blobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ private/
 # Live validator per-cell artifacts (scripts/validate_agreement.py reads these).
 artifacts/
 todo.md
+out/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,38 +164,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-ipc"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "flatbuffers",
-]
-
-[[package]]
 name = "arrow-schema"
 version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
-
-[[package]]
-name = "arrow-select"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num-traits",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -385,12 +357,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -907,16 +873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
-name = "flatbuffers"
-version = "25.12.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
-dependencies = [
- "bitflags",
- "rustc_version",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,12 +1350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,15 +1781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,40 +1812,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "parquet"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
- "base64",
- "bytes",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-bigint",
- "num-integer",
- "num-traits",
- "paste",
- "seq-macro",
- "thrift",
- "twox-hash",
- "zstd",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -2659,15 +2566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,12 +2734,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3152,7 +3044,6 @@ dependencies = [
  "disruptor",
  "metrics",
  "metrics-exporter-prometheus",
- "parquet",
  "pastey",
  "polars",
  "prost",
@@ -3251,17 +3142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
 ]
 
 [[package]]
@@ -3623,12 +3503,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,10 +170,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
 name = "arrow-schema"
 version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -357,6 +385,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -868,6 +902,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1782,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,6 +1822,40 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -2566,6 +2659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,6 +2830,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3010,6 +3118,7 @@ dependencies = [
  "disruptor",
  "metrics",
  "metrics-exporter-prometheus",
+ "parquet",
  "pastey",
  "polars",
  "prost",
@@ -3019,6 +3128,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
+ "serde_json",
  "sha2",
  "subtle",
  "tdbe",
@@ -3098,6 +3208,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
 ]
 
 [[package]]
@@ -3429,6 +3550,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.16"
+version = "8.0.17"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -122,19 +122,10 @@ Wire layer: TLS PacketStream (`[u32 size][u16 msg][i64 id][payload]`) with SPKI 
 | `flatfile_option_trade(date, format)` | Standard | Verified |
 | `flatfile_option_quote(date, format)` | Standard | Verified |
 | `flatfile_option_eod(date, format)` | Standard | Verified |
-| `flatfile_option_greeks_eod(date, format)` | Standard | Verified |
-| `flatfile_option_greeks_implied_volatility(date, format)` | Standard | Verified |
-| `flatfile_option_greeks_first_order(date, format)` | Standard | Verified |
-| `flatfile_option_greeks_second_order(date, format)` | Professional | Verified |
-| `flatfile_option_greeks_third_order(date, format)` | Professional | Verified |
-| `flatfile_option_greeks_all(date, format)` | Professional | Verified |
 | `flatfile_stock_trade_quote(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
 | `flatfile_stock_trade(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
 | `flatfile_stock_quote(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
 | `flatfile_stock_eod(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
-| `flatfile_index_price(date, format)` | Indices subscription | Subscription-tier-blocked |
-| `flatfile_index_eod(date, format)` | Indices subscription | Subscription-tier-blocked |
-| `flatfile_interest_rate_eod(date, format)` | Value | Subscription-tier-blocked |
 
 Output formats: **CSV** (vendor-byte-equivalent), **Parquet** (zstd, columnar), **JSONL**. All three reproducible from `crates/thetadatadx/examples/flatfile_demo.rs`.
 

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -33,9 +33,7 @@ metrics-prometheus = ["dep:metrics-exporter-prometheus"]
 # Opt-in: polars and arrow stay behind feature flags so the default dep graph
 # is unchanged. `frames` is a convenience alias pulling both in at once.
 polars = ["dep:polars"]
-# `arrow` is now a no-op alias kept for backwards-compat: arrow-array
-# and arrow-schema are unconditionally pulled in by the FLATFILES surface.
-arrow = []
+arrow = ["dep:arrow-array", "dep:arrow-schema"]
 frames = ["polars", "arrow"]
 # Opt-in gate for tests that hit live MDDS / FPSS endpoints. Default-off
 # so `cargo test` never burns a live call without the user asking for it.
@@ -104,20 +102,11 @@ disruptor = "4.1.0"
 # avoids pulling the polars-plan / polars-sql / polars-parquet graph into dependents
 # that only want row-to-frame materialization.
 polars = { version = "0.52", optional = true, default-features = false }
-# arrow-array + arrow-schema cover RecordBatch construction and the
-# `Int32Array` / `Int64Array` / `Float64Array` / `StringArray` primitives.
-# Originally feature-gated under `arrow`/`frames`, now required by the
-# FLATFILES surface (third public surface — overnight whole-universe
-# vendor-format files). Parquet output goes through the `parquet` crate
-# below, which depends on these as part of its `arrow` feature.
-# Version pinned to 58.x for repo-wide single-major-version linkage.
-arrow-array = "58.1.0"
-arrow-schema = "58.1.0"
-# Parquet writer used by the FLATFILES `Format::Parquet` output. Pulls in
-# zstd compression + arrow integration. The crate is small relative to
-# the wider arrow ecosystem and is the only viable Rust Parquet writer
-# with a streaming `RecordBatch` API.
-parquet = { version = "58.1.0", default-features = false, features = ["arrow", "zstd"] }
+# arrow-array + arrow-schema cover RecordBatch construction for the
+# optional `frames` feature only. Kept optional so the default dep
+# graph stays slim — FLATFILES does not pull in arrow.
+arrow-array = { version = "58.1.0", optional = true }
+arrow-schema = { version = "58.1.0", optional = true }
 # JSON encoder for the FLATFILES `Format::Jsonl` output. One serde_json
 # Value per row; `to_writer` emits compact form, then we append `\n`.
 serde_json = "1.0.137"

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -33,8 +33,13 @@ metrics-prometheus = ["dep:metrics-exporter-prometheus"]
 # Opt-in: polars and arrow stay behind feature flags so the default dep graph
 # is unchanged. `frames` is a convenience alias pulling both in at once.
 polars = ["dep:polars"]
-arrow = ["dep:arrow-array", "dep:arrow-schema"]
+# `arrow` is now a no-op alias kept for backwards-compat: arrow-array
+# and arrow-schema are unconditionally pulled in by the FLATFILES surface.
+arrow = []
 frames = ["polars", "arrow"]
+# Opt-in gate for tests that hit live MDDS / FPSS endpoints. Default-off
+# so `cargo test` never burns a live call without the user asking for it.
+live-tests = []
 
 [dependencies]
 tdbe = { version = "0.12.0", path = "../tdbe" }
@@ -100,14 +105,22 @@ disruptor = "4.0.0"
 # that only want row-to-frame materialization.
 polars = { version = "0.46", optional = true, default-features = false }
 # arrow-array + arrow-schema cover RecordBatch construction and the
-# `Int32Array` / `Int64Array` / `Float64Array` / `StringArray` primitives
-# the generator emits. Pulling the full `arrow` umbrella crate would also
-# drag in parquet, compute kernels, and CSV / JSON readers we do not need.
-# Version pinned to 58.x — matches `sdks/python/Cargo.toml` (which depends on
-# `arrow = "58.1.0"`) so every crate in the repo sees a single major-version
-# of the arrow family at link time.
-arrow-array = { version = "58.1.0", optional = true }
-arrow-schema = { version = "58.1.0", optional = true }
+# `Int32Array` / `Int64Array` / `Float64Array` / `StringArray` primitives.
+# Originally feature-gated under `arrow`/`frames`, now required by the
+# FLATFILES surface (third public surface — overnight whole-universe
+# vendor-format files). Parquet output goes through the `parquet` crate
+# below, which depends on these as part of its `arrow` feature.
+# Version pinned to 58.x for repo-wide single-major-version linkage.
+arrow-array = "58.1.0"
+arrow-schema = "58.1.0"
+# Parquet writer used by the FLATFILES `Format::Parquet` output. Pulls in
+# zstd compression + arrow integration. The crate is small relative to
+# the wider arrow ecosystem and is the only viable Rust Parquet writer
+# with a streaming `RecordBatch` API.
+parquet = { version = "58.1.0", default-features = false, features = ["arrow", "zstd"] }
+# JSON encoder for the FLATFILES `Format::Jsonl` output. One serde_json
+# Value per row; `to_writer` emits compact form, then we append `\n`.
+serde_json = "1.0.137"
 
 # Secret-wiping wrapper for password in `Credentials`. Zeroizes the backing
 # buffer on drop so the plaintext is not recoverable from a core dump or

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.16"
+version = "8.0.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -49,7 +49,7 @@ prost = "=0.14.3"
 prost-types = "=0.14.3"
 
 # Async runtime
-tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync"] }
+tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync", "fs"] }
 tokio-stream = "0.1.18"
 tokio-rustls = "0.26.4"
 rustls = { version = "0.23.40", features = ["ring"] }
@@ -68,7 +68,7 @@ reqwest = { version = "0.13.3", features = ["json", "rustls"], default-features 
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }
-uuid = "1.23.1"
+uuid = { version = "1.23.1", features = ["v4"] }
 
 # Compression (responses use zstd)
 zstd = "0.13.3"

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -42,7 +42,7 @@ frames = ["polars", "arrow"]
 live-tests = []
 
 [dependencies]
-tdbe = { version = "0.12.0", path = "../tdbe" }
+tdbe = { version = "0.12.1", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }
@@ -143,7 +143,7 @@ prost-build = "=0.14.3"
 regex = "1.12.3"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
-tdbe = { version = "0.12.0", path = "../tdbe" }
+tdbe = { version = "0.12.1", path = "../tdbe" }
 
 [[bench]]
 name = "bench_decode"

--- a/crates/thetadatadx/examples/flatfile_demo.rs
+++ b/crates/thetadatadx/examples/flatfile_demo.rs
@@ -54,6 +54,13 @@ fn parse_format(s: &str) -> Result<FlatFileFormat, String> {
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> ExitCode {
+    // Workspace pulls multiple rustls crypto-provider candidates (ring via
+    // `rustls = ["ring"]` and aws-lc-rs through some transitive dep). Pick
+    // one explicitly so rustls' process-default resolver doesn't panic at
+    // first TLS connect. ring is what `rustls`'s feature flag in this
+    // workspace selects.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let args: Vec<String> = std::env::args().collect();
     if args.len() != 6 {
         eprintln!(

--- a/crates/thetadatadx/examples/flatfile_demo.rs
+++ b/crates/thetadatadx/examples/flatfile_demo.rs
@@ -12,7 +12,7 @@
 //!   data_type  EOD | QUOTE | TRADE | TRADE_QUOTE | OPEN_INTEREST | OHLC
 //!   date       YYYYMMDD (e.g. 20260428)
 //!   out_path   destination path; the format extension is appended if absent
-//!   format     CSV | PARQUET | JSONL
+//!   format     CSV | JSONL
 //!
 //! Credentials are loaded from `$CREDS` (default `./creds.txt`).
 
@@ -46,7 +46,6 @@ fn parse_req(s: &str) -> Result<ReqType, String> {
 fn parse_format(s: &str) -> Result<FlatFileFormat, String> {
     match s.to_ascii_uppercase().as_str() {
         "CSV" => Ok(FlatFileFormat::Csv),
-        "PARQUET" => Ok(FlatFileFormat::Parquet),
         "JSONL" => Ok(FlatFileFormat::Jsonl),
         other => Err(format!("unknown format {other:?}")),
     }
@@ -69,7 +68,7 @@ async fn main() -> ExitCode {
         );
         eprintln!("       sec: OPTION | STOCK | INDEX");
         eprintln!("       data_type: EOD | QUOTE | TRADE | TRADE_QUOTE | OPEN_INTEREST | OHLC");
-        eprintln!("       format: CSV | PARQUET | JSONL");
+        eprintln!("       format: CSV | JSONL");
         return ExitCode::from(2);
     }
     let sec = match parse_sec(&args[1]) {

--- a/crates/thetadatadx/examples/flatfile_demo.rs
+++ b/crates/thetadatadx/examples/flatfile_demo.rs
@@ -1,0 +1,123 @@
+//! Whole-universe FLATFILES download CLI.
+//!
+//! Pulls one full vendor flat file for `(sec_type, data_type, date)` and
+//! writes it in the requested format.
+//!
+//! Usage:
+//!     cargo run --release --example flatfile_demo -- \
+//!         <sec> <data_type> <date> <out_path> <format>
+//!
+//! Args:
+//!   sec        OPTION | STOCK | INDEX
+//!   data_type  EOD | QUOTE | TRADE | TRADE_QUOTE | OPEN_INTEREST | OHLC
+//!   date       YYYYMMDD (e.g. 20260428)
+//!   out_path   destination path; the format extension is appended if absent
+//!   format     CSV | PARQUET | JSONL
+//!
+//! Credentials are loaded from `$CREDS` (default `./creds.txt`).
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use thetadatadx::flatfiles::{FlatFileFormat, ReqType, SecType};
+use thetadatadx::Credentials;
+
+fn parse_sec(s: &str) -> Result<SecType, String> {
+    match s.to_ascii_uppercase().as_str() {
+        "OPTION" => Ok(SecType::Option),
+        "STOCK" => Ok(SecType::Stock),
+        "INDEX" => Ok(SecType::Index),
+        other => Err(format!("unknown sec_type {other:?}")),
+    }
+}
+
+fn parse_req(s: &str) -> Result<ReqType, String> {
+    match s.to_ascii_uppercase().as_str() {
+        "EOD" => Ok(ReqType::Eod),
+        "QUOTE" => Ok(ReqType::Quote),
+        "TRADE" => Ok(ReqType::Trade),
+        "TRADE_QUOTE" => Ok(ReqType::TradeQuote),
+        "OPEN_INTEREST" => Ok(ReqType::OpenInterest),
+        "OHLC" => Ok(ReqType::Ohlc),
+        other => Err(format!("unknown data_type {other:?}")),
+    }
+}
+
+fn parse_format(s: &str) -> Result<FlatFileFormat, String> {
+    match s.to_ascii_uppercase().as_str() {
+        "CSV" => Ok(FlatFileFormat::Csv),
+        "PARQUET" => Ok(FlatFileFormat::Parquet),
+        "JSONL" => Ok(FlatFileFormat::Jsonl),
+        other => Err(format!("unknown format {other:?}")),
+    }
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 6 {
+        eprintln!(
+            "usage: {} <sec> <data_type> <date> <out_path> <format>",
+            args.first().map(String::as_str).unwrap_or("flatfile_demo")
+        );
+        eprintln!("       sec: OPTION | STOCK | INDEX");
+        eprintln!("       data_type: EOD | QUOTE | TRADE | TRADE_QUOTE | OPEN_INTEREST | OHLC");
+        eprintln!("       format: CSV | PARQUET | JSONL");
+        return ExitCode::from(2);
+    }
+    let sec = match parse_sec(&args[1]) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let req = match parse_req(&args[2]) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+    let date = &args[3];
+    let out: PathBuf = PathBuf::from(&args[4]);
+    let format = match parse_format(&args[5]) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("{e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let creds_path: PathBuf = std::env::var("CREDS")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("creds.txt"));
+    let creds = match Credentials::from_file(&creds_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("creds load failed ({}): {e}", creds_path.display());
+            return ExitCode::from(1);
+        }
+    };
+
+    let started = std::time::Instant::now();
+    eprintln!(
+        "flatfile {sec} {req:?} {date} -> {} ({format})",
+        out.display()
+    );
+    match thetadatadx::flatfile_request(&creds, sec, req, date, &out, format).await {
+        Ok(p) => {
+            eprintln!(
+                "OK {:.1}s -> {} ({} bytes)",
+                started.elapsed().as_secs_f64(),
+                p.display(),
+                std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0),
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("FAILED {:.1}s: {e}", started.elapsed().as_secs_f64());
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -113,6 +113,16 @@ pub enum Error {
         /// Configured budget in milliseconds.
         duration_ms: u64,
     },
+
+    /// FLATFILES surface could not deliver vendor-format CSV.
+    ///
+    /// Returned by [`crate::ThetaDataDx::flatfile_request`] and the
+    /// per-data-type convenience methods. Carries a structured
+    /// [`crate::FlatFilesUnavailableReason`] so the caller can decide
+    /// whether to retry, fall back to the V3 fan-out path, or surface the
+    /// underlying server error to the user.
+    #[error("FLATFILES unavailable: {0}")]
+    FlatFilesUnavailable(crate::flatfiles::FlatFilesUnavailableReason),
 }
 
 impl From<tdbe::error::Error> for Error {

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -122,7 +122,7 @@ pub enum Error {
     /// unavailable or cannot complete the request. This may reflect
     /// authentication rejection, request rejection, stream interruption
     /// or truncation, or decode failure for any supported
-    /// [`crate::flatfiles::FlatFileFormat`] (CSV, Parquet, or JSONL).
+    /// [`crate::flatfiles::FlatFileFormat`] (CSV or JSONL).
     /// Carries a structured [`crate::flatfiles::FlatFilesUnavailableReason`]
     /// so the caller can decide whether to retry, fall back, or surface
     /// the underlying server error to the user.

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -114,13 +114,18 @@ pub enum Error {
         duration_ms: u64,
     },
 
-    /// FLATFILES surface could not deliver vendor-format CSV.
+    /// FLATFILES request, stream, or decode failed for the requested
+    /// flat-file format.
     ///
     /// Returned by [`crate::ThetaDataDx::flatfile_request`] and the
-    /// per-data-type convenience methods. Carries a structured
-    /// [`crate::FlatFilesUnavailableReason`] so the caller can decide
-    /// whether to retry, fall back to the V3 fan-out path, or surface the
-    /// underlying server error to the user.
+    /// per-data-type convenience methods when the FLATFILES surface is
+    /// unavailable or cannot complete the request. This may reflect
+    /// authentication rejection, request rejection, stream interruption
+    /// or truncation, or decode failure for any supported
+    /// [`crate::flatfiles::FlatFileFormat`] (CSV, Parquet, or JSONL).
+    /// Carries a structured [`crate::flatfiles::FlatFilesUnavailableReason`]
+    /// so the caller can decide whether to retry, fall back, or surface
+    /// the underlying server error to the user.
     #[error("FLATFILES unavailable: {0}")]
     FlatFilesUnavailable(crate::flatfiles::FlatFilesUnavailableReason),
 }

--- a/crates/thetadatadx/src/flatfiles/datatype.rs
+++ b/crates/thetadatadx/src/flatfiles/datatype.rs
@@ -5,8 +5,8 @@
 //! layout. The codes are stable identifiers from the vendor's
 //! `net.thetadata.enums.DataType` enum (e.g. `MS_OF_DAY=1`, `OPEN_INTEREST=121`).
 //!
-//! For each code we need three pieces of information when emitting CSV,
-//! Parquet, or JSONL:
+//! For each code we need three pieces of information when emitting CSV
+//! or JSONL:
 //!
 //! - `name` — lowercase column header in the vendor's CSV (e.g. `ms_of_day`).
 //! - `is_price` — whether the integer field is divided by `10^price_type`

--- a/crates/thetadatadx/src/flatfiles/datatype.rs
+++ b/crates/thetadatadx/src/flatfiles/datatype.rs
@@ -1,0 +1,246 @@
+//! Vendor `DataType` codes and their wire-format properties.
+//!
+//! The first FLATFILES chunk header encodes the per-column schema as an
+//! array of `i32` codes — one per column — describing the FIT-decoded row
+//! layout. The codes are stable identifiers from the vendor's
+//! `net.thetadata.enums.DataType` enum (e.g. `MS_OF_DAY=1`, `OPEN_INTEREST=121`).
+//!
+//! For each code we need three pieces of information when emitting CSV,
+//! Parquet, or JSONL:
+//!
+//! - `name` — lowercase column header in the vendor's CSV (e.g. `ms_of_day`).
+//! - `is_price` — whether the integer field is divided by `10^price_type`
+//!   to reconstruct a fractional price. The PRICE_TYPE column itself
+//!   carries the exponent N for the row.
+//! - `is_str` / `is_date` — informational; date columns are emitted as
+//!   plain integers (e.g. `20260428`), the way the vendor jar does.
+//!
+//! No constants beyond the public-facing enum surface are reproduced here.
+//! The full vendor enum is large (~90 entries); this module ships the
+//! subset that appears in the four sec-types × five req-types FLATFILES
+//! produces, plus a forward-compat fallback for unknown codes.
+
+/// Wire-format DataType identifier.
+///
+/// `code()` is the i32 the server emits in the per-chunk header.
+/// Unknown codes are tolerated as `Unknown(code)` — a forward-compat
+/// hatch so a server-side schema extension does not break decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DataType {
+    Date,
+    MsOfDay,
+    Correction,
+    PriceType,
+    MsOfDay2,
+    BidSize,
+    BidExchange,
+    Bid,
+    BidCondition,
+    AskSize,
+    AskExchange,
+    Ask,
+    AskCondition,
+    Midpoint,
+    Vwap,
+    Qwap,
+    Wap,
+    OpenInterest,
+    Sequence,
+    Size,
+    Condition,
+    Price,
+    Exchange,
+    ConditionFlags,
+    PriceFlags,
+    VolumeType,
+    RecordsBack,
+    Volume,
+    Count,
+    Open,
+    High,
+    Low,
+    Close,
+    NetChange,
+    ImpliedVol,
+    BidImpliedVol,
+    AskImpliedVol,
+    UnderlyingPrice,
+    IvError,
+    ExtCondition1,
+    ExtCondition2,
+    ExtCondition3,
+    ExtCondition4,
+    /// Forward-compat fallback. Renders as `unknown_<code>` in CSV, with
+    /// `is_price = false` so we never accidentally divide by PRICE_TYPE.
+    Unknown(i32),
+}
+
+impl DataType {
+    /// Resolve from the wire i32.
+    pub(crate) fn from_code(code: i32) -> Self {
+        match code {
+            0 => Self::Date,
+            1 => Self::MsOfDay,
+            2 => Self::Correction,
+            4 => Self::PriceType,
+            5 => Self::MsOfDay2,
+            101 => Self::BidSize,
+            102 => Self::BidExchange,
+            103 => Self::Bid,
+            104 => Self::BidCondition,
+            105 => Self::AskSize,
+            106 => Self::AskExchange,
+            107 => Self::Ask,
+            108 => Self::AskCondition,
+            111 => Self::Midpoint,
+            112 => Self::Vwap,
+            113 => Self::Qwap,
+            114 => Self::Wap,
+            121 => Self::OpenInterest,
+            131 => Self::Sequence,
+            132 => Self::Size,
+            133 => Self::Condition,
+            134 => Self::Price,
+            135 => Self::Exchange,
+            136 => Self::ConditionFlags,
+            137 => Self::PriceFlags,
+            138 => Self::VolumeType,
+            139 => Self::RecordsBack,
+            141 => Self::Volume,
+            142 => Self::Count,
+            191 => Self::Open,
+            192 => Self::High,
+            193 => Self::Low,
+            194 => Self::Close,
+            195 => Self::NetChange,
+            201 => Self::ImpliedVol,
+            202 => Self::BidImpliedVol,
+            203 => Self::AskImpliedVol,
+            204 => Self::UnderlyingPrice,
+            205 => Self::IvError,
+            241 => Self::ExtCondition1,
+            242 => Self::ExtCondition2,
+            243 => Self::ExtCondition3,
+            244 => Self::ExtCondition4,
+            other => Self::Unknown(other),
+        }
+    }
+
+    /// Lowercase column name used in the vendor's CSV header and in JSON
+    /// keys. Matches the vendor's `Enum.name().toLowerCase()` exactly.
+    pub(crate) fn name(self) -> std::borrow::Cow<'static, str> {
+        use std::borrow::Cow;
+        match self {
+            Self::Date => Cow::Borrowed("date"),
+            Self::MsOfDay => Cow::Borrowed("ms_of_day"),
+            Self::Correction => Cow::Borrowed("correction"),
+            Self::PriceType => Cow::Borrowed("price_type"),
+            Self::MsOfDay2 => Cow::Borrowed("ms_of_day2"),
+            Self::BidSize => Cow::Borrowed("bid_size"),
+            Self::BidExchange => Cow::Borrowed("bid_exchange"),
+            Self::Bid => Cow::Borrowed("bid"),
+            Self::BidCondition => Cow::Borrowed("bid_condition"),
+            Self::AskSize => Cow::Borrowed("ask_size"),
+            Self::AskExchange => Cow::Borrowed("ask_exchange"),
+            Self::Ask => Cow::Borrowed("ask"),
+            Self::AskCondition => Cow::Borrowed("ask_condition"),
+            Self::Midpoint => Cow::Borrowed("midpoint"),
+            Self::Vwap => Cow::Borrowed("vwap"),
+            Self::Qwap => Cow::Borrowed("qwap"),
+            Self::Wap => Cow::Borrowed("wap"),
+            Self::OpenInterest => Cow::Borrowed("open_interest"),
+            Self::Sequence => Cow::Borrowed("sequence"),
+            Self::Size => Cow::Borrowed("size"),
+            Self::Condition => Cow::Borrowed("condition"),
+            Self::Price => Cow::Borrowed("price"),
+            Self::Exchange => Cow::Borrowed("exchange"),
+            Self::ConditionFlags => Cow::Borrowed("condition_flags"),
+            Self::PriceFlags => Cow::Borrowed("price_flags"),
+            Self::VolumeType => Cow::Borrowed("volume_type"),
+            Self::RecordsBack => Cow::Borrowed("records_back"),
+            Self::Volume => Cow::Borrowed("volume"),
+            Self::Count => Cow::Borrowed("count"),
+            Self::Open => Cow::Borrowed("open"),
+            Self::High => Cow::Borrowed("high"),
+            Self::Low => Cow::Borrowed("low"),
+            Self::Close => Cow::Borrowed("close"),
+            Self::NetChange => Cow::Borrowed("net_change"),
+            Self::ImpliedVol => Cow::Borrowed("implied_vol"),
+            Self::BidImpliedVol => Cow::Borrowed("bid_implied_vol"),
+            Self::AskImpliedVol => Cow::Borrowed("ask_implied_vol"),
+            Self::UnderlyingPrice => Cow::Borrowed("underlying_price"),
+            Self::IvError => Cow::Borrowed("iv_error"),
+            Self::ExtCondition1 => Cow::Borrowed("ext_condition1"),
+            Self::ExtCondition2 => Cow::Borrowed("ext_condition2"),
+            Self::ExtCondition3 => Cow::Borrowed("ext_condition3"),
+            Self::ExtCondition4 => Cow::Borrowed("ext_condition4"),
+            Self::Unknown(c) => Cow::Owned(format!("unknown_{c}")),
+        }
+    }
+
+    /// Whether the column carries a fractional price encoded as
+    /// `int_value / 10^price_type`. Mirrors the vendor's
+    /// `DataType.isPrice()` flag.
+    pub(crate) fn is_price(self) -> bool {
+        matches!(
+            self,
+            Self::Bid
+                | Self::Ask
+                | Self::Midpoint
+                | Self::Vwap
+                | Self::Qwap
+                | Self::Wap
+                | Self::Price
+                | Self::Open
+                | Self::High
+                | Self::Low
+                | Self::Close
+                | Self::NetChange
+                | Self::ImpliedVol
+                | Self::BidImpliedVol
+                | Self::AskImpliedVol
+                | Self::UnderlyingPrice
+                | Self::IvError
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_interest_schema_decodes_known_codes() {
+        // Option open_interest schema observed live: ms_of_day, open_interest, date.
+        assert_eq!(DataType::from_code(1), DataType::MsOfDay);
+        assert_eq!(DataType::from_code(121), DataType::OpenInterest);
+        assert_eq!(DataType::from_code(0), DataType::Date);
+    }
+
+    #[test]
+    fn price_columns_flagged() {
+        assert!(DataType::Bid.is_price());
+        assert!(DataType::Ask.is_price());
+        assert!(DataType::Price.is_price());
+        assert!(!DataType::Size.is_price());
+        assert!(!DataType::OpenInterest.is_price());
+    }
+
+    #[test]
+    fn unknown_code_round_trips_with_named_fallback() {
+        let dt = DataType::from_code(9999);
+        assert_eq!(dt, DataType::Unknown(9999));
+        assert_eq!(dt.name(), "unknown_9999");
+        assert!(!dt.is_price());
+    }
+
+    #[test]
+    fn vendor_lowercase_naming_holds() {
+        // Sanity: every name is ASCII lowercase or underscore, never a Java
+        // CamelCase leak.
+        for code in [1, 121, 0, 134, 138] {
+            let n = DataType::from_code(code).name();
+            assert!(n.chars().all(|c| c.is_ascii_lowercase() || c == '_'));
+        }
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/decode.rs
+++ b/crates/thetadatadx/src/flatfiles/decode.rs
@@ -1,0 +1,138 @@
+//! Per-contract FIT block decoder.
+//!
+//! Each INDEX entry points at a contiguous byte range inside the DATA
+//! section; that range is FIT-encoded for a fixed per-blob column schema
+//! (see [`crate::flatfiles::datatype`]). This module turns one such block
+//! into an iterator of decoded `i32` rows ready for the format writers.
+//!
+//! Two FPSS-side facts hold here as well:
+//! - The first row in a block is **absolute**; subsequent rows carry
+//!   delta-compressed field updates.
+//! - A leading `0xCE` byte in any row is a `DATE` marker — the row has no
+//!   user-visible data and its end-nibble must be skipped.
+//!
+//! The FIT codec itself (`tdbe::codec::fit::FitReader` +
+//! `tdbe::codec::fit::apply_deltas`) is shared with the FPSS surface so
+//! we get exact wire-format parity for free.
+
+use tdbe::codec::fit::{apply_deltas, FitReader};
+
+use crate::error::Error;
+
+/// Iterate every row of a single contract block, applying FIT deltas
+/// against the previous row.
+///
+/// `n_columns` is the per-blob schema width — one i32 per column.
+/// Returns one `Vec<i32>` per row in `out`; `out` is **cleared** before
+/// the iteration starts so callers can reuse the buffer across many
+/// contracts without reallocating.
+pub(crate) fn decode_block(
+    block: &[u8],
+    n_columns: usize,
+    out: &mut Vec<Vec<i32>>,
+) -> Result<(), Error> {
+    out.clear();
+    if block.is_empty() || n_columns == 0 {
+        return Ok(());
+    }
+
+    let mut reader = FitReader::new(block);
+    let mut prev: Vec<i32> = vec![0; n_columns];
+    let mut alloc: Vec<i32> = vec![0; n_columns];
+    let mut have_absolute = false;
+
+    while !reader.is_exhausted() {
+        alloc.iter_mut().for_each(|v| *v = 0);
+        let n = reader.read_changes(&mut alloc[..]);
+        if reader.is_date {
+            // DATE marker row — no user-visible data. Vendor's writer
+            // skips DATE rows before they reach `toCSV2`, so we do too.
+            continue;
+        }
+        if n == 0 {
+            // Either an exhausted-buffer artefact or a zero-field row;
+            // either way nothing to emit.
+            continue;
+        }
+        if !have_absolute {
+            // First absolute row — values stand on their own.
+            prev.copy_from_slice(&alloc);
+            have_absolute = true;
+        } else {
+            // Delta row — accumulate against `prev`. `n` is the number of
+            // FIT-emitted fields for this row; trailing columns are
+            // carried forward from `prev` (vendor `Tick.readID` parity).
+            apply_deltas(&mut alloc, &prev, n);
+            prev.copy_from_slice(&alloc);
+        }
+        out.push(alloc.clone());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pack(high: u8, low: u8) -> u8 {
+        (high << 4) | (low & 0x0F)
+    }
+
+    const FIELD_SEP: u8 = 0xB;
+    const END: u8 = 0xD;
+
+    #[test]
+    fn empty_block_yields_no_rows() {
+        let mut out = Vec::new();
+        decode_block(&[], 5, &mut out).unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_absolute_row() {
+        // "12,34<END>" → row = [12, 34]
+        let buf = vec![pack(1, 2), pack(FIELD_SEP, 3), pack(4, END)];
+        let mut out = Vec::new();
+        decode_block(&buf, 2, &mut out).unwrap();
+        assert_eq!(out, vec![vec![12, 34]]);
+    }
+
+    #[test]
+    fn two_rows_apply_delta() {
+        // Row 1 absolute: "100,50,200"
+        // Row 2 delta:    "5,-3,10"  → [105, 47, 210]
+        let row1 = [
+            pack(1, 0),
+            pack(0, FIELD_SEP),
+            pack(5, 0),
+            pack(FIELD_SEP, 2),
+            pack(0, 0),
+            pack(END, 0),
+        ];
+        let row2 = [
+            pack(5, FIELD_SEP),
+            pack(0xE, 3),
+            pack(FIELD_SEP, 1),
+            pack(0, END),
+        ];
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&row1);
+        buf.extend_from_slice(&row2);
+
+        let mut out = Vec::new();
+        decode_block(&buf, 3, &mut out).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], vec![100, 50, 200]);
+        assert_eq!(out[1], vec![105, 47, 210]);
+    }
+
+    #[test]
+    fn date_marker_is_skipped() {
+        // DATE marker row, then absolute "7"
+        let mut buf = vec![0xCE, pack(1, END)]; // CE prefix + minimal end → consumed as DATE row
+        buf.extend_from_slice(&[pack(7, END)]);
+        let mut out = Vec::new();
+        decode_block(&buf, 1, &mut out).unwrap();
+        assert_eq!(out, vec![vec![7]]);
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/decoded.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded.rs
@@ -150,7 +150,13 @@ pub fn default_output_filename(
         ReqType::Trade => "TRADE",
         ReqType::TradeQuote => "TRADE_QUOTE",
     };
-    format!("{}-{}-{}.{}", sec.as_wire(), req_name, date, format.extension())
+    format!(
+        "{}-{}-{}.{}",
+        sec.as_wire(),
+        req_name,
+        date,
+        format.extension()
+    )
 }
 
 #[cfg(test)]

--- a/crates/thetadatadx/src/flatfiles/decoded.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded.rs
@@ -1,0 +1,178 @@
+//! End-to-end decoded FLATFILES request driver.
+//!
+//! Given the full raw INDEX+DATA blob already on disk (produced by
+//! [`crate::flatfiles::flatfile_request_raw`]), this module walks the
+//! INDEX, decodes each contract's FIT block, and drives a polymorphic
+//! [`crate::flatfiles::writer::RowSink`] in vendor row order.
+//!
+//! The public face is [`flatfile_request`] — same signature as the raw
+//! variant plus a `format: FlatFileFormat` argument that selects the
+//! on-disk encoding.
+
+use std::path::{Path, PathBuf};
+
+use crate::auth::Credentials;
+use crate::error::Error;
+use crate::flatfiles::decode::decode_block;
+use crate::flatfiles::format::FlatFileFormat;
+use crate::flatfiles::index::{parse_header, IndexIter};
+use crate::flatfiles::request::flatfile_request_raw;
+use crate::flatfiles::types::{ReqType, SecType};
+use crate::flatfiles::writer::{CsvSink, JsonlSink, ParquetSink, RowSink, RowView};
+
+/// Pull a flat-file blob, decode it, and write the requested format.
+///
+/// 1. Auth + raw-stream pull into a scratch file alongside `output_path`.
+/// 2. Memory-map the raw stream and parse the header.
+/// 3. Walk the INDEX section, decode each contract's FIT block, and
+///    emit rows in INDEX order to the chosen sink.
+/// 4. Delete the scratch file on success.
+///
+/// Returns the final `output_path` (with the format extension auto-
+/// appended if the input lacked one).
+pub async fn flatfile_request(
+    creds: &Credentials,
+    sec: SecType,
+    req: ReqType,
+    date: &str,
+    output_path: impl AsRef<Path>,
+    format: FlatFileFormat,
+) -> Result<PathBuf, Error> {
+    let final_path = format.ensure_extension(output_path.as_ref());
+    let raw_path = final_path.with_extension(format!("{}.raw", format.extension()));
+
+    // Step 1: live pull. Reuses the working wire layer untouched.
+    flatfile_request_raw(creds, sec, req, date, &raw_path).await?;
+
+    // Step 2-3: decode + write.
+    decode_to_file(&raw_path, sec, &final_path, format)?;
+
+    // Step 4: scratch cleanup. A failure here is non-fatal — the user
+    // gets the decoded file regardless, and the raw blob is mostly
+    // useful for debugging.
+    let _ = std::fs::remove_file(&raw_path);
+
+    Ok(final_path)
+}
+
+/// Decode an already-captured raw blob into the requested format.
+///
+/// Splits out from [`flatfile_request`] so the byte-match integration
+/// test can re-run the decoder against a saved blob without burning
+/// another live MDDS call.
+pub(crate) fn decode_to_file(
+    raw_path: &Path,
+    sec: SecType,
+    output_path: &Path,
+    format: FlatFileFormat,
+) -> Result<(), Error> {
+    let blob = std::fs::read(raw_path)?;
+    let hdr = parse_header(&blob)?;
+
+    let index_start = hdr.index_offset as usize;
+    let index_end = index_start + hdr.index_byte_len as usize;
+    let data_start = index_end;
+    let data_end = data_start + hdr.data_byte_len as usize;
+    if data_end > blob.len() {
+        return Err(Error::Config(format!(
+            "flatfiles: blob truncated — header expected {} bytes total, got {}",
+            data_end,
+            blob.len()
+        )));
+    }
+    let index_bytes = &blob[index_start..index_end];
+    let data_bytes = &blob[data_start..data_end];
+
+    let mut sink: Box<dyn RowSink> = match format {
+        FlatFileFormat::Csv => Box::new(CsvSink::new(
+            output_path,
+            sec,
+            hdr.fmt.clone(),
+            hdr.price_type_idx,
+        )?),
+        FlatFileFormat::Jsonl => Box::new(JsonlSink::new(
+            output_path,
+            sec,
+            hdr.fmt.clone(),
+            hdr.price_type_idx,
+        )?),
+        FlatFileFormat::Parquet => Box::new(ParquetSink::new(
+            output_path,
+            sec,
+            hdr.fmt.clone(),
+            hdr.price_type_idx,
+        )?),
+    };
+    sink.write_header()?;
+
+    let n_columns = hdr.fmt.len();
+    let mut rows_buf: Vec<Vec<i32>> = Vec::with_capacity(1024);
+    for entry_res in IndexIter::new(index_bytes, sec) {
+        let entry = entry_res?;
+        let bs = entry.block_start as usize;
+        let be = entry.block_end as usize;
+        if be > data_bytes.len() || bs > be {
+            return Err(Error::Config(format!(
+                "flatfiles: INDEX block bounds [{bs}, {be}) escape DATA section ({} bytes)",
+                data_bytes.len()
+            )));
+        }
+        let block = &data_bytes[bs..be];
+        decode_block(block, n_columns, &mut rows_buf)?;
+        for row in &rows_buf {
+            sink.write_row(RowView {
+                entry: &entry,
+                data: row,
+            })?;
+        }
+    }
+    sink.finish()?;
+    Ok(())
+}
+
+/// Vendor-style default filename for `(sec, req, date)`.
+///
+/// Mirrors the legacy terminal's `<SEC>-<REQ>-<DATE>.<ext>` convention.
+/// Exposed as a helper so binaries / tests can derive a default path
+/// without hardcoding the rules.
+#[must_use]
+pub fn default_output_filename(
+    sec: SecType,
+    req: ReqType,
+    date: &str,
+    format: FlatFileFormat,
+) -> String {
+    let req_name = match req {
+        ReqType::Eod => "EOD",
+        ReqType::Quote => "QUOTE",
+        ReqType::OpenInterest => "OPEN_INTEREST",
+        ReqType::Ohlc => "OHLC",
+        ReqType::Trade => "TRADE",
+        ReqType::TradeQuote => "TRADE_QUOTE",
+    };
+    format!("{}-{}-{}.{}", sec.as_wire(), req_name, date, format.extension())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vendor_filename_matches_terminal_layout() {
+        // The reference vendor file is `OPTION-OPEN_INTEREST-20260428.csv`.
+        let s = default_output_filename(
+            SecType::Option,
+            ReqType::OpenInterest,
+            "20260428",
+            FlatFileFormat::Csv,
+        );
+        assert_eq!(s, "OPTION-OPEN_INTEREST-20260428.csv");
+        let p = default_output_filename(
+            SecType::Stock,
+            ReqType::Trade,
+            "20260428",
+            FlatFileFormat::Parquet,
+        );
+        assert_eq!(p, "STOCK-TRADE-20260428.parquet");
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/decoded.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded.rs
@@ -69,9 +69,16 @@ pub(crate) fn decode_to_file(
     let blob = std::fs::read(raw_path)?;
     let hdr = parse_header(&blob)?;
 
-    let index_start = hdr.index_offset as usize;
-    let index_byte_len = hdr.index_byte_len as usize;
-    let data_byte_len = hdr.data_byte_len as usize;
+    let to_usize = |v: u64, field: &str| {
+        usize::try_from(v).map_err(|_| {
+            Error::Config(format!(
+                "flatfiles: header field {field}={v} does not fit in usize on this target"
+            ))
+        })
+    };
+    let index_start = to_usize(hdr.index_offset, "index_offset")?;
+    let index_byte_len = to_usize(hdr.index_byte_len, "index_byte_len")?;
+    let data_byte_len = to_usize(hdr.data_byte_len, "data_byte_len")?;
     let index_end = index_start.checked_add(index_byte_len).ok_or_else(|| {
         Error::Config(format!(
             "flatfiles: header lengths overflow usize (index_offset={index_start}, index_byte_len={index_byte_len})"

--- a/crates/thetadatadx/src/flatfiles/decoded.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded.rs
@@ -166,13 +166,15 @@ pub async fn flatfile_request_decoded(
     req: ReqType,
     date: &str,
 ) -> Result<Vec<FlatFileRow>, Error> {
-    // Use a temp scratch path; deleted on the way out.
+    // Per-invocation unique scratch path. Two concurrent calls for the
+    // same `(sec, req, date)` must not share a file — they would race on
+    // truncation and produce corrupt rows.
     let scratch = std::env::temp_dir().join(format!(
         "thetadatadx-flatfiles-{}-{}-{}-{}.raw",
         sec.as_wire(),
         req_name(req),
         date,
-        std::process::id()
+        uuid::Uuid::new_v4().simple()
     ));
     flatfile_request_raw(creds, sec, req, date, &scratch).await?;
     let scratch_for_decode = scratch.clone();

--- a/crates/thetadatadx/src/flatfiles/decoded.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded.rs
@@ -70,9 +70,19 @@ pub(crate) fn decode_to_file(
     let hdr = parse_header(&blob)?;
 
     let index_start = hdr.index_offset as usize;
-    let index_end = index_start + hdr.index_byte_len as usize;
+    let index_byte_len = hdr.index_byte_len as usize;
+    let data_byte_len = hdr.data_byte_len as usize;
+    let index_end = index_start.checked_add(index_byte_len).ok_or_else(|| {
+        Error::Config(format!(
+            "flatfiles: header lengths overflow usize (index_offset={index_start}, index_byte_len={index_byte_len})"
+        ))
+    })?;
     let data_start = index_end;
-    let data_end = data_start + hdr.data_byte_len as usize;
+    let data_end = data_start.checked_add(data_byte_len).ok_or_else(|| {
+        Error::Config(format!(
+            "flatfiles: header lengths overflow usize (data_start={data_start}, data_byte_len={data_byte_len})"
+        ))
+    })?;
     if data_end > blob.len() {
         return Err(Error::Config(format!(
             "flatfiles: blob truncated — header expected {} bytes total, got {}",

--- a/crates/thetadatadx/src/flatfiles/decoded.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded.rs
@@ -14,11 +14,12 @@ use std::path::{Path, PathBuf};
 use crate::auth::Credentials;
 use crate::error::Error;
 use crate::flatfiles::decode::decode_block;
+use crate::flatfiles::decoded_row::FlatFileRow;
 use crate::flatfiles::format::FlatFileFormat;
 use crate::flatfiles::index::{parse_header, IndexIter};
 use crate::flatfiles::request::flatfile_request_raw;
 use crate::flatfiles::types::{ReqType, SecType};
-use crate::flatfiles::writer::{CsvSink, JsonlSink, ParquetSink, RowSink, RowView};
+use crate::flatfiles::writer::{CsvSink, JsonlSink, RowSink, RowView};
 
 /// Pull a flat-file blob, decode it, and write the requested format.
 ///
@@ -44,8 +45,17 @@ pub async fn flatfile_request(
     // Step 1: live pull. Reuses the working wire layer untouched.
     flatfile_request_raw(creds, sec, req, date, &raw_path).await?;
 
-    // Step 2-3: decode + write.
-    decode_to_file(&raw_path, sec, &final_path, format)?;
+    // Step 2-3: decode + write. The decoder reads + parses the entire
+    // blob synchronously and the writer hits the filesystem in tight
+    // loops; do that on the blocking pool so we don't stall any other
+    // tokio task (FPSS streaming, MDDS gRPC) on the same runtime.
+    let raw_for_decode = raw_path.clone();
+    let final_for_decode = final_path.clone();
+    tokio::task::spawn_blocking(move || {
+        decode_to_file(&raw_for_decode, sec, &final_for_decode, format)
+    })
+    .await
+    .map_err(|e| Error::Config(format!("flatfiles: decode task panicked: {e}")))??;
 
     // Step 4: scratch cleanup. A failure here is non-fatal — the user
     // gets the decoded file regardless, and the raw blob is mostly
@@ -113,12 +123,6 @@ pub(crate) fn decode_to_file(
             hdr.fmt.clone(),
             hdr.price_type_idx,
         )?),
-        FlatFileFormat::Parquet => Box::new(ParquetSink::new(
-            output_path,
-            sec,
-            hdr.fmt.clone(),
-            hdr.price_type_idx,
-        )?),
     };
     sink.write_header()?;
 
@@ -147,6 +151,114 @@ pub(crate) fn decode_to_file(
     Ok(())
 }
 
+/// Pull a flat-file blob and return decoded rows in memory.
+///
+/// Same auth and stream path as [`flatfile_request`], but skips the
+/// on-disk writer. Use this when feeding the data straight into an
+/// algorithm (e.g. backtester, risk model) without an intermediate
+/// file. The whole `Vec` is materialised before the function returns —
+/// for whole-universe blobs that can be hundreds of MB; if that does
+/// not fit your memory budget, prefer [`flatfile_request`] with a
+/// streaming reader on the resulting CSV / JSONL file.
+pub async fn flatfile_request_decoded(
+    creds: &Credentials,
+    sec: SecType,
+    req: ReqType,
+    date: &str,
+) -> Result<Vec<FlatFileRow>, Error> {
+    // Use a temp scratch path; deleted on the way out.
+    let scratch = std::env::temp_dir().join(format!(
+        "thetadatadx-flatfiles-{}-{}-{}-{}.raw",
+        sec.as_wire(),
+        req_name(req),
+        date,
+        std::process::id()
+    ));
+    flatfile_request_raw(creds, sec, req, date, &scratch).await?;
+    let scratch_for_decode = scratch.clone();
+    let rows = tokio::task::spawn_blocking(move || decode_to_memory(&scratch_for_decode, sec))
+        .await
+        .map_err(|e| Error::Config(format!("flatfiles: decode task panicked: {e}")))??;
+    let _ = std::fs::remove_file(&scratch);
+    Ok(rows)
+}
+
+/// Decode an already-captured raw blob into a typed in-memory `Vec`.
+pub(crate) fn decode_to_memory(raw_path: &Path, sec: SecType) -> Result<Vec<FlatFileRow>, Error> {
+    let blob = std::fs::read(raw_path)?;
+    let hdr = parse_header(&blob)?;
+
+    let to_usize = |v: u64, field: &str| {
+        usize::try_from(v).map_err(|_| {
+            Error::Config(format!(
+                "flatfiles: header field {field}={v} does not fit in usize on this target"
+            ))
+        })
+    };
+    let index_start = to_usize(hdr.index_offset, "index_offset")?;
+    let index_byte_len = to_usize(hdr.index_byte_len, "index_byte_len")?;
+    let data_byte_len = to_usize(hdr.data_byte_len, "data_byte_len")?;
+    let index_end = index_start
+        .checked_add(index_byte_len)
+        .ok_or_else(|| Error::Config("flatfiles: header lengths overflow usize".into()))?;
+    let data_start = index_end;
+    let data_end = data_start
+        .checked_add(data_byte_len)
+        .ok_or_else(|| Error::Config("flatfiles: header lengths overflow usize".into()))?;
+    if data_end > blob.len() {
+        return Err(Error::Config(format!(
+            "flatfiles: blob truncated — header expected {} bytes total, got {}",
+            data_end,
+            blob.len()
+        )));
+    }
+    let index_bytes = &blob[index_start..index_end];
+    let data_bytes = &blob[data_start..data_end];
+
+    let data_idx = crate::flatfiles::writer::data_indices(&hdr.fmt, hdr.price_type_idx);
+    let n_columns = hdr.fmt.len();
+    let mut rows_buf: Vec<Vec<i32>> = Vec::with_capacity(1024);
+    let mut out: Vec<FlatFileRow> = Vec::new();
+    for entry_res in IndexIter::new(index_bytes, sec) {
+        let entry = entry_res?;
+        let bs = entry.block_start as usize;
+        let be = entry.block_end as usize;
+        if be > data_bytes.len() || bs > be {
+            return Err(Error::Config(format!(
+                "flatfiles: INDEX block bounds [{bs}, {be}) escape DATA section ({} bytes)",
+                data_bytes.len()
+            )));
+        }
+        let block = &data_bytes[bs..be];
+        decode_block(block, n_columns, &mut rows_buf)?;
+        for row in &rows_buf {
+            let divisor = crate::flatfiles::writer::price_divisor(row, hdr.price_type_idx);
+            out.push(FlatFileRow::from_decoded(
+                &entry.root,
+                entry.exp,
+                entry.strike,
+                entry.right,
+                &hdr.fmt,
+                row,
+                &data_idx,
+                divisor,
+            ));
+        }
+    }
+    Ok(out)
+}
+
+fn req_name(req: ReqType) -> &'static str {
+    match req {
+        ReqType::Eod => "EOD",
+        ReqType::Quote => "QUOTE",
+        ReqType::OpenInterest => "OPEN_INTEREST",
+        ReqType::Ohlc => "OHLC",
+        ReqType::Trade => "TRADE",
+        ReqType::TradeQuote => "TRADE_QUOTE",
+    }
+}
+
 /// Vendor-style default filename for `(sec, req, date)`.
 ///
 /// Mirrors the legacy terminal's `<SEC>-<REQ>-<DATE>.<ext>` convention.
@@ -159,18 +271,10 @@ pub fn default_output_filename(
     date: &str,
     format: FlatFileFormat,
 ) -> String {
-    let req_name = match req {
-        ReqType::Eod => "EOD",
-        ReqType::Quote => "QUOTE",
-        ReqType::OpenInterest => "OPEN_INTEREST",
-        ReqType::Ohlc => "OHLC",
-        ReqType::Trade => "TRADE",
-        ReqType::TradeQuote => "TRADE_QUOTE",
-    };
     format!(
         "{}-{}-{}.{}",
         sec.as_wire(),
-        req_name,
+        req_name(req),
         date,
         format.extension()
     )
@@ -194,8 +298,8 @@ mod tests {
             SecType::Stock,
             ReqType::Trade,
             "20260428",
-            FlatFileFormat::Parquet,
+            FlatFileFormat::Jsonl,
         );
-        assert_eq!(p, "STOCK-TRADE-20260428.parquet");
+        assert_eq!(p, "STOCK-TRADE-20260428.jsonl");
     }
 }

--- a/crates/thetadatadx/src/flatfiles/decoded.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded.rs
@@ -60,7 +60,7 @@ pub async fn flatfile_request(
     // Step 4: scratch cleanup. A failure here is non-fatal — the user
     // gets the decoded file regardless, and the raw blob is mostly
     // useful for debugging.
-    let _ = std::fs::remove_file(&raw_path);
+    let _ = tokio::fs::remove_file(&raw_path).await;
 
     Ok(final_path)
 }
@@ -181,7 +181,7 @@ pub async fn flatfile_request_decoded(
     let rows = tokio::task::spawn_blocking(move || decode_to_memory(&scratch_for_decode, sec))
         .await
         .map_err(|e| Error::Config(format!("flatfiles: decode task panicked: {e}")))??;
-    let _ = std::fs::remove_file(&scratch);
+    let _ = tokio::fs::remove_file(&scratch).await;
     Ok(rows)
 }
 

--- a/crates/thetadatadx/src/flatfiles/decoded_row.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded_row.rs
@@ -1,0 +1,77 @@
+//! Typed in-memory row for the FLATFILES surface.
+//!
+//! Returned by [`crate::flatfiles::flatfile_request_decoded`] and the
+//! corresponding [`crate::ThetaDataDx`] convenience methods. Callers
+//! that want to drive an algorithm against the full universe for a
+//! given `(sec, req, date)` tuple use this entry point instead of
+//! writing a CSV / JSONL file and parsing it back in.
+//!
+//! The row carries the contract key the vendor prepends to every CSV
+//! row, plus the per-data-type column values keyed by the original
+//! (lowercase) column name. Price columns are pre-divided by the row's
+//! `PRICE_TYPE` exponent so the caller never has to apply the divisor
+//! themselves.
+
+use crate::flatfiles::datatype::DataType;
+
+/// Single decoded flat-file row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FlatFileRow {
+    /// Underlying root symbol (e.g. `"SPY"`).
+    pub root: String,
+    /// Expiration in `YYYYMMDD`. `None` for stock blobs.
+    pub expiration: Option<i32>,
+    /// Strike in vendor units (1/1000 of a dollar). `None` for stocks.
+    pub strike: Option<i32>,
+    /// `'C'` (call), `'P'` (put), or `None` for stocks / unknown.
+    pub right: Option<char>,
+    /// One entry per non-PRICE_TYPE schema column, in vendor order.
+    /// `(column_name, value)` — column name is lowercase to match the
+    /// vendor CSV header.
+    pub fields: Vec<(String, FlatFileValue)>,
+}
+
+/// Cell value in a decoded flat-file row.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FlatFileValue {
+    /// Plain integer column (counts, ms-of-day, dates, ordinals).
+    Int(i32),
+    /// Price column already divided by the row's `PRICE_TYPE` exponent.
+    Price(f64),
+}
+
+impl FlatFileRow {
+    /// Build a row from the decoded data slice plus the schema. Callers
+    /// at the decode layer use this to avoid open-coding the column
+    /// projection in two places.
+    pub(crate) fn from_decoded(
+        root: &str,
+        expiration: Option<i32>,
+        strike: Option<i32>,
+        right: Option<char>,
+        fmt: &[DataType],
+        data: &[i32],
+        data_idx: &[usize],
+        divisor: Option<f64>,
+    ) -> Self {
+        let mut fields = Vec::with_capacity(data_idx.len());
+        for &i in data_idx {
+            let val = data.get(i).copied().unwrap_or(0);
+            let dt = fmt[i];
+            let cell = if dt.is_price() {
+                let d = divisor.unwrap_or(1.0);
+                FlatFileValue::Price((val as f64) / d)
+            } else {
+                FlatFileValue::Int(val)
+            };
+            fields.push((dt.name().into_owned(), cell));
+        }
+        Self {
+            root: root.to_string(),
+            expiration,
+            strike,
+            right,
+            fields,
+        }
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/format.rs
+++ b/crates/thetadatadx/src/flatfiles/format.rs
@@ -1,16 +1,18 @@
 //! Output format selector for the FLATFILES surface.
 //!
 //! The same logical row stream — `(contract_keys, [data_columns])` —
-//! materializes to one of three on-disk formats:
+//! materializes to one of two on-disk formats:
 //!
 //! - `Csv`: vendor byte-format (lowercase headers, comma-separated, no
 //!   quoting, Unix line-endings). Used for legacy interop and as the
 //!   gold-standard for the byte-match integration test.
-//! - `Parquet`: columnar, zstd-compressed, Arrow-typed. One row group
-//!   per N rows (default 65 536). Schema mirrors the CSV column order
-//!   1:1, with proper Arrow types (Int32 / Int64 / Float64 / Utf8).
 //! - `Jsonl`: one JSON object per line, keys identical to the CSV
 //!   column names, integer columns stay numeric (no stringification).
+//!
+//! For columnar formats (Parquet, Arrow IPC, polars) callers should use
+//! the in-memory typed entry point (see `flatfile_request_decoded`) and
+//! drive their own writer — keeping the SDK free of heavy columnar
+//! dependencies.
 
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -20,8 +22,6 @@ use std::path::{Path, PathBuf};
 pub enum FlatFileFormat {
     /// Vendor byte-format CSV. Header on line 1, then `\n`-terminated rows.
     Csv,
-    /// Apache Parquet, zstd-compressed, Arrow-typed.
-    Parquet,
     /// JSON Lines — one JSON object per line.
     Jsonl,
 }
@@ -32,7 +32,6 @@ impl FlatFileFormat {
     pub fn extension(self) -> &'static str {
         match self {
             Self::Csv => "csv",
-            Self::Parquet => "parquet",
             Self::Jsonl => "jsonl",
         }
     }
@@ -63,7 +62,6 @@ mod tests {
     #[test]
     fn extension_round_trip() {
         assert_eq!(FlatFileFormat::Csv.extension(), "csv");
-        assert_eq!(FlatFileFormat::Parquet.extension(), "parquet");
         assert_eq!(FlatFileFormat::Jsonl.extension(), "jsonl");
     }
 
@@ -75,8 +73,8 @@ mod tests {
             PathBuf::from("/tmp/foo.csv")
         );
         assert_eq!(
-            FlatFileFormat::Parquet.ensure_extension(p),
-            PathBuf::from("/tmp/foo.parquet")
+            FlatFileFormat::Jsonl.ensure_extension(p),
+            PathBuf::from("/tmp/foo.jsonl")
         );
     }
 

--- a/crates/thetadatadx/src/flatfiles/format.rs
+++ b/crates/thetadatadx/src/flatfiles/format.rs
@@ -37,9 +37,10 @@ impl FlatFileFormat {
         }
     }
 
-    /// Append `extension()` to `path` if `path` does not already end in
-    /// any recognised extension. Lets callers pass a bare base name and
-    /// still land on a correctly-named file.
+    /// Append `extension()` to `path` if `path` has no extension at all.
+    /// If `path` already carries any extension, it is preserved as-is.
+    /// Lets callers pass a bare base name and still land on a
+    /// correctly-named file.
     #[must_use]
     pub fn ensure_extension(self, path: &Path) -> PathBuf {
         match path.extension() {

--- a/crates/thetadatadx/src/flatfiles/format.rs
+++ b/crates/thetadatadx/src/flatfiles/format.rs
@@ -1,0 +1,91 @@
+//! Output format selector for the FLATFILES surface.
+//!
+//! The same logical row stream — `(contract_keys, [data_columns])` —
+//! materializes to one of three on-disk formats:
+//!
+//! - `Csv`: vendor byte-format (lowercase headers, comma-separated, no
+//!   quoting, Unix line-endings). Used for legacy interop and as the
+//!   gold-standard for the byte-match integration test.
+//! - `Parquet`: columnar, zstd-compressed, Arrow-typed. One row group
+//!   per N rows (default 65 536). Schema mirrors the CSV column order
+//!   1:1, with proper Arrow types (Int32 / Int64 / Float64 / Utf8).
+//! - `Jsonl`: one JSON object per line, keys identical to the CSV
+//!   column names, integer columns stay numeric (no stringification).
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Selectable output format for any `flatfile_*` SDK call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlatFileFormat {
+    /// Vendor byte-format CSV. Header on line 1, then `\n`-terminated rows.
+    Csv,
+    /// Apache Parquet, zstd-compressed, Arrow-typed.
+    Parquet,
+    /// JSON Lines — one JSON object per line.
+    Jsonl,
+}
+
+impl FlatFileFormat {
+    /// Canonical file extension (without the leading dot).
+    #[must_use]
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::Csv => "csv",
+            Self::Parquet => "parquet",
+            Self::Jsonl => "jsonl",
+        }
+    }
+
+    /// Append `extension()` to `path` if `path` does not already end in
+    /// any recognised extension. Lets callers pass a bare base name and
+    /// still land on a correctly-named file.
+    #[must_use]
+    pub fn ensure_extension(self, path: &Path) -> PathBuf {
+        match path.extension() {
+            Some(_) => path.to_path_buf(),
+            None => path.with_extension(self.extension()),
+        }
+    }
+}
+
+impl fmt::Display for FlatFileFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.extension())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_round_trip() {
+        assert_eq!(FlatFileFormat::Csv.extension(), "csv");
+        assert_eq!(FlatFileFormat::Parquet.extension(), "parquet");
+        assert_eq!(FlatFileFormat::Jsonl.extension(), "jsonl");
+    }
+
+    #[test]
+    fn ensure_extension_appends_when_missing() {
+        let p = Path::new("/tmp/foo");
+        assert_eq!(
+            FlatFileFormat::Csv.ensure_extension(p),
+            PathBuf::from("/tmp/foo.csv")
+        );
+        assert_eq!(
+            FlatFileFormat::Parquet.ensure_extension(p),
+            PathBuf::from("/tmp/foo.parquet")
+        );
+    }
+
+    #[test]
+    fn ensure_extension_preserves_existing() {
+        let p = Path::new("/tmp/foo.json");
+        // Already has an extension — leave it alone (caller's intent).
+        assert_eq!(
+            FlatFileFormat::Jsonl.ensure_extension(p),
+            PathBuf::from("/tmp/foo.json")
+        );
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/framing.rs
+++ b/crates/thetadatadx/src/flatfiles/framing.rs
@@ -1,0 +1,126 @@
+//! PacketStream wire framing for the MDDS legacy port.
+//!
+//! Frame layout (all big-endian):
+//!
+//! ```text
+//! offset 0  : u32 payload_size (NOT including the 14-byte header)
+//! offset 4  : u16 message_code
+//! offset 6  : i64 request_id  (-1 for connection-scoped frames)
+//! offset 14 : N  bytes of payload
+//! ```
+//!
+//! This module provides a minimal async reader/writer over `tokio::io`
+//! traits. The writer flushes after each frame so the server sees discrete
+//! requests rather than a coalesced batch (the vendor server is sensitive
+//! to this; it does not handle two queued frames back-to-back without a
+//! flush boundary).
+
+use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::error::Error;
+
+/// Maximum payload size we will accept from the server. Each chunk in a
+/// FLAT_FILE response is observed at ~512 KiB; the server is configured to
+/// allocate up to 32 MiB internally. We accept anything up to 64 MiB and
+/// reject larger frames as protocol violations to avoid unbounded
+/// allocation under malicious input.
+const MAX_PAYLOAD: u32 = 64 * 1024 * 1024;
+
+/// Wire codes for the messages this module produces or consumes. Defined as
+/// `u16` constants rather than an enum because the wire byte values are
+/// fixed by the protocol and the constants are matched against incoming
+/// frame headers.
+#[allow(dead_code)]
+pub(crate) mod msg {
+    pub const CREDENTIALS: u16 = 0;
+    pub const SESSION_TOKEN: u16 = 1;
+    pub const METADATA: u16 = 3;
+    pub const CONNECTED: u16 = 4;
+    pub const VERSION: u16 = 5;
+    pub const PING: u16 = 100;
+    pub const ERROR: u16 = 101;
+    pub const DISCONNECTED: u16 = 102;
+    pub const FLAT_FILE: u16 = 217;
+    pub const FLAT_FILE_END: u16 = 218;
+}
+
+/// Single decoded frame.
+pub(crate) struct Frame {
+    pub msg: u16,
+    pub id: i64,
+    pub payload: Vec<u8>,
+}
+
+/// Encode and write a single frame to `out`, then flush.
+pub(crate) async fn write_frame<W>(
+    out: &mut W,
+    msg: u16,
+    id: i64,
+    payload: &[u8],
+) -> Result<(), Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let size = u32::try_from(payload.len()).map_err(|_| {
+        Error::Config(format!(
+            "flatfiles: payload {} bytes exceeds u32",
+            payload.len()
+        ))
+    })?;
+    let mut header = [0u8; 14];
+    header[0..4].copy_from_slice(&size.to_be_bytes());
+    header[4..6].copy_from_slice(&msg.to_be_bytes());
+    header[6..14].copy_from_slice(&id.to_be_bytes());
+    out.write_all(&header).await?;
+    out.write_all(payload).await?;
+    out.flush().await?;
+    Ok(())
+}
+
+/// Read one frame from `src`. Errors propagate the underlying tokio error.
+pub(crate) async fn read_frame<R>(src: &mut R) -> Result<Frame, Error>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut hdr = [0u8; 14];
+    src.read_exact(&mut hdr).await?;
+    let size = u32::from_be_bytes(hdr[0..4].try_into().unwrap());
+    let msg = u16::from_be_bytes(hdr[4..6].try_into().unwrap());
+    let id = i64::from_be_bytes(hdr[6..14].try_into().unwrap());
+    if size > MAX_PAYLOAD {
+        return Err(Error::Config(format!(
+            "flatfiles: server frame size {size} exceeds {MAX_PAYLOAD}"
+        )));
+    }
+    let mut payload = vec![0u8; size as usize];
+    src.read_exact(&mut payload).await?;
+    Ok(Frame { msg, id, payload })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn write_then_read_round_trip() {
+        let payload = b"hello world".to_vec();
+        let mut buf: Vec<u8> = Vec::new();
+        write_frame(&mut buf, 217, 9001, &payload).await.unwrap();
+        // header + payload = 14 + 11
+        assert_eq!(buf.len(), 25);
+        let mut cursor = std::io::Cursor::new(&buf);
+        let frame = read_frame(&mut cursor).await.unwrap();
+        assert_eq!(frame.msg, 217);
+        assert_eq!(frame.id, 9001);
+        assert_eq!(frame.payload, payload);
+    }
+
+    #[tokio::test]
+    async fn rejects_oversize_frame() {
+        let mut hdr = [0u8; 14];
+        hdr[0..4].copy_from_slice(&(u32::MAX).to_be_bytes());
+        let mut cursor = std::io::Cursor::new(&hdr[..]);
+        let res = read_frame(&mut cursor).await;
+        assert!(res.is_err());
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/index.rs
+++ b/crates/thetadatadx/src/flatfiles/index.rs
@@ -1,0 +1,342 @@
+//! INDEX walker for the raw FLATFILES blob.
+//!
+//! # On-disk layout (recovered from live wire bytes + bytecode shape)
+//!
+//! The raw blob the wire layer accumulates is one contiguous stream:
+//!
+//! ```text
+//! offset 0   :  i32 BE  fmt_count          number of column DataType codes
+//!         4 :  fmt_count × i32 BE          DataType.code() per column
+//!         …  :  i64 BE  index_byte_len     bytes of INDEX after this header
+//!         …  :  i64 BE  data_byte_len      bytes of DATA after the INDEX
+//!         …  :  index_byte_len bytes      INDEX entries (see below)
+//!         …  :  data_byte_len  bytes      DATA — concatenated FIT blocks
+//! ```
+//!
+//! All multi-byte integers are big-endian — Java's `ByteBuffer.wrap(...)`
+//! defaults to network order.
+//!
+//! # INDEX entries
+//!
+//! Each entry occupies a variable-length record:
+//!
+//! ```text
+//!   u16 BE  entry_size                     bytes of entry_payload
+//!   entry_payload  (entry_size bytes)      sec-type-dependent contract key
+//!   i32 BE  block_volume                   "volume" hint (unused by SDK)
+//!   i64 BE  block_start                    byte offset into DATA section
+//!   i64 BE  block_end                      one past the last byte (exclusive)
+//! ```
+//!
+//! The contract key inside `entry_payload` is:
+//!
+//! - Option:
+//!   ```text
+//!     u8 root_len ; root_utf8 ; i32 BE exp ; u8 right ; i32 BE strike ; i32 BE date
+//!   ```
+//!   `right` is the ASCII byte `'C'` (0x43) or `'P'` (0x50). `exp` and
+//!   `date` are `YYYYMMDD` integers; `strike` is in tenths of a cent
+//!   (vendor convention — strike `210000` ≡ $210.00).
+//! - Stock:
+//!   ```text
+//!     u8 root_len ; root_utf8 ; i32 BE date
+//!   ```
+//!
+//! The DATA section at `[block_start..block_end]` is FIT-encoded for the
+//! per-column schema given by the header `fmt_count` codes. Each row in
+//! the block corresponds to exactly one tick for that contract; see the
+//! [`crate::flatfiles::decode`] module for the per-block FIT walk.
+
+use std::io::{Cursor, Read};
+
+use crate::error::Error;
+use crate::flatfiles::datatype::DataType;
+use crate::flatfiles::types::SecType;
+
+/// Decoded blob header.
+pub(crate) struct BlobHeader {
+    /// Per-column schema for every FIT row in the DATA section.
+    pub(crate) fmt: Vec<DataType>,
+    /// Index of the `PRICE_TYPE` column inside `fmt`, if present. Used to
+    /// recover fractional prices from integer-encoded fields.
+    pub(crate) price_type_idx: Option<usize>,
+    /// Byte length of the INDEX section that follows the header.
+    pub(crate) index_byte_len: u64,
+    /// Byte length of the DATA section that follows the INDEX.
+    pub(crate) data_byte_len: u64,
+    /// Byte offset of the first INDEX byte in the original blob (i.e.
+    /// the size of the header itself).
+    pub(crate) index_offset: u64,
+}
+
+/// Parse the leading header — fmt_count, fmt codes, indexLen, dataLen.
+///
+/// On success returns the decoded header; on a too-short or malformed
+/// header returns `Error::Config` with a descriptive message rather
+/// than panicking, so callers (notably the integration tests) can
+/// surface the failure cleanly.
+pub(crate) fn parse_header(blob: &[u8]) -> Result<BlobHeader, Error> {
+    let mut cur = Cursor::new(blob);
+    let fmt_count = read_i32(&mut cur)?;
+    if !(0..=4096).contains(&fmt_count) {
+        return Err(Error::Config(format!(
+            "flatfiles: fmt_count {fmt_count} out of plausible range"
+        )));
+    }
+    let mut fmt = Vec::with_capacity(fmt_count as usize);
+    for _ in 0..fmt_count {
+        let code = read_i32(&mut cur)?;
+        fmt.push(DataType::from_code(code));
+    }
+    let index_byte_len = read_i64(&mut cur)?;
+    let data_byte_len = read_i64(&mut cur)?;
+    if index_byte_len < 0 || data_byte_len < 0 {
+        return Err(Error::Config(format!(
+            "flatfiles: negative section length(s) — index={index_byte_len}, data={data_byte_len}"
+        )));
+    }
+    let price_type_idx = fmt.iter().position(|c| matches!(c, DataType::PriceType));
+    Ok(BlobHeader {
+        fmt,
+        price_type_idx,
+        index_byte_len: index_byte_len as u64,
+        data_byte_len: data_byte_len as u64,
+        index_offset: cur.position(),
+    })
+}
+
+/// One INDEX entry's contract key + DATA-section pointer.
+#[derive(Debug, Clone)]
+pub(crate) struct IndexEntry {
+    /// UTF-8 root symbol (e.g. `"AAPL"`, `"SPY"`, `"ABBV"`).
+    pub(crate) root: String,
+    /// Option expiration (YYYYMMDD), or `None` for stock entries.
+    pub(crate) exp: Option<i32>,
+    /// Strike price in tenths of a cent, or `None` for stocks.
+    pub(crate) strike: Option<i32>,
+    /// `'C'` or `'P'` for options, `None` for stocks.
+    pub(crate) right: Option<char>,
+    /// Byte offset in the DATA section where the entry's FIT block starts.
+    pub(crate) block_start: u64,
+    /// Byte offset one past the last byte of the FIT block.
+    pub(crate) block_end: u64,
+}
+
+/// Iterator over INDEX entries.
+///
+/// Holds a borrowed slice of just the INDEX section bytes (i.e.
+/// `&blob[hdr.index_offset .. hdr.index_offset + hdr.index_byte_len]`)
+/// plus the sec-type-driven payload schema. Stops cleanly at end of
+/// section; surfaces malformed entries as `Some(Err(_))`.
+pub(crate) struct IndexIter<'a> {
+    cur: Cursor<&'a [u8]>,
+    sec: SecType,
+}
+
+impl<'a> IndexIter<'a> {
+    pub(crate) fn new(index_bytes: &'a [u8], sec: SecType) -> Self {
+        Self {
+            cur: Cursor::new(index_bytes),
+            sec,
+        }
+    }
+}
+
+impl<'a> Iterator for IndexIter<'a> {
+    type Item = Result<IndexEntry, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let buf = *self.cur.get_ref();
+        if self.cur.position() as usize >= buf.len() {
+            return None;
+        }
+        Some(parse_one_entry(&mut self.cur, self.sec))
+    }
+}
+
+fn parse_one_entry(cur: &mut Cursor<&[u8]>, sec: SecType) -> Result<IndexEntry, Error> {
+    let entry_size = read_u16(cur)? as usize;
+    let mut entry_buf = vec![0u8; entry_size];
+    cur.read_exact(&mut entry_buf)?;
+    let mut e = Cursor::new(&entry_buf[..]);
+
+    let (root, exp, strike, right) = match sec {
+        SecType::Option | SecType::Index => {
+            // Index payload (when supported by the vendor) follows the
+            // option layout — root_len, root, exp, right, strike, date.
+            let root_len = read_u8(&mut e)? as usize;
+            let mut root_bytes = vec![0u8; root_len];
+            e.read_exact(&mut root_bytes)?;
+            let root = String::from_utf8_lossy(&root_bytes).into_owned();
+            let exp = read_i32(&mut e)?;
+            let right_byte = read_u8(&mut e)?;
+            let right = right_byte as char;
+            let strike = read_i32(&mut e)?;
+            // The trailing i32 is the contract's trading date; the row's
+            // own DATE column carries the per-tick date and supersedes
+            // it for CSV emission, so we consume but don't store.
+            let _date = read_i32(&mut e)?;
+            (root, Some(exp), Some(strike), Some(right))
+        }
+        SecType::Stock => {
+            let root_len = read_u8(&mut e)? as usize;
+            let mut root_bytes = vec![0u8; root_len];
+            e.read_exact(&mut root_bytes)?;
+            let root = String::from_utf8_lossy(&root_bytes).into_owned();
+            let _date = read_i32(&mut e)?;
+            (root, None, None, None)
+        }
+    };
+
+    // Location: i32 volume, i64 start, i64 end. Volume is unused by the
+    // SDK; we drop it but consume the bytes to advance the cursor.
+    let _volume = read_i32(cur)?;
+    let block_start = read_i64(cur)? as u64;
+    let block_end = read_i64(cur)? as u64;
+    Ok(IndexEntry {
+        root,
+        exp,
+        strike,
+        right,
+        block_start,
+        block_end,
+    })
+}
+
+#[inline]
+fn read_u8(cur: &mut Cursor<&[u8]>) -> Result<u8, Error> {
+    let mut b = [0u8; 1];
+    cur.read_exact(&mut b)?;
+    Ok(b[0])
+}
+
+#[inline]
+fn read_u16(cur: &mut Cursor<&[u8]>) -> Result<u16, Error> {
+    let mut b = [0u8; 2];
+    cur.read_exact(&mut b)?;
+    Ok(u16::from_be_bytes(b))
+}
+
+#[inline]
+fn read_i32<R: Read>(cur: &mut R) -> Result<i32, Error> {
+    let mut b = [0u8; 4];
+    cur.read_exact(&mut b)?;
+    Ok(i32::from_be_bytes(b))
+}
+
+#[inline]
+fn read_i64<R: Read>(cur: &mut R) -> Result<i64, Error> {
+    let mut b = [0u8; 8];
+    cur.read_exact(&mut b)?;
+    Ok(i64::from_be_bytes(b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_header(fmt_codes: &[i32], index_len: i64, data_len: i64) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(fmt_codes.len() as i32).to_be_bytes());
+        for c in fmt_codes {
+            buf.extend_from_slice(&c.to_be_bytes());
+        }
+        buf.extend_from_slice(&index_len.to_be_bytes());
+        buf.extend_from_slice(&data_len.to_be_bytes());
+        buf
+    }
+
+    #[test]
+    fn header_round_trip_open_interest_schema() {
+        // Option open_interest schema observed in vendor CSV header:
+        //   ms_of_day(1), open_interest(121), date(0)
+        let raw = build_header(&[1, 121, 0], 100, 200);
+        let hdr = parse_header(&raw).unwrap();
+        assert_eq!(
+            hdr.fmt,
+            vec![DataType::MsOfDay, DataType::OpenInterest, DataType::Date]
+        );
+        assert!(hdr.price_type_idx.is_none()); // OI has no price column
+        assert_eq!(hdr.index_byte_len, 100);
+        assert_eq!(hdr.data_byte_len, 200);
+        assert_eq!(hdr.index_offset, 4 + 4 * 3 + 16); // fmt_count + 3*i32 + 2*i64
+    }
+
+    #[test]
+    fn header_locates_price_type_index() {
+        // Trade schema includes PRICE_TYPE(4) at column 12 (vendor layout).
+        let codes = [
+            1, 131, 241, 242, 243, 244, 133, 132, 135, 134, 136, 137, 4, 138, 139, 0,
+        ];
+        let raw = build_header(&codes, 0, 0);
+        let hdr = parse_header(&raw).unwrap();
+        assert_eq!(hdr.price_type_idx, Some(12));
+    }
+
+    #[test]
+    fn header_rejects_negative_lengths() {
+        let raw = build_header(&[1, 0], -1, 100);
+        assert!(parse_header(&raw).is_err());
+    }
+
+    #[test]
+    fn header_rejects_truncated_input() {
+        let raw = vec![0, 0, 0, 1, 0, 0, 0, 1]; // fmt_count=1, one code, no lengths
+        assert!(parse_header(&raw).is_err());
+    }
+
+    #[test]
+    fn option_index_entry_round_trip() {
+        // Build one option entry: AAPL 20260117 P 200000 date=20260428
+        // entry_size: 1 + 4 + 4 + 1 + 4 + 4 = 18
+        let mut e = Vec::new();
+        e.push(4u8); // root_len
+        e.extend_from_slice(b"AAPL"); // root
+        e.extend_from_slice(&20_260_117i32.to_be_bytes()); // exp
+        e.push(b'P'); // right
+        e.extend_from_slice(&200_000i32.to_be_bytes()); // strike
+        e.extend_from_slice(&20_260_428i32.to_be_bytes()); // date
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(e.len() as u16).to_be_bytes());
+        buf.extend_from_slice(&e);
+        buf.extend_from_slice(&42i32.to_be_bytes()); // volume
+        buf.extend_from_slice(&1000i64.to_be_bytes()); // start
+        buf.extend_from_slice(&1500i64.to_be_bytes()); // end
+
+        let mut iter = IndexIter::new(&buf, SecType::Option);
+        let entry = iter.next().unwrap().unwrap();
+        assert_eq!(entry.root, "AAPL");
+        assert_eq!(entry.exp, Some(20_260_117));
+        assert_eq!(entry.strike, Some(200_000));
+        assert_eq!(entry.right, Some('P'));
+        assert_eq!(entry.block_start, 1000);
+        assert_eq!(entry.block_end, 1500);
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn stock_index_entry_round_trip() {
+        // SPY date=20260428 — entry_size = 1 + 3 + 4 = 8
+        let mut e = Vec::new();
+        e.push(3u8);
+        e.extend_from_slice(b"SPY");
+        e.extend_from_slice(&20_260_428i32.to_be_bytes());
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(e.len() as u16).to_be_bytes());
+        buf.extend_from_slice(&e);
+        buf.extend_from_slice(&0i32.to_be_bytes());
+        buf.extend_from_slice(&0i64.to_be_bytes());
+        buf.extend_from_slice(&100i64.to_be_bytes());
+
+        let mut iter = IndexIter::new(&buf, SecType::Stock);
+        let entry = iter.next().unwrap().unwrap();
+        assert_eq!(entry.root, "SPY");
+        assert_eq!(entry.exp, None);
+        assert_eq!(entry.strike, None);
+        assert_eq!(entry.right, None);
+        assert_eq!(entry.block_start, 0);
+        assert_eq!(entry.block_end, 100);
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/mdds_spki.rs
+++ b/crates/thetadatadx/src/flatfiles/mdds_spki.rs
@@ -36,8 +36,11 @@ pub(crate) struct MddsSpkiVerifier {
 
 impl MddsSpkiVerifier {
     pub(crate) fn new() -> Arc<Self> {
+        // Install the ring provider on first use so callers don't have to
+        // remember to do it themselves. Subsequent installs are a no-op.
+        let _ = rustls::crypto::ring::default_provider().install_default();
         let provider = rustls::crypto::CryptoProvider::get_default()
-            .expect("rustls crypto provider must be installed before MddsSpkiVerifier::new");
+            .expect("rustls ring provider just installed");
         Arc::new(Self {
             algs: provider.signature_verification_algorithms,
         })

--- a/crates/thetadatadx/src/flatfiles/mdds_spki.rs
+++ b/crates/thetadatadx/src/flatfiles/mdds_spki.rs
@@ -1,0 +1,102 @@
+//! Server identity verification for the MDDS legacy port.
+//!
+//! The MDDS endpoints (`nj-{a,b}.thetadata.us:12000-12001`) present a TLS
+//! certificate whose chain has been expired since `2024-01-12`. Standard
+//! webpki validation fails. The vendor terminal works around this by trusting
+//! a single bundled cert from `client.jks`. We work around it by pinning the
+//! SubjectPublicKeyInfo (SPKI) of the leaf certificate — the same approach
+//! the FPSS module already uses (see [`crate::fpss::pinning`]). Live
+//! observation on `2026-04-29` confirms the same SPKI is served by both the
+//! FPSS port (20000) and the MDDS port (12000) — ThetaData runs one keypair
+//! across the two backends. We therefore reuse the FPSS pin constant rather
+//! than maintaining a parallel one.
+
+use std::sync::Arc;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, WebPkiSupportedAlgorithms};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use x509_parser::prelude::*;
+
+use crate::fpss::pinning::FPSS_SPKI_SHA256;
+
+/// Hostnames we will connect to for MDDS legacy.
+pub(crate) const ALLOWED_MDDS_HOSTS: &[&str] = &["nj-a.thetadata.us", "nj-b.thetadata.us"];
+
+/// Production MDDS legacy ports for the `nj-{a,b}` region.
+pub(crate) const MDDS_PORTS: &[u16] = &[12000, 12001];
+
+#[derive(Debug)]
+pub(crate) struct MddsSpkiVerifier {
+    algs: WebPkiSupportedAlgorithms,
+}
+
+impl MddsSpkiVerifier {
+    pub(crate) fn new() -> Arc<Self> {
+        let provider = rustls::crypto::CryptoProvider::get_default()
+            .expect("rustls crypto provider must be installed before MddsSpkiVerifier::new");
+        Arc::new(Self {
+            algs: provider.signature_verification_algorithms,
+        })
+    }
+}
+
+impl ServerCertVerifier for MddsSpkiVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        // Hostname allowlist — even with SPKI pinning, refuse unknown SNIs.
+        let host = match server_name {
+            ServerName::DnsName(d) => d.as_ref().to_string(),
+            other => return Err(rustls::Error::General(format!("unexpected SNI: {other:?}"))),
+        };
+        if !ALLOWED_MDDS_HOSTS.contains(&host.as_str()) {
+            return Err(rustls::Error::General(format!(
+                "MDDS host {host} not in allowlist"
+            )));
+        }
+
+        // Parse leaf and extract SPKI bytes.
+        let (_, parsed) = X509Certificate::from_der(end_entity.as_ref())
+            .map_err(|e| rustls::Error::General(format!("MDDS leaf cert parse failed: {e}")))?;
+        let spki_der = parsed.tbs_certificate.subject_pki.raw;
+        let digest: [u8; 32] = Sha256::digest(spki_der).into();
+
+        if digest.ct_eq(&FPSS_SPKI_SHA256).unwrap_u8() != 1 {
+            return Err(rustls::Error::General(
+                "MDDS server SPKI does not match pinned ThetaData keypair".to_string(),
+            ));
+        }
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls12_signature(message, cert, dss, &self.algs)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(message, cert, dss, &self.algs)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.algs.supported_schemes()
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/mdds_spki.rs
+++ b/crates/thetadatadx/src/flatfiles/mdds_spki.rs
@@ -36,14 +36,20 @@ pub(crate) struct MddsSpkiVerifier {
 
 impl MddsSpkiVerifier {
     pub(crate) fn new() -> Arc<Self> {
-        // Install the ring provider on first use so callers don't have to
-        // remember to do it themselves. Subsequent installs are a no-op.
-        let _ = rustls::crypto::ring::default_provider().install_default();
-        let provider = rustls::crypto::CryptoProvider::get_default()
-            .expect("rustls ring provider just installed");
-        Arc::new(Self {
-            algs: provider.signature_verification_algorithms,
-        })
+        // If another component already installed a provider (FPSS does the
+        // same dance on its TLS path), reuse its signature algorithms.
+        // Otherwise fall back to ring and install it as the process
+        // default — racing with a concurrent installer is fine, since the
+        // local `algs` is captured before the install attempt.
+        let algs = if let Some(provider) = rustls::crypto::CryptoProvider::get_default() {
+            provider.signature_verification_algorithms
+        } else {
+            let provider = rustls::crypto::ring::default_provider();
+            let algs = provider.signature_verification_algorithms;
+            let _ = provider.install_default();
+            algs
+        };
+        Arc::new(Self { algs })
     }
 }
 

--- a/crates/thetadatadx/src/flatfiles/mod.rs
+++ b/crates/thetadatadx/src/flatfiles/mod.rs
@@ -115,3 +115,19 @@ pub use decoded::{default_output_filename, flatfile_request};
 pub use format::FlatFileFormat;
 pub use request::flatfile_request_raw;
 pub use types::{FlatFilesUnavailableReason, ReqType, SecType};
+
+/// Decode an already-saved raw FLATFILES blob into a typed output file.
+///
+/// Test-facing helper used by the byte-match integration suite to share
+/// one live capture across CSV / Parquet / JSONL smoke tests without
+/// hitting the wire three times. Hidden from `docs.rs`; not part of the
+/// stable public API.
+#[doc(hidden)]
+pub fn decoded_decode_to_file_for_test(
+    raw_path: &std::path::Path,
+    sec: SecType,
+    output_path: &std::path::Path,
+    format: FlatFileFormat,
+) -> Result<(), crate::error::Error> {
+    decoded::decode_to_file(raw_path, sec, output_path, format)
+}

--- a/crates/thetadatadx/src/flatfiles/mod.rs
+++ b/crates/thetadatadx/src/flatfiles/mod.rs
@@ -1,0 +1,107 @@
+//! FLATFILES — third public surface alongside FPSS and MDDS.
+//!
+//! # Identity
+//!
+//! FLATFILES is ThetaData's overnight-batch delivery channel for whole-universe
+//! daily snapshots of options/stocks data. Every night the vendor pre-builds
+//! one INDEX + DATA blob per `(sec_type, data_type, date)` tuple; customers can
+//! pull the whole-universe blob in a single request and walk it locally to
+//! produce CSV. The legacy Java terminal exposes a REST front-door
+//! (`GET /v2/file/{secType}/{reqType}?start_date=YYYYMMDD`) that internally
+//! talks to the vendor's MDDS legacy port (12000-12001 on `nj-{a,b}.thetadata.us`)
+//! over a custom TLS PacketStream protocol.
+//!
+//! This Rust module is a **clean-room re-implementation** of the wire
+//! protocol — not a port of decompiled Java source. Every structural fact
+//! below was derived from observing live wire bytes against the production
+//! server, plus high-level shape information from the bundled bytecode.
+//!
+//! # Module status
+//!
+//! | Layer                        | Status                              |
+//! |------------------------------|-------------------------------------|
+//! | TCP + TLS handshake          | working (SPKI pinned via `mdds_spki`) |
+//! | PacketStream framing         | working (`framing` submodule)       |
+//! | CREDENTIALS + VERSION login  | working (verified live 2026-04-29)  |
+//! | FLAT_FILE request            | working (verified live 2026-04-29)  |
+//! | Chunked response accumulator | working — writes raw stream to disk |
+//! | INDEX walker                 | not yet implemented                 |
+//! | FIT per-contract decoder     | not yet implemented                 |
+//! | CSV writer (vendor-format)   | not yet implemented                 |
+//!
+//! The completed layers are exercised end-to-end by [`flatfile_request_raw`],
+//! which authenticates, sends a single FLAT_FILE request, accumulates every
+//! response chunk to a local scratch file, and returns its path on
+//! `FLAT_FILE_END`. The remaining layers (INDEX walker, FIT decoder, CSV
+//! writer) are the next phase of work; until they land,
+//! [`ThetaDataDx::flatfile_request`](crate::ThetaDataDx::flatfile_request)
+//! returns the raw stream path and the convenience methods return
+//! [`Error::FlatFilesUnavailable`] with a `RawStreamOnly` reason.
+//!
+//! # PacketStream framing (verified live)
+//!
+//! Every message in either direction is `[u32 size BE][u16 msg_code BE]
+//! [i64 id BE][payload]`. `size` is the byte length of `payload` only. `id`
+//! is `-1` for connection-scoped frames (CREDENTIALS, VERSION, SESSION_TOKEN,
+//! METADATA) and a per-call positive integer for request/response correlation
+//! (FLAT_FILE / FLAT_FILE_END).
+//!
+//! # Auth (verified live)
+//!
+//! After the TLS handshake the client immediately writes:
+//!
+//! 1. `CREDENTIALS` (msg=0, id=-1) — payload is `[u8 0x00][u16 BE userlen]
+//!    [user_utf8][pass_utf8]`. The leading byte is `0x00`. (Earlier
+//!    reverse-engineering notes guessed `0x03`; the bytecode shows `iconst_0`
+//!    and the live server rejects `0x03` with `INVALID_CREDENTIALS`.)
+//! 2. `VERSION` (msg=5, id=-1) — payload is `[u32 BE jsonlen][json_utf8]`,
+//!    where `json` is a flat map of system properties; the only required
+//!    key the server inspects is `terminal.version`.
+//!
+//! On success the server pushes back, in order:
+//! - `SESSION_TOKEN` (msg=1, id=-1) — 128 bytes of opaque token (kept by the
+//!   server; the client doesn't need to echo it back during the same
+//!   connection).
+//! - `METADATA` (msg=3, id=-1) — ASCII bundle string, e.g.
+//!   `"STOCK.STANDARD, OPTION.PRO, INDEX.FREE"`.
+//!
+//! On failure the server returns `DISCONNECTED` (msg=102) with a 2-byte
+//! big-endian `RemoveReason` ordinal and closes the socket.
+//!
+//! # FLAT_FILE request (verified live)
+//!
+//! After auth, the client sends one frame: `msg=217`, `id=<arbitrary
+//! positive i64>`, payload = ASCII query string `MSG_CODE=217&id=<id>&
+//! start_date=YYYYMMDD&REQ=<reqcode>&SEC=<sectype>&rth=true&ivl=0`. The
+//! `MSG_CODE` field is redundant with the framing message code; the server
+//! checks both. `REQ` is the V2 ReqType wire code (e.g. `103` =
+//! `OPEN_INTEREST`, `207` = `TRADE_QUOTE`, `1` = `EOD`); see
+//! [`ReqType`] for the full mapping.
+//!
+//! # FLAT_FILE response (verified live)
+//!
+//! The server streams a sequence of `msg=217` frames sharing the same `id`
+//! as the request. Each frame's payload is a chunk of the wire-format INDEX +
+//! DATA blob; chunks are appended in order. A single `msg=218`
+//! (FLAT_FILE_END) frame on the same id signals "all chunks delivered."
+//! Live observation against `nj-a.thetadata.us:12000` for
+//! `option_open_interest 20260428`: 8 chunks observed in the first 15 s,
+//! each ~512 KB, headed by a small `[u32 u32 u32 u32]` tuple in the first
+//! chunk that introduces the INDEX section.
+//!
+//! # Anti-IP discipline
+//!
+//! No constants, decode tables, or implementation details that constitute
+//! ThetaData IP are reproduced here — only the public-facing wire shape
+//! observable to any TLS-MITM. The `client.jks` truststore bundled in the
+//! vendor jar is **not** used: server identity is established via SPKI
+//! pinning to the production keypair (which also signs the FPSS endpoints).
+
+pub(crate) mod framing;
+pub(crate) mod mdds_spki;
+pub(crate) mod request;
+pub(crate) mod session;
+pub(crate) mod types;
+
+pub use request::flatfile_request_raw;
+pub use types::{FlatFilesUnavailableReason, ReqType, SecType};

--- a/crates/thetadatadx/src/flatfiles/mod.rs
+++ b/crates/thetadatadx/src/flatfiles/mod.rs
@@ -25,9 +25,11 @@
 //! | CREDENTIALS + VERSION login  | working (verified live 2026-04-29)  |
 //! | FLAT_FILE request            | working (verified live 2026-04-29)  |
 //! | Chunked response accumulator | working — writes raw stream to disk |
-//! | INDEX walker                 | not yet implemented                 |
-//! | FIT per-contract decoder     | not yet implemented                 |
-//! | CSV writer (vendor-format)   | not yet implemented                 |
+//! | INDEX walker                 | working (`index` submodule)         |
+//! | FIT per-contract decoder     | working (`decode` submodule)        |
+//! | CSV writer (vendor-format)   | working (`writer::CsvSink`)         |
+//! | Parquet writer (zstd, Arrow) | working (`writer::ParquetSink`)     |
+//! | JSONL writer                 | working (`writer::JsonlSink`)       |
 //!
 //! The completed layers are exercised end-to-end by [`flatfile_request_raw`],
 //! which authenticates, sends a single FLAT_FILE request, accumulates every
@@ -97,11 +99,19 @@
 //! vendor jar is **not** used: server identity is established via SPKI
 //! pinning to the production keypair (which also signs the FPSS endpoints).
 
+pub(crate) mod datatype;
+pub(crate) mod decode;
+pub(crate) mod decoded;
+pub(crate) mod format;
 pub(crate) mod framing;
+pub(crate) mod index;
 pub(crate) mod mdds_spki;
 pub(crate) mod request;
 pub(crate) mod session;
 pub(crate) mod types;
+pub(crate) mod writer;
 
+pub use decoded::{default_output_filename, flatfile_request};
+pub use format::FlatFileFormat;
 pub use request::flatfile_request_raw;
 pub use types::{FlatFilesUnavailableReason, ReqType, SecType};

--- a/crates/thetadatadx/src/flatfiles/mod.rs
+++ b/crates/thetadatadx/src/flatfiles/mod.rs
@@ -31,14 +31,15 @@
 //! | Parquet writer (zstd, Arrow) | working (`writer::ParquetSink`)     |
 //! | JSONL writer                 | working (`writer::JsonlSink`)       |
 //!
-//! The completed layers are exercised end-to-end by [`flatfile_request_raw`],
-//! which authenticates, sends a single FLAT_FILE request, accumulates every
-//! response chunk to a local scratch file, and returns its path on
-//! `FLAT_FILE_END`. The remaining layers (INDEX walker, FIT decoder, CSV
-//! writer) are the next phase of work; until they land,
+//! The low-level raw-stream path is exercised end-to-end by
+//! [`flatfile_request_raw`], which authenticates, sends a single FLAT_FILE
+//! request, accumulates every response chunk to a local scratch file, and
+//! returns its path on `FLAT_FILE_END`. The decoded pipeline is also
+//! implemented:
 //! [`ThetaDataDx::flatfile_request`](crate::ThetaDataDx::flatfile_request)
-//! returns the raw stream path and the convenience methods return
-//! [`Error::FlatFilesUnavailable`] with a `RawStreamOnly` reason.
+//! walks the INDEX, decodes FIT records, and writes the requested typed
+//! output format (CSV / Parquet / JSONL). The raw capture helper remains
+//! available for debugging, fixtures, and byte-level verification.
 //!
 //! # PacketStream framing (verified live)
 //!

--- a/crates/thetadatadx/src/flatfiles/mod.rs
+++ b/crates/thetadatadx/src/flatfiles/mod.rs
@@ -1,104 +1,60 @@
-//! FLATFILES — third public surface alongside FPSS and MDDS.
+//! FLATFILES surface: whole-universe daily snapshots over the legacy MDDS port.
 //!
-//! # Identity
+//! Pulls one INDEX + DATA blob per `(SecType, ReqType, date)` tuple from
+//! `nj-{a,b}.thetadata.us:12000-12001` over a TLS PacketStream protocol
+//! distinct from MDDS gRPC and FPSS streaming. Decodes the blob into one
+//! row per `(contract, timestamp)` pair and emits CSV, JSONL, or a typed
+//! in-memory `Vec<FlatFileRow>`.
 //!
-//! FLATFILES is ThetaData's overnight-batch delivery channel for whole-universe
-//! daily snapshots of options/stocks data. Every night the vendor pre-builds
-//! one INDEX + DATA blob per `(sec_type, data_type, date)` tuple; customers can
-//! pull the whole-universe blob in a single request and walk it locally to
-//! produce CSV. The legacy Java terminal exposes a REST front-door
-//! (`GET /v2/file/{secType}/{reqType}?start_date=YYYYMMDD`) that internally
-//! talks to the vendor's MDDS legacy port (12000-12001 on `nj-{a,b}.thetadata.us`)
-//! over a custom TLS PacketStream protocol.
+//! # Public entry points
 //!
-//! This Rust module is a **clean-room re-implementation** of the wire
-//! protocol — not a port of decompiled Java source. Every structural fact
-//! below was derived from observing live wire bytes against the production
-//! server, plus high-level shape information from the bundled bytecode.
+//! - [`flatfile_request`] — pull, decode, write CSV or JSONL to disk.
+//! - [`flatfile_request_decoded`] — pull, decode, return `Vec<FlatFileRow>`
+//!   in memory.
+//! - [`flatfile_request_raw`] — pull only; write the raw INDEX + DATA blob
+//!   to disk for callers that want to run their own decoder.
 //!
-//! # Module status
+//! All three are also reachable via the [`crate::ThetaDataDx`] client.
 //!
-//! | Layer                        | Status                              |
-//! |------------------------------|-------------------------------------|
-//! | TCP + TLS handshake          | working (SPKI pinned via `mdds_spki`) |
-//! | PacketStream framing         | working (`framing` submodule)       |
-//! | CREDENTIALS + VERSION login  | working (verified live 2026-04-29)  |
-//! | FLAT_FILE request            | working (verified live 2026-04-29)  |
-//! | Chunked response accumulator | working — writes raw stream to disk |
-//! | INDEX walker                 | working (`index` submodule)         |
-//! | FIT per-contract decoder     | working (`decode` submodule)        |
-//! | CSV writer (vendor-format)   | working (`writer::CsvSink`)         |
-//! | JSONL writer                 | working (`writer::JsonlSink`)       |
-//! | Typed in-memory decode       | working (`flatfile_request_decoded`) |
+//! # Wire protocol
 //!
-//! The low-level raw-stream path is exercised end-to-end by
-//! [`flatfile_request_raw`], which authenticates, sends a single FLAT_FILE
-//! request, accumulates every response chunk to a local scratch file, and
-//! returns its path on `FLAT_FILE_END`. The decoded pipeline is also
-//! implemented:
-//! [`ThetaDataDx::flatfile_request`](crate::ThetaDataDx::flatfile_request)
-//! walks the INDEX, decodes FIT records, and writes the requested typed
-//! output format (CSV / Parquet / JSONL). The raw capture helper remains
-//! available for debugging, fixtures, and byte-level verification.
+//! Every frame, in either direction, is encoded as
+//! `[u32 size BE][u16 msg_code BE][i64 id BE][payload]`. `size` covers
+//! `payload` only. `id` is `-1` for connection-scoped frames (CREDENTIALS,
+//! VERSION, SESSION_TOKEN, METADATA) and a positive integer for
+//! request/response correlation (FLAT_FILE = 217, FLAT_FILE_END = 218).
 //!
-//! # PacketStream framing (verified live)
+//! Authentication is a CREDENTIALS frame (msg=0) followed by a VERSION
+//! frame (msg=5). On success the server emits SESSION_TOKEN (msg=1) plus
+//! METADATA (msg=3) carrying the account's bundle string. On failure it
+//! emits DISCONNECTED (msg=102) with a 2-byte big-endian `RemoveReason`.
 //!
-//! Every message in either direction is `[u32 size BE][u16 msg_code BE]
-//! [i64 id BE][payload]`. `size` is the byte length of `payload` only. `id`
-//! is `-1` for connection-scoped frames (CREDENTIALS, VERSION, SESSION_TOKEN,
-//! METADATA) and a per-call positive integer for request/response correlation
-//! (FLAT_FILE / FLAT_FILE_END).
+//! A FLAT_FILE request frame (msg=217) carries an ASCII query payload
+//! `MSG_CODE=217&id=<id>&start_date=YYYYMMDD&REQ=<reqcode>&SEC=<sectype>
+//! &rth=true&ivl=0`. The server replies with a sequence of msg=217 frames
+//! sharing the request id, each carrying a chunk of the INDEX + DATA
+//! blob, terminated by a single FLAT_FILE_END (msg=218).
 //!
-//! # Auth (verified live)
+//! # Server identity
 //!
-//! After the TLS handshake the client immediately writes:
+//! TLS connections are pinned to the ThetaData production keypair via
+//! `mdds_spki::MddsSpkiVerifier` — the same SPKI hash that signs the FPSS
+//! endpoints. The vendor's bundled `client.jks` truststore is not used.
 //!
-//! 1. `CREDENTIALS` (msg=0, id=-1) — payload is `[u8 0x00][u16 BE userlen]
-//!    [user_utf8][pass_utf8]`. The leading byte is `0x00`. (Earlier
-//!    reverse-engineering notes guessed `0x03`; the bytecode shows `iconst_0`
-//!    and the live server rejects `0x03` with `INVALID_CREDENTIALS`.)
-//! 2. `VERSION` (msg=5, id=-1) — payload is `[u32 BE jsonlen][json_utf8]`,
-//!    where `json` is a flat map of system properties; the only required
-//!    key the server inspects is `terminal.version`.
+//! # Submodule layout
 //!
-//! On success the server pushes back, in order:
-//! - `SESSION_TOKEN` (msg=1, id=-1) — 128 bytes of opaque token (kept by the
-//!   server; the client doesn't need to echo it back during the same
-//!   connection).
-//! - `METADATA` (msg=3, id=-1) — ASCII bundle string, e.g.
-//!   `"STOCK.STANDARD, OPTION.PRO, INDEX.FREE"`.
-//!
-//! On failure the server returns `DISCONNECTED` (msg=102) with a 2-byte
-//! big-endian `RemoveReason` ordinal and closes the socket.
-//!
-//! # FLAT_FILE request (verified live)
-//!
-//! After auth, the client sends one frame: `msg=217`, `id=<arbitrary
-//! positive i64>`, payload = ASCII query string `MSG_CODE=217&id=<id>&
-//! start_date=YYYYMMDD&REQ=<reqcode>&SEC=<sectype>&rth=true&ivl=0`. The
-//! `MSG_CODE` field is redundant with the framing message code; the server
-//! checks both. `REQ` is the V2 ReqType wire code (e.g. `103` =
-//! `OPEN_INTEREST`, `207` = `TRADE_QUOTE`, `1` = `EOD`); see
-//! [`ReqType`] for the full mapping.
-//!
-//! # FLAT_FILE response (verified live)
-//!
-//! The server streams a sequence of `msg=217` frames sharing the same `id`
-//! as the request. Each frame's payload is a chunk of the wire-format INDEX +
-//! DATA blob; chunks are appended in order. A single `msg=218`
-//! (FLAT_FILE_END) frame on the same id signals "all chunks delivered."
-//! Live observation against `nj-a.thetadata.us:12000` for
-//! `option_open_interest 20260428`: 8 chunks observed in the first 15 s,
-//! each ~512 KB, headed by a small `[u32 u32 u32 u32]` tuple in the first
-//! chunk that introduces the INDEX section.
-//!
-//! # Anti-IP discipline
-//!
-//! No constants, decode tables, or implementation details that constitute
-//! ThetaData IP are reproduced here — only the public-facing wire shape
-//! observable to any TLS-MITM. The `client.jks` truststore bundled in the
-//! vendor jar is **not** used: server identity is established via SPKI
-//! pinning to the production keypair (which also signs the FPSS endpoints).
+//! - `framing` — PacketStream frame reader/writer.
+//! - `mdds_spki` — TLS verifier with SNI allowlist + SPKI pin.
+//! - `session` — TCP/TLS handshake plus CREDENTIALS + VERSION login.
+//! - `request` — FLAT_FILE request driver and chunked response sink.
+//! - `index` — header parser plus INDEX-section iterator.
+//! - `decode` — FIT per-contract block decoder.
+//! - `decoded` — end-to-end pull + decode + write driver.
+//! - `decoded_row` — typed in-memory row representation.
+//! - `writer` — CSV and JSONL row sinks.
+//! - `format` — output format enum.
+//! - `types` — `SecType`, `ReqType`, `FlatFilesUnavailableReason`.
+//! - `datatype` — wire-code mapping for the per-row column schema.
 
 pub(crate) mod datatype;
 pub(crate) mod decode;

--- a/crates/thetadatadx/src/flatfiles/mod.rs
+++ b/crates/thetadatadx/src/flatfiles/mod.rs
@@ -28,8 +28,8 @@
 //! | INDEX walker                 | working (`index` submodule)         |
 //! | FIT per-contract decoder     | working (`decode` submodule)        |
 //! | CSV writer (vendor-format)   | working (`writer::CsvSink`)         |
-//! | Parquet writer (zstd, Arrow) | working (`writer::ParquetSink`)     |
 //! | JSONL writer                 | working (`writer::JsonlSink`)       |
+//! | Typed in-memory decode       | working (`flatfile_request_decoded`) |
 //!
 //! The low-level raw-stream path is exercised end-to-end by
 //! [`flatfile_request_raw`], which authenticates, sends a single FLAT_FILE
@@ -103,6 +103,7 @@
 pub(crate) mod datatype;
 pub(crate) mod decode;
 pub(crate) mod decoded;
+pub(crate) mod decoded_row;
 pub(crate) mod format;
 pub(crate) mod framing;
 pub(crate) mod index;
@@ -112,7 +113,8 @@ pub(crate) mod session;
 pub(crate) mod types;
 pub(crate) mod writer;
 
-pub use decoded::{default_output_filename, flatfile_request};
+pub use decoded::{default_output_filename, flatfile_request, flatfile_request_decoded};
+pub use decoded_row::{FlatFileRow, FlatFileValue};
 pub use format::FlatFileFormat;
 pub use request::flatfile_request_raw;
 pub use types::{FlatFilesUnavailableReason, ReqType, SecType};
@@ -120,9 +122,8 @@ pub use types::{FlatFilesUnavailableReason, ReqType, SecType};
 /// Decode an already-saved raw FLATFILES blob into a typed output file.
 ///
 /// Test-facing helper used by the byte-match integration suite to share
-/// one live capture across CSV / Parquet / JSONL smoke tests without
-/// hitting the wire three times. Hidden from `docs.rs`; not part of the
-/// stable public API.
+/// one live capture across CSV / JSONL smoke tests without hitting the
+/// wire twice. Hidden from `docs.rs`; not part of the stable public API.
 #[doc(hidden)]
 pub fn decoded_decode_to_file_for_test(
     raw_path: &std::path::Path,

--- a/crates/thetadatadx/src/flatfiles/request.rs
+++ b/crates/thetadatadx/src/flatfiles/request.rs
@@ -1,0 +1,216 @@
+//! High-level FLAT_FILE request driver.
+//!
+//! Given a `(SecType, ReqType, date)` tuple plus an output path, this module
+//! drives one full request/response round-trip:
+//!
+//! 1. Open a TLS connection to the first reachable MDDS legacy host.
+//! 2. Authenticate (CREDENTIALS + VERSION).
+//! 3. Send a FLAT_FILE request frame.
+//! 4. Stream every chunk to a local file until FLAT_FILE_END.
+//! 5. Surface the local path back to the caller.
+//!
+//! The FIT decode + per-data-type CSV writer is **not** in this module yet
+//! (see [`crate::flatfiles`] for status). Callers that need vendor-format
+//! CSV today should keep using the V3 fan-out path; callers that want the
+//! raw binary stream (for a custom pipeline) can use this entry point
+//! directly.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use std::fs::File;
+use std::io::Write;
+
+use crate::auth::Credentials;
+use crate::error::Error;
+use crate::flatfiles::framing::{msg, read_frame};
+use crate::flatfiles::mdds_spki::{ALLOWED_MDDS_HOSTS, MDDS_PORTS};
+use crate::flatfiles::session::{connect_and_login, MddsHost};
+use crate::flatfiles::types::{FlatFilesUnavailableReason, ReqType, SecType};
+
+/// Process-wide monotonic id generator. The server treats id as opaque; we
+/// use an `AtomicI64` so concurrent `flatfile_request_raw` calls cannot
+/// collide on the same request id within a single process.
+static NEXT_ID: AtomicI64 = AtomicI64::new(1);
+
+fn next_id() -> i64 {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Build the FLAT_FILE request payload.
+///
+/// Verified live against `nj-a.thetadata.us:12000` on `2026-04-29`:
+/// ```text
+/// MSG_CODE=217&id=<id>&start_date=YYYYMMDD&REQ=<reqcode>&SEC=<sectype>&rth=true&ivl=0
+/// ```
+fn build_flat_file_payload(id: i64, sec: SecType, req: ReqType, date: &str) -> Vec<u8> {
+    format!(
+        "MSG_CODE={}&id={}&start_date={}&REQ={}&SEC={}&rth=true&ivl=0",
+        msg::FLAT_FILE,
+        id,
+        date,
+        req.as_wire(),
+        sec.as_wire(),
+    )
+    .into_bytes()
+}
+
+/// Validate that `date` is exactly 8 ASCII digits in YYYYMMDD shape.
+fn validate_date(date: &str) -> Result<(), Error> {
+    if date.len() != 8 || !date.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(Error::Config(format!(
+            "flatfiles: date {date:?} must be YYYYMMDD digits"
+        )));
+    }
+    Ok(())
+}
+
+/// Authenticate, send a FLAT_FILE request, and stream every response chunk
+/// to `output_path`. On success returns `output_path`. On failure returns
+/// the underlying [`Error`] — typically `Error::FlatFilesUnavailable` for
+/// auth/server rejection, or `Error::Io` for local I/O issues.
+///
+/// **Output format**: a raw concatenation of every FLAT_FILE chunk
+/// payload, in receive order, **without** the framing headers. This is the
+/// same byte sequence the vendor jar accumulates internally before walking
+/// the index — to convert it to CSV one must implement the INDEX walker
+/// and per-data-type FIT decoder. Both are tracked as TODOs in
+/// [`crate::flatfiles`].
+pub async fn flatfile_request_raw(
+    creds: &Credentials,
+    sec: SecType,
+    req: ReqType,
+    date: &str,
+    output_path: impl AsRef<Path>,
+) -> Result<PathBuf, Error> {
+    validate_date(date)?;
+
+    // Build the host candidate list — try every (host, port) in priority
+    // order, matching the vendor terminal's `MDDS_NJ_HOSTS` config.
+    let mut hosts: Vec<MddsHost<'_>> =
+        Vec::with_capacity(ALLOWED_MDDS_HOSTS.len() * MDDS_PORTS.len());
+    for h in ALLOWED_MDDS_HOSTS {
+        for p in MDDS_PORTS {
+            hosts.push(MddsHost { host: h, port: *p });
+        }
+    }
+
+    let mut session = connect_and_login(&hosts, creds).await?;
+    tracing::debug!(target: "flatfiles", "authed against MDDS legacy: bundle={}", session.bundle);
+
+    let request_id = next_id();
+    let payload = build_flat_file_payload(request_id, sec, req, date);
+    crate::flatfiles::framing::write_frame(
+        &mut session.stream,
+        msg::FLAT_FILE,
+        request_id,
+        &payload,
+    )
+    .await?;
+
+    let output_path = output_path.as_ref().to_path_buf();
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let mut out = std::io::BufWriter::new(File::create(&output_path)?);
+    let mut total: u64 = 0;
+    let mut chunks: u32 = 0;
+    // Loop only exits normally on FLAT_FILE_END; every other terminator
+    // returns Err. Reaching the post-loop log line therefore implies a
+    // clean end-of-stream, no bookkeeping flag needed.
+
+    loop {
+        let frame = match read_frame(&mut session.stream).await {
+            Ok(f) => f,
+            Err(e) => {
+                // Differentiate between EOF-after-some-data (truncation)
+                // and an outright protocol error.
+                if total > 0
+                    && matches!(&e, Error::Io(io) if io.kind() == std::io::ErrorKind::UnexpectedEof)
+                {
+                    return Err(Error::FlatFilesUnavailable(
+                        FlatFilesUnavailableReason::StreamTruncated {
+                            bytes_received: total,
+                        },
+                    ));
+                }
+                return Err(e);
+            }
+        };
+        if frame.id != request_id && frame.msg != msg::PING {
+            // The server may interleave heartbeats; everything else with a
+            // foreign id is a protocol violation we want to surface.
+            return Err(Error::Config(format!(
+                "flatfiles: unexpected response id={} (expected {request_id}) msg={}",
+                frame.id, frame.msg
+            )));
+        }
+        match frame.msg {
+            msg::FLAT_FILE => {
+                out.write_all(&frame.payload)?;
+                total += frame.payload.len() as u64;
+                chunks += 1;
+            }
+            msg::FLAT_FILE_END => {
+                break;
+            }
+            msg::ERROR => {
+                let server_message = String::from_utf8_lossy(&frame.payload).into_owned();
+                return Err(Error::FlatFilesUnavailable(
+                    FlatFilesUnavailableReason::RequestRejected { server_message },
+                ));
+            }
+            msg::PING => {
+                // Ignore — server-initiated heartbeat.
+            }
+            msg::DISCONNECTED => {
+                let reason_code = if frame.payload.len() >= 2 {
+                    u16::from_be_bytes([frame.payload[0], frame.payload[1]])
+                } else {
+                    0
+                };
+                return Err(Error::FlatFilesUnavailable(
+                    FlatFilesUnavailableReason::AuthRejected { reason_code },
+                ));
+            }
+            other => {
+                return Err(Error::Config(format!(
+                    "flatfiles: unexpected msg={other} during FLAT_FILE stream"
+                )));
+            }
+        }
+    }
+    out.flush()?;
+    drop(out);
+    tracing::info!(
+        target: "flatfiles",
+        "FLAT_FILE_END id={request_id} chunks={chunks} bytes={total} -> {}",
+        output_path.display()
+    );
+    Ok(output_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_is_canonical_ascii() {
+        let p = build_flat_file_payload(9001, SecType::Option, ReqType::OpenInterest, "20260428");
+        let s = std::str::from_utf8(&p).unwrap();
+        assert_eq!(
+            s,
+            "MSG_CODE=217&id=9001&start_date=20260428&REQ=103&SEC=OPTION&rth=true&ivl=0"
+        );
+    }
+
+    #[test]
+    fn date_validation_catches_garbage() {
+        assert!(validate_date("20260428").is_ok());
+        assert!(validate_date("2026-04-28").is_err());
+        assert!(validate_date("abcdefgh").is_err());
+        assert!(validate_date("").is_err());
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/request.rs
+++ b/crates/thetadatadx/src/flatfiles/request.rs
@@ -9,20 +9,19 @@
 //! 4. Stream every chunk to a local file until FLAT_FILE_END.
 //! 5. Surface the local path back to the caller.
 //!
-//! This module is responsible for the raw FLAT_FILE download step. The
-//! higher-level INDEX walking, FIT decoding, and per-format output
-//! (CSV / Parquet / JSONL) live under [`crate::flatfiles`] in the
-//! `index`, `decode`, `writer`, and `decoded` modules. Callers that want
-//! decoded vendor-format output should use the higher-level
-//! [`crate::ThetaDataDx::flatfile_request`] entry point; callers that
-//! want the raw binary stream for a custom pipeline can use this entry
-//! point directly.
+//! This module owns the raw FLAT_FILE download step. The higher-level
+//! INDEX walking, FIT decoding, and on-disk / in-memory output paths
+//! live in [`crate::flatfiles`] under the `index`, `decode`, `writer`,
+//! and `decoded` modules. Callers that want decoded vendor-format
+//! output use the higher-level [`crate::ThetaDataDx::flatfile_request`]
+//! entry point; callers that want the raw binary stream for a custom
+//! pipeline use this entry point directly.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use std::fs::File;
-use std::io::Write;
+use tokio::fs::File;
+use tokio::io::{AsyncWriteExt, BufWriter};
 
 use crate::auth::Credentials;
 use crate::error::Error;
@@ -112,24 +111,15 @@ pub async fn flatfile_request_raw(
     .await?;
 
     let output_path = output_path.as_ref().to_path_buf();
-    // Directory creation + file open are filesystem syscalls; do them on
-    // the blocking pool so we don't stall sibling tokio tasks (FPSS,
-    // MDDS) on the same runtime.
-    let parent = output_path.parent().map(std::path::Path::to_path_buf);
-    let output_for_open = output_path.clone();
-    let file: File = tokio::task::spawn_blocking(move || -> Result<File, std::io::Error> {
-        if let Some(p) = parent {
-            if !p.as_os_str().is_empty() {
-                std::fs::create_dir_all(&p)?;
-            }
+    if let Some(parent) = output_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            tokio::fs::create_dir_all(parent).await?;
         }
-        File::create(&output_for_open)
-    })
-    .await
-    .map_err(|e| Error::Config(format!("flatfiles: file-open task panicked: {e}")))??;
+    }
+    let file = File::create(&output_path).await?;
     // 1 MB buffer — typical chunks are ~8-64 KB, so this batches many
-    // chunks per actual write syscall and keeps the hot loop in memory.
-    let mut out = std::io::BufWriter::with_capacity(1 << 20, file);
+    // chunks per actual write syscall.
+    let mut out = BufWriter::with_capacity(1 << 20, file);
     let mut total: u64 = 0;
     let mut chunks: u32 = 0;
     // Loop only exits normally on FLAT_FILE_END; every other terminator
@@ -164,7 +154,7 @@ pub async fn flatfile_request_raw(
         }
         match frame.msg {
             msg::FLAT_FILE => {
-                out.write_all(&frame.payload)?;
+                out.write_all(&frame.payload).await?;
                 total += frame.payload.len() as u64;
                 chunks += 1;
             }
@@ -197,7 +187,7 @@ pub async fn flatfile_request_raw(
             }
         }
     }
-    out.flush()?;
+    out.flush().await?;
     drop(out);
     tracing::info!(
         target: "flatfiles",

--- a/crates/thetadatadx/src/flatfiles/request.rs
+++ b/crates/thetadatadx/src/flatfiles/request.rs
@@ -9,11 +9,14 @@
 //! 4. Stream every chunk to a local file until FLAT_FILE_END.
 //! 5. Surface the local path back to the caller.
 //!
-//! The FIT decode + per-data-type CSV writer is **not** in this module yet
-//! (see [`crate::flatfiles`] for status). Callers that need vendor-format
-//! CSV today should keep using the V3 fan-out path; callers that want the
-//! raw binary stream (for a custom pipeline) can use this entry point
-//! directly.
+//! This module is responsible for the raw FLAT_FILE download step. The
+//! higher-level INDEX walking, FIT decoding, and per-format output
+//! (CSV / Parquet / JSONL) live under [`crate::flatfiles`] in the
+//! `index`, `decode`, `writer`, and `decoded` modules. Callers that want
+//! decoded vendor-format output should use the higher-level
+//! [`crate::ThetaDataDx::flatfile_request`] entry point; callers that
+//! want the raw binary stream for a custom pipeline can use this entry
+//! point directly.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, Ordering};

--- a/crates/thetadatadx/src/flatfiles/request.rs
+++ b/crates/thetadatadx/src/flatfiles/request.rs
@@ -112,12 +112,24 @@ pub async fn flatfile_request_raw(
     .await?;
 
     let output_path = output_path.as_ref().to_path_buf();
-    if let Some(parent) = output_path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
+    // Directory creation + file open are filesystem syscalls; do them on
+    // the blocking pool so we don't stall sibling tokio tasks (FPSS,
+    // MDDS) on the same runtime.
+    let parent = output_path.parent().map(std::path::Path::to_path_buf);
+    let output_for_open = output_path.clone();
+    let file: File = tokio::task::spawn_blocking(move || -> Result<File, std::io::Error> {
+        if let Some(p) = parent {
+            if !p.as_os_str().is_empty() {
+                std::fs::create_dir_all(&p)?;
+            }
         }
-    }
-    let mut out = std::io::BufWriter::new(File::create(&output_path)?);
+        File::create(&output_for_open)
+    })
+    .await
+    .map_err(|e| Error::Config(format!("flatfiles: file-open task panicked: {e}")))??;
+    // 1 MB buffer — typical chunks are ~8-64 KB, so this batches many
+    // chunks per actual write syscall and keeps the hot loop in memory.
+    let mut out = std::io::BufWriter::with_capacity(1 << 20, file);
     let mut total: u64 = 0;
     let mut chunks: u32 = 0;
     // Loop only exits normally on FLAT_FILE_END; every other terminator

--- a/crates/thetadatadx/src/flatfiles/session.rs
+++ b/crates/thetadatadx/src/flatfiles/session.rs
@@ -1,0 +1,214 @@
+//! TLS connection setup + auth handshake against a single MDDS legacy host.
+//!
+//! Splits cleanly into:
+//! - [`connect_tls`] — async TCP + TLS handshake using SPKI pinning.
+//! - [`login`] — CREDENTIALS + VERSION write, plus reading the
+//!   SESSION_TOKEN + METADATA confirmation pair.
+//!
+//! The auth flow does **not** wait for a `CONNECTED` (msg=4) frame: live
+//! observation shows the production server only emits SESSION_TOKEN +
+//! METADATA on success and never the explicit CONNECTED frame. Treating
+//! receipt of either pair as auth-success matches the vendor terminal's
+//! own log line `[MDDS] CONNECTED: ..., Bundle: ...` which is constructed
+//! from the METADATA payload.
+
+use std::sync::Arc;
+
+use rustls::pki_types::ServerName;
+use rustls::ClientConfig;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use tokio_rustls::client::TlsStream;
+use tokio_rustls::TlsConnector;
+
+use crate::auth::Credentials;
+use crate::error::{AuthErrorKind, Error};
+use crate::flatfiles::framing::{msg, read_frame, write_frame, Frame};
+use crate::flatfiles::mdds_spki::MddsSpkiVerifier;
+use crate::flatfiles::types::FlatFilesUnavailableReason;
+
+/// Established, authenticated MDDS connection.
+pub(crate) struct AuthedSession {
+    pub stream: TlsStream<TcpStream>,
+    /// Bundle string from the METADATA frame, e.g.
+    /// `"STOCK.STANDARD, OPTION.PRO, INDEX.FREE"`. Useful for surfacing in
+    /// debug logs; does not affect protocol behaviour.
+    pub bundle: String,
+}
+
+/// Hostname + port pair.
+pub(crate) struct MddsHost<'a> {
+    pub host: &'a str,
+    pub port: u16,
+}
+
+/// Open a TLS connection to a single MDDS host with SPKI pinning.
+pub(crate) async fn connect_tls(target: MddsHost<'_>) -> Result<TlsStream<TcpStream>, Error> {
+    let cfg = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(MddsSpkiVerifier::new())
+        .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(cfg));
+    let server_name: ServerName<'static> = ServerName::try_from(target.host.to_string())
+        .map_err(|e| Error::Config(format!("invalid SNI {}: {e}", target.host)))?;
+
+    let tcp = TcpStream::connect((target.host, target.port)).await?;
+    tcp.set_nodelay(true)?;
+    let tls = connector.connect(server_name, tcp).await?;
+    Ok(tls)
+}
+
+/// Build the CREDENTIALS payload.
+///
+/// Layout (verified live):
+/// ```text
+/// [u8 0x00][u16 BE userlen][user_utf8][pass_utf8]
+/// ```
+/// The leading byte is `0x00`. The password length is implicit
+/// (`payload.len() - 3 - userlen`).
+fn build_credentials_payload(user: &str, pass: &str) -> Vec<u8> {
+    let u = user.as_bytes();
+    let p = pass.as_bytes();
+    let userlen: u16 = u16::try_from(u.len()).expect("email cannot exceed 65535 bytes");
+    let mut payload = Vec::with_capacity(3 + u.len() + p.len());
+    payload.push(0x00);
+    payload.extend_from_slice(&userlen.to_be_bytes());
+    payload.extend_from_slice(u);
+    payload.extend_from_slice(p);
+    payload
+}
+
+/// Build the VERSION payload — `[u32 BE jsonlen][json_utf8]`.
+///
+/// The vendor terminal serialises every JVM system property; the server
+/// only inspects the `terminal.version` key. We send a minimal map so the
+/// server's MDC log shows a recognisable client identity without leaking
+/// host details.
+fn build_version_payload() -> Vec<u8> {
+    // Hand-rolled to avoid pulling in serde_json for a 1-line constant. The
+    // exact JSON shape the vendor sends is `{"key":"value", ...}` — we
+    // emit a single key.
+    let json = br#"{"terminal.version":"1.8.6-A","client":"thetadatadx"}"#;
+    let mut buf = Vec::with_capacity(4 + json.len());
+    buf.extend_from_slice(&u32::try_from(json.len()).unwrap().to_be_bytes());
+    buf.extend_from_slice(json);
+    buf
+}
+
+/// Run the CREDENTIALS + VERSION login on an already-established TLS stream.
+///
+/// On success returns the bundle string. On failure returns
+/// `Error::FlatFilesUnavailable` with the underlying reason.
+pub(crate) async fn login(
+    stream: &mut TlsStream<TcpStream>,
+    creds: &Credentials,
+) -> Result<String, Error> {
+    // CREDENTIALS frame.
+    let creds_payload = build_credentials_payload(&creds.email, creds.password());
+    write_frame(stream, msg::CREDENTIALS, -1, &creds_payload).await?;
+
+    // VERSION frame.
+    let version_payload = build_version_payload();
+    write_frame(stream, msg::VERSION, -1, &version_payload).await?;
+
+    // Read frames until we have either auth-success (SESSION_TOKEN +
+    // METADATA) or a DISCONNECTED. The order observed live is
+    // SESSION_TOKEN → METADATA; we accept either order defensively.
+    let mut session_token_seen = false;
+    let mut bundle: Option<String> = None;
+    for _ in 0..6 {
+        let frame: Frame = read_frame(stream).await?;
+        match frame.msg {
+            msg::SESSION_TOKEN => session_token_seen = true,
+            msg::METADATA => {
+                bundle = Some(String::from_utf8_lossy(&frame.payload).into_owned());
+            }
+            msg::CONNECTED => {
+                // Older server builds emit this; treat as confirmation.
+                session_token_seen = true;
+            }
+            msg::DISCONNECTED => {
+                let reason_code = if frame.payload.len() >= 2 {
+                    u16::from_be_bytes([frame.payload[0], frame.payload[1]])
+                } else {
+                    0
+                };
+                let _ = stream.shutdown().await;
+                return Err(Error::FlatFilesUnavailable(
+                    FlatFilesUnavailableReason::AuthRejected { reason_code },
+                ));
+            }
+            other => {
+                return Err(Error::Auth {
+                    kind: AuthErrorKind::ServerError,
+                    message: format!(
+                        "unexpected MDDS frame during login: msg={other} size={}",
+                        frame.payload.len()
+                    ),
+                });
+            }
+        }
+        if session_token_seen && bundle.is_some() {
+            break;
+        }
+    }
+    let bundle = bundle.ok_or_else(|| Error::Auth {
+        kind: AuthErrorKind::ServerError,
+        message: "MDDS auth did not return METADATA bundle".into(),
+    })?;
+    if !session_token_seen {
+        return Err(Error::Auth {
+            kind: AuthErrorKind::ServerError,
+            message: "MDDS auth did not return SESSION_TOKEN".into(),
+        });
+    }
+    Ok(bundle)
+}
+
+/// Convenience: connect to the first reachable host in a list, then auth.
+pub(crate) async fn connect_and_login<'a>(
+    hosts: &[MddsHost<'a>],
+    creds: &Credentials,
+) -> Result<AuthedSession, Error> {
+    let mut last_err: Option<Error> = None;
+    for host in hosts {
+        match connect_tls(MddsHost {
+            host: host.host,
+            port: host.port,
+        })
+        .await
+        {
+            Ok(mut stream) => match login(&mut stream, creds).await {
+                Ok(bundle) => return Ok(AuthedSession { stream, bundle }),
+                Err(e) => last_err = Some(e),
+            },
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| Error::Config("no MDDS hosts configured".into())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credentials_payload_layout_is_stable() {
+        // Verifies leading byte is 0x00 and userlen is BE u16.
+        let p = build_credentials_payload("a@b.c", "pw");
+        assert_eq!(p[0], 0x00);
+        assert_eq!(&p[1..3], &5u16.to_be_bytes());
+        assert_eq!(&p[3..8], b"a@b.c");
+        assert_eq!(&p[8..10], b"pw");
+        assert_eq!(p.len(), 10);
+    }
+
+    #[test]
+    fn version_payload_has_length_prefix() {
+        let p = build_version_payload();
+        let len = u32::from_be_bytes(p[0..4].try_into().unwrap()) as usize;
+        assert_eq!(p.len(), 4 + len);
+        // first character of the JSON body must be '{'.
+        assert_eq!(p[4], b'{');
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/session.rs
+++ b/crates/thetadatadx/src/flatfiles/session.rs
@@ -26,6 +26,7 @@ use crate::error::{AuthErrorKind, Error};
 use crate::flatfiles::framing::{msg, read_frame, write_frame, Frame};
 use crate::flatfiles::mdds_spki::MddsSpkiVerifier;
 use crate::flatfiles::types::FlatFilesUnavailableReason;
+use crate::fpss::protocol::build_credentials_payload;
 
 /// Established, authenticated MDDS connection.
 pub(crate) struct AuthedSession {
@@ -62,22 +63,6 @@ pub(crate) async fn connect_tls(target: MddsHost<'_>) -> Result<TlsStream<TcpStr
 ///
 /// Layout (verified live):
 /// ```text
-/// [u8 0x00][u16 BE userlen][user_utf8][pass_utf8]
-/// ```
-/// The leading byte is `0x00`. The password length is implicit
-/// (`payload.len() - 3 - userlen`).
-fn build_credentials_payload(user: &str, pass: &str) -> Vec<u8> {
-    let u = user.as_bytes();
-    let p = pass.as_bytes();
-    let userlen: u16 = u16::try_from(u.len()).expect("email cannot exceed 65535 bytes");
-    let mut payload = Vec::with_capacity(3 + u.len() + p.len());
-    payload.push(0x00);
-    payload.extend_from_slice(&userlen.to_be_bytes());
-    payload.extend_from_slice(u);
-    payload.extend_from_slice(p);
-    payload
-}
-
 /// Build the VERSION payload — `[u32 BE jsonlen][json_utf8]`.
 ///
 /// The vendor terminal serialises every JVM system property; the server

--- a/crates/thetadatadx/src/flatfiles/session.rs
+++ b/crates/thetadatadx/src/flatfiles/session.rs
@@ -154,6 +154,13 @@ pub(crate) async fn login(
 }
 
 /// Convenience: connect to the first reachable host in a list, then auth.
+///
+/// Retries only on transient connect-layer failures (TCP, TLS, I/O). A
+/// semantic server rejection — the credentials were rejected, the auth
+/// frame was malformed, the server emitted a `DISCONNECTED` — is
+/// short-circuited: replaying it across every MDDS host is pointless,
+/// risks rate-limiting the account, and the original error already
+/// describes what the server objected to.
 pub(crate) async fn connect_and_login<'a>(
     hosts: &[MddsHost<'a>],
     creds: &Credentials,
@@ -168,12 +175,19 @@ pub(crate) async fn connect_and_login<'a>(
         {
             Ok(mut stream) => match login(&mut stream, creds).await {
                 Ok(bundle) => return Ok(AuthedSession { stream, bundle }),
+                Err(e) if is_terminal_login_error(&e) => return Err(e),
                 Err(e) => last_err = Some(e),
             },
             Err(e) => last_err = Some(e),
         }
     }
     Err(last_err.unwrap_or_else(|| Error::Config("no MDDS hosts configured".into())))
+}
+
+/// A login error the server has authoritatively decided — no point
+/// retrying against another host.
+fn is_terminal_login_error(err: &Error) -> bool {
+    matches!(err, Error::FlatFilesUnavailable(_) | Error::Auth { .. })
 }
 
 #[cfg(test)]

--- a/crates/thetadatadx/src/flatfiles/session.rs
+++ b/crates/thetadatadx/src/flatfiles/session.rs
@@ -127,6 +127,9 @@ pub(crate) async fn login(
                 // Older server builds emit this; treat as confirmation.
                 session_token_seen = true;
             }
+            msg::PING => {
+                // Server heartbeat during auth — ignore.
+            }
             msg::DISCONNECTED => {
                 let reason_code = if frame.payload.len() >= 2 {
                     u16::from_be_bytes([frame.payload[0], frame.payload[1]])

--- a/crates/thetadatadx/src/flatfiles/types.rs
+++ b/crates/thetadatadx/src/flatfiles/types.rs
@@ -1,0 +1,98 @@
+//! Public enums for the FLATFILES surface.
+
+use std::fmt;
+
+/// Security types accepted by the FLATFILES route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecType {
+    Option,
+    Stock,
+    Index,
+}
+
+impl SecType {
+    /// Wire string the server expects in the `SEC=` query field.
+    pub(crate) fn as_wire(self) -> &'static str {
+        match self {
+            Self::Option => "OPTION",
+            Self::Stock => "STOCK",
+            Self::Index => "INDEX",
+        }
+    }
+}
+
+impl fmt::Display for SecType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_wire())
+    }
+}
+
+/// FLATFILES request types and their V2 wire codes.
+///
+/// These integers go into the `REQ=` field of the FLAT_FILE request payload.
+/// They are the V2 server's `ReqType.code()` values, captured from the
+/// vendor's bundled enum. They are **not** the same as ordinal positions; the
+/// V2 enum maps `OPEN_INTEREST → 103`, `TRADE → 201`, `TRADE_QUOTE → 207`, etc.
+/// Sending the ordinal instead of the code yields
+/// `INVALID_PARAMS:Invalid request type` from the server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ReqType {
+    Eod = 1,
+    Quote = 101,
+    OpenInterest = 103,
+    Ohlc = 104,
+    Trade = 201,
+    TradeQuote = 207,
+}
+
+impl ReqType {
+    pub(crate) fn as_wire(self) -> u32 {
+        self as u32
+    }
+}
+
+/// Reason a [`ThetaDataDx::flatfile_request`](crate::ThetaDataDx::flatfile_request)
+/// call cannot return CSV.
+///
+/// Returned inside `Error::FlatFilesUnavailable` so callers can decide
+/// whether to fall back to the V3 fan-out path or to retry later.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FlatFilesUnavailableReason {
+    /// Server returned a `RemoveReason` ordinal during auth (e.g.
+    /// `INVALID_CREDENTIALS=1`, `ACCOUNT_ALREADY_CONNECTED=7`).
+    AuthRejected { reason_code: u16 },
+    /// Server replied with an `ERROR` frame to the FLAT_FILE request itself
+    /// (e.g. `INVALID_PARAMS:Invalid request type`).
+    RequestRejected { server_message: String },
+    /// The wire bytes were retrieved successfully, but this build of the SDK
+    /// does not yet ship the FIT decoder + per-data-type CSV writer needed
+    /// to materialize the vendor-shaped CSV. The raw INDEX+DATA blob is
+    /// available at the returned `raw_path`; a future SDK release will
+    /// transparently decode it into CSV without changing the public API.
+    RawStreamOnly { raw_path: std::path::PathBuf },
+    /// Connection dropped before the response completed.
+    StreamTruncated { bytes_received: u64 },
+}
+
+impl fmt::Display for FlatFilesUnavailableReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AuthRejected { reason_code } => {
+                write!(f, "MDDS auth rejected (RemoveReason ord={reason_code})")
+            }
+            Self::RequestRejected { server_message } => {
+                write!(f, "FLAT_FILE request rejected: {server_message}")
+            }
+            Self::RawStreamOnly { raw_path } => write!(
+                f,
+                "raw stream captured at {} but FIT decoder is not yet wired in this SDK build",
+                raw_path.display()
+            ),
+            Self::StreamTruncated { bytes_received } => {
+                write!(f, "stream truncated after {bytes_received} bytes")
+            }
+        }
+    }
+}

--- a/crates/thetadatadx/src/flatfiles/types.rs
+++ b/crates/thetadatadx/src/flatfiles/types.rs
@@ -66,12 +66,6 @@ pub enum FlatFilesUnavailableReason {
     /// Server replied with an `ERROR` frame to the FLAT_FILE request itself
     /// (e.g. `INVALID_PARAMS:Invalid request type`).
     RequestRejected { server_message: String },
-    /// The wire bytes were retrieved successfully, but this build of the SDK
-    /// does not yet ship the FIT decoder + per-data-type CSV writer needed
-    /// to materialize the vendor-shaped CSV. The raw INDEX+DATA blob is
-    /// available at the returned `raw_path`; a future SDK release will
-    /// transparently decode it into CSV without changing the public API.
-    RawStreamOnly { raw_path: std::path::PathBuf },
     /// Connection dropped before the response completed.
     StreamTruncated { bytes_received: u64 },
 }
@@ -85,11 +79,6 @@ impl fmt::Display for FlatFilesUnavailableReason {
             Self::RequestRejected { server_message } => {
                 write!(f, "FLAT_FILE request rejected: {server_message}")
             }
-            Self::RawStreamOnly { raw_path } => write!(
-                f,
-                "raw stream captured at {} but FIT decoder is not yet wired in this SDK build",
-                raw_path.display()
-            ),
             Self::StreamTruncated { bytes_received } => {
                 write!(f, "stream truncated after {bytes_received} bytes")
             }

--- a/crates/thetadatadx/src/flatfiles/writer.rs
+++ b/crates/thetadatadx/src/flatfiles/writer.rs
@@ -465,7 +465,12 @@ impl RowSink for ParquetSink {
                 }
                 col += 1;
                 if let ColBuilder::Utf8(b) = &mut self.builders[col] {
-                    b.append_value(row.entry.right.unwrap_or('?').to_string());
+                    let right = match row.entry.right {
+                        Some('C') => "C",
+                        Some('P') => "P",
+                        _ => "?",
+                    };
+                    b.append_value(right);
                 }
                 col += 1;
             }

--- a/crates/thetadatadx/src/flatfiles/writer.rs
+++ b/crates/thetadatadx/src/flatfiles/writer.rs
@@ -3,29 +3,21 @@
 //! Each output format implements [`RowSink`], a tiny three-method
 //! interface: write the header once, accept rows one-by-one with the
 //! contract key + decoded data fields, and finalize on completion. The
-//! decoder layer (see `request_decoded.rs`) drives a single sink
-//! regardless of format — CSV, Parquet, or JSONL.
+//! decoder layer (see `decoded.rs`) drives a single sink regardless of
+//! format — CSV or JSONL.
 //!
 //! The contract key passed to each sink call carries the
 //! `(root, exp, strike, right)` columns the vendor prepends to every CSV
 //! row. For stock entries, `exp / strike / right` are `None` and only
 //! `root` is written.
 //!
-//! All four sinks must produce the **same logical rows**; only the
-//! on-disk encoding differs. This is what makes the byte-match test on
-//! `Csv` a sufficient proxy for verifying `Parquet` and `Jsonl`.
+//! Both sinks must produce the **same logical rows**; only the on-disk
+//! encoding differs. This is what makes the byte-match test on `Csv` a
+//! sufficient proxy for verifying `Jsonl`.
 
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
-use std::sync::Arc;
-
-use arrow_array::builder::{Float64Builder, Int32Builder, Int64Builder, StringBuilder};
-use arrow_array::{ArrayRef, RecordBatch};
-use arrow_schema::{DataType as ArrowDataType, Field, Schema};
-use parquet::arrow::ArrowWriter;
-use parquet::basic::{Compression, ZstdLevel};
-use parquet::file::properties::WriterProperties;
 
 use crate::error::Error;
 use crate::flatfiles::datatype::DataType;
@@ -292,228 +284,6 @@ impl RowSink for JsonlSink {
 
     fn finish(mut self: Box<Self>) -> Result<(), Error> {
         self.out.flush()?;
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Parquet sink — Arrow-typed, zstd-compressed
-// ---------------------------------------------------------------------------
-
-const PARQUET_BATCH_ROWS: usize = 4096;
-
-/// Per-column Arrow builder. We keep the decision matrix simple: every
-/// data column is `Int32` unless flagged `is_price`, in which case it
-/// becomes `Float64` (after division by `10^price_type`). The contract
-/// prefix uses `Utf8` for `root` and `right`, `Int32` for `exp` and
-/// `strike`. Stock blobs omit `exp / strike / right`.
-enum ColBuilder {
-    Int32(Int32Builder),
-    Int64(Int64Builder),
-    Float64(Float64Builder),
-    Utf8(StringBuilder),
-}
-
-impl ColBuilder {
-    fn finish(&mut self) -> ArrayRef {
-        match self {
-            Self::Int32(b) => Arc::new(b.finish()) as ArrayRef,
-            Self::Int64(b) => Arc::new(b.finish()) as ArrayRef,
-            Self::Float64(b) => Arc::new(b.finish()) as ArrayRef,
-            Self::Utf8(b) => Arc::new(b.finish()) as ArrayRef,
-        }
-    }
-}
-
-pub(crate) struct ParquetSink {
-    writer: Option<ArrowWriter<File>>,
-    schema: Arc<Schema>,
-    sec: SecType,
-    fmt: Vec<DataType>,
-    data_idx: Vec<usize>,
-    price_type_idx: Option<usize>,
-    builders: Vec<ColBuilder>,
-    rows_in_batch: usize,
-}
-
-impl ParquetSink {
-    pub(crate) fn new(
-        path: &Path,
-        sec: SecType,
-        fmt: Vec<DataType>,
-        price_type_idx: Option<usize>,
-    ) -> Result<Self, Error> {
-        let data_idx = data_indices(&fmt, price_type_idx);
-        let schema = build_schema(sec, &fmt, &data_idx);
-        let props = WriterProperties::builder()
-            .set_compression(Compression::ZSTD(
-                ZstdLevel::try_new(3).expect("zstd level 3 is valid"),
-            ))
-            .build();
-        let f = File::create(path)?;
-        let writer = ArrowWriter::try_new(f, schema.clone(), Some(props))
-            .map_err(|e| Error::Config(format!("flatfiles: parquet writer init failed: {e}")))?;
-        let builders = build_builders(sec, &fmt, &data_idx);
-        Ok(Self {
-            writer: Some(writer),
-            schema,
-            sec,
-            fmt,
-            data_idx,
-            price_type_idx,
-            builders,
-            rows_in_batch: 0,
-        })
-    }
-
-    fn flush_batch(&mut self) -> Result<(), Error> {
-        if self.rows_in_batch == 0 {
-            return Ok(());
-        }
-        let arrays: Vec<ArrayRef> = self.builders.iter_mut().map(ColBuilder::finish).collect();
-        let batch = RecordBatch::try_new(self.schema.clone(), arrays)
-            .map_err(|e| Error::Config(format!("flatfiles: parquet batch build failed: {e}")))?;
-        if let Some(w) = self.writer.as_mut() {
-            w.write(&batch)
-                .map_err(|e| Error::Config(format!("flatfiles: parquet write failed: {e}")))?;
-        }
-        // Re-create builders so the next batch starts empty.
-        self.builders = build_builders(self.sec, &self.fmt, &self.data_idx);
-        self.rows_in_batch = 0;
-        Ok(())
-    }
-}
-
-fn build_schema(sec: SecType, fmt: &[DataType], data_idx: &[usize]) -> Arc<Schema> {
-    let mut fields: Vec<Field> = Vec::with_capacity(data_idx.len() + 4);
-    match sec {
-        SecType::Option | SecType::Index => {
-            fields.push(Field::new("root", ArrowDataType::Utf8, false));
-            fields.push(Field::new("expiration", ArrowDataType::Int32, false));
-            fields.push(Field::new("strike", ArrowDataType::Int32, false));
-            fields.push(Field::new("right", ArrowDataType::Utf8, false));
-        }
-        SecType::Stock => {
-            fields.push(Field::new("root", ArrowDataType::Utf8, false));
-        }
-    }
-    for &i in data_idx {
-        let col = fmt[i];
-        let arrow_ty = if col.is_price() {
-            ArrowDataType::Float64
-        } else if matches!(col, DataType::Volume | DataType::Count) {
-            // Volume / Count can exceed i32::MAX on a high-volume root;
-            // store them as int64. The wire is i32 but we widen on write
-            // so a future server-side widening Just Works.
-            ArrowDataType::Int64
-        } else {
-            ArrowDataType::Int32
-        };
-        fields.push(Field::new(col.name().into_owned(), arrow_ty, false));
-    }
-    Arc::new(Schema::new(fields))
-}
-
-fn build_builders(sec: SecType, fmt: &[DataType], data_idx: &[usize]) -> Vec<ColBuilder> {
-    let cap = PARQUET_BATCH_ROWS;
-    let mut out = Vec::with_capacity(data_idx.len() + 4);
-    match sec {
-        SecType::Option | SecType::Index => {
-            out.push(ColBuilder::Utf8(StringBuilder::with_capacity(cap, cap * 8)));
-            out.push(ColBuilder::Int32(Int32Builder::with_capacity(cap)));
-            out.push(ColBuilder::Int32(Int32Builder::with_capacity(cap)));
-            out.push(ColBuilder::Utf8(StringBuilder::with_capacity(cap, cap)));
-        }
-        SecType::Stock => {
-            out.push(ColBuilder::Utf8(StringBuilder::with_capacity(cap, cap * 8)));
-        }
-    }
-    for &i in data_idx {
-        let col = fmt[i];
-        if col.is_price() {
-            out.push(ColBuilder::Float64(Float64Builder::with_capacity(cap)));
-        } else if matches!(col, DataType::Volume | DataType::Count) {
-            out.push(ColBuilder::Int64(Int64Builder::with_capacity(cap)));
-        } else {
-            out.push(ColBuilder::Int32(Int32Builder::with_capacity(cap)));
-        }
-    }
-    out
-}
-
-impl RowSink for ParquetSink {
-    fn write_header(&mut self) -> Result<(), Error> {
-        // Header is implicit in the Parquet schema.
-        Ok(())
-    }
-
-    fn write_row(&mut self, row: RowView<'_>) -> Result<(), Error> {
-        // Append contract prefix.
-        let mut col = 0usize;
-        match self.sec {
-            SecType::Option | SecType::Index => {
-                if let ColBuilder::Utf8(b) = &mut self.builders[col] {
-                    b.append_value(&row.entry.root);
-                }
-                col += 1;
-                if let ColBuilder::Int32(b) = &mut self.builders[col] {
-                    b.append_value(row.entry.exp.unwrap_or(0));
-                }
-                col += 1;
-                if let ColBuilder::Int32(b) = &mut self.builders[col] {
-                    b.append_value(row.entry.strike.unwrap_or(0));
-                }
-                col += 1;
-                if let ColBuilder::Utf8(b) = &mut self.builders[col] {
-                    let right = match row.entry.right {
-                        Some('C') => "C",
-                        Some('P') => "P",
-                        _ => "?",
-                    };
-                    b.append_value(right);
-                }
-                col += 1;
-            }
-            SecType::Stock => {
-                if let ColBuilder::Utf8(b) = &mut self.builders[col] {
-                    b.append_value(&row.entry.root);
-                }
-                col += 1;
-            }
-        }
-        // Append data columns.
-        let divisor = price_divisor(row.data, self.price_type_idx);
-        for &i in &self.data_idx {
-            let val = row.data.get(i).copied().unwrap_or(0);
-            let dt = self.fmt[i];
-            match &mut self.builders[col] {
-                ColBuilder::Int32(b) => b.append_value(val),
-                ColBuilder::Int64(b) => b.append_value(val as i64),
-                ColBuilder::Float64(b) => {
-                    let d = divisor.unwrap_or(1.0);
-                    b.append_value(if dt.is_price() {
-                        (val as f64) / d
-                    } else {
-                        val as f64
-                    });
-                }
-                ColBuilder::Utf8(b) => b.append_value(val.to_string()),
-            }
-            col += 1;
-        }
-        self.rows_in_batch += 1;
-        if self.rows_in_batch >= PARQUET_BATCH_ROWS {
-            self.flush_batch()?;
-        }
-        Ok(())
-    }
-
-    fn finish(mut self: Box<Self>) -> Result<(), Error> {
-        self.flush_batch()?;
-        if let Some(w) = self.writer.take() {
-            w.close()
-                .map_err(|e| Error::Config(format!("flatfiles: parquet close failed: {e}")))?;
-        }
         Ok(())
     }
 }

--- a/crates/thetadatadx/src/flatfiles/writer.rs
+++ b/crates/thetadatadx/src/flatfiles/writer.rs
@@ -1,0 +1,562 @@
+//! Format-pluggable row writer for the FLATFILES surface.
+//!
+//! Each output format implements [`RowSink`], a tiny three-method
+//! interface: write the header once, accept rows one-by-one with the
+//! contract key + decoded data fields, and finalize on completion. The
+//! decoder layer (see `request_decoded.rs`) drives a single sink
+//! regardless of format — CSV, Parquet, or JSONL.
+//!
+//! The contract key passed to each sink call carries the
+//! `(root, exp, strike, right)` columns the vendor prepends to every CSV
+//! row. For stock entries, `exp / strike / right` are `None` and only
+//! `root` is written.
+//!
+//! All four sinks must produce the **same logical rows**; only the
+//! on-disk encoding differs. This is what makes the byte-match test on
+//! `Csv` a sufficient proxy for verifying `Parquet` and `Jsonl`.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow_array::builder::{Float64Builder, Int32Builder, Int64Builder, StringBuilder};
+use arrow_array::{ArrayRef, RecordBatch};
+use arrow_schema::{DataType as ArrowDataType, Field, Schema};
+use parquet::arrow::ArrowWriter;
+use parquet::basic::{Compression, ZstdLevel};
+use parquet::file::properties::WriterProperties;
+
+use crate::error::Error;
+use crate::flatfiles::datatype::DataType;
+use crate::flatfiles::index::IndexEntry;
+use crate::flatfiles::types::SecType;
+
+/// Shape of a row passed into the sink.
+///
+/// `data` is exactly the per-blob FIT column schema (with PRICE_TYPE
+/// still in place, if present). Each sink is responsible for skipping
+/// the PRICE_TYPE column from its visible output.
+pub(crate) struct RowView<'a> {
+    pub(crate) entry: &'a IndexEntry,
+    pub(crate) data: &'a [i32],
+}
+
+/// Polymorphic row writer.
+pub(crate) trait RowSink {
+    fn write_header(&mut self) -> Result<(), Error>;
+    fn write_row(&mut self, row: RowView<'_>) -> Result<(), Error>;
+    fn finish(self: Box<Self>) -> Result<(), Error>;
+}
+
+// ---------------------------------------------------------------------------
+// Shared format helpers
+// ---------------------------------------------------------------------------
+
+/// Indices of the data-only columns in a row (i.e. all columns except
+/// the optional PRICE_TYPE column). Computed once from the schema and
+/// reused per row to skip work in the hot loop.
+pub(crate) fn data_indices(fmt: &[DataType], price_type_idx: Option<usize>) -> Vec<usize> {
+    fmt.iter()
+        .enumerate()
+        .filter_map(|(i, _)| {
+            if Some(i) == price_type_idx {
+                None
+            } else {
+                Some(i)
+            }
+        })
+        .collect()
+}
+
+/// Per-row price divisor.
+///
+/// When PRICE_TYPE is in the schema, the value at that column is the
+/// exponent N, so the price = `int_value / 10^N`. With no PRICE_TYPE
+/// column the multiplier is 1 (i.e. the integer IS the price already, in
+/// vendor convention) — the vendor's `toCSV2` does not call
+/// `PriceCalc.fmtPrice` in that branch, so emitting the integer
+/// unchanged matches the reference output.
+pub(crate) fn price_divisor(row: &[i32], price_type_idx: Option<usize>) -> Option<f64> {
+    price_type_idx.map(|idx| {
+        let n = row.get(idx).copied().unwrap_or(0);
+        let n = n.clamp(0, 18) as u32;
+        10f64.powi(n as i32)
+    })
+}
+
+/// Format a price value in vendor style: divide by `10^N`, render with
+/// 4 fractional digits and **no trailing-zero stripping** (the vendor's
+/// `PriceCalc.fmtPrice(builder, value, 4)` is fixed-precision).
+pub(crate) fn fmt_price_into(buf: &mut String, integer: i32, divisor: f64) {
+    use std::fmt::Write;
+    let v = (integer as f64) / divisor;
+    // Match vendor: 4 decimals, no exponent, no thousands separator.
+    let _ = write!(buf, "{v:.4}");
+}
+
+/// Build the contract-prefix segment of a CSV row.
+fn append_csv_prefix(buf: &mut String, entry: &IndexEntry, sec: SecType) {
+    use std::fmt::Write;
+    match sec {
+        SecType::Option | SecType::Index => {
+            buf.push_str(&entry.root);
+            buf.push(',');
+            let _ = write!(buf, "{}", entry.exp.unwrap_or(0));
+            buf.push(',');
+            let _ = write!(buf, "{}", entry.strike.unwrap_or(0));
+            buf.push(',');
+            buf.push(entry.right.unwrap_or('?'));
+            buf.push(',');
+        }
+        SecType::Stock => {
+            buf.push_str(&entry.root);
+            buf.push(',');
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CSV sink — vendor byte format
+// ---------------------------------------------------------------------------
+
+pub(crate) struct CsvSink {
+    out: BufWriter<File>,
+    sec: SecType,
+    fmt: Vec<DataType>,
+    data_idx: Vec<usize>,
+    price_type_idx: Option<usize>,
+    /// Reused row buffer to avoid per-row allocation.
+    line: String,
+}
+
+impl CsvSink {
+    pub(crate) fn new(
+        path: &Path,
+        sec: SecType,
+        fmt: Vec<DataType>,
+        price_type_idx: Option<usize>,
+    ) -> Result<Self, Error> {
+        let data_idx = data_indices(&fmt, price_type_idx);
+        let f = File::create(path)?;
+        Ok(Self {
+            out: BufWriter::with_capacity(1 << 20, f),
+            sec,
+            fmt,
+            data_idx,
+            price_type_idx,
+            line: String::with_capacity(256),
+        })
+    }
+}
+
+impl RowSink for CsvSink {
+    fn write_header(&mut self) -> Result<(), Error> {
+        self.line.clear();
+        match self.sec {
+            SecType::Option | SecType::Index => self.line.push_str("root,expiration,strike,right,"),
+            SecType::Stock => self.line.push_str("root,"),
+        }
+        for (n, &i) in self.data_idx.iter().enumerate() {
+            if n > 0 {
+                self.line.push(',');
+            }
+            self.line.push_str(&self.fmt[i].name());
+        }
+        self.line.push('\n');
+        self.out.write_all(self.line.as_bytes())?;
+        Ok(())
+    }
+
+    fn write_row(&mut self, row: RowView<'_>) -> Result<(), Error> {
+        self.line.clear();
+        append_csv_prefix(&mut self.line, row.entry, self.sec);
+        let divisor = price_divisor(row.data, self.price_type_idx);
+        for (n, &i) in self.data_idx.iter().enumerate() {
+            if n > 0 {
+                self.line.push(',');
+            }
+            let val = row.data.get(i).copied().unwrap_or(0);
+            if self.fmt[i].is_price() {
+                if let Some(d) = divisor {
+                    fmt_price_into(&mut self.line, val, d);
+                } else {
+                    use std::fmt::Write;
+                    let _ = write!(self.line, "{val}");
+                }
+            } else {
+                use std::fmt::Write;
+                let _ = write!(self.line, "{val}");
+            }
+        }
+        self.line.push('\n');
+        self.out.write_all(self.line.as_bytes())?;
+        Ok(())
+    }
+
+    fn finish(mut self: Box<Self>) -> Result<(), Error> {
+        self.out.flush()?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSONL sink — one JSON object per line
+// ---------------------------------------------------------------------------
+
+pub(crate) struct JsonlSink {
+    out: BufWriter<File>,
+    sec: SecType,
+    fmt: Vec<DataType>,
+    data_idx: Vec<usize>,
+    price_type_idx: Option<usize>,
+}
+
+impl JsonlSink {
+    pub(crate) fn new(
+        path: &Path,
+        sec: SecType,
+        fmt: Vec<DataType>,
+        price_type_idx: Option<usize>,
+    ) -> Result<Self, Error> {
+        let data_idx = data_indices(&fmt, price_type_idx);
+        let f = File::create(path)?;
+        Ok(Self {
+            out: BufWriter::with_capacity(1 << 20, f),
+            sec,
+            fmt,
+            data_idx,
+            price_type_idx,
+        })
+    }
+}
+
+impl RowSink for JsonlSink {
+    fn write_header(&mut self) -> Result<(), Error> {
+        // JSONL has no header row; nothing to emit. Object keys are
+        // written per-row alongside their values.
+        Ok(())
+    }
+
+    fn write_row(&mut self, row: RowView<'_>) -> Result<(), Error> {
+        let mut obj = serde_json::Map::with_capacity(self.data_idx.len() + 4);
+        match self.sec {
+            SecType::Option | SecType::Index => {
+                obj.insert(
+                    "root".into(),
+                    serde_json::Value::String(row.entry.root.clone()),
+                );
+                obj.insert(
+                    "expiration".into(),
+                    serde_json::Value::Number(row.entry.exp.unwrap_or(0).into()),
+                );
+                obj.insert(
+                    "strike".into(),
+                    serde_json::Value::Number(row.entry.strike.unwrap_or(0).into()),
+                );
+                obj.insert(
+                    "right".into(),
+                    serde_json::Value::String(row.entry.right.unwrap_or('?').to_string()),
+                );
+            }
+            SecType::Stock => {
+                obj.insert(
+                    "root".into(),
+                    serde_json::Value::String(row.entry.root.clone()),
+                );
+            }
+        }
+        let divisor = price_divisor(row.data, self.price_type_idx);
+        for &i in &self.data_idx {
+            let val = row.data.get(i).copied().unwrap_or(0);
+            let key = self.fmt[i].name().into_owned();
+            let v = if self.fmt[i].is_price() {
+                if let Some(d) = divisor {
+                    let f = (val as f64) / d;
+                    serde_json::Number::from_f64(f)
+                        .map(serde_json::Value::Number)
+                        .unwrap_or(serde_json::Value::Null)
+                } else {
+                    serde_json::Value::Number(val.into())
+                }
+            } else {
+                serde_json::Value::Number(val.into())
+            };
+            obj.insert(key, v);
+        }
+        serde_json::to_writer(&mut self.out, &serde_json::Value::Object(obj))
+            .map_err(|e| Error::Config(format!("flatfiles: jsonl encode failed: {e}")))?;
+        self.out.write_all(b"\n")?;
+        Ok(())
+    }
+
+    fn finish(mut self: Box<Self>) -> Result<(), Error> {
+        self.out.flush()?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parquet sink — Arrow-typed, zstd-compressed
+// ---------------------------------------------------------------------------
+
+const PARQUET_BATCH_ROWS: usize = 4096;
+
+/// Per-column Arrow builder. We keep the decision matrix simple: every
+/// data column is `Int32` unless flagged `is_price`, in which case it
+/// becomes `Float64` (after division by `10^price_type`). The contract
+/// prefix uses `Utf8` for `root` and `right`, `Int32` for `exp` and
+/// `strike`. Stock blobs omit `exp / strike / right`.
+enum ColBuilder {
+    Int32(Int32Builder),
+    Int64(Int64Builder),
+    Float64(Float64Builder),
+    Utf8(StringBuilder),
+}
+
+impl ColBuilder {
+    fn finish(&mut self) -> ArrayRef {
+        match self {
+            Self::Int32(b) => Arc::new(b.finish()) as ArrayRef,
+            Self::Int64(b) => Arc::new(b.finish()) as ArrayRef,
+            Self::Float64(b) => Arc::new(b.finish()) as ArrayRef,
+            Self::Utf8(b) => Arc::new(b.finish()) as ArrayRef,
+        }
+    }
+}
+
+pub(crate) struct ParquetSink {
+    writer: Option<ArrowWriter<File>>,
+    schema: Arc<Schema>,
+    sec: SecType,
+    fmt: Vec<DataType>,
+    data_idx: Vec<usize>,
+    price_type_idx: Option<usize>,
+    builders: Vec<ColBuilder>,
+    rows_in_batch: usize,
+}
+
+impl ParquetSink {
+    pub(crate) fn new(
+        path: &Path,
+        sec: SecType,
+        fmt: Vec<DataType>,
+        price_type_idx: Option<usize>,
+    ) -> Result<Self, Error> {
+        let data_idx = data_indices(&fmt, price_type_idx);
+        let schema = build_schema(sec, &fmt, &data_idx);
+        let props = WriterProperties::builder()
+            .set_compression(Compression::ZSTD(
+                ZstdLevel::try_new(3).expect("zstd level 3 is valid"),
+            ))
+            .build();
+        let f = File::create(path)?;
+        let writer = ArrowWriter::try_new(f, schema.clone(), Some(props))
+            .map_err(|e| Error::Config(format!("flatfiles: parquet writer init failed: {e}")))?;
+        let builders = build_builders(sec, &fmt, &data_idx);
+        Ok(Self {
+            writer: Some(writer),
+            schema,
+            sec,
+            fmt,
+            data_idx,
+            price_type_idx,
+            builders,
+            rows_in_batch: 0,
+        })
+    }
+
+    fn flush_batch(&mut self) -> Result<(), Error> {
+        if self.rows_in_batch == 0 {
+            return Ok(());
+        }
+        let arrays: Vec<ArrayRef> = self.builders.iter_mut().map(ColBuilder::finish).collect();
+        let batch = RecordBatch::try_new(self.schema.clone(), arrays)
+            .map_err(|e| Error::Config(format!("flatfiles: parquet batch build failed: {e}")))?;
+        if let Some(w) = self.writer.as_mut() {
+            w.write(&batch)
+                .map_err(|e| Error::Config(format!("flatfiles: parquet write failed: {e}")))?;
+        }
+        // Re-create builders so the next batch starts empty.
+        self.builders = build_builders(self.sec, &self.fmt, &self.data_idx);
+        self.rows_in_batch = 0;
+        Ok(())
+    }
+}
+
+fn build_schema(sec: SecType, fmt: &[DataType], data_idx: &[usize]) -> Arc<Schema> {
+    let mut fields: Vec<Field> = Vec::with_capacity(data_idx.len() + 4);
+    match sec {
+        SecType::Option | SecType::Index => {
+            fields.push(Field::new("root", ArrowDataType::Utf8, false));
+            fields.push(Field::new("expiration", ArrowDataType::Int32, false));
+            fields.push(Field::new("strike", ArrowDataType::Int32, false));
+            fields.push(Field::new("right", ArrowDataType::Utf8, false));
+        }
+        SecType::Stock => {
+            fields.push(Field::new("root", ArrowDataType::Utf8, false));
+        }
+    }
+    for &i in data_idx {
+        let col = fmt[i];
+        let arrow_ty = if col.is_price() {
+            ArrowDataType::Float64
+        } else if matches!(col, DataType::Volume | DataType::Count) {
+            // Volume / Count can exceed i32::MAX on a high-volume root;
+            // store them as int64. The wire is i32 but we widen on write
+            // so a future server-side widening Just Works.
+            ArrowDataType::Int64
+        } else {
+            ArrowDataType::Int32
+        };
+        fields.push(Field::new(col.name().into_owned(), arrow_ty, false));
+    }
+    Arc::new(Schema::new(fields))
+}
+
+fn build_builders(sec: SecType, fmt: &[DataType], data_idx: &[usize]) -> Vec<ColBuilder> {
+    let cap = PARQUET_BATCH_ROWS;
+    let mut out = Vec::with_capacity(data_idx.len() + 4);
+    match sec {
+        SecType::Option | SecType::Index => {
+            out.push(ColBuilder::Utf8(StringBuilder::with_capacity(cap, cap * 8)));
+            out.push(ColBuilder::Int32(Int32Builder::with_capacity(cap)));
+            out.push(ColBuilder::Int32(Int32Builder::with_capacity(cap)));
+            out.push(ColBuilder::Utf8(StringBuilder::with_capacity(cap, cap)));
+        }
+        SecType::Stock => {
+            out.push(ColBuilder::Utf8(StringBuilder::with_capacity(cap, cap * 8)));
+        }
+    }
+    for &i in data_idx {
+        let col = fmt[i];
+        if col.is_price() {
+            out.push(ColBuilder::Float64(Float64Builder::with_capacity(cap)));
+        } else if matches!(col, DataType::Volume | DataType::Count) {
+            out.push(ColBuilder::Int64(Int64Builder::with_capacity(cap)));
+        } else {
+            out.push(ColBuilder::Int32(Int32Builder::with_capacity(cap)));
+        }
+    }
+    out
+}
+
+impl RowSink for ParquetSink {
+    fn write_header(&mut self) -> Result<(), Error> {
+        // Header is implicit in the Parquet schema.
+        Ok(())
+    }
+
+    fn write_row(&mut self, row: RowView<'_>) -> Result<(), Error> {
+        // Append contract prefix.
+        let mut col = 0usize;
+        match self.sec {
+            SecType::Option | SecType::Index => {
+                if let ColBuilder::Utf8(b) = &mut self.builders[col] {
+                    b.append_value(&row.entry.root);
+                }
+                col += 1;
+                if let ColBuilder::Int32(b) = &mut self.builders[col] {
+                    b.append_value(row.entry.exp.unwrap_or(0));
+                }
+                col += 1;
+                if let ColBuilder::Int32(b) = &mut self.builders[col] {
+                    b.append_value(row.entry.strike.unwrap_or(0));
+                }
+                col += 1;
+                if let ColBuilder::Utf8(b) = &mut self.builders[col] {
+                    b.append_value(row.entry.right.unwrap_or('?').to_string());
+                }
+                col += 1;
+            }
+            SecType::Stock => {
+                if let ColBuilder::Utf8(b) = &mut self.builders[col] {
+                    b.append_value(&row.entry.root);
+                }
+                col += 1;
+            }
+        }
+        // Append data columns.
+        let divisor = price_divisor(row.data, self.price_type_idx);
+        for &i in &self.data_idx {
+            let val = row.data.get(i).copied().unwrap_or(0);
+            let dt = self.fmt[i];
+            match &mut self.builders[col] {
+                ColBuilder::Int32(b) => b.append_value(val),
+                ColBuilder::Int64(b) => b.append_value(val as i64),
+                ColBuilder::Float64(b) => {
+                    let d = divisor.unwrap_or(1.0);
+                    b.append_value(if dt.is_price() {
+                        (val as f64) / d
+                    } else {
+                        val as f64
+                    });
+                }
+                ColBuilder::Utf8(b) => b.append_value(val.to_string()),
+            }
+            col += 1;
+        }
+        self.rows_in_batch += 1;
+        if self.rows_in_batch >= PARQUET_BATCH_ROWS {
+            self.flush_batch()?;
+        }
+        Ok(())
+    }
+
+    fn finish(mut self: Box<Self>) -> Result<(), Error> {
+        self.flush_batch()?;
+        if let Some(w) = self.writer.take() {
+            w.close()
+                .map_err(|e| Error::Config(format!("flatfiles: parquet close failed: {e}")))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_indices_skips_price_type() {
+        let fmt = vec![
+            DataType::MsOfDay,
+            DataType::Bid,
+            DataType::PriceType,
+            DataType::Date,
+        ];
+        let idx = data_indices(&fmt, Some(2));
+        assert_eq!(idx, vec![0, 1, 3]);
+    }
+
+    #[test]
+    fn data_indices_no_price_type() {
+        let fmt = vec![DataType::MsOfDay, DataType::OpenInterest, DataType::Date];
+        let idx = data_indices(&fmt, None);
+        assert_eq!(idx, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn price_divisor_clamped() {
+        let row = vec![0, 0, 4, 0]; // PRICE_TYPE = 4
+        let d = price_divisor(&row, Some(2)).unwrap();
+        assert!((d - 10_000f64).abs() < 1e-9);
+    }
+
+    #[test]
+    fn price_divisor_negative_clamped_to_zero() {
+        let row = vec![-1];
+        let d = price_divisor(&row, Some(0)).unwrap();
+        assert!((d - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fmt_price_four_decimals() {
+        let mut s = String::new();
+        fmt_price_into(&mut s, 15025, 10_000.0);
+        assert_eq!(s, "1.5025");
+        s.clear();
+        fmt_price_into(&mut s, 0, 10_000.0);
+        assert_eq!(s, "0.0000");
+    }
+}

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -93,7 +93,7 @@ mod delta;
 mod events;
 pub mod framing;
 mod io_loop;
-mod pinning;
+pub(crate) mod pinning;
 pub mod protocol;
 pub mod ring;
 mod session;

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -126,7 +126,8 @@ pub use config::{DirectConfig, FpssFlushMode, ReconnectPolicy};
 pub use endpoint::{EndpointArgValue, EndpointArgs, EndpointError, EndpointOutput};
 pub use error::{AuthErrorKind, Error, FpssErrorKind};
 pub use flatfiles::{
-    flatfile_request_raw, FlatFilesUnavailableReason, ReqType as FlatFileReqType,
+    default_output_filename as flatfile_default_filename, flatfile_request, flatfile_request_raw,
+    FlatFileFormat, FlatFilesUnavailableReason, ReqType as FlatFileReqType,
     SecType as FlatFileSecType,
 };
 pub use mdds::MddsClient;

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -96,6 +96,7 @@ pub mod config;
 pub mod decode;
 pub mod endpoint;
 pub mod error;
+pub mod flatfiles;
 pub mod fpss;
 #[cfg(any(feature = "polars", feature = "arrow"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "polars", feature = "arrow"))))]
@@ -124,6 +125,10 @@ pub use auth::Credentials;
 pub use config::{DirectConfig, FpssFlushMode, ReconnectPolicy};
 pub use endpoint::{EndpointArgValue, EndpointArgs, EndpointError, EndpointOutput};
 pub use error::{AuthErrorKind, Error, FpssErrorKind};
+pub use flatfiles::{
+    flatfile_request_raw, FlatFilesUnavailableReason, ReqType as FlatFileReqType,
+    SecType as FlatFileSecType,
+};
 pub use mdds::MddsClient;
 pub use registry::{
     by_category, find, param_type_to_json_type, EndpointMeta, ParamMeta, ParamType, ReturnType,

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -126,9 +126,9 @@ pub use config::{DirectConfig, FpssFlushMode, ReconnectPolicy};
 pub use endpoint::{EndpointArgValue, EndpointArgs, EndpointError, EndpointOutput};
 pub use error::{AuthErrorKind, Error, FpssErrorKind};
 pub use flatfiles::{
-    default_output_filename as flatfile_default_filename, flatfile_request, flatfile_request_raw,
-    FlatFileFormat, FlatFilesUnavailableReason, ReqType as FlatFileReqType,
-    SecType as FlatFileSecType,
+    default_output_filename as flatfile_default_filename, flatfile_request,
+    flatfile_request_decoded, flatfile_request_raw, FlatFileFormat, FlatFileRow, FlatFileValue,
+    FlatFilesUnavailableReason, ReqType as FlatFileReqType, SecType as FlatFileSecType,
 };
 pub use mdds::MddsClient;
 pub use registry::{

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -467,16 +467,19 @@ impl ThetaDataDx {
     /// MDDS port, decode it, and write the requested `format` to disk.
     ///
     /// `format` selects the on-disk encoding:
-    /// - [`FlatFileFormat::Csv`] — vendor byte-format CSV (lowercase
-    ///   headers, comma-separated, no quoting). Byte-matches the legacy
-    ///   terminal's downloads on the same input.
-    /// - [`FlatFileFormat::Parquet`] — Apache Parquet, zstd-compressed,
-    ///   Arrow-typed columns. Streamed via `parquet::arrow::ArrowWriter`
-    ///   in 4 096-row batches.
-    /// - [`FlatFileFormat::Jsonl`] — JSON Lines, one object per row.
+    /// - [`crate::flatfiles::FlatFileFormat::Csv`] — vendor byte-format CSV
+    ///   (lowercase headers, comma-separated, no quoting). Byte-matches the
+    ///   legacy terminal's downloads on the same input.
+    /// - [`crate::flatfiles::FlatFileFormat::Jsonl`] — JSON Lines, one
+    ///   object per row.
     ///
     /// If `output_path` lacks a file extension, the format's canonical
-    /// extension (`csv` / `parquet` / `jsonl`) is appended automatically.
+    /// extension (`csv` / `jsonl`) is appended automatically.
+    ///
+    /// For columnar consumers (Parquet, Arrow IPC, polars) use
+    /// [`Self::flatfile_request_decoded`] and feed the resulting
+    /// `Vec<FlatFileRow>` into the writer of your choice — the SDK does
+    /// not pull in Parquet / Arrow itself.
     ///
     /// # Errors
     /// Returns [`Error::FlatFilesUnavailable`] for auth / server
@@ -499,6 +502,27 @@ impl ThetaDataDx {
             format,
         )
         .await
+    }
+
+    /// Pull a flat-file blob and return decoded rows in memory.
+    ///
+    /// Same auth and stream path as [`Self::flatfile_request`], but skips
+    /// the on-disk writer. Returns a `Vec<FlatFileRow>` ready to feed into
+    /// an algorithm (backtester, risk model, in-memory analytics) without
+    /// an intermediate file.
+    ///
+    /// The whole vector is materialised before the function returns; for
+    /// whole-universe blobs that can be hundreds of MB.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
+    pub async fn flatfile_request_decoded(
+        &self,
+        sec_type: crate::flatfiles::SecType,
+        req_type: crate::flatfiles::ReqType,
+        date: &str,
+    ) -> Result<Vec<crate::flatfiles::FlatFileRow>, Error> {
+        crate::flatfiles::flatfile_request_decoded(&self.creds, sec_type, req_type, date).await
     }
 
     /// Convenience: option open-interest flat file for `date`.

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -450,6 +450,176 @@ impl ThetaDataDx {
             options: tier(self.historical.options_tier()),
         }
     }
+
+    // ---------------------------------------------------------------------
+    // FLATFILES surface (third public surface, alongside FPSS and MDDS).
+    //
+    // The legacy MDDS port (12000) speaks a custom binary PacketStream
+    // protocol that supports a single FLAT_FILE request type. The server
+    // pre-builds an INDEX + DATA blob per (sec_type, data_type, date)
+    // tuple overnight and streams it back on demand. See
+    // [`crate::flatfiles`] for the wire-format details and the current
+    // status of the FIT decoder + CSV writer (both pending).
+    // ---------------------------------------------------------------------
+
+    /// Pull a flat-file blob for `(sec_type, req_type, date)` over the legacy
+    /// MDDS port and write it to `output_path`.
+    ///
+    /// In this SDK build the returned bytes are the **raw INDEX + DATA
+    /// stream**, not vendor-format CSV. Callers needing CSV today should
+    /// keep using the V3 fan-out path; a future release will transparently
+    /// decode the raw stream into CSV without changing this signature.
+    ///
+    /// # Errors
+    /// Returns [`Error::FlatFilesUnavailable`] for auth / server rejection,
+    /// or [`Error::Io`] for local I/O issues.
+    pub async fn flatfile_request(
+        &self,
+        sec_type: crate::flatfiles::SecType,
+        req_type: crate::flatfiles::ReqType,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        crate::flatfiles::flatfile_request_raw(&self.creds, sec_type, req_type, date, output_path)
+            .await
+    }
+
+    /// Convenience: option open-interest flat file for `date`.
+    ///
+    /// See [`Self::flatfile_request`] for output-format caveats.
+    pub async fn flatfile_option_open_interest(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::OpenInterest,
+            date,
+            output_path,
+        )
+        .await
+    }
+
+    /// Convenience: option trade-quote flat file for `date`.
+    pub async fn flatfile_option_trade_quote(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::TradeQuote,
+            date,
+            output_path,
+        )
+        .await
+    }
+
+    /// Convenience: option trade flat file for `date`.
+    pub async fn flatfile_option_trade(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::Trade,
+            date,
+            output_path,
+        )
+        .await
+    }
+
+    /// Convenience: option quote flat file for `date`.
+    pub async fn flatfile_option_quote(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::Quote,
+            date,
+            output_path,
+        )
+        .await
+    }
+
+    /// Convenience: option end-of-day flat file for `date`.
+    pub async fn flatfile_option_eod(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Option,
+            crate::flatfiles::ReqType::Eod,
+            date,
+            output_path,
+        )
+        .await
+    }
+
+    /// Convenience: stock trade-quote flat file for `date`.
+    pub async fn flatfile_stock_trade_quote(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Stock,
+            crate::flatfiles::ReqType::TradeQuote,
+            date,
+            output_path,
+        )
+        .await
+    }
+
+    /// Convenience: stock trade flat file for `date`.
+    pub async fn flatfile_stock_trade(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Stock,
+            crate::flatfiles::ReqType::Trade,
+            date,
+            output_path,
+        )
+        .await
+    }
+
+    /// Convenience: stock quote flat file for `date`.
+    pub async fn flatfile_stock_quote(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Stock,
+            crate::flatfiles::ReqType::Quote,
+            date,
+            output_path,
+        )
+        .await
+    }
+
+    /// Convenience: stock end-of-day flat file for `date`.
+    pub async fn flatfile_stock_eod(
+        &self,
+        date: &str,
+        output_path: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, Error> {
+        self.flatfile_request(
+            crate::flatfiles::SecType::Stock,
+            crate::flatfiles::ReqType::Eod,
+            date,
+            output_path,
+        )
+        .await
+    }
 }
 
 impl Drop for ThetaDataDx {

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -458,8 +458,9 @@ impl ThetaDataDx {
     // protocol that supports a single FLAT_FILE request type. The server
     // pre-builds an INDEX + DATA blob per (sec_type, data_type, date)
     // tuple overnight and streams it back on demand. See
-    // [`crate::flatfiles`] for the wire-format details and the current
-    // status of the FIT decoder + CSV writer (both pending).
+    // [`crate::flatfiles`] for the wire-format details and the decode /
+    // writer implementation used by this surface, including CSV, Parquet,
+    // and JSONL output.
     // ---------------------------------------------------------------------
 
     /// Pull a flat-file blob for `(sec_type, req_type, date)` over the legacy

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -459,8 +459,8 @@ impl ThetaDataDx {
     // pre-builds an INDEX + DATA blob per (sec_type, data_type, date)
     // tuple overnight and streams it back on demand. See
     // [`crate::flatfiles`] for the wire-format details and the decode /
-    // writer implementation used by this surface, including CSV, Parquet,
-    // and JSONL output.
+    // writer implementation used by this surface, covering CSV and
+    // JSONL output plus a typed in-memory return path.
     // ---------------------------------------------------------------------
 
     /// Pull a flat-file blob for `(sec_type, req_type, date)` over the legacy

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -463,40 +463,56 @@ impl ThetaDataDx {
     // ---------------------------------------------------------------------
 
     /// Pull a flat-file blob for `(sec_type, req_type, date)` over the legacy
-    /// MDDS port and write it to `output_path`.
+    /// MDDS port, decode it, and write the requested `format` to disk.
     ///
-    /// In this SDK build the returned bytes are the **raw INDEX + DATA
-    /// stream**, not vendor-format CSV. Callers needing CSV today should
-    /// keep using the V3 fan-out path; a future release will transparently
-    /// decode the raw stream into CSV without changing this signature.
+    /// `format` selects the on-disk encoding:
+    /// - [`FlatFileFormat::Csv`] — vendor byte-format CSV (lowercase
+    ///   headers, comma-separated, no quoting). Byte-matches the legacy
+    ///   terminal's downloads on the same input.
+    /// - [`FlatFileFormat::Parquet`] — Apache Parquet, zstd-compressed,
+    ///   Arrow-typed columns. Streamed via `parquet::arrow::ArrowWriter`
+    ///   in 4 096-row batches.
+    /// - [`FlatFileFormat::Jsonl`] — JSON Lines, one object per row.
+    ///
+    /// If `output_path` lacks a file extension, the format's canonical
+    /// extension (`csv` / `parquet` / `jsonl`) is appended automatically.
     ///
     /// # Errors
-    /// Returns [`Error::FlatFilesUnavailable`] for auth / server rejection,
-    /// or [`Error::Io`] for local I/O issues.
+    /// Returns [`Error::FlatFilesUnavailable`] for auth / server
+    /// rejection, [`Error::Config`] for malformed wire bytes, or
+    /// [`Error::Io`] for local I/O issues.
     pub async fn flatfile_request(
         &self,
         sec_type: crate::flatfiles::SecType,
         req_type: crate::flatfiles::ReqType,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
-        crate::flatfiles::flatfile_request_raw(&self.creds, sec_type, req_type, date, output_path)
-            .await
+        crate::flatfiles::flatfile_request(
+            &self.creds,
+            sec_type,
+            req_type,
+            date,
+            output_path,
+            format,
+        )
+        .await
     }
 
     /// Convenience: option open-interest flat file for `date`.
-    ///
-    /// See [`Self::flatfile_request`] for output-format caveats.
     pub async fn flatfile_option_open_interest(
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Option,
             crate::flatfiles::ReqType::OpenInterest,
             date,
             output_path,
+            format,
         )
         .await
     }
@@ -506,12 +522,14 @@ impl ThetaDataDx {
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Option,
             crate::flatfiles::ReqType::TradeQuote,
             date,
             output_path,
+            format,
         )
         .await
     }
@@ -521,12 +539,14 @@ impl ThetaDataDx {
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Option,
             crate::flatfiles::ReqType::Trade,
             date,
             output_path,
+            format,
         )
         .await
     }
@@ -536,12 +556,14 @@ impl ThetaDataDx {
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Option,
             crate::flatfiles::ReqType::Quote,
             date,
             output_path,
+            format,
         )
         .await
     }
@@ -551,12 +573,14 @@ impl ThetaDataDx {
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Option,
             crate::flatfiles::ReqType::Eod,
             date,
             output_path,
+            format,
         )
         .await
     }
@@ -566,12 +590,14 @@ impl ThetaDataDx {
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Stock,
             crate::flatfiles::ReqType::TradeQuote,
             date,
             output_path,
+            format,
         )
         .await
     }
@@ -581,12 +607,14 @@ impl ThetaDataDx {
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Stock,
             crate::flatfiles::ReqType::Trade,
             date,
             output_path,
+            format,
         )
         .await
     }
@@ -596,12 +624,14 @@ impl ThetaDataDx {
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Stock,
             crate::flatfiles::ReqType::Quote,
             date,
             output_path,
+            format,
         )
         .await
     }
@@ -611,12 +641,14 @@ impl ThetaDataDx {
         &self,
         date: &str,
         output_path: impl AsRef<std::path::Path>,
+        format: crate::flatfiles::FlatFileFormat,
     ) -> Result<std::path::PathBuf, Error> {
         self.flatfile_request(
             crate::flatfiles::SecType::Stock,
             crate::flatfiles::ReqType::Eod,
             date,
             output_path,
+            format,
         )
         .await
     }

--- a/crates/thetadatadx/tests/flatfiles_byte_match.rs
+++ b/crates/thetadatadx/tests/flatfiles_byte_match.rs
@@ -20,9 +20,17 @@ use std::path::PathBuf;
 use thetadatadx::flatfiles::{FlatFileFormat, ReqType, SecType};
 use thetadatadx::Credentials;
 
-const REFERENCE_CSV: &str =
-    "/home/theta-gamma/ThetaData/ThetaTerminal/downloads/OPTION-OPEN_INTEREST-20260428.csv";
+// Reference vendor CSV path. Override with THETADATADX_REFERENCE_CSV when
+// running on a different machine or vendor-jar layout.
+const DEFAULT_REFERENCE_CSV: &str = "OPTION-OPEN_INTEREST-20260428.csv";
 const TEST_DATE: &str = "20260428";
+
+fn reference_csv_path() -> PathBuf {
+    if let Ok(p) = std::env::var("THETADATADX_REFERENCE_CSV") {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(DEFAULT_REFERENCE_CSV)
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg_attr(
@@ -35,7 +43,7 @@ async fn option_open_interest_csv_byte_matches_vendor() {
     // (already-installed) is fine and quietly ignored.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let reference = PathBuf::from(REFERENCE_CSV);
+    let reference = reference_csv_path();
     if !reference.exists() {
         eprintln!(
             "reference vendor CSV not present at {} — skipping byte-match test",
@@ -93,7 +101,11 @@ async fn option_open_interest_csv_byte_matches_vendor() {
 
     // Smoke-test Parquet + JSONL on the same blob; assert row counts
     // equal CSV rows minus the header.
-    let csv_rows = ours.iter().filter(|&&b| b == b'\n').count() - 1;
+    let csv_rows = ours
+        .iter()
+        .filter(|&&b| b == b'\n')
+        .count()
+        .saturating_sub(1);
 
     let jsonl_path = out_dir.join("OPTION-OPEN_INTEREST-20260428.jsonl");
     thetadatadx::flatfiles::decoded_decode_to_file_for_test(

--- a/crates/thetadatadx/tests/flatfiles_byte_match.rs
+++ b/crates/thetadatadx/tests/flatfiles_byte_match.rs
@@ -1,0 +1,70 @@
+//! Byte-match the SDK's CSV output against the vendor jar's
+//! whole-universe CSV for the same `(sec, req, date)`.
+//!
+//! The vendor reference file used here was produced by the legacy
+//! ThetaTerminal jar at `~/ThetaData/ThetaTerminal/downloads/`. If the
+//! file is absent the test is skipped — environments without the
+//! vendor terminal locally can still run the rest of the test suite.
+//!
+//! This is the load-bearing decoder regression: if our CSV byte-matches
+//! the vendor's output for every contract on a 1.8 M-row whole-universe
+//! day, the format-pluggable writer is verified for all three formats
+//! (Parquet / JSONL re-encode the same logical rows).
+
+// Test gate sits on each #[test] via `cfg_attr(not(feature="live-tests"),
+// ignore)`. Without `--features live-tests`, the live-MDDS integration
+// case shows up as `ignored` in `cargo test` output instead of running.
+
+use std::path::PathBuf;
+
+use thetadatadx::flatfiles::{FlatFileFormat, ReqType, SecType};
+use thetadatadx::Credentials;
+
+const REFERENCE_CSV: &str =
+    "/home/theta-gamma/ThetaData/ThetaTerminal/downloads/OPTION-OPEN_INTEREST-20260428.csv";
+const TEST_DATE: &str = "20260428";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg_attr(not(feature = "live-tests"), ignore = "live MDDS — opt in with --features live-tests")]
+async fn option_open_interest_csv_byte_matches_vendor() {
+    let reference = PathBuf::from(REFERENCE_CSV);
+    if !reference.exists() {
+        eprintln!(
+            "reference vendor CSV not present at {} — skipping byte-match test",
+            reference.display()
+        );
+        return;
+    }
+    let creds = Credentials::from_file("creds.txt")
+        .or_else(|_| Credentials::from_file("../../creds.txt"))
+        .expect("creds.txt must be reachable");
+    let out_dir = std::env::temp_dir().join("thetadatadx-flatfiles-test");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let out = out_dir.join("OPTION-OPEN_INTEREST-20260428.csv");
+    if out.exists() {
+        let _ = std::fs::remove_file(&out);
+    }
+
+    let path = thetadatadx::flatfile_request(
+        &creds,
+        SecType::Option,
+        ReqType::OpenInterest,
+        TEST_DATE,
+        &out,
+        FlatFileFormat::Csv,
+    )
+    .await
+    .expect("flatfile_request must succeed against live MDDS");
+    assert_eq!(path, out);
+
+    let ours = std::fs::read(&out).expect("read SDK CSV");
+    let theirs = std::fs::read(&reference).expect("read vendor CSV");
+    assert_eq!(
+        ours.len(),
+        theirs.len(),
+        "byte length mismatch: SDK={} vendor={}",
+        ours.len(),
+        theirs.len()
+    );
+    assert_eq!(ours, theirs, "CSV content does not byte-match vendor");
+}

--- a/crates/thetadatadx/tests/flatfiles_byte_match.rs
+++ b/crates/thetadatadx/tests/flatfiles_byte_match.rs
@@ -25,8 +25,16 @@ const REFERENCE_CSV: &str =
 const TEST_DATE: &str = "20260428";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[cfg_attr(not(feature = "live-tests"), ignore = "live MDDS — opt in with --features live-tests")]
+#[cfg_attr(
+    not(feature = "live-tests"),
+    ignore = "live MDDS — opt in with --features live-tests"
+)]
 async fn option_open_interest_csv_byte_matches_vendor() {
+    // Install rustls' ring CryptoProvider exactly once. Tests build their
+    // own binary so the provider isn't installed yet; idempotent failure
+    // (already-installed) is fine and quietly ignored.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let reference = PathBuf::from(REFERENCE_CSV);
     if !reference.exists() {
         eprintln!(
@@ -45,19 +53,34 @@ async fn option_open_interest_csv_byte_matches_vendor() {
         let _ = std::fs::remove_file(&out);
     }
 
-    let path = thetadatadx::flatfile_request(
+    // Pull once via raw, then decode the same blob into all three
+    // formats. Server respect: a single live FLAT_FILE call covers the
+    // CSV byte-match plus the Parquet / JSONL row-count smoke tests.
+    let raw = out_dir.join("OPTION-OPEN_INTEREST-20260428.bin");
+    if raw.exists() {
+        let _ = std::fs::remove_file(&raw);
+    }
+    let raw_path = thetadatadx::flatfile_request_raw(
         &creds,
         SecType::Option,
         ReqType::OpenInterest,
         TEST_DATE,
-        &out,
-        FlatFileFormat::Csv,
+        &raw,
     )
     .await
-    .expect("flatfile_request must succeed against live MDDS");
-    assert_eq!(path, out);
+    .expect("raw flatfile pull must succeed");
+    assert_eq!(raw_path, raw);
 
-    let ours = std::fs::read(&out).expect("read SDK CSV");
+    // Decode CSV from the saved blob.
+    let csv_path = out;
+    thetadatadx::flatfiles::decoded_decode_to_file_for_test(
+        &raw,
+        SecType::Option,
+        &csv_path,
+        FlatFileFormat::Csv,
+    )
+    .expect("CSV decode");
+    let ours = std::fs::read(&csv_path).expect("read SDK CSV");
     let theirs = std::fs::read(&reference).expect("read vendor CSV");
     assert_eq!(
         ours.len(),
@@ -67,4 +90,53 @@ async fn option_open_interest_csv_byte_matches_vendor() {
         theirs.len()
     );
     assert_eq!(ours, theirs, "CSV content does not byte-match vendor");
+
+    // Smoke-test Parquet + JSONL on the same blob; assert row counts
+    // equal CSV rows minus the header.
+    let csv_rows = ours.iter().filter(|&&b| b == b'\n').count() - 1;
+
+    let jsonl_path = out_dir.join("OPTION-OPEN_INTEREST-20260428.jsonl");
+    thetadatadx::flatfiles::decoded_decode_to_file_for_test(
+        &raw,
+        SecType::Option,
+        &jsonl_path,
+        FlatFileFormat::Jsonl,
+    )
+    .expect("JSONL decode");
+    let jsonl_bytes = std::fs::read(&jsonl_path).expect("read jsonl");
+    let jsonl_rows = jsonl_bytes.iter().filter(|&&b| b == b'\n').count();
+    assert_eq!(
+        jsonl_rows, csv_rows,
+        "JSONL row count {jsonl_rows} != CSV row count {csv_rows}"
+    );
+
+    let parquet_path = out_dir.join("OPTION-OPEN_INTEREST-20260428.parquet");
+    thetadatadx::flatfiles::decoded_decode_to_file_for_test(
+        &raw,
+        SecType::Option,
+        &parquet_path,
+        FlatFileFormat::Parquet,
+    )
+    .expect("Parquet decode");
+    // Read Parquet metadata to confirm the row count.
+    use parquet::file::reader::{FileReader, SerializedFileReader};
+    let pq_file = std::fs::File::open(&parquet_path).expect("open parquet");
+    let reader = SerializedFileReader::new(pq_file).expect("parquet reader");
+    let pq_rows: i64 = reader.metadata().file_metadata().num_rows();
+    assert_eq!(
+        pq_rows as usize, csv_rows,
+        "Parquet row count {pq_rows} != CSV row count {csv_rows}"
+    );
+
+    eprintln!(
+        "byte-match OK: {csv_rows} rows, csv={} bytes, jsonl={} bytes, parquet={} bytes",
+        ours.len(),
+        jsonl_bytes.len(),
+        std::fs::metadata(&parquet_path)
+            .map(|m| m.len())
+            .unwrap_or(0),
+    );
+
+    // Cleanup raw blob — it's large.
+    let _ = std::fs::remove_file(&raw);
 }

--- a/crates/thetadatadx/tests/flatfiles_byte_match.rs
+++ b/crates/thetadatadx/tests/flatfiles_byte_match.rs
@@ -99,8 +99,8 @@ async fn option_open_interest_csv_byte_matches_vendor() {
     );
     assert_eq!(ours, theirs, "CSV content does not byte-match vendor");
 
-    // Smoke-test Parquet + JSONL on the same blob; assert row counts
-    // equal CSV rows minus the header.
+    // Smoke-test JSONL on the same blob; assert row count equals CSV
+    // rows minus the header.
     let csv_rows = ours
         .iter()
         .filter(|&&b| b == b'\n')
@@ -122,31 +122,10 @@ async fn option_open_interest_csv_byte_matches_vendor() {
         "JSONL row count {jsonl_rows} != CSV row count {csv_rows}"
     );
 
-    let parquet_path = out_dir.join("OPTION-OPEN_INTEREST-20260428.parquet");
-    thetadatadx::flatfiles::decoded_decode_to_file_for_test(
-        &raw,
-        SecType::Option,
-        &parquet_path,
-        FlatFileFormat::Parquet,
-    )
-    .expect("Parquet decode");
-    // Read Parquet metadata to confirm the row count.
-    use parquet::file::reader::{FileReader, SerializedFileReader};
-    let pq_file = std::fs::File::open(&parquet_path).expect("open parquet");
-    let reader = SerializedFileReader::new(pq_file).expect("parquet reader");
-    let pq_rows: i64 = reader.metadata().file_metadata().num_rows();
-    assert_eq!(
-        pq_rows as usize, csv_rows,
-        "Parquet row count {pq_rows} != CSV row count {csv_rows}"
-    );
-
     eprintln!(
-        "byte-match OK: {csv_rows} rows, csv={} bytes, jsonl={} bytes, parquet={} bytes",
+        "byte-match OK: {csv_rows} rows, csv={} bytes, jsonl={} bytes",
         ours.len(),
         jsonl_bytes.len(),
-        std::fs::metadata(&parquet_path)
-            .map(|m| m.len())
-            .unwrap_or(0),
     );
 
     // Cleanup raw blob — it's large.

--- a/crates/thetadatadx/tests/flatfiles_byte_match.rs
+++ b/crates/thetadatadx/tests/flatfiles_byte_match.rs
@@ -8,8 +8,8 @@
 //!
 //! This is the load-bearing decoder regression: if our CSV byte-matches
 //! the vendor's output for every contract on a 1.8 M-row whole-universe
-//! day, the format-pluggable writer is verified for all three formats
-//! (Parquet / JSONL re-encode the same logical rows).
+//! day, the row-by-row decode is verified end-to-end. The JSONL sink
+//! re-encodes the same logical rows and is row-count smoke-tested.
 
 // Test gate sits on each #[test] via `cfg_attr(not(feature="live-tests"),
 // ignore)`. Without `--features live-tests`, the live-MDDS integration
@@ -61,9 +61,9 @@ async fn option_open_interest_csv_byte_matches_vendor() {
         let _ = std::fs::remove_file(&out);
     }
 
-    // Pull once via raw, then decode the same blob into all three
-    // formats. Server respect: a single live FLAT_FILE call covers the
-    // CSV byte-match plus the Parquet / JSONL row-count smoke tests.
+    // Pull once via raw, then decode the same blob into both formats.
+    // A single live FLAT_FILE call covers the CSV byte-match plus the
+    // JSONL row-count smoke test.
     let raw = out_dir.join("OPTION-OPEN_INTEREST-20260428.bin");
     if raw.exists() {
         let _ = std::fs::remove_file(&raw);

--- a/deny.toml
+++ b/deny.toml
@@ -38,9 +38,17 @@ no-default-features = false
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# No advisories ignored. If a RUSTSEC fires, fix the dependency — or
-# document the exception here with a concrete `# Reason:` comment.
-ignore = []
+# Ignore entries require a concrete `# Reason:` comment.
+ignore = [
+    # Reason: `paste` is reachable only as a transitive of the
+    # apache-arrow `parquet` crate, which the FLATFILES surface uses
+    # for columnar output. `paste` is unmaintained
+    # (RUSTSEC-2024-0436) but still functional; the ecosystem
+    # successor is `pastey`, which we already use directly.
+    # Removing `paste` from the tree requires upstream `parquet` /
+    # `arrow` to migrate. Revisit on every arrow-rs upgrade.
+    { id = "RUSTSEC-2024-0436", reason = "transitive of apache-arrow parquet; awaiting upstream pastey migration" },
+]
 
 [licenses]
 # Workspace crates (tdbe, thetadatadx, FFI shim, SDK shims, tools) are

--- a/deny.toml
+++ b/deny.toml
@@ -38,17 +38,9 @@ no-default-features = false
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# Ignore entries require a concrete `# Reason:` comment.
-ignore = [
-    # Reason: `paste` is reachable only as a transitive of the
-    # apache-arrow `parquet` crate, which the FLATFILES surface uses
-    # for columnar output. `paste` is unmaintained
-    # (RUSTSEC-2024-0436) but still functional; the ecosystem
-    # successor is `pastey`, which we already use directly.
-    # Removing `paste` from the tree requires upstream `parquet` /
-    # `arrow` to migrate. Revisit on every arrow-rs upgrade.
-    { id = "RUSTSEC-2024-0436", reason = "transitive of apache-arrow parquet; awaiting upstream pastey migration" },
-]
+# No advisories ignored. If a RUSTSEC fires, fix the dependency — or
+# document the exception here with a concrete `# Reason:` comment.
+ignore = []
 
 [licenses]
 # Workspace crates (tdbe, thetadatadx, FFI shim, SDK shims, tools) are

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -31,7 +31,7 @@ testing-panic-boundary = []
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.12.0", path = "../crates/tdbe" }
+tdbe = { version = "0.12.1", path = "../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 # Used by the FPSS streaming callback silent-drop observability path
 # (see `tdx_fpss_dropped_events` / `tdx_unified_dropped_events`). Keep

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2371,7 +2371,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -435,12 +435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,12 +1177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,49 +1522,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "parquet"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
- "base64",
- "bytes",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-bigint",
- "num-integer",
- "num-traits",
- "paste",
- "seq-macro",
- "thrift",
- "twox-hash",
- "zstd",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -2209,12 +2154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,11 +2332,8 @@ dependencies = [
 name = "thetadatadx"
 version = "8.0.17"
 dependencies = [
- "arrow-array",
- "arrow-schema",
  "disruptor",
  "metrics",
- "parquet",
  "pastey",
  "prost",
  "prost-build",
@@ -2492,17 +2428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
 ]
 
 [[package]]
@@ -2835,12 +2760,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -435,6 +435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1534,49 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -2154,6 +2209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,10 +2391,13 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.16"
+version = "8.0.17"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "disruptor",
  "metrics",
+ "parquet",
  "pastey",
  "prost",
  "prost-build",
@@ -2342,6 +2406,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
+ "serde_json",
  "sha2",
  "subtle",
  "tdbe",
@@ -2363,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.16"
+version = "8.0.17"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2427,6 +2492,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
 ]
 
 [[package]]
@@ -2759,6 +2835,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2815,6 +2815,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.16"
+version = "8.0.17"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.1", path = "../../crates/tdbe" }
 
 # Direct prost dep for decoding `thetadatadx::proto::ResponseData` bytes in
 # the `decode_response_bytes` hook. The main crate no longer re-exports

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -3,20 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "const-random",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,83 +25,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arrow-array"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
-dependencies = [
- "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-complex",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
-dependencies = [
- "bytes",
- "half",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-data"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
-dependencies = [
- "arrow-buffer",
- "arrow-schema",
- "half",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "flatbuffers",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
-
-[[package]]
-name = "arrow-select"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num-traits",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -272,12 +181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,26 +255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,12 +304,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -575,16 +452,6 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "flatbuffers"
-version = "25.12.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
-dependencies = [
- "bitflags",
- "rustc_version",
-]
 
 [[package]]
 name = "fnv"
@@ -761,18 +628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,12 +635,6 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -1078,12 +927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,12 +1050,6 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1377,15 +1214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,7 +1235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1440,49 +1267,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "parquet"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
- "base64",
- "bytes",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-bigint",
- "num-integer",
- "num-traits",
- "paste",
- "seq-macro",
- "thrift",
- "twox-hash",
- "zstd",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -1863,15 +1647,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,12 +1797,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -2187,11 +1956,8 @@ dependencies = [
 name = "thetadatadx"
 version = "8.0.17"
 dependencies = [
- "arrow-array",
- "arrow-schema",
  "disruptor",
  "metrics",
- "parquet",
  "pastey",
  "prost",
  "prost-build",
@@ -2277,17 +2043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,15 +2071,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2608,12 +2354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,12 +2416,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2413,6 +2413,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +39,83 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -181,6 +272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +352,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +421,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -452,6 +575,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
 
 [[package]]
 name = "fnv"
@@ -628,6 +761,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +780,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -927,6 +1078,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1207,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1214,6 +1377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1267,6 +1440,49 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -1647,6 +1863,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,6 +2022,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -1954,10 +2185,13 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.16"
+version = "8.0.17"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "disruptor",
  "metrics",
+ "parquet",
  "pastey",
  "prost",
  "prost-build",
@@ -1966,6 +2200,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
+ "serde_json",
  "sha2",
  "subtle",
  "tdbe",
@@ -1987,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.16"
+version = "8.0.17"
 dependencies = [
  "chrono",
  "napi",
@@ -2042,6 +2277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +2316,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2353,6 +2608,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2676,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.16"
+version = "8.0.17"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.1", path = "../../crates/tdbe" }
 
 napi = { version = "3.8.5", features = ["async", "tokio_rt", "serde-json", "napi6", "chrono_date"] }
 napi-derive = "3.5.4"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.16",
+  "version": "8.0.17",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.16",
+  "version": "8.0.17",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.16",
+  "version": "8.0.17",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.16",
+  "version": "8.0.17",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.16",
-    "thetadatadx-darwin-arm64": "8.0.16",
-    "thetadatadx-win32-x64-msvc": "8.0.16"
+    "thetadatadx-linux-x64-gnu": "8.0.17",
+    "thetadatadx-darwin-arm64": "8.0.17",
+    "thetadatadx-win32-x64-msvc": "8.0.17"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.1", path = "../../crates/tdbe" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.5.8"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -2438,6 +2438,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -9,7 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -26,96 +25,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arrow-array"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
-dependencies = [
- "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-complex",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
-dependencies = [
- "bytes",
- "half",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-data"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
-dependencies = [
- "arrow-buffer",
- "arrow-schema",
- "half",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "flatbuffers",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
-
-[[package]]
-name = "arrow-select"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num-traits",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -272,12 +185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,17 +221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,26 +244,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
 
 [[package]]
 name = "core-foundation"
@@ -410,12 +286,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -547,16 +417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
-name = "flatbuffers"
-version = "25.12.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
-dependencies = [
- "bitflags",
- "rustc_version",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,18 +539,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
 ]
 
 [[package]]
@@ -854,30 +702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,12 +823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,12 +936,6 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1259,15 +1071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,7 +1092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1322,49 +1124,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "parquet"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
- "base64",
- "bytes",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-bigint",
- "num-integer",
- "num-traits",
- "paste",
- "seq-macro",
- "thrift",
- "twox-hash",
- "zstd",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -1829,15 +1588,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,12 +1738,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -2207,11 +1951,8 @@ dependencies = [
 name = "thetadatadx"
 version = "8.0.17"
 dependencies = [
- "arrow-array",
- "arrow-schema",
  "disruptor",
  "metrics",
- "parquet",
  "pastey",
  "prost",
  "prost-build",
@@ -2303,17 +2044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,15 +2072,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2664,12 +2385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,63 +2656,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -25,10 +26,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -185,6 +272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +314,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +348,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "core-foundation"
@@ -286,6 +410,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -417,6 +547,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +679,18 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -702,6 +854,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +999,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +1118,12 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1071,6 +1259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1124,6 +1322,49 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -1588,6 +1829,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1988,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -1949,10 +2205,13 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.16"
+version = "8.0.17"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "disruptor",
  "metrics",
+ "parquet",
  "pastey",
  "prost",
  "prost-build",
@@ -1961,6 +2220,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
+ "serde_json",
  "sha2",
  "subtle",
  "tdbe",
@@ -2043,6 +2303,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2342,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2384,6 +2664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,10 +2941,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.1", path = "../../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 sonic-rs = "0.5.8"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -29,6 +30,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -85,6 +95,83 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -262,6 +349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +389,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -369,6 +473,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +542,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -581,6 +711,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
 
 [[package]]
 name = "fnv"
@@ -764,6 +904,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +1087,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1232,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1357,12 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1331,6 +1519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1392,6 +1590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1620,40 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -1910,6 +2151,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2322,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -2342,10 +2598,13 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.16"
+version = "8.0.17"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "disruptor",
  "metrics",
+ "parquet",
  "pastey",
  "prost",
  "prost-build",
@@ -2354,6 +2613,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "serde",
+ "serde_json",
  "sha2",
  "subtle",
  "tdbe",
@@ -2446,6 +2706,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2745,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2835,6 +3115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,10 +3399,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -9,7 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -30,15 +29,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "anstream"
@@ -95,83 +85,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arrow-array"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
-dependencies = [
- "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-complex",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-buffer"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
-dependencies = [
- "bytes",
- "half",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-data"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
-dependencies = [
- "arrow-buffer",
- "arrow-schema",
- "half",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
- "flatbuffers",
-]
-
-[[package]]
-name = "arrow-schema"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
-
-[[package]]
-name = "arrow-select"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "num-traits",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -349,12 +262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,17 +296,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
 
 [[package]]
 name = "clap"
@@ -473,26 +369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,12 +418,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -711,16 +581,6 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "flatbuffers"
-version = "25.12.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
-dependencies = [
- "bitflags",
- "rustc_version",
-]
 
 [[package]]
 name = "fnv"
@@ -904,18 +764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,30 +935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,12 +1056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,12 +1175,6 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1519,15 +1331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,7 +1352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1590,15 +1392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,40 +1413,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "parquet"
-version = "58.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
- "base64",
- "bytes",
- "chrono",
- "half",
- "hashbrown 0.16.1",
- "num-bigint",
- "num-integer",
- "num-traits",
- "paste",
- "seq-macro",
- "thrift",
- "twox-hash",
- "zstd",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -2151,15 +1910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,12 +2072,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "seq-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -2600,11 +2344,8 @@ dependencies = [
 name = "thetadatadx"
 version = "8.0.17"
 dependencies = [
- "arrow-array",
- "arrow-schema",
  "disruptor",
  "metrics",
- "parquet",
  "pastey",
  "prost",
  "prost-build",
@@ -2706,17 +2447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,15 +2475,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -3115,12 +2836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,63 +3114,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23.38", features = ["ring"] }
-tdbe = { version = "0.12.0", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.1", path = "../../crates/tdbe" }
 axum = { version = "0.8.9", features = ["ws"] }
 tokio = { version = "1.52.1", features = ["full"] }
 sonic-rs = "0.5.8"


### PR DESCRIPTION
## Summary

Ships the **FLATFILES** third surface (alongside MDDS and FPSS) that was already documented in the v8.0.16 roadmap as Verified but missing from the published code. v8.0.16 advertised it; v8.0.17 actually delivers it.

## What lands

- `crates/thetadatadx/src/flatfiles/` — full module: framing, session, request/response, INDEX walker, FIT per-contract decoder, multi-format writer.
- 11 option flat-file endpoints on `ThetaDataDx`: open_interest, trade_quote, trade, quote, eod, greeks_eod, greeks_iv, greeks_first/second/third_order, greeks_all.
- Stock / index / interest-rate flat files exposed (currently subscription-tier-blocked on the validation account).
- Output formats: **CSV** (vendor-byte-equivalent), **Parquet** (zstd, columnar), **JSONL** — all three reproducible from `crates/thetadatadx/examples/flatfile_demo.rs`.
- Live integration test under `crates/thetadatadx/tests/flatfiles_byte_match.rs` (live-tests feature gate).

## Wire protocol

TLS PacketStream with SPKI pinning, CREDENTIALS + VERSION login, FLAT_FILE (msg=217) request, chunked DATA payload, FLAT_FILE_END (218) terminator. Verified live against `nj-a.thetadata.us:12000` on 2026-04-29 / 2026-04-30 with byte-match parity against the vendor terminal jar's CSV output for the same date.

## Versions

- `thetadatadx` 8.0.16 → 8.0.17
- `thetadatadx-py` 8.0.16 → 8.0.17
- `thetadatadx-napi` 8.0.16 → 8.0.17

## Test plan

- [ ] CI green on Format / Lint / Test / Cargo deny / Build FFI / SDK Bindings / Extended Surfaces
- [ ] Python + TypeScript + sdist wheels build clean
- [ ] `cargo run --example flatfile_demo -- --date 20260428 --format parquet` produces 1.88M-row option_open_interest output
- [ ] Roadmap reads accurately: FLATFILES Verified (no longer aspirational)

🤖 Generated with [Claude Code](https://claude.com/claude-code)