### PR TITLE
fix(thetadatadx): non-panicking Contract encoder; non-blocking session refresh; align workspace versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.17"
+version = "8.0.18"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.15"
+version = "8.0.18"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.15"
+version = "8.0.18"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.17"
+version = "8.0.18"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/benches/bench_protocol.rs
+++ b/crates/thetadatadx/benches/bench_protocol.rs
@@ -61,7 +61,7 @@ fn bench_build_subscribe_payload(c: &mut Criterion) {
     let contract = Contract::option("SPY", "20261218", "60", "C").unwrap();
     c.bench_function("build_subscribe_payload", |b| {
         b.iter(|| {
-            black_box(build_subscribe_payload(black_box(42), black_box(&contract)));
+            let _ = black_box(build_subscribe_payload(black_box(42), black_box(&contract)));
         });
     });
 }

--- a/crates/thetadatadx/src/auth/session.rs
+++ b/crates/thetadatadx/src/auth/session.rs
@@ -28,15 +28,26 @@
 
 use std::sync::Arc;
 
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use super::{authenticate_at, Credentials};
 use crate::error::Error;
 
 /// Opaque handle to a shared, mutable session UUID.
+///
+/// `state` is held under an `RwLock` so [`SessionToken::snapshot`] /
+/// [`SessionToken::current_uuid`] never block on a concurrent
+/// [`SessionToken::refresh`] — the Nexus round-trip happens with only
+/// `refresh_lock` held, and the write lock is taken only for the brief
+/// UUID swap.
 #[derive(Clone)]
 pub struct SessionToken {
-    inner: Arc<Mutex<Inner>>,
+    state: Arc<RwLock<Inner>>,
+    /// Serializes concurrent refresh attempts so N tasks observing the
+    /// same stale version dedupe into a single Nexus round-trip. The
+    /// network call itself runs while holding *only* this mutex —
+    /// readers continue to get fresh `state` snapshots throughout.
+    refresh_lock: Arc<Mutex<()>>,
 }
 
 struct Inner {
@@ -72,19 +83,21 @@ impl SessionToken {
     #[must_use]
     pub fn new(uuid: String, nexus_url: String, creds: Credentials) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(Inner {
+            state: Arc::new(RwLock::new(Inner {
                 uuid,
                 version: 0,
                 nexus_url,
                 creds,
             })),
+            refresh_lock: Arc::new(Mutex::new(())),
         }
     }
 
     /// Return a snapshot of the current token. Cheap — acquires the
-    /// async mutex briefly, clones the UUID, and releases.
+    /// state read lock briefly, clones the UUID, and releases. Never
+    /// blocks behind a concurrent Nexus round-trip.
     pub async fn snapshot(&self) -> SessionSnapshot {
-        let guard = self.inner.lock().await;
+        let guard = self.state.read().await;
         SessionSnapshot {
             uuid: guard.uuid.clone(),
             version: guard.version,
@@ -95,9 +108,12 @@ impl SessionToken {
     /// place. If another task already refreshed past `stale.version`,
     /// skip the round-trip and return the already-refreshed snapshot.
     ///
-    /// This is the knob used by the auto-refresh retry path: on
-    /// `Unauthenticated`, the caller snapshots, asks us to refresh
-    /// past that snapshot, and retries once with the resulting UUID.
+    /// The Nexus round-trip runs with only [`Self::refresh_lock`] held;
+    /// concurrent [`Self::snapshot`] / [`Self::current_uuid`] callers
+    /// continue to read the previous (still-valid) UUID throughout,
+    /// and the write lock is taken only for the millisecond swap once
+    /// the new UUID is in hand. Two concurrent refresh attempts at the
+    /// same stale version dedupe to a single Nexus call.
     ///
     /// # Errors
     ///
@@ -107,16 +123,39 @@ impl SessionToken {
     /// itself and an infinite refresh loop is worse than a surfaced
     /// error.
     pub async fn refresh(&self, stale: &SessionSnapshot) -> Result<SessionSnapshot, Error> {
-        let mut guard = self.inner.lock().await;
-        if guard.version != stale.version {
-            // Another task refreshed past us — hand the fresh token
-            // back without a redundant Nexus round-trip.
-            return Ok(SessionSnapshot {
-                uuid: guard.uuid.clone(),
-                version: guard.version,
-            });
+        // Fast path: someone may have already refreshed past `stale`.
+        {
+            let guard = self.state.read().await;
+            if guard.version != stale.version {
+                return Ok(SessionSnapshot {
+                    uuid: guard.uuid.clone(),
+                    version: guard.version,
+                });
+            }
         }
-        let resp = authenticate_at(&guard.nexus_url, &guard.creds).await?;
+
+        // Serialize refresh attempts. Inside this critical section the
+        // state RwLock is NOT held, so snapshot()/current_uuid() readers
+        // proceed unimpeded.
+        let _refresh_guard = self.refresh_lock.lock().await;
+
+        // Re-check under the refresh lock — another task may have done
+        // the work while we waited at the gate.
+        let (nexus_url, creds) = {
+            let guard = self.state.read().await;
+            if guard.version != stale.version {
+                return Ok(SessionSnapshot {
+                    uuid: guard.uuid.clone(),
+                    version: guard.version,
+                });
+            }
+            (guard.nexus_url.clone(), guard.creds.clone())
+        };
+
+        let resp = authenticate_at(&nexus_url, &creds).await?;
+
+        // Briefly take the write lock to swap the UUID + bump the version.
+        let mut guard = self.state.write().await;
         guard.uuid = resp.session_id;
         guard.version = guard.version.wrapping_add(1);
         metrics::counter!("thetadatadx.auth.refresh").increment(1);
@@ -136,7 +175,7 @@ impl SessionToken {
     ///
     /// [`snapshot`]: Self::snapshot
     pub async fn current_uuid(&self) -> String {
-        self.inner.lock().await.uuid.clone()
+        self.state.read().await.uuid.clone()
     }
 }
 
@@ -185,7 +224,7 @@ mod tests {
         // Manually bump the version without network to emulate the
         // "another task already refreshed" race.
         {
-            let mut guard = t.inner.lock().await;
+            let mut guard = t.state.write().await;
             guard.uuid = "v1".to_string();
             guard.version = 1;
         }

--- a/crates/thetadatadx/src/fpss/io_loop.rs
+++ b/crates/thetadatadx/src/fpss/io_loop.rs
@@ -603,7 +603,13 @@ pub(super) fn io_loop<F>(
 
         let writer = reader.get_mut();
         for (kind, contract) in &subs_snapshot {
-            let payload = protocol::build_subscribe_payload(-1, contract);
+            let payload = match protocol::build_subscribe_payload(-1, contract) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(error = %e, contract = %contract, "skipping re-subscribe; contract no longer encodes");
+                    continue;
+                }
+            };
             let code = kind.subscribe_code();
             if let Err(e) = write_raw_frame_no_flush(writer, code, &payload) {
                 tracing::warn!(error = %e, contract = %contract, "failed to re-subscribe on reconnect");

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -637,10 +637,11 @@ impl FpssClient {
 
     /// Internal subscribe implementation.
     fn subscribe(&self, kind: SubscriptionKind, contract: &Contract) -> Result<(), Error> {
+        contract.validate()?;
         self.check_connected()?;
 
         let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
-        let payload = build_subscribe_payload(req_id, contract);
+        let payload = build_subscribe_payload(req_id, contract)?;
         let code = kind.subscribe_code();
 
         self.send_cmd(IoCommand::WriteFrame { code, payload })?;
@@ -665,10 +666,11 @@ impl FpssClient {
 
     /// Internal unsubscribe implementation.
     fn unsubscribe(&self, kind: SubscriptionKind, contract: &Contract) -> Result<(), Error> {
+        contract.validate()?;
         self.check_connected()?;
 
         let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
-        let payload = build_subscribe_payload(req_id, contract);
+        let payload = build_subscribe_payload(req_id, contract)?;
         let code = kind.unsubscribe_code();
 
         self.send_cmd(IoCommand::WriteFrame { code, payload })?;

--- a/crates/thetadatadx/src/fpss/protocol.rs
+++ b/crates/thetadatadx/src/fpss/protocol.rs
@@ -376,19 +376,60 @@ impl Contract {
     ///
     /// Java's `fromBytes()` validates `len == size`, confirming the size byte
     /// counts itself.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Config`] if the contract root exceeds 16 bytes,
+    /// which is the maximum length accepted by Java's `Contract.toBytes()`.
+    /// All FPSS subscribe / unsubscribe paths surface this error to the
+    /// caller; user input is never permitted to panic the encoder.
+    pub fn try_to_bytes(&self) -> Result<Vec<u8>, Error> {
+        self.validate()?;
+        Ok(self.encode_unchecked())
+    }
+
+    /// Encode the contract on the wire, asserting the root length invariant.
+    ///
+    /// Use [`Contract::try_to_bytes`] for paths that accept user input. This
+    /// helper exists so the encoder can be inlined into hot loops once the
+    /// caller has already validated the contract.
+    ///
     /// # Panics
     ///
-    /// Panics if the contract root symbol exceeds 16 bytes (the maximum
-    /// length accepted by Java's `Contract.toBytes()`).
+    /// Panics if the root exceeds 16 bytes. Callers must call
+    /// [`Contract::validate`] first or originate the contract from a
+    /// validated source.
     #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
-        let root_bytes = self.root.as_bytes();
-        assert!(
-            root_bytes.len() <= 16,
-            "contract root too long: {} bytes (max 16 to match Java Contract.toBytes())",
-            root_bytes.len()
+        debug_assert!(
+            self.validate().is_ok(),
+            "Contract::to_bytes called with invalid root; use try_to_bytes for caller-supplied input"
         );
-        let root_len = u8::try_from(root_bytes.len()).expect("root length validated <= 16");
+        self.encode_unchecked()
+    }
+
+    /// Validate that the contract can be encoded on the FPSS wire.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Config`] if the root is empty or longer than 16
+    /// bytes. The 16-byte limit matches Java's `Contract.toBytes()`.
+    pub fn validate(&self) -> Result<(), Error> {
+        let len = self.root.len();
+        if len == 0 {
+            return Err(Error::Config("contract root is empty".into()));
+        }
+        if len > 16 {
+            return Err(Error::Config(format!(
+                "contract root too long: {len} bytes (max 16 to match Java Contract.toBytes())"
+            )));
+        }
+        Ok(())
+    }
+
+    fn encode_unchecked(&self) -> Vec<u8> {
+        let root_bytes = self.root.as_bytes();
+        let root_len = u8::try_from(root_bytes.len()).expect("validate() bounds root_len to <= 16");
 
         let is_option = self.sec_type == SecType::Option;
 
@@ -704,13 +745,18 @@ pub fn build_credentials_payload(username: &str, password: &str) -> Vec<u8> {
 ///
 /// The message code (21=QUOTE, 22=TRADE, `23=OPEN_INTEREST`) is set by the caller
 /// in the frame header; this function only builds the payload.
-#[must_use]
-pub fn build_subscribe_payload(req_id: i32, contract: &Contract) -> Vec<u8> {
-    let contract_bytes = contract.to_bytes();
+///
+/// # Errors
+///
+/// Returns [`Error::Config`] if the contract root is empty or longer
+/// than 16 bytes, surfacing the Java-parity invariant from
+/// [`Contract::try_to_bytes`].
+pub fn build_subscribe_payload(req_id: i32, contract: &Contract) -> Result<Vec<u8>, Error> {
+    let contract_bytes = contract.try_to_bytes()?;
     let mut buf = Vec::with_capacity(4 + contract_bytes.len());
     buf.extend_from_slice(&req_id.to_be_bytes());
     buf.extend_from_slice(&contract_bytes);
-    buf
+    Ok(buf)
 }
 
 /// Build a full-type subscription payload (subscribe to all contracts of a security type).
@@ -975,7 +1021,7 @@ mod tests {
     #[test]
     fn subscribe_payload_with_stock() {
         let contract = Contract::stock("MSFT");
-        let payload = build_subscribe_payload(42, &contract);
+        let payload = build_subscribe_payload(42, &contract).expect("valid root");
         // req_id(4) + contract(1+1+4+1 = 7) = 11
         assert_eq!(payload.len(), 11);
         let req_id = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
@@ -983,6 +1029,26 @@ mod tests {
         // Rest is the contract bytes
         let (parsed, _) = Contract::from_bytes(&payload[4..]).unwrap();
         assert_eq!(parsed, contract);
+    }
+
+    #[test]
+    fn build_subscribe_payload_rejects_oversize_root() {
+        let contract = Contract::stock("ABCDEFGHIJKLMNOPQ"); // 17 chars
+        let err = build_subscribe_payload(1, &contract).expect_err("too-long root must error");
+        match err {
+            Error::Config(msg) => assert!(msg.contains("too long")),
+            other => panic!("expected Error::Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_subscribe_payload_rejects_empty_root() {
+        let contract = Contract::stock("");
+        let err = build_subscribe_payload(1, &contract).expect_err("empty root must error");
+        match err {
+            Error::Config(msg) => assert!(msg.contains("empty")),
+            other => panic!("expected Error::Config, got {other:?}"),
+        }
     }
 
     #[test]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.15"
+version = "8.0.18"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.17"
+version = "8.0.18"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.17"
+version = "8.0.18"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.17"
+version = "8.0.18"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.17"
+version = "8.0.18"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.17"
+version = "8.0.18"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.17"
+version = "8.0.18"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.17",
+  "version": "8.0.18",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.17",
+  "version": "8.0.18",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.17",
+  "version": "8.0.18",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.11",
+  "version": "8.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "8.0.11",
+      "version": "8.0.18",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2"
@@ -15,9 +15,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "8.0.11",
-        "thetadatadx-linux-x64-gnu": "8.0.11",
-        "thetadatadx-win32-x64-msvc": "8.0.11"
+        "thetadatadx-darwin-arm64": "8.0.18",
+        "thetadatadx-linux-x64-gnu": "8.0.18",
+        "thetadatadx-win32-x64-msvc": "8.0.18"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.17",
+  "version": "8.0.18",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.17",
-    "thetadatadx-darwin-arm64": "8.0.17",
-    "thetadatadx-win32-x64-msvc": "8.0.17"
+    "thetadatadx-linux-x64-gnu": "8.0.18",
+    "thetadatadx-darwin-arm64": "8.0.18",
+    "thetadatadx-win32-x64-msvc": "8.0.18"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.15"
+version = "8.0.18"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.17"
+version = "8.0.18"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.15"
+version = "8.0.18"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.15"
+version = "8.0.18"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.17"
+version = "8.0.18"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.15"
+version = "8.0.18"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.15"
+version = "8.0.18"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

Three blocking findings from the repo-wide staff-engineer audit pass. None are FLATFILES-related (those landed in 8.0.17); these are pre-existing issues that the audit surfaced.

### Workspace version drift

ffi, tools/cli, tools/server, tools/mcp were still pinned to 8.0.15 while the SDK crates moved through 8.0.16 → 8.0.17. Workspace compiled, but shipped artifact metadata was unreliable. All crates / package.json files / npm package-lock entries now report 8.0.18.

### Contract panics on caller-supplied input

`Contract::stock` / `index` / `rate` / `option_raw` accept any `String`; the Java-parity wire encoder then `assert!(root.len() <= 16)`, which means a malformed ticker from a Python / TS / Go / C++ binding panics the entire SDK. Fixed:

- `Contract::validate()` — typed `Result<(), Error::Config>`.
- `Contract::try_to_bytes()` — fallible encoder for caller-supplied input.
- `build_subscribe_payload()` now returns `Result<Vec<u8>, Error>`.
- `FpssClient::{subscribe, unsubscribe}` validate before encoding.
- Reconnect re-subscribe loop logs and skips invalid contracts.

Net: malformed roots return `Error::Config` to every binding instead of crashing.

### SessionToken refresh blocked readers across Nexus RTT

`SessionToken::refresh` held a `tokio::Mutex` across `authenticate_at(...).await`, serializing every `snapshot()` / `current_uuid()` reader behind the network round-trip. Replaced with `tokio::RwLock<Inner>` for state + a separate `tokio::Mutex<()>` for refresh dedup. The Nexus call holds only the refresh mutex; readers continue against the previous UUID throughout. Concurrent-refresh dedup test still passes.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (287 lib + 104 + sundries; 0 fail)
- [x] `cargo deny check` (advisories ok, bans ok, licenses ok, sources ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)