### PR TITLE
fix(flatfiles): decode prices through tdbe::Price; preserve full f64 precision in CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.20] - 2026-04-30
+
+### Fixed
+
+- **FLATFILES price decoding was off by powers of ten across every output
+  format.** The CSV / JSONL writers and the typed in-memory `FlatFileRow`
+  return path were dividing the wire integer by `10^N` where N was read
+  directly from the row's `PRICE_TYPE` column. The vendor convention is
+  `real_price = value * 10^(price_type - 10)` (see
+  [`tdbe::types::price::Price`]), so for `price_type = 8` (cents) the
+  correct factor is `0.01` (i.e. `value / 10^2`), not `value / 10^8` —
+  off by **10^6**. Effect: option `bid` / `ask` / `price` columns came
+  out near-zero (e.g. `1.9e-6` instead of `1.90`), and the CSV
+  `{:.4}`-formatted output rounded those to `0.0000`. Every consumer of
+  the flat-file pipeline was affected.
+- The CSV price formatter no longer hardcodes 4 fractional digits.
+  Rust's default `f64` Display now preserves the full IEEE-754
+  precision the wire decoder produced, so micro-priced contracts
+  survive the on-disk round-trip.
+
+### Changed
+
+- `flatfiles::writer::price_divisor` (private API) replaced with
+  `price_type_for_row` + `decode_price`. Both new helpers route price
+  decoding through `tdbe::types::price::Price::to_f64()`, which is the
+  authoritative implementation of the ThetaData price convention.
+- The `OPTION/OPEN_INTEREST` byte-match integration test still passes —
+  open-interest rows have no price columns, so the test never exercised
+  the broken formatter. A new unit test
+  (`decode_price_uses_vendor_semantics`) locks the corrected
+  behaviour, and `fmt_price_preserves_full_precision` asserts that
+  micro-priced rows do not round to zero.
+
 ## [8.0.19] - 2026-04-30
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.19"
+version = "8.0.20"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/src/flatfiles/decoded.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded.rs
@@ -234,7 +234,7 @@ pub(crate) fn decode_to_memory(raw_path: &Path, sec: SecType) -> Result<Vec<Flat
         let block = &data_bytes[bs..be];
         decode_block(block, n_columns, &mut rows_buf)?;
         for row in &rows_buf {
-            let divisor = crate::flatfiles::writer::price_divisor(row, hdr.price_type_idx);
+            let pt = crate::flatfiles::writer::price_type_for_row(row, hdr.price_type_idx);
             out.push(FlatFileRow::from_decoded(
                 &entry.root,
                 entry.exp,
@@ -243,7 +243,7 @@ pub(crate) fn decode_to_memory(raw_path: &Path, sec: SecType) -> Result<Vec<Flat
                 &hdr.fmt,
                 row,
                 &data_idx,
-                divisor,
+                pt,
             ));
         }
     }

--- a/crates/thetadatadx/src/flatfiles/decoded_row.rs
+++ b/crates/thetadatadx/src/flatfiles/decoded_row.rs
@@ -44,6 +44,10 @@ impl FlatFileRow {
     /// Build a row from the decoded data slice plus the schema. Callers
     /// at the decode layer use this to avoid open-coding the column
     /// projection in two places.
+    ///
+    /// `price_type` carries the row's PRICE_TYPE column value (vendor
+    /// `Price.price_type`). `None` means the schema has no PRICE_TYPE
+    /// column, so price-bearing values are emitted as raw integers.
     pub(crate) fn from_decoded(
         root: &str,
         expiration: Option<i32>,
@@ -52,15 +56,19 @@ impl FlatFileRow {
         fmt: &[DataType],
         data: &[i32],
         data_idx: &[usize],
-        divisor: Option<f64>,
+        price_type: Option<i32>,
     ) -> Self {
         let mut fields = Vec::with_capacity(data_idx.len());
         for &i in data_idx {
             let val = data.get(i).copied().unwrap_or(0);
             let dt = fmt[i];
             let cell = if dt.is_price() {
-                let d = divisor.unwrap_or(1.0);
-                FlatFileValue::Price((val as f64) / d)
+                match price_type {
+                    Some(pt) => {
+                        FlatFileValue::Price(crate::flatfiles::writer::decode_price(val, pt))
+                    }
+                    None => FlatFileValue::Int(val),
+                }
             } else {
                 FlatFileValue::Int(val)
             };

--- a/crates/thetadatadx/src/flatfiles/writer.rs
+++ b/crates/thetadatadx/src/flatfiles/writer.rs
@@ -61,30 +61,32 @@ pub(crate) fn data_indices(fmt: &[DataType], price_type_idx: Option<usize>) -> V
         .collect()
 }
 
-/// Per-row price divisor.
+/// Per-row PRICE_TYPE exponent for `tdbe::Price` decoding.
 ///
 /// When PRICE_TYPE is in the schema, the value at that column is the
-/// exponent N, so the price = `int_value / 10^N`. With no PRICE_TYPE
-/// column the multiplier is 1 (i.e. the integer IS the price already, in
-/// vendor convention) — the vendor's `toCSV2` does not call
-/// `PriceCalc.fmtPrice` in that branch, so emitting the integer
-/// unchanged matches the reference output.
-pub(crate) fn price_divisor(row: &[i32], price_type_idx: Option<usize>) -> Option<f64> {
-    price_type_idx.map(|idx| {
-        let n = row.get(idx).copied().unwrap_or(0);
-        let n = n.clamp(0, 18) as u32;
-        10f64.powi(n as i32)
-    })
+/// vendor `price_type` field (real price = `value * 10^(price_type - 10)`).
+/// When PRICE_TYPE is absent, the column is not a price (the vendor's
+/// `toCSV2` does not call `PriceCalc.fmtPrice` in that branch), so the
+/// integer value is emitted unchanged.
+pub(crate) fn price_type_for_row(row: &[i32], price_type_idx: Option<usize>) -> Option<i32> {
+    price_type_idx.map(|idx| row.get(idx).copied().unwrap_or(0))
 }
 
-/// Format a price value in vendor style: divide by `10^N`, render with
-/// 4 fractional digits and **no trailing-zero stripping** (the vendor's
-/// `PriceCalc.fmtPrice(builder, value, 4)` is fixed-precision).
-pub(crate) fn fmt_price_into(buf: &mut String, integer: i32, divisor: f64) {
+/// Convert a wire `(value, price_type)` pair to its real f64 price using
+/// the canonical [`tdbe::types::price::Price`] semantics. Returns 0.0 for
+/// `price_type == 0` (vendor sentinel for "no price").
+pub(crate) fn decode_price(integer: i32, price_type: i32) -> f64 {
+    tdbe::types::price::Price::new(integer, price_type).to_f64()
+}
+
+/// Render the decoded price using Rust's default `f64` Display, which
+/// preserves the full IEEE-754 precision the wire decoder produced. For
+/// micro-priced contracts (sub-cent options) this is the only viable
+/// representation — fixed-point rendering rounds those to zero.
+pub(crate) fn fmt_price_into(buf: &mut String, integer: i32, price_type: i32) {
     use std::fmt::Write;
-    let v = (integer as f64) / divisor;
-    // Match vendor: 4 decimals, no exponent, no thousands separator.
-    let _ = write!(buf, "{v:.4}");
+    let v = decode_price(integer, price_type);
+    let _ = write!(buf, "{v}");
 }
 
 /// Build the contract-prefix segment of a CSV row.
@@ -163,15 +165,15 @@ impl RowSink for CsvSink {
     fn write_row(&mut self, row: RowView<'_>) -> Result<(), Error> {
         self.line.clear();
         append_csv_prefix(&mut self.line, row.entry, self.sec);
-        let divisor = price_divisor(row.data, self.price_type_idx);
+        let pt = price_type_for_row(row.data, self.price_type_idx);
         for (n, &i) in self.data_idx.iter().enumerate() {
             if n > 0 {
                 self.line.push(',');
             }
             let val = row.data.get(i).copied().unwrap_or(0);
             if self.fmt[i].is_price() {
-                if let Some(d) = divisor {
-                    fmt_price_into(&mut self.line, val, d);
+                if let Some(t) = pt {
+                    fmt_price_into(&mut self.line, val, t);
                 } else {
                     use std::fmt::Write;
                     let _ = write!(self.line, "{val}");
@@ -258,13 +260,13 @@ impl RowSink for JsonlSink {
                 );
             }
         }
-        let divisor = price_divisor(row.data, self.price_type_idx);
+        let pt = price_type_for_row(row.data, self.price_type_idx);
         for &i in &self.data_idx {
             let val = row.data.get(i).copied().unwrap_or(0);
             let key = self.fmt[i].name().into_owned();
             let v = if self.fmt[i].is_price() {
-                if let Some(d) = divisor {
-                    let f = (val as f64) / d;
+                if let Some(t) = pt {
+                    let f = decode_price(val, t);
                     serde_json::Number::from_f64(f)
                         .map(serde_json::Value::Number)
                         .unwrap_or(serde_json::Value::Null)
@@ -312,26 +314,33 @@ mod tests {
     }
 
     #[test]
-    fn price_divisor_clamped() {
-        let row = vec![0, 0, 4, 0]; // PRICE_TYPE = 4
-        let d = price_divisor(&row, Some(2)).unwrap();
-        assert!((d - 10_000f64).abs() < 1e-9);
+    fn price_type_for_row_reads_column() {
+        let row = vec![0, 0, 8, 0]; // PRICE_TYPE = 8 (cents)
+        assert_eq!(price_type_for_row(&row, Some(2)), Some(8));
+        assert_eq!(price_type_for_row(&row, None), None);
     }
 
     #[test]
-    fn price_divisor_negative_clamped_to_zero() {
-        let row = vec![-1];
-        let d = price_divisor(&row, Some(0)).unwrap();
-        assert!((d - 1.0).abs() < 1e-9);
+    fn decode_price_uses_vendor_semantics() {
+        // PRICE_TYPE = 8 means real = value * 0.01 (cents).
+        assert!((decode_price(15025, 8) - 150.25).abs() < 1e-9);
+        // PRICE_TYPE = 10 means real = value (integer).
+        assert!((decode_price(150, 10) - 150.0).abs() < 1e-9);
+        // PRICE_TYPE = 0 is the vendor "no price" sentinel.
+        assert_eq!(decode_price(123, 0), 0.0);
+        // Sub-cent micro-pricing: PRICE_TYPE = 4 => value * 1e-6.
+        assert!((decode_price(19, 4) - 1.9e-5).abs() < 1e-12);
     }
 
     #[test]
-    fn fmt_price_four_decimals() {
+    fn fmt_price_preserves_full_precision() {
         let mut s = String::new();
-        fmt_price_into(&mut s, 15025, 10_000.0);
-        assert_eq!(s, "1.5025");
+        fmt_price_into(&mut s, 15025, 8);
+        assert_eq!(s, "150.25");
         s.clear();
-        fmt_price_into(&mut s, 0, 10_000.0);
-        assert_eq!(s, "0.0000");
+        // Micro-priced option: must NOT round to 0.
+        fmt_price_into(&mut s, 19, 4);
+        assert!(s.starts_with("0.0000") || s.contains("e-"), "got {s:?}");
+        assert_ne!(s, "0.0000");
     }
 }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.20] - 2026-04-30
+
+### Fixed
+
+- **FLATFILES price decoding was off by powers of ten across every output
+  format.** The CSV / JSONL writers and the typed in-memory `FlatFileRow`
+  return path were dividing the wire integer by `10^N` where N was read
+  directly from the row's `PRICE_TYPE` column. The vendor convention is
+  `real_price = value * 10^(price_type - 10)` (see
+  [`tdbe::types::price::Price`]), so for `price_type = 8` (cents) the
+  correct factor is `0.01` (i.e. `value / 10^2`), not `value / 10^8` —
+  off by **10^6**. Effect: option `bid` / `ask` / `price` columns came
+  out near-zero (e.g. `1.9e-6` instead of `1.90`), and the CSV
+  `{:.4}`-formatted output rounded those to `0.0000`. Every consumer of
+  the flat-file pipeline was affected.
+- The CSV price formatter no longer hardcodes 4 fractional digits.
+  Rust's default `f64` Display now preserves the full IEEE-754
+  precision the wire decoder produced, so micro-priced contracts
+  survive the on-disk round-trip.
+
+### Changed
+
+- `flatfiles::writer::price_divisor` (private API) replaced with
+  `price_type_for_row` + `decode_price`. Both new helpers route price
+  decoding through `tdbe::types::price::Price::to_f64()`, which is the
+  authoritative implementation of the ThetaData price convention.
+- The `OPTION/OPEN_INTEREST` byte-match integration test still passes —
+  open-interest rows have no price columns, so the test never exercised
+  the broken formatter. A new unit test
+  (`decode_price_uses_vendor_semantics`) locks the corrected
+  behaviour, and `fmt_price_preserves_full_precision` asserts that
+  micro-priced rows do not round to zero.
+
 ## [8.0.19] - 2026-04-30
 
 ### Changed

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.19"
+version = "8.0.20"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.19"
+version = "8.0.20"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.19"
+version = "8.0.20"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.19",
+  "version": "8.0.20",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.19",
+  "version": "8.0.20",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.19",
+  "version": "8.0.20",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.19",
+  "version": "8.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "8.0.19",
+      "version": "8.0.20",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2"
@@ -15,9 +15,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "8.0.19",
-        "thetadatadx-linux-x64-gnu": "8.0.19",
-        "thetadatadx-win32-x64-msvc": "8.0.19"
+        "thetadatadx-darwin-arm64": "8.0.20",
+        "thetadatadx-linux-x64-gnu": "8.0.20",
+        "thetadatadx-win32-x64-msvc": "8.0.20"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.19",
+  "version": "8.0.20",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.19",
-    "thetadatadx-darwin-arm64": "8.0.19",
-    "thetadatadx-win32-x64-msvc": "8.0.19"
+    "thetadatadx-linux-x64-gnu": "8.0.20",
+    "thetadatadx-darwin-arm64": "8.0.20",
+    "thetadatadx-win32-x64-msvc": "8.0.20"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.19"
+version = "8.0.20"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.19"
+version = "8.0.20"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.19"
+version = "8.0.20"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.19"
+version = "8.0.20"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Problem

FLATFILES price decoding was off by powers of ten across every output format (CSV, JSONL, in-memory `FlatFileRow`). The writer divided the wire integer by `10^N` where N was the row's `PRICE_TYPE` column value; the vendor convention is `real_price = value * 10^(price_type - 10)` per `tdbe::types::price::Price`. For `PRICE_TYPE = 8` (cents) the correct factor is `value * 0.01` — my code applied `value / 10^8`, off by **10^6**. Option `bid` / `ask` / `price` came out near-zero (e.g. `1.9e-6` instead of `1.90`), and the CSV's `{:.4}` formatter then rounded those to `0.0000`.

The `OPEN_INTEREST` byte-match integration test still passed because OI rows carry no price columns; the broken formatter was never exercised by the test.

## Fix

- Replace the private `price_divisor` helper with `price_type_for_row` + `decode_price`. Both route through `tdbe::types::price::Price::to_f64()`, the authoritative implementation of the ThetaData price convention.
- CSV price formatter drops the hardcoded 4-digit precision and uses Rust's default `f64` Display so micro-priced contracts survive the on-disk round-trip.
- Add two unit tests: `decode_price_uses_vendor_semantics` (PRICE_TYPE values 0, 4, 8, 10) and `fmt_price_preserves_full_precision` (asserts micro-priced rows do not round to zero).

Workspace bumped to **8.0.20**.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p thetadatadx --lib flatfiles` — 29 / 29 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)