### PR TITLE
docs(repo): document FLATFILES surface across READMEs, roadmap, and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,118 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.19] - 2026-04-30
+
+### Changed
+
+- `tools/mcp` replaced `Arc<RwLock<Option<ThetaDataDx>>>` with
+  `Arc<OnceCell<ThetaDataDx>>`. The JSON-RPC handler no longer holds
+  a read guard across awaited tool execution; `OnceCell::get` is
+  lock-free.
+- `tools/cli` `get_arg()` now uses `unreachable!()` with an explicit
+  invariant comment. All call sites declare the argument with clap's
+  `required(true)`, so the `None` branch indicates a clap config bug,
+  not user input.
+
+### Added
+
+- `crates/tdbe::FitRows::get()` returns `Option<&[i32]>` for
+  caller-supplied indices. The existing `FitRows::row()` keeps its
+  panic-on-OOB contract with a clearer message.
+
+## [8.0.18] - 2026-04-30
+
+### Fixed
+
+- Workspace version drift: `ffi`, `tools/cli`, `tools/server`, and
+  `tools/mcp` were pinned at 8.0.15 while the SDK crates moved
+  through 8.0.16 → 8.0.17. Every Rust crate, every npm
+  `package.json`, and the TypeScript `package-lock.json` now report
+  a single 8.0.18 surface.
+- `Contract::to_bytes()` no longer panics on caller input. New
+  `Contract::validate()` returns a typed `Result<(), Error::Config>`;
+  new `Contract::try_to_bytes()` is the fallible encoder.
+  `build_subscribe_payload()` now returns `Result<Vec<u8>, Error>`,
+  and `FpssClient::{subscribe, unsubscribe}` validate before
+  encoding. The reconnect re-subscribe loop logs and skips invalid
+  contracts instead of failing the whole reconnect. Net: malformed
+  roots flow back as `Error::Config` to every binding instead of
+  crashing the process.
+- `SessionToken::refresh` no longer holds a `tokio::Mutex` across the
+  Nexus `authenticate_at(...).await`. Replaced with
+  `tokio::RwLock<Inner>` for state plus a separate `tokio::Mutex<()>`
+  for refresh dedup. Concurrent `snapshot()` / `current_uuid()`
+  readers continue against the previous (still-valid) UUID
+  throughout.
+
+## [8.0.17] - 2026-04-30
+
+### Added
+
+- **FLATFILES** — third public surface alongside MDDS and FPSS.
+  Pulls one whole-universe INDEX + DATA blob per
+  `(SecType, ReqType, date)` tuple from
+  `nj-{a,b}.thetadata.us:12000` over a TLS PacketStream protocol
+  distinct from MDDS gRPC and FPSS streaming. Server identity pinned
+  to the production keypair via `MddsSpkiVerifier`. Login:
+  CREDENTIALS + VERSION → SESSION_TOKEN + METADATA, with PING
+  heartbeats during auth tolerated and terminal login errors
+  short-circuiting host retry. The raw download path uses async
+  `tokio::fs` with a 1 MB BufWriter; decode + write run on
+  `tokio::task::spawn_blocking` so FPSS / MDDS tasks on the same
+  runtime do not stall.
+- `crates/thetadatadx::flatfiles` module: `framing`, `mdds_spki`,
+  `session`, `request`, `index`, `decode`, `decoded`, `decoded_row`,
+  `format`, `types`, `writer`, `datatype` submodules.
+- Three free-function entry points: `flatfile_request`,
+  `flatfile_request_decoded`, `flatfile_request_raw`. Mirror methods
+  on the unified `ThetaDataDx` client. Convenience methods for the
+  option / stock × `{open_interest, trade_quote, trade, quote, eod}`
+  matrix.
+- Public types: `FlatFileFormat::{Csv, Jsonl}`, `SecType`, `ReqType`,
+  `FlatFileRow`, `FlatFileValue`, `FlatFilesUnavailableReason`.
+- `crates/thetadatadx/examples/flatfile_demo.rs` end-to-end CLI
+  example.
+- `crates/thetadatadx/tests/flatfiles_byte_match.rs` live integration
+  test (`live-tests` feature gate) that byte-matches CSV output
+  against the vendor terminal jar.
+
+### Changed
+
+- `tdbe` 0.12.0 → 0.12.1. Republishes the SSOT-generator enum surface
+  (`Interval`, `RequestType`, `Version`) so `thetadatadx` publish
+  resolves on crates.io.
+
+### Notes
+
+- Cross-language coverage of FLATFILES (CLI, MCP, REST/WS server,
+  FFI, Python, TypeScript, Go, C++) is tracked in the issue tracker;
+  the Rust core is shipped today. See `ROADMAP.md` for the binding
+  coverage matrix.
+
+## [8.0.16] - 2026-04-30
+
+### Added
+
+- `thetadatadx::utils` namespace exposes `conditions`, `exchange`,
+  `sequences` for tick post-processing without a separate `tdbe`
+  dependency.
+- Re-exports at the `thetadatadx` crate root for every tick struct
+  returned by an SDK method (`CalendarDay`, `EodTick`, `GreeksTick`,
+  `InterestRateTick`, `IvTick`, `MarketValueTick`, `OhlcTick`,
+  `OpenInterestTick`, `OptionContract`, `PriceTick`, `QuoteTick`,
+  `TradeQuoteTick`, `TradeTick`), the enums named on those structs
+  (`DataType`, `Interval`, `RateType`, `RemoveReason`, `RequestType`,
+  `Right`, `SecType`, `StreamMsgType`, `StreamResponseType`, `Venue`,
+  `Version`), `Price`, and the offline Greeks helpers (`all_greeks`,
+  `implied_volatility`, `GreeksResult`).
+
+### Changed
+
+- `ROADMAP.md` aligned with the 2026-04-20 validator run (127 PASS /
+  7 subscription-tier-blocked / 0 FAIL) and the 2026-04-29 / 04-30
+  FLATFILES live run.
+
 ## [8.0.15] - 2026-04-24
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,14 @@
 Thank you for your interest in contributing. This guide covers everything
 you need to get started.
 
+The SDK speaks three independent ThetaData surfaces — MDDS (gRPC), FPSS
+(streaming), and FLATFILES (whole-universe daily blobs). When opening
+an issue or PR that touches any of them, name the surface in the title
+prefix: `feat(mdds): ...`, `feat(fpss): ...`, `feat(flatfiles): ...`.
+Cross-language binding parity is tracked under separate per-binding
+issues; see [`ROADMAP.md`](./ROADMAP.md#flatfiles--binding-coverage)
+for the FLATFILES coverage matrix.
+
 ## Prerequisites
 
 - **Rust stable** (see `rust-toolchain.toml` - includes rustfmt and clippy)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rust SDK for ThetaData market data — single Rust core, five language surfaces 
 [![Docs](https://img.shields.io/docsrs/thetadatadx)](https://docs.rs/thetadatadx)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2.svg?logo=discord&logoColor=white)](https://discord.thetadata.us/)
 
-`thetadatadx` is a native Rust SDK for [ThetaData](https://thetadata.us) market data. It connects directly to ThetaData's MDDS (historical, gRPC) and FPSS (real-time, TCP) services, decodes ticks in-process, and exposes a typed surface across Rust, Python, TypeScript, Go, and C++ from a single Rust core. No JVM, no subprocess, no IPC serialization.
+`thetadatadx` is a native Rust SDK for [ThetaData](https://thetadata.us) market data. It connects directly to ThetaData's three public surfaces — MDDS (historical request/response over gRPC), FPSS (real-time streaming over TCP), and FLATFILES (whole-universe daily blobs over the legacy MDDS port) — decodes ticks in-process, and exposes a typed API across Rust, Python, TypeScript, Go, and C++ from a single Rust core. No JVM, no subprocess, no IPC serialization.
 
 > [!IMPORTANT]
 > A valid [ThetaData](https://thetadata.us) subscription is required. The SDK authenticates against ThetaData's Nexus API using your account credentials.
@@ -22,7 +22,8 @@ Rust SDK for ThetaData market data — single Rust core, five language surfaces 
 - **SPKI-pinned FPSS TLS.** Public-key pinning on the FPSS streaming handshake.
 - **FIT decoder + SPSC ring buffer** on the FPSS path. Decode cost is measured in the benchmarks under `crates/thetadatadx/benches/`.
 - **Shared FFI layer.** Go, C++, and Node.js go through the same `extern "C"` layer; the Python wheel uses PyO3 ABI3 directly.
-- **Covers the MDDS gRPC endpoints and FPSS wire format.** Reconnect semantics follow the terminal protocol. See the [parity checklist](docs/java-parity-checklist.md).
+- **Covers all three public surfaces.** MDDS gRPC endpoints, FPSS wire format with reconnect semantics, and the FLATFILES daily-blob protocol — every transport speaks directly to ThetaData's production servers from a single client. See the [parity checklist](docs/java-parity-checklist.md) and the [vendor flat-file reference](https://http-docs.thetadata.us/operations/get-v2-flat-file-getting-started.html).
+- **FLATFILES daily blobs.** Pull whole-universe `(sec_type, req_type, date)` blobs over the legacy MDDS port; decode to vendor-byte CSV, JSONL, or a typed `Vec<FlatFileRow>` in memory. Cross-language coverage is tracked under the binding issues; the Rust core is shipped today.
 
 ## Quick start
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -127,9 +127,26 @@ Wire layer: TLS PacketStream (`[u32 size][u16 msg][i64 id][payload]`) with SPKI 
 | `flatfile_stock_quote(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
 | `flatfile_stock_eod(date, format)` | Stock-flatfile bundle | Subscription-tier-blocked |
 
-Output formats: **CSV** (vendor-byte-equivalent), **Parquet** (zstd, columnar), **JSONL**. All three reproducible from `crates/thetadatadx/examples/flatfile_demo.rs`.
+Output formats: **CSV** (vendor-byte-equivalent), **JSONL**, plus a typed in-memory `Vec<FlatFileRow>`. All three reproducible from `crates/thetadatadx/examples/flatfile_demo.rs`. Columnar consumers (Parquet, Arrow IPC, polars) drive their own writer from the in-memory entry point — the SDK does not pull in Parquet or Arrow itself.
 
 Server retention window: 7 calendar days. Older history: contact ThetaData sales for a deeper-history bundle.
+
+### FLATFILES — Binding Coverage
+
+| Binding | Status | Tracking |
+|---------|--------|----------|
+| Rust (`crates/thetadatadx`) | Shipped | v8.0.17 |
+| FFI (`ffi/`) | Pending | #434 |
+| CLI (`tools/cli`) | Pending | #433 |
+| MCP (`tools/mcp`) | Pending | #431 |
+| REST/WS server (`tools/server`) | Pending | #432 |
+| Python (`sdks/python`) | Pending | #435 |
+| TypeScript (`sdks/typescript`) | Pending | #436 |
+| Go (`sdks/go`) | Pending | #437 |
+| C++ (`sdks/cpp`) | Pending | #438 |
+| `sdk_surface.toml` declarative spec | Pending | #439 |
+
+`#439` (extending `sdk_surface.toml` and the per-target renderers) is the upstream blocker for the binding issues — once the spec carries the flatfile method kinds, a single `cargo build` regenerates every binding.
 
 ## FPSS — Streaming Status
 

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -1,6 +1,6 @@
 # thetadatadx
 
-Core Rust crate - direct wire-protocol access to ThetaData's MDDS (gRPC) and FPSS (TCP) servers.
+Core Rust crate — direct wire-protocol access to all three of ThetaData's public surfaces: MDDS (request/response history over gRPC), FPSS (real-time streaming over TCP), and FLATFILES (whole-universe daily blobs over the legacy MDDS port).
 
 This is the engine that powers all ThetaDataDx SDKs (Python, TypeScript/Node.js, Go, C++, CLI, MCP, REST server).
 
@@ -22,9 +22,20 @@ tdx.subscribe_quotes(&Contract::stock("AAPL"))?;
 
 // When done
 tdx.stop_streaming();
+
+// Flat files - per-call TLS to the legacy MDDS port (12000).
+use thetadatadx::flatfiles::{FlatFileFormat, ReqType, SecType};
+let csv_path = tdx
+    .flatfile_request(SecType::Option, ReqType::OpenInterest, "20240315", "oi.csv", FlatFileFormat::Csv)
+    .await?;
+
+// Or pull straight into memory for an algorithm:
+let rows = tdx
+    .flatfile_request_decoded(SecType::Option, ReqType::OpenInterest, "20240315")
+    .await?;
 ```
 
-`ThetaDataDx::connect()` authenticates once. Historical data (MDDS gRPC) is available immediately via `Deref` to the internal `MddsClient`. Streaming (FPSS TCP) connects lazily when you call `start_streaming()`.
+`ThetaDataDx::connect()` authenticates once. Historical data (MDDS gRPC) is available immediately via `Deref` to the internal `MddsClient`. Streaming (FPSS TCP) connects lazily when you call `start_streaming()`. Flat-file requests (FLATFILES) open a per-call TLS connection to the legacy MDDS port and are independent of the MDDS gRPC and FPSS sessions — see [vendor docs](https://http-docs.thetadata.us/operations/get-v2-flat-file-getting-started.html) for the full flat-file matrix.
 
 ## Crate Layout
 

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -5,9 +5,9 @@ description: Complete API reference for the ThetaDataDx SDK covering all endpoin
 
 # API Reference
 
-ThetaDataDx provides a unified client for accessing ThetaData market data. Historical data flows over MDDS/gRPC; real-time streaming flows over FPSS/TCP. The SDK ships native bindings for Rust, Python, TypeScript/Node.js, Go, and C++, all backed by the same compiled Rust core.
+ThetaDataDx provides a unified client for accessing ThetaData market data across three public surfaces: historical request/response (MDDS over gRPC), real-time streaming (FPSS over TCP), and whole-universe daily blobs (FLATFILES over the legacy MDDS port). The SDK ships native bindings for Rust, Python, TypeScript/Node.js, Go, and C++, all backed by the same compiled Rust core.
 
-Complete typed historical surface + 4 streaming variants + 22 Greeks functions + IV solver.
+Complete typed historical surface + 4 streaming variants + the FLATFILES daily-blob surface (Rust today; cross-language bindings tracked under the FLATFILES roadmap section) + 22 Greeks functions + IV solver.
 
 ## Client Construction
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,118 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.19] - 2026-04-30
+
+### Changed
+
+- `tools/mcp` replaced `Arc<RwLock<Option<ThetaDataDx>>>` with
+  `Arc<OnceCell<ThetaDataDx>>`. The JSON-RPC handler no longer holds
+  a read guard across awaited tool execution; `OnceCell::get` is
+  lock-free.
+- `tools/cli` `get_arg()` now uses `unreachable!()` with an explicit
+  invariant comment. All call sites declare the argument with clap's
+  `required(true)`, so the `None` branch indicates a clap config bug,
+  not user input.
+
+### Added
+
+- `crates/tdbe::FitRows::get()` returns `Option<&[i32]>` for
+  caller-supplied indices. The existing `FitRows::row()` keeps its
+  panic-on-OOB contract with a clearer message.
+
+## [8.0.18] - 2026-04-30
+
+### Fixed
+
+- Workspace version drift: `ffi`, `tools/cli`, `tools/server`, and
+  `tools/mcp` were pinned at 8.0.15 while the SDK crates moved
+  through 8.0.16 → 8.0.17. Every Rust crate, every npm
+  `package.json`, and the TypeScript `package-lock.json` now report
+  a single 8.0.18 surface.
+- `Contract::to_bytes()` no longer panics on caller input. New
+  `Contract::validate()` returns a typed `Result<(), Error::Config>`;
+  new `Contract::try_to_bytes()` is the fallible encoder.
+  `build_subscribe_payload()` now returns `Result<Vec<u8>, Error>`,
+  and `FpssClient::{subscribe, unsubscribe}` validate before
+  encoding. The reconnect re-subscribe loop logs and skips invalid
+  contracts instead of failing the whole reconnect. Net: malformed
+  roots flow back as `Error::Config` to every binding instead of
+  crashing the process.
+- `SessionToken::refresh` no longer holds a `tokio::Mutex` across the
+  Nexus `authenticate_at(...).await`. Replaced with
+  `tokio::RwLock<Inner>` for state plus a separate `tokio::Mutex<()>`
+  for refresh dedup. Concurrent `snapshot()` / `current_uuid()`
+  readers continue against the previous (still-valid) UUID
+  throughout.
+
+## [8.0.17] - 2026-04-30
+
+### Added
+
+- **FLATFILES** — third public surface alongside MDDS and FPSS.
+  Pulls one whole-universe INDEX + DATA blob per
+  `(SecType, ReqType, date)` tuple from
+  `nj-{a,b}.thetadata.us:12000` over a TLS PacketStream protocol
+  distinct from MDDS gRPC and FPSS streaming. Server identity pinned
+  to the production keypair via `MddsSpkiVerifier`. Login:
+  CREDENTIALS + VERSION → SESSION_TOKEN + METADATA, with PING
+  heartbeats during auth tolerated and terminal login errors
+  short-circuiting host retry. The raw download path uses async
+  `tokio::fs` with a 1 MB BufWriter; decode + write run on
+  `tokio::task::spawn_blocking` so FPSS / MDDS tasks on the same
+  runtime do not stall.
+- `crates/thetadatadx::flatfiles` module: `framing`, `mdds_spki`,
+  `session`, `request`, `index`, `decode`, `decoded`, `decoded_row`,
+  `format`, `types`, `writer`, `datatype` submodules.
+- Three free-function entry points: `flatfile_request`,
+  `flatfile_request_decoded`, `flatfile_request_raw`. Mirror methods
+  on the unified `ThetaDataDx` client. Convenience methods for the
+  option / stock × `{open_interest, trade_quote, trade, quote, eod}`
+  matrix.
+- Public types: `FlatFileFormat::{Csv, Jsonl}`, `SecType`, `ReqType`,
+  `FlatFileRow`, `FlatFileValue`, `FlatFilesUnavailableReason`.
+- `crates/thetadatadx/examples/flatfile_demo.rs` end-to-end CLI
+  example.
+- `crates/thetadatadx/tests/flatfiles_byte_match.rs` live integration
+  test (`live-tests` feature gate) that byte-matches CSV output
+  against the vendor terminal jar.
+
+### Changed
+
+- `tdbe` 0.12.0 → 0.12.1. Republishes the SSOT-generator enum surface
+  (`Interval`, `RequestType`, `Version`) so `thetadatadx` publish
+  resolves on crates.io.
+
+### Notes
+
+- Cross-language coverage of FLATFILES (CLI, MCP, REST/WS server,
+  FFI, Python, TypeScript, Go, C++) is tracked in the issue tracker;
+  the Rust core is shipped today. See `ROADMAP.md` for the binding
+  coverage matrix.
+
+## [8.0.16] - 2026-04-30
+
+### Added
+
+- `thetadatadx::utils` namespace exposes `conditions`, `exchange`,
+  `sequences` for tick post-processing without a separate `tdbe`
+  dependency.
+- Re-exports at the `thetadatadx` crate root for every tick struct
+  returned by an SDK method (`CalendarDay`, `EodTick`, `GreeksTick`,
+  `InterestRateTick`, `IvTick`, `MarketValueTick`, `OhlcTick`,
+  `OpenInterestTick`, `OptionContract`, `PriceTick`, `QuoteTick`,
+  `TradeQuoteTick`, `TradeTick`), the enums named on those structs
+  (`DataType`, `Interval`, `RateType`, `RemoveReason`, `RequestType`,
+  `Right`, `SecType`, `StreamMsgType`, `StreamResponseType`, `Venue`,
+  `Version`), `Price`, and the offline Greeks helpers (`all_greeks`,
+  `implied_volatility`, `GreeksResult`).
+
+### Changed
+
+- `ROADMAP.md` aligned with the 2026-04-20 validator run (127 PASS /
+  7 subscription-tier-blocked / 0 FAIL) and the 2026-04-29 / 04-30
+  FLATFILES live run.
+
 ## [8.0.15] - 2026-04-24
 
 ### Fixed

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "ThetaDataDx"
   text: "Rust SDK for ThetaData market data"
-  tagline: "Historical (MDDS gRPC) and real-time (FPSS) surfaces plus a local Greeks calculator, exposed in Rust, Python, TypeScript, Go, and C++ from a single Rust core."
+  tagline: "Three public surfaces — historical request/response (MDDS gRPC), real-time streaming (FPSS), and whole-universe daily blobs (FLATFILES) — plus a local Greeks calculator, exposed in Rust, Python, TypeScript, Go, and C++ from a single Rust core."
   actions:
     - theme: brand
       text: Get Started

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,11 +10,13 @@ graph LR
         Nexus["Nexus API<br/>nexus-api.thetadata.us<br/>POST /identity/terminal/auth_user"]
         MDDS["MDDS<br/>mdds-01.thetadata.us:443<br/>gRPC server-streaming<br/>60 RPC methods"]
         FPSS["FPSS<br/>nj-a.thetadata.us:20000/20001<br/>nj-b.thetadata.us:20000/20001<br/>Custom TLS/TCP protocol"]
+        FLATFILES["FLATFILES<br/>nj-a.thetadata.us:12000/12001<br/>nj-b.thetadata.us:12000/12001<br/>TLS PacketStream<br/>Whole-universe daily blobs"]
     end
 
     App -->|"HTTPS<br/>email + password"| Nexus
     App -->|"gRPC over TLS<br/>session UUID in QueryInfo"| MDDS
     App -->|"TLS/TCP<br/>email + password<br/>FIT-encoded ticks"| FPSS
+    App -->|"TLS PacketStream<br/>email + password<br/>INDEX + DATA blob"| FLATFILES
 
     Nexus -. "session UUID" .-> App
 ```

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -1,8 +1,10 @@
 # thetadatadx-ffi
 
-C FFI layer for `thetadatadx` - exposes the Rust SDK as `extern "C"` functions.
+C FFI layer for `thetadatadx` — exposes the Rust SDK as `extern "C"` functions.
 
 Compiled as both `cdylib` (shared library) and `staticlib` (archive). Consumed by the Go (CGo), C++ (RAII), and TypeScript/Node.js (napi-rs) SDKs.
+
+> **FLATFILES coverage:** the FFI layer currently exposes the MDDS (historical) and FPSS (streaming) surfaces only. The third surface — FLATFILES whole-universe daily blobs — is shipped in the Rust core (v8.0.17+) and is being added to the C ABI under issue [#434](https://github.com/userFRM/ThetaDataDx/issues/434). The Go (#437) and C++ (#438) bindings track this issue as their upstream blocker. See [`ROADMAP.md`](../ROADMAP.md#flatfiles--binding-coverage) for the per-binding status.
 
 ## Building
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -2,6 +2,8 @@
 
 Interactive Jupyter notebooks demonstrating the `thetadatadx` Python SDK. Each notebook is self-contained and progresses from basics to advanced real-time streaming.
 
+> **FLATFILES coverage:** the existing notebooks cover the MDDS (historical) and FPSS (streaming) surfaces. A FLATFILES notebook walking through whole-universe daily blobs is tracked alongside the Python binding work — see issue [#435](https://github.com/userFRM/ThetaDataDx/issues/435) and the per-binding flat-file demos issue [#445](https://github.com/userFRM/ThetaDataDx/issues/445). Once the Python binding ships flat-file methods, a `notebooks/flat-files/` directory will land here.
+
 ## Prerequisites
 
 ```bash

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -4,6 +4,8 @@ C++ SDK for ThetaData market data. Header-only RAII wrappers over the `thetadata
 
 Every call crosses the C ABI boundary into compiled Rust: gRPC communication, protobuf parsing, zstd decompression, and TCP streaming run inside the `thetadatadx` crate.
 
+> **FLATFILES coverage:** the C++ binding currently exposes the MDDS (historical) and FPSS (streaming) surfaces only. The third surface — FLATFILES whole-universe daily blobs — is shipped in the Rust core (v8.0.17+) and is being wired through the FFI layer (issue [#434](https://github.com/userFRM/ThetaDataDx/issues/434)) into C++ under issue [#438](https://github.com/userFRM/ThetaDataDx/issues/438). See [`ROADMAP.md`](../../ROADMAP.md#flatfiles--binding-coverage) for the per-binding status.
+
 ## Prerequisites
 
 - C++17 compiler

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -4,6 +4,8 @@ Go SDK for ThetaData market data. CGo bindings over the `thetadatadx` Rust crate
 
 Every call crosses the CGo boundary into compiled Rust: gRPC communication, protobuf parsing, zstd decompression, and TCP streaming run inside the `thetadatadx` crate.
 
+> **FLATFILES coverage:** the Go binding currently exposes the MDDS (historical) and FPSS (streaming) surfaces only. The third surface — FLATFILES whole-universe daily blobs — is shipped in the Rust core (v8.0.17+) and is being wired through the FFI layer (issue [#434](https://github.com/userFRM/ThetaDataDx/issues/434)) into Go under issue [#437](https://github.com/userFRM/ThetaDataDx/issues/437). See [`ROADMAP.md`](../../ROADMAP.md#flatfiles--binding-coverage) for the per-binding status.
+
 ## Prerequisites
 
 - Go 1.21+

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -2,6 +2,8 @@
 
 Python bindings over the Rust core. Every call crosses the PyO3 boundary into Rust: gRPC communication, protobuf parsing, zstd decompression, FIT tick decoding, and TCP streaming run inside the `thetadatadx` crate.
 
+> **FLATFILES coverage:** the Python binding currently exposes the MDDS (historical) and FPSS (streaming) surfaces only. The third surface — FLATFILES whole-universe daily blobs — is shipped in the Rust core (v8.0.17+) and is being wired into Python under issue [#435](https://github.com/userFRM/ThetaDataDx/issues/435). See [`ROADMAP.md`](../../ROADMAP.md#flatfiles--binding-coverage) for the per-binding status.
+
 ## Installation
 
 ```bash

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -4,6 +4,8 @@ Node.js SDK for ThetaData market data. napi-rs bindings over the `thetadatadx` R
 
 Every call crosses the napi boundary into compiled Rust: gRPC, protobuf, zstd, FIT decoding, and TCP streaming run inside the `thetadatadx` crate.
 
+> **FLATFILES coverage:** the TypeScript binding currently exposes the MDDS (historical) and FPSS (streaming) surfaces only. The third surface — FLATFILES whole-universe daily blobs — is shipped in the Rust core (v8.0.17+) and is being wired into TypeScript under issue [#436](https://github.com/userFRM/ThetaDataDx/issues/436). See [`ROADMAP.md`](../../ROADMAP.md#flatfiles--binding-coverage) for the per-binding status.
+
 ## Install
 
 ```bash

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -1,6 +1,8 @@
-# tdx - ThetaDataDx CLI
+# tdx — ThetaDataDx CLI
 
 Command-line interface for querying ThetaData market data.
+
+> **FLATFILES coverage:** the CLI currently exposes the MDDS (historical request/response) and FPSS (streaming) surfaces only. The third surface — FLATFILES whole-universe daily blobs — is shipped in the Rust core (v8.0.17+) and is being wired into the CLI under issue [#433](https://github.com/userFRM/ThetaDataDx/issues/433). See [`ROADMAP.md`](../../ROADMAP.md#flatfiles--binding-coverage) for the per-binding status.
 
 ## Install
 

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -1,6 +1,8 @@
 # thetadatadx-mcp
 
-MCP (Model Context Protocol) server for [ThetaDataDx](https://github.com/userFRM/ThetaDataDx) - gives any LLM instant access to ThetaData market data via structured tool calls over stdio JSON-RPC 2.0.
+MCP (Model Context Protocol) server for [ThetaDataDx](https://github.com/userFRM/ThetaDataDx) — gives any LLM instant access to ThetaData market data via structured tool calls over stdio JSON-RPC 2.0.
+
+> **FLATFILES coverage:** the MCP server currently exposes the MDDS (historical) and FPSS (streaming) surfaces only. The third surface — FLATFILES whole-universe daily blobs — is shipped in the Rust core (v8.0.17+) and is being wired into the MCP tool list under issue [#431](https://github.com/userFRM/ThetaDataDx/issues/431). See [`ROADMAP.md`](../../ROADMAP.md#flatfiles--binding-coverage) for the per-binding status.
 
 ## Architecture
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -4,6 +4,8 @@ Runs a local HTTP REST server and WebSocket server that expose the ThetaData `/v
 
 Existing clients using the current `/v3/*` local terminal routes can point at this binary on the same port.
 
+> **FLATFILES coverage:** the REST/WS server currently exposes the MDDS and FPSS surfaces only. The third surface — FLATFILES whole-universe daily blobs — is shipped in the Rust core (v8.0.17+) and is being wired into the route surface under issue [#432](https://github.com/userFRM/ThetaDataDx/issues/432). See [`ROADMAP.md`](../../ROADMAP.md#flatfiles--binding-coverage) for the per-binding status.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary

Bring FLATFILES — the third public ThetaData surface, shipped in v8.0.17 — into every customer-facing doc surface.

- Top-level README + `crates/thetadatadx/README.md`: list three surfaces, Highlights bullet, Rust quick-start.
- `ROADMAP.md`: new "FLATFILES — Binding Coverage" matrix mapping each binding to its tracking issue (#431-#439).
- `CHANGELOG.md` + `docs-site/docs/changelog.md`: backfill v8.0.16-v8.0.19 entries.
- `docs/architecture.md`: add FLATFILES to the system overview diagram.
- `docs-site/docs/index.md` + `api-reference.md`: hero tagline + preamble list three surfaces.
- Per-binding READMEs (`sdks/{python,typescript,go,cpp}`, `tools/{cli,mcp,server}`, `ffi`): coverage callout linking to the upstream tracking issue.

Vendor reference: https://http-docs.thetadata.us/operations/get-v2-flat-file-getting-started.html

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo fmt --all`
- [ ] CI green (no code changes; doc/manifest only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)