### PR TITLE
refactor: lock-free MCP client cell; fallible FitRows accessor; document CLI clap invariant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/tdbe/src/codec/fit.rs
+++ b/crates/tdbe/src/codec/fit.rs
@@ -71,11 +71,28 @@ impl FitRows {
         self.num_columns
     }
 
-    /// Borrow the row at index `i`. Panics if `i >= self.len()`.
+    /// Borrow the row at index `i`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i >= self.len()`. Prefer [`Self::get`] in any path
+    /// that operates on caller-supplied indices.
     #[must_use]
     pub fn row(&self, i: usize) -> &[i32] {
-        let start = i * self.num_columns;
-        &self.data[start..start + self.num_columns]
+        self.get(i)
+            .unwrap_or_else(|| panic!("FitRows::row index out of bounds: {i} >= {}", self.len()))
+    }
+
+    /// Borrow the row at index `i`, returning `None` if out of bounds.
+    /// The fallible cousin of [`Self::row`].
+    #[must_use]
+    pub fn get(&self, i: usize) -> Option<&[i32]> {
+        if i >= self.len() {
+            return None;
+        }
+        let start = i.checked_mul(self.num_columns)?;
+        let end = start.checked_add(self.num_columns)?;
+        self.data.get(start..end)
     }
 
     /// Iterator over rows as slices.

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.18"
+version = "8.0.19"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/build_support/sdk_surface/templates/mcp/try_execute_preamble.rs.tmpl
+++ b/crates/thetadatadx/build_support/sdk_surface/templates/mcp/try_execute_preamble.rs.tmpl
@@ -1,5 +1,5 @@
 async fn try_execute_generated_utility(
-    client: &Option<ThetaDataDx>,
+    client: Option<&ThetaDataDx>,
     name: &str,
     args: &Value,
     start_time: std::time::Instant,

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.18"
+version = "8.0.19"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.18"
+version = "8.0.19"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.18"
+version = "8.0.19"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.18",
+  "version": "8.0.19",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.18",
+  "version": "8.0.19",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.18",
+  "version": "8.0.19",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.18",
+  "version": "8.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "8.0.18",
+      "version": "8.0.19",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2"
@@ -15,9 +15,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "8.0.18",
-        "thetadatadx-linux-x64-gnu": "8.0.18",
-        "thetadatadx-win32-x64-msvc": "8.0.18"
+        "thetadatadx-darwin-arm64": "8.0.19",
+        "thetadatadx-linux-x64-gnu": "8.0.19",
+        "thetadatadx-win32-x64-msvc": "8.0.19"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.18",
+  "version": "8.0.19",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.18",
-    "thetadatadx-darwin-arm64": "8.0.18",
-    "thetadatadx-win32-x64-msvc": "8.0.18"
+    "thetadatadx-linux-x64-gnu": "8.0.19",
+    "thetadatadx-darwin-arm64": "8.0.19",
+    "thetadatadx-win32-x64-msvc": "8.0.19"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.18"
+version = "8.0.19"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -110,10 +110,17 @@ fn build_cli() -> Command {
     app
 }
 
-/// Extract a string arg from clap matches, or panic with a clear message.
+/// Extract a clap-required string argument from the parsed matches.
+///
+/// All call sites pass a `name` that was declared with
+/// `Arg::new(name).required(true)`. Clap aborts argument parsing
+/// before `main` is invoked if a required argument is missing, so
+/// reaching the `None` branch here implies a clap configuration bug
+/// rather than user input. `unreachable!` documents that invariant
+/// and gives a clearer panic site than a chained `unwrap` would.
 fn get_arg<'a>(m: &'a ArgMatches, name: &str) -> &'a str {
     m.get_one::<String>(name).map_or_else(
-        || panic!("missing required argument: {name}"),
+        || unreachable!("clap-required argument {name:?} missing from matches; arg config bug"),
         std::string::String::as_str,
     )
 }

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.18"
+version = "8.0.19"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use serde::Serialize;
 use sonic_rs::{json, JsonContainerTrait, JsonValueMutTrait, JsonValueTrait, Value};
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::sync::RwLock;
+use tokio::sync::OnceCell;
 
 use thetadatadx::endpoint::{self, EndpointArgValue, EndpointArgs, EndpointError, EndpointOutput};
 use thetadatadx::{
@@ -771,7 +771,7 @@ macro_rules! param {
 include!("utilities.rs");
 
 async fn execute_tool(
-    client: &Option<ThetaDataDx>,
+    client: Option<&ThetaDataDx>,
     name: &str,
     args: &Value,
     start_time: std::time::Instant,
@@ -781,7 +781,7 @@ async fn execute_tool(
     }
 
     // ── Online tools (require connected client) ─────────────────────
-    let client = client.as_ref().ok_or_else(|| {
+    let client = client.ok_or_else(|| {
         ToolError::ServerError(
             "ThetaData client not connected. Set THETA_EMAIL + THETA_PASSWORD env vars or use --creds flag.".to_string(),
         )
@@ -810,11 +810,11 @@ async fn execute_tool(
 
 async fn handle_request(
     req: &JsonRpcRequest,
-    client: &Arc<RwLock<Option<ThetaDataDx>>>,
+    client: &Arc<OnceCell<ThetaDataDx>>,
     start_time: std::time::Instant,
 ) -> JsonRpcResponse {
-    let client = client.read().await;
-    let client = &*client;
+    // OnceCell::get is lock-free; no guard is held across the awaits below.
+    let client = client.get();
     let id = req.id.clone().unwrap_or(Value::new_null());
 
     match req.method.as_str() {
@@ -987,7 +987,7 @@ async fn main() {
     // on the ThetaData gRPC handshake (~800 ms).  Wrap the client in an
     // Arc<RwLock> so the background task can populate it while the stdin loop
     // is already running.
-    let client: Arc<RwLock<Option<ThetaDataDx>>> = Arc::new(RwLock::new(None));
+    let client: Arc<OnceCell<ThetaDataDx>> = Arc::new(OnceCell::new());
 
     if let Some(creds) = creds {
         let client_bg = Arc::clone(&client);
@@ -995,7 +995,9 @@ async fn main() {
             match ThetaDataDx::connect(&creds, DirectConfig::production()).await {
                 Ok(c) => {
                     tracing::info!("connected to ThetaData MDDS");
-                    *client_bg.write().await = Some(c);
+                    if client_bg.set(c).is_err() {
+                        tracing::warn!("client already initialised; dropping duplicate connect");
+                    }
                 }
                 Err(e) => {
                     tracing::error!(error = %e, "failed to connect to ThetaData, running in offline mode");

--- a/tools/mcp/src/utilities.rs
+++ b/tools/mcp/src/utilities.rs
@@ -48,7 +48,7 @@ fn push_generated_utility_tool_definitions(tools: &mut Vec<Value>) {
 }
 
 async fn try_execute_generated_utility(
-    client: &Option<ThetaDataDx>,
+    client: Option<&ThetaDataDx>,
     name: &str,
     args: &Value,
     start_time: std::time::Instant,

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.18"
+version = "8.0.19"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.18"
+version = "8.0.19"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

Final pass on the three NICE-TO-HAVE items the prior audit deferred. None are crash-bugs today; all three are tightenings a senior reviewer would flag at code-review time.

1. **tools/mcp**: `Arc<RwLock<Option<ThetaDataDx>>>` → `Arc<OnceCell<ThetaDataDx>>`. Removes the await-held read-guard pattern in the JSON-RPC handler before any reconnect / re-init logic lands.
2. **tools/cli**: `get_arg()` now uses `unreachable!()` with a documented clap-required invariant instead of `panic!()`.
3. **crates/tdbe**: `FitRows::row()` keeps its panic-on-OOB contract; new `FitRows::get()` returns `Option<&[i32]>` for caller-supplied indices and correctly handles the zero-column / empty-rows edge.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo deny check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)