### PR TITLE
fix: Java-parity wrap, row_number_i64 clamp, synthetic flatfiles golden, Greek doc count

### DIFF
--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -102,7 +102,12 @@ jobs:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/release
           CGO_LDFLAGS: -L${{ github.workspace }}/target/release
         run: cd sdks/go && go run ./cmd/fpss_smoke ../../creds.txt
-      - name: FLATFILES byte-match
+      - name: FLATFILES synthetic golden (decoder)
+        # Runs against a hand-built blob in the repo; no live wire. This
+        # is the always-on regression gate for the FIT decoder + CSV
+        # writer. Fast and deterministic.
+        run: cargo test --test flatfiles_synthetic_golden -- --nocapture
+      - name: FLATFILES byte-match (vendor reference)
         run: |
           # The byte-match test panics when THETADATADX_REFERENCE_CSV /
           # THETADATADX_REFERENCE_EOD_CSV is set but the file is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.22] - 2026-05-01
+
+### Fixed
+
+- **`fpss::accumulator::change_price_type` now matches the JVM terminal's
+  `PriceCalcUtils.changePriceType` byte-for-byte.** v8.0.21 widened the
+  multiplication through `i64` and returned the unscaled input on
+  overflow, which broke parity with the Java reference (Java `int * int`
+  silently wraps under two's-complement). The rescale now uses
+  `i32::wrapping_mul`, reproducing the JVM's exact wire bits in both
+  debug and release. Tests pin the wrapping result to manually-computed
+  Java-equivalent values (e.g. `2_148 * 10^6 → -2_146_967_296`).
+- **`decode::row_number_i64` clamps `price_type` to `0..=19`** so the
+  same wire cell decodes identically through `row_number_i64` and
+  `row_price_f64` (the latter routes through `tdbe::Price::new`, which
+  has clamped to that range since it was introduced). Under the clamped
+  contract, `i32::MAX * 10^9 ≈ 2.15e18` is well below `i64::MAX`, so
+  scale-up cannot overflow and the previous `Price overflowing i64`
+  error path is no longer reachable.
+
+### Added
+
+- `crates/thetadatadx/tests/flatfiles_synthetic_golden.rs` — a
+  deterministic decoder-only golden test that builds a synthetic
+  FLATFILES blob (header + INDEX + FIT-encoded DATA) in Rust and pins
+  the CSV writer's output byte-for-byte. Runs in plain `cargo test`
+  with no live wire and no env var, giving CI a hard regression gate
+  on the FIT decoder, INDEX walker, and price formatter on every push.
+
+### Changed
+
+- Documentation references to "22 Greeks" updated to "23 Greeks" to
+  reflect the `vera` field added in v8.0.21. Touches the `tdbe`
+  README + module docs, the `thetadatadx` README tick-types table,
+  and the Python and C++ SDK READMEs.
+
 ## [8.0.21] - 2026-04-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tdbe/README.md
+++ b/crates/tdbe/README.md
@@ -11,7 +11,7 @@ The `thetadatadx` client crate depends on `tdbe` for type definitions.
 |--------|----------|
 | `types` | `Price`, `SecType`, `DataType`, `StreamMsgType`, and the generated tick structs (`TradeTick`, `QuoteTick`, `EodTick`, `OhlcTick`, ...) |
 | `codec` | FIT nibble decoder and FIE string encoder used by FPSS tick compression |
-| `greeks` | Full Black-Scholes calculator: 22 Greeks + IV bisection solver |
+| `greeks` | Full Black-Scholes calculator: 23 Greeks + IV bisection solver |
 | `flags` | Bit flags and condition codes for market data records |
 | `latency` | Wire-to-application latency computation (`latency_ns`) |
 | `error` | Encoding-layer error types |

--- a/crates/tdbe/src/lib.rs
+++ b/crates/tdbe/src/lib.rs
@@ -7,7 +7,7 @@
 //! - **Price** -- fixed-point price encoding used by `ThetaData`
 //! - **Enums** -- [`SecType`], [`DataType`], [`StreamMsgType`](types::enums::StreamMsgType), etc.
 //! - **FIT/FIE codecs** -- 4-bit nibble encoding for FPSS tick compression
-//! - **Greeks** -- Black-Scholes option pricing (22 Greeks + IV solver)
+//! - **Greeks** -- Black-Scholes option pricing (23 Greeks + IV solver)
 //! - **Error** -- encoding-layer error types
 //! - **Flags** -- bit flags and condition codes for market data records
 //!

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.21"
+version = "8.0.22"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -40,7 +40,7 @@ frames = ["polars", "arrow"]
 live-tests = []
 
 [dependencies]
-tdbe = { version = "0.12.2", path = "../tdbe" }
+tdbe = { version = "0.12.3", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }
@@ -132,7 +132,7 @@ prost-build = "=0.14.3"
 regex = "1.12.3"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
-tdbe = { version = "0.12.2", path = "../tdbe" }
+tdbe = { version = "0.12.3", path = "../tdbe" }
 
 [[bench]]
 name = "bench_decode"

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -96,7 +96,7 @@ endpoint declarations.
 | `TradeQuoteTick` | 26 | Combined trade + quote |
 | `OpenInterestTick` | 3 | Open interest |
 | `MarketValueTick` | 7 | Market cap, shares out, etc. |
-| `GreeksTick` | 24 | All 22 Greeks + ms_of_day + date |
+| `GreeksTick` | 25 | All 23 Greeks + ms_of_day + date |
 | `IvTick` | 4 | Implied volatility + error |
 | `PriceTick` | 4 | Index price |
 | `CalendarDay` | 5 | Market open/close schedule |

--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -617,11 +617,16 @@ pub(crate) fn row_text(
 /// with the EodTick `volume`/`count` widening (where on high-volume
 /// symbols the values exceed `i32::MAX`).
 ///
+/// `price_type` is clamped to `0..=19` to match
+/// [`tdbe::types::price::Price::new`], so the same wire cell decodes
+/// identically through this function and [`row_price_f64`].
+///
 /// # Errors
 ///
-/// Returns `DecodeError::TypeMismatch` for any other cell variant, or
-/// when a `Price` cell's scale-up overflows `i64`. Returns
-/// `DecodeError::MissingCell` for an out-of-bounds column index.
+/// Returns `DecodeError::TypeMismatch` for any other cell variant. Returns
+/// `DecodeError::MissingCell` for an out-of-bounds column index. Under the
+/// clamped `0..=19` price-type contract, scale-up cannot overflow `i64`
+/// (max product is `i32::MAX * 10^9 ≈ 2.15e18`, well under `i64::MAX`).
 pub(crate) fn row_number_i64(
     row: &proto::DataValueList,
     idx: usize,
@@ -633,22 +638,26 @@ pub(crate) fn row_number_i64(
         Some(proto::data_value::DataType::Number(n)) => Ok(Some(*n)),
         Some(proto::data_value::DataType::Price(p)) => {
             // Vendor convention: real_value = value * 10^(type - 10).
-            // Positive exp scales up; negative exp scales down. v == 0
-            // short-circuits to 0 so a zero price never trips the
-            // scale-up overflow guard.
+            // Clamp `type` to 0..=19 to match `tdbe::Price::new`, so the
+            // same wire cell decodes identically through `row_price_f64`
+            // and `row_number_i64`. Positive exp scales up; negative exp
+            // scales down. v == 0 short-circuits to 0 so a zero price
+            // never trips the scale-up overflow guard.
             let v = i64::from(p.value);
             if v == 0 {
                 return Ok(Some(0));
             }
-            let exp = p.r#type - 10;
+            let price_type = p.r#type.clamp(0, 19);
+            let exp = price_type - 10;
+            // After clamping, exp ∈ [-10, 9]. Scale-up: i32::MAX * 10^9
+            // ≈ 2.147e18 < i64::MAX (≈ 9.22e18), so checked_mul cannot
+            // overflow. checked_mul preserves the contract anyway.
             let scaled = if exp >= 0 {
                 10i64
                     .checked_pow(exp.unsigned_abs())
                     .and_then(|m| v.checked_mul(m))
-            } else if exp >= -18 {
-                Some(v / 10i64.pow(exp.unsigned_abs()))
             } else {
-                Some(0)
+                Some(v / 10i64.pow(exp.unsigned_abs()))
             };
             match scaled {
                 Some(n) => Ok(Some(n)),
@@ -1477,8 +1486,7 @@ mod tests {
         );
     }
 
-    /// Pin a Price cell past `2^53` to the i64-native result. Overflow
-    /// is covered by `row_number_i64_price_overflowing_i64_returns_error`.
+    /// Pin a Price cell past `2^53` to the i64-native result for `type=17`.
     #[test]
     fn row_number_i64_price_cell_returns_bit_exact_i64() {
         let row = row_of(vec![dv_price(1_073_741_823, 17)]);
@@ -1487,29 +1495,57 @@ mod tests {
         assert!(got > (1_i64 << 53));
     }
 
-    /// `value == 0` decodes to 0 regardless of the exponent, even for
-    /// `price_type` values that would otherwise overflow the scale-up
-    /// guard. Mathematically the product is zero; the decoder must not
-    /// reject a zero cell.
+    /// `value == 0` decodes to 0 regardless of the exponent. Mathematically
+    /// the product is zero; the decoder must not reject a zero cell, even
+    /// when `price_type` is at the clamp boundary.
     #[test]
     fn row_number_i64_price_zero_value_short_circuits() {
-        let row = row_of(vec![dv_price(0, 20)]);
+        let row = row_of(vec![dv_price(0, 19)]);
         assert_eq!(row_number_i64(&row, 0), Ok(Some(0)));
     }
 
-    /// `Price { value: i32::MAX, type: 20 }` rescales by 10^10 — overflows i64.
-    /// The new path surfaces this as a clean `TypeMismatch` rather than a
-    /// silent saturation through `f64 as i64`.
+    /// `row_number_i64` and `row_price_f64` must agree on the same wire
+    /// cell. With `type=19` (in-range) and `value=42`, `row_price_f64`
+    /// routes through `Price::new` which keeps `price_type=19`, and
+    /// `row_number_i64` produces the i64-native scale. Both should match.
+    /// Manual: 42 * 10^(19-10) = 42 * 10^9 = 42_000_000_000.
     #[test]
-    fn row_number_i64_price_overflowing_i64_returns_error() {
-        let row = row_of(vec![dv_price(i32::MAX, 20)]);
+    fn row_number_i64_matches_row_price_f64_at_type_19() {
+        let row = row_of(vec![dv_price(42, 19)]);
+        let as_int = row_number_i64(&row, 0).unwrap().expect("Some");
+        let as_float = row_price_f64(&row, 0).unwrap().expect("Some");
+        assert_eq!(as_int, 42_000_000_000_i64);
+        assert!((as_float - 42_000_000_000.0_f64).abs() < 1.0);
+    }
+
+    /// `price_type=20` is out-of-range; both decoders must clamp to 19
+    /// (matching `Price::new`). A `type=20` cell and a `type=19` cell with
+    /// the same value must therefore decode to the same i64.
+    #[test]
+    fn row_number_i64_clamps_price_type_above_19() {
+        let row_clamped = row_of(vec![dv_price(7, 20)]);
+        let row_in_range = row_of(vec![dv_price(7, 19)]);
         assert_eq!(
-            row_number_i64(&row, 0),
-            Err(DecodeError::TypeMismatch {
-                column: 0,
-                expected: "i64-fitting Price",
-                observed: "Price overflowing i64",
-            })
+            row_number_i64(&row_clamped, 0).unwrap(),
+            row_number_i64(&row_in_range, 0).unwrap(),
+        );
+        // Pin the absolute value too: 7 * 10^9 = 7_000_000_000.
+        assert_eq!(
+            row_number_i64(&row_clamped, 0).unwrap(),
+            Some(7_000_000_000_i64)
+        );
+    }
+
+    /// Maximum scale-up under the clamped contract: `value=i32::MAX,
+    /// type=19` yields `i32::MAX * 10^9 = 2_147_483_647_000_000_000`,
+    /// which is below `i64::MAX = 9_223_372_036_854_775_807`. The product
+    /// must fit and decode bit-exact (no `TypeMismatch`).
+    #[test]
+    fn row_number_i64_max_in_range_price_fits_i64() {
+        let row = row_of(vec![dv_price(i32::MAX, 19)]);
+        assert_eq!(
+            row_number_i64(&row, 0).unwrap(),
+            Some(2_147_483_647_000_000_000_i64),
         );
     }
 

--- a/crates/thetadatadx/src/fpss/accumulator.rs
+++ b/crates/thetadatadx/src/fpss/accumulator.rs
@@ -102,14 +102,13 @@ impl OhlcvcAccumulator {
 }
 
 /// Convert a price from one `price_type` to another (mirrors Java
-/// `PriceCalcUtils.changePriceType`). Multiplication widens through `i64`;
-/// when the widened result does not fit back in `i32` the function returns
-/// the input price unchanged and traces a warning. Result is never a
-/// wrapped value.
-// Reason: protocol-defined integer widths from Java FPSS specification.
-#[allow(clippy::cast_possible_truncation)]
+/// `PriceCalcUtils.changePriceType`). The JVM terminal performs `int * int`
+/// which silently wraps on overflow under Java's two's-complement semantics;
+/// downstream consumers depend on that exact wire-bit pattern, so we use
+/// `wrapping_mul` to reproduce it byte-for-byte. Plain `*` would panic in
+/// debug Rust on the same inputs that the JVM accepts without comment.
 pub(super) fn change_price_type(price: i32, price_type: i32, new_price_type: i32) -> i32 {
-    const POW10: [i64; 10] = [
+    const POW10: [i32; 10] = [
         1,
         10,
         100,
@@ -128,30 +127,19 @@ pub(super) fn change_price_type(price: i32, price_type: i32, new_price_type: i32
     if exp <= 0 {
         let idx = usize::try_from(-exp).unwrap_or(0);
         if idx < POW10.len() {
-            // Widen to i64 before multiplying. The Java reference silently
-            // wraps; we instead catch the overflow, return the original
-            // price, and trace.
-            let scaled = i64::from(price) * POW10[idx];
-            if let Ok(narrowed) = i32::try_from(scaled) {
-                narrowed
-            } else {
-                tracing::warn!(
-                    price,
-                    price_type,
-                    new_price_type,
-                    "change_price_type: rescale overflows i32; returning unscaled price (accumulator may go stale)"
-                );
-                price
-            }
+            // Match Java terminal's `int * int` wrap; differs from Rust's
+            // default `*` which panics in debug. wrapping_mul makes the
+            // overflow contract explicit and debug-safe.
+            price.wrapping_mul(POW10[idx])
         } else {
             price
         }
     } else {
         let idx = usize::try_from(exp).unwrap_or(0);
         if idx < POW10.len() {
-            // Down-scale via i64 division — never overflows for valid
-            // (price, idx) since |i32| / 10^k <= |i32|.
-            (i64::from(price) / POW10[idx]) as i32
+            // Down-scale by integer division. |i32| / 10^k <= |i32|, so this
+            // never overflows; mirrors Java's `int / int` exactly.
+            price / POW10[idx]
         } else {
             0
         }
@@ -226,35 +214,47 @@ mod tests {
         assert_eq!(change_price_type(2_147, 6, 0), 2_147_000_000);
     }
 
-    /// One unit past the boundary: 2_148 * 10^6 = 2_148_000_000 > i32::MAX.
-    /// Must fall back to the original price unchanged (no panic, no wrap).
+    /// One unit past the boundary: 2_148 * 10^6 = 2_148_000_000.
+    ///
+    /// Java semantics: `int * int` wraps mod 2^32. Manual calculation:
+    ///   2_148 * 1_000_000 = 2_148_000_000 (mathematical)
+    ///   2_148_000_000 - 2^32 = 2_148_000_000 - 4_294_967_296 = -2_146_967_296
+    /// JVM terminal emits -2_146_967_296 on the wire and we mirror it.
     #[test]
-    fn change_price_type_overflow_returns_original_price() {
-        assert_eq!(change_price_type(2_148, 6, 0), 2_148);
+    fn change_price_type_wraps_like_java_at_2148() {
+        assert_eq!(change_price_type(2_148, 6, 0), -2_146_967_296);
     }
 
-    /// BRK.A in cents: 71_396_865 rescaled by 10^4 = 7.14e11, hard-overflows i32.
-    /// Must return the original price unchanged.
+    /// BRK.A in cents: 71_396_865 rescaled by 10^4.
+    ///
+    /// Manual calculation under two's-complement wrap:
+    ///   71_396_865 * 10_000 = 713_968_650_000
+    ///   713_968_650_000 mod 2^32 = 713_968_650_000 - 166 * 4_294_967_296
+    ///                            = 713_968_650_000 - 712_964_571_136
+    ///                            = 1_004_078_864
+    /// 1_004_078_864 < 2^31 so the signed result is +1_004_078_864.
+    /// This matches what `PriceCalcUtils.changePriceType` returns in the JVM.
     #[test]
-    fn change_price_type_brk_a_overflow_no_op() {
-        assert_eq!(change_price_type(71_396_865, 8, 4), 71_396_865);
+    fn change_price_type_brk_a_wraps_like_java() {
+        assert_eq!(change_price_type(71_396_865, 8, 4), 1_004_078_864);
     }
 
-    /// A second tick at a price_type whose rescale to the accumulator's
-    /// pricetype overflows i32 must be a no-op, leaving high/low/close
-    /// at the unscaled value rather than a wrapped one.
+    /// A second tick whose rescale wraps under Java semantics must produce
+    /// the same wrapped value the JVM terminal would compute, so accumulator
+    /// state stays bit-identical to the reference implementation.
+    /// 71_396_865 * 10_000 wraps to +1_004_078_864 (see test above).
     #[test]
-    fn ohlcvc_accumulator_overflow_rescale_is_no_op() {
+    fn ohlcvc_accumulator_rescale_matches_java_wrap() {
         let mut acc = OhlcvcAccumulator::new();
         acc.process_trade(34200000, 71_396_865, 1, 4, 20240315);
         assert_eq!(acc.price_type, 4);
         assert_eq!(acc.high, 71_396_865);
-        assert_eq!(acc.low, 71_396_865);
-        assert_eq!(acc.close, 71_396_865);
-        // Tick at price_type=8 needs *10^4 to rescale into pricetype=4.
+        // Tick at price_type=8 needs *10^4 to rescale into pricetype=4 and
+        // wraps to +1_004_078_864, which exceeds the prior high.
         acc.process_trade(34200100, 71_396_865, 1, 8, 20240315);
-        assert_eq!(acc.high, 71_396_865);
+        assert_eq!(acc.high, 1_004_078_864);
+        assert_eq!(acc.close, 1_004_078_864);
+        // Low stays at the original (smaller) value.
         assert_eq!(acc.low, 71_396_865);
-        assert_eq!(acc.close, 71_396_865);
     }
 }

--- a/crates/thetadatadx/tests/flatfiles_synthetic_golden.rs
+++ b/crates/thetadatadx/tests/flatfiles_synthetic_golden.rs
@@ -1,0 +1,165 @@
+//! Decoder-only golden test for the FLATFILES surface.
+//!
+//! Builds a synthetic raw blob (header + INDEX + FIT-encoded DATA) in
+//! Rust against a hand-computed CSV expectation, then exercises the
+//! same `decode_to_file` driver the live byte-match path uses. The
+//! whole test runs in plain `cargo test` — no live wire, no env vars,
+//! no vendor jar — so CI gets a hard regression gate on every push
+//! whether or not the live byte-match step is wired up.
+//!
+//! Coverage: header parse, schema decoding, INDEX walk for an option
+//! contract, FIT block decode (absolute row + delta row), CSV row
+//! formatting, and the price formatter via `PRICE_TYPE` propagation.
+
+use std::io::Write;
+
+use thetadatadx::flatfiles::{FlatFileFormat, SecType};
+
+/// Pack two 4-bit nibbles into one byte (high nibble first). Mirrors
+/// the convention the FIT codec uses on the wire.
+fn pack(high: u8, low: u8) -> u8 {
+    (high << 4) | (low & 0x0F)
+}
+
+/// FIT field separator. Flushes the current integer to the output slot
+/// and advances the slot index.
+const FIELD_SEP: u8 = 0xB;
+/// FIT row terminator. Flushes the current integer and ends the row.
+const END: u8 = 0xD;
+
+/// Build a minimal valid FLATFILES blob with one option contract and
+/// two rows (one absolute, one FIT-delta) in the DATA section.
+///
+/// Schema: `[MsOfDay (1), Bid (103), PriceType (4), Date (0)]`
+/// — a price-bearing schema so the test covers `fmt_price_into`.
+fn synthetic_option_blob() -> Vec<u8> {
+    // ----- Header -----
+    let mut blob: Vec<u8> = Vec::new();
+    let fmt_codes: [i32; 4] = [1, 103, 4, 0]; // ms_of_day, bid, price_type, date
+    blob.write_all(&i32::to_be_bytes(fmt_codes.len() as i32))
+        .unwrap();
+    for c in fmt_codes {
+        blob.write_all(&i32::to_be_bytes(c)).unwrap();
+    }
+
+    // We will splice index_byte_len and data_byte_len after we build the
+    // sections, so reserve two i64 BE slots and remember their offsets.
+    let index_len_pos = blob.len();
+    blob.write_all(&i64::to_be_bytes(0)).unwrap();
+    let data_len_pos = blob.len();
+    blob.write_all(&i64::to_be_bytes(0)).unwrap();
+
+    // ----- INDEX (one option entry pointing at the whole DATA section) -----
+    let mut index: Vec<u8> = Vec::new();
+    // Entry payload for an option: u8 root_len + root + i32 exp + u8 right
+    // + i32 strike + i32 contract_date. The contract_date is unused by
+    // the writer (per-row DATE column wins), so any value is fine.
+    let root = b"SPY";
+    let mut payload: Vec<u8> = Vec::new();
+    payload.push(root.len() as u8);
+    payload.extend_from_slice(root);
+    payload.write_all(&i32::to_be_bytes(20240315)).unwrap(); // exp
+    payload.push(b'C'); // right
+    payload.write_all(&i32::to_be_bytes(580_000)).unwrap(); // strike (tenths of a cent → $580.00)
+    payload.write_all(&i32::to_be_bytes(20240315)).unwrap(); // contract_date
+
+    index
+        .write_all(&u16::to_be_bytes(payload.len() as u16))
+        .unwrap();
+    index.extend_from_slice(&payload);
+    index.write_all(&i32::to_be_bytes(0)).unwrap(); // volume hint (unused)
+
+    // ----- DATA (FIT-encoded, two rows for the same contract) -----
+    //
+    // Row 1 absolute: ms_of_day=34_200_000, bid=12345 (price_type=8 →
+    // 123.45), price_type=8, date=20_240_315.
+    // Encoded as plain decimal nibbles separated by 0xB and terminated
+    // with 0xD. 34_200_000 has 8 digits → bytes "3 4 2 0 0 0 0 0",
+    // then FIELD_SEP (0xB), then "1 2 3 4 5", FIELD_SEP, "8", FIELD_SEP,
+    // "2 0 2 4 0 3 1 5", END.
+    //
+    // Total nibbles for row 1:
+    //   8 (ms_of_day) + 1 (sep) + 5 (bid) + 1 (sep) + 1 (pt) + 1 (sep)
+    //   + 8 (date) + 1 (END) = 26 nibbles → 13 bytes.
+    let row1_nibbles: [u8; 26] = [
+        3, 4, 2, 0, 0, 0, 0, 0, FIELD_SEP, 1, 2, 3, 4, 5, FIELD_SEP, 8, FIELD_SEP, 2, 0, 2, 4, 0,
+        3, 1, 5, END,
+    ];
+    let mut data: Vec<u8> = Vec::new();
+    for w in row1_nibbles.chunks(2) {
+        data.push(pack(w[0], w[1]));
+    }
+    // Row 2 delta: ms_of_day += 100, bid += 5, price_type unchanged,
+    // date carried forward. Encoded as "100", FIELD_SEP, "5", END
+    // (price_type and date columns are not emitted, so the FIT decoder
+    // will return n=2 fields and `apply_deltas` carries the trailing
+    // columns from the previous row).
+    //   3 (100) + 1 (sep) + 1 (5) + 1 (END) = 6 nibbles → 3 bytes.
+    let row2_nibbles: [u8; 6] = [1, 0, 0, FIELD_SEP, 5, END];
+    for w in row2_nibbles.chunks(2) {
+        data.push(pack(w[0], w[1]));
+    }
+
+    // INDEX needs block_start (i64) and block_end (i64) for this entry,
+    // which we know now that DATA is sized.
+    index.write_all(&i64::to_be_bytes(0)).unwrap(); // block_start
+    index
+        .write_all(&i64::to_be_bytes(data.len() as i64))
+        .unwrap(); // block_end
+
+    // Splice in the section lengths, then append INDEX and DATA.
+    let index_len = index.len() as i64;
+    let data_len = data.len() as i64;
+    blob[index_len_pos..index_len_pos + 8].copy_from_slice(&i64::to_be_bytes(index_len));
+    blob[data_len_pos..data_len_pos + 8].copy_from_slice(&i64::to_be_bytes(data_len));
+    blob.extend_from_slice(&index);
+    blob.extend_from_slice(&data);
+    blob
+}
+
+/// Decode-only golden: the synthetic blob must produce this exact CSV.
+///
+/// Manual derivation:
+/// - header columns (price_type column suppressed by the writer):
+///   `root,expiration,strike,right,ms_of_day,bid,date`.
+/// - row 1: contract prefix `SPY,20240315,580000,C` plus
+///   `34200000,123.45,20240315`. Bid=12345 with price_type=8 →
+///   `12345 / 10^(10-8) = 12345 / 100 = 123.45`.
+/// - row 2: contract prefix is the same; ms_of_day delta +100 →
+///   34200100; bid delta +5 → 12350 → 123.5 (Rust f64 Display drops
+///   the trailing zero); date carried forward → 20240315.
+const EXPECTED_CSV: &str = "\
+root,expiration,strike,right,ms_of_day,bid,date
+SPY,20240315,580000,C,34200000,123.45,20240315
+SPY,20240315,580000,C,34200100,123.5,20240315
+";
+
+#[test]
+fn synthetic_blob_decodes_to_pinned_csv() {
+    let blob = synthetic_option_blob();
+    let dir = std::env::temp_dir().join(format!(
+        "thetadatadx-flatfiles-synthetic-{}",
+        uuid::Uuid::new_v4().simple()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let raw = dir.join("synthetic.bin");
+    let csv = dir.join("synthetic.csv");
+    std::fs::write(&raw, &blob).unwrap();
+
+    thetadatadx::flatfiles::decoded_decode_to_file_for_test(
+        &raw,
+        SecType::Option,
+        &csv,
+        FlatFileFormat::Csv,
+    )
+    .expect("synthetic blob must decode cleanly");
+
+    let got = std::fs::read_to_string(&csv).expect("read decoded CSV");
+    assert_eq!(
+        got, EXPECTED_CSV,
+        "synthetic-blob CSV output drifted; left=actual right=expected\n--- actual ---\n{got}\n--- expected ---\n{EXPECTED_CSV}",
+    );
+
+    // Cleanup. Failures above keep the artefacts in place for triage.
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -7,7 +7,7 @@ description: Complete API reference for the ThetaDataDx SDK covering all endpoin
 
 ThetaDataDx provides a unified client for accessing ThetaData market data across three public surfaces: historical request/response (MDDS over gRPC), real-time streaming (FPSS over TCP), and whole-universe daily blobs (FLATFILES over the legacy MDDS port). The SDK ships native bindings for Rust, Python, TypeScript/Node.js, Go, and C++, all backed by the same compiled Rust core.
 
-Complete typed historical surface + 4 streaming variants + the FLATFILES daily-blob surface (Rust today; cross-language bindings tracked under the FLATFILES roadmap section) + 22 Greeks functions + IV solver.
+Complete typed historical surface + 4 streaming variants + the FLATFILES daily-blob surface (Rust today; cross-language bindings tracked under the FLATFILES roadmap section) + 23 Greeks functions + IV solver.
 
 ## Client Construction
 
@@ -940,7 +940,7 @@ auto greeks = client.option_snapshot_greeks_all("SPY", "20241220", "500", "C");
 | `min_time` | string | No | Minimum time of day |
 | `use_market_value` | bool | No | Use market value instead of last trade |
 
-**Returns:** Array of GreeksTick records with all 22 Greeks.
+**Returns:** Array of GreeksTick records with all 23 Greeks.
 
 **Tier:** Pro
 
@@ -1357,7 +1357,7 @@ auto g = client.option_history_greeks_all("SPY", "20241220", "500", "C", "202403
 | `version` | string | No | Greeks calculation version |
 | `strike_range` | int | No | Strike range filter |
 
-**Returns:** Array of GreeksTick records with all 22 Greeks at each sampled point.
+**Returns:** Array of GreeksTick records with all 23 Greeks at each sampled point.
 
 **Tier:** Pro
 
@@ -1401,7 +1401,7 @@ auto g = client.option_history_trade_greeks_all("SPY", "20241220", "500", "C", "
 | `max_dte` | int | No | Maximum days to expiration |
 | `strike_range` | int | No | Strike range filter |
 
-**Returns:** Array of GreeksTick records with all 22 Greeks per trade.
+**Returns:** Array of GreeksTick records with all 23 Greeks per trade.
 
 **Tier:** Pro
 
@@ -2160,7 +2160,7 @@ Full Black-Scholes calculator with 20 individual Greek functions, an IV solver, 
 
 ### all_greeks
 
-Compute all 22 Greeks at once. Solves for IV first, then computes all Greeks using the solved volatility. This is much more efficient than calling individual functions because it avoids redundant `d1`/`d2`/`exp()`/`norm_cdf()` recomputation.
+Compute all 23 Greeks at once. Solves for IV first, then computes all Greeks using the solved volatility. This is much more efficient than calling individual functions because it avoids redundant `d1`/`d2`/`exp()`/`norm_cdf()` recomputation.
 
 ::: code-group
 ```rust [Rust]
@@ -2206,7 +2206,7 @@ std::cout << "IV: " << g.iv << ", Delta: " << g.delta << std::endl;
 | `option_price` | float | Yes | Market price of the option |
 | `right` | string | Yes | Option side: `"C"`/`"P"` or `"call"`/`"put"` (case-insensitive) |
 
-**Returns:** [GreeksResult](#greeksresult) containing all 22 fields.
+**Returns:** [GreeksResult](#greeksresult) containing all 23 fields.
 
 ---
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.22] - 2026-05-01
+
+### Fixed
+
+- **`fpss::accumulator::change_price_type` now matches the JVM terminal's
+  `PriceCalcUtils.changePriceType` byte-for-byte.** v8.0.21 widened the
+  multiplication through `i64` and returned the unscaled input on
+  overflow, which broke parity with the Java reference (Java `int * int`
+  silently wraps under two's-complement). The rescale now uses
+  `i32::wrapping_mul`, reproducing the JVM's exact wire bits in both
+  debug and release. Tests pin the wrapping result to manually-computed
+  Java-equivalent values (e.g. `2_148 * 10^6 → -2_146_967_296`).
+- **`decode::row_number_i64` clamps `price_type` to `0..=19`** so the
+  same wire cell decodes identically through `row_number_i64` and
+  `row_price_f64` (the latter routes through `tdbe::Price::new`, which
+  has clamped to that range since it was introduced). Under the clamped
+  contract, `i32::MAX * 10^9 ≈ 2.15e18` is well below `i64::MAX`, so
+  scale-up cannot overflow and the previous `Price overflowing i64`
+  error path is no longer reachable.
+
+### Added
+
+- `crates/thetadatadx/tests/flatfiles_synthetic_golden.rs` — a
+  deterministic decoder-only golden test that builds a synthetic
+  FLATFILES blob (header + INDEX + FIT-encoded DATA) in Rust and pins
+  the CSV writer's output byte-for-byte. Runs in plain `cargo test`
+  with no live wire and no env var, giving CI a hard regression gate
+  on the FIT decoder, INDEX walker, and price formatter on every push.
+
+### Changed
+
+- Documentation references to "22 Greeks" updated to "23 Greeks" to
+  reflect the `vera` field added in v8.0.21. Touches the `tdbe`
+  README + module docs, the `thetadatadx` README tick-types table,
+  and the Python and C++ SDK READMEs.
+
 ## [8.0.21] - 2026-04-30
 
 ### Fixed

--- a/docs-site/docs/getting-started/greeks.md
+++ b/docs-site/docs/getting-started/greeks.md
@@ -5,11 +5,11 @@ description: 22 local Black-Scholes Greeks and IV solver with no server round-tr
 
 # Greeks Calculator
 
-ThetaDataDx ships a local Black-Scholes calculator in the Rust core (`tdbe/greeks.rs`) that computes 22 Greeks plus an IV solver without a server round-trip. No subscription is required for the calculator itself, which makes it usable for offline what-if analysis, batch scenario sweeps, and integration tests that must not depend on a live server. The server-computed Greeks endpoints are also exposed for callers that want the canonical upstream values.
+ThetaDataDx ships a local Black-Scholes calculator in the Rust core (`tdbe/greeks.rs`) that computes 23 Greeks plus an IV solver without a server round-trip. No subscription is required for the calculator itself, which makes it usable for offline what-if analysis, batch scenario sweeps, and integration tests that must not depend on a live server. The server-computed Greeks endpoints are also exposed for callers that want the canonical upstream values.
 
 This page covers the calculator at a first-use level. For the full reference — per-Greek formula mapping, wildcard chain workflows, edge cases — see [Options & Greeks](../options).
 
-## All 22 Greeks from a market price
+## All 23 Greeks from a market price
 
 The most common call: feed in the market option price, back out IV, then derive every Greek in one pass.
 
@@ -56,7 +56,7 @@ std::cout << "IV=" << g.iv << " delta=" << g.delta << " gamma=" << g.gamma << st
 ```
 :::
 
-Result keys across the 22 Greeks: `value`, `delta`, `gamma`, `theta`, `vega`, `rho`, `iv`, `iv_error`, `vanna`, `charm`, `vomma`, `veta`, `speed`, `zomma`, `color`, `ultima`, `d1`, `d2`, `dual_delta`, `dual_gamma`, `epsilon`, `lambda`.
+Result keys across the 23 Greeks: `value`, `delta`, `gamma`, `theta`, `vega`, `rho`, `iv`, `iv_error`, `vanna`, `charm`, `vomma`, `veta`, `speed`, `zomma`, `color`, `ultima`, `d1`, `d2`, `dual_delta`, `dual_gamma`, `epsilon`, `lambda`.
 
 ## IV only
 
@@ -85,5 +85,5 @@ Pair the server endpoints with the local calculator: pull a chain with server Gr
 
 ## Next
 
-- [Options & Greeks](../options) — full reference: 22 Greeks formulas, chain workflow, wildcard queries
+- [Options & Greeks](../options) — full reference: 23 Greeks formulas, chain workflow, wildcard queries
 - [DataFrames](./dataframes) — chain `.to_polars()` on an option chain for scenario sweeps in columnar form

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -28,7 +28,7 @@ features:
   - icon:
       src: /icons/chart.svg
     title: "Local Greeks"
-    details: "22 Black-Scholes Greeks plus an IV solver, computed in Rust with no server round-trip. The server-computed Greeks endpoints are also exposed."
+    details: "23 Black-Scholes Greeks plus an IV solver, computed in Rust with no server round-trip. The server-computed Greeks endpoints are also exposed."
   - icon:
       src: /icons/terminal.svg
     title: "CLI, MCP, REST server"
@@ -146,7 +146,7 @@ for (const auto& q : quotes) {
 | Languages | Rust, Python, TypeScript, Go, C++ |
 | Historical endpoints | Full typed historical surface (plus 4 `_stream` SDK-only variants) |
 | Real-time streaming | FPSS with SPKI pinning, SPSC ring, reconnect policy |
-| Local Greeks calculator | 22 Greeks + IV solver in Rust |
+| Local Greeks calculator | 23 Greeks + IV solver in Rust |
 | Async Python surface | `*_async` variant of every endpoint |
 | DataFrame output | Arrow / polars / pandas via explicit conversion |
 

--- a/docs-site/docs/options.md
+++ b/docs-site/docs/options.md
@@ -1,6 +1,6 @@
 ---
 title: Options & Greeks
-description: Option chain workflows and local Black-Scholes Greeks calculator with 22 Greeks, IV solver, and edge-case handling.
+description: Option chain workflows and local Black-Scholes Greeks calculator with 23 Greeks, IV solver, and edge-case handling.
 ---
 
 # Options & Greeks
@@ -8,7 +8,7 @@ description: Option chain workflows and local Black-Scholes Greeks calculator wi
 ThetaDataDx provides two complementary approaches to options analytics:
 
 1. **Server-computed Greeks** - query ThetaData's servers for pre-calculated Greeks via the standard endpoints
-2. **Local Greeks calculator** - compute all 22 Black-Scholes Greeks offline with no server call and no subscription required
+2. **Local Greeks calculator** - compute all 23 Black-Scholes Greeks offline with no server call and no subscription required
 
 ## Option Chain Workflow
 
@@ -179,9 +179,9 @@ In Go and Python, the `right` field is a human-readable string: `"C"` (call), `"
 
 Compute Greeks locally without any server call using the built-in Black-Scholes calculator. Works offline, no ThetaData subscription needed.
 
-### All 22 Greeks at Once
+### All 23 Greeks at Once
 
-The most common usage: compute IV from the market price, then derive all 22 Greeks in a single call.
+The most common usage: compute IV from the market price, then derive all 23 Greeks in a single call.
 
 ::: code-group
 ```rust [Rust]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.21"
+version = "8.0.22"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -31,7 +31,7 @@ testing-panic-boundary = []
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.12.2", path = "../crates/tdbe" }
+tdbe = { version = "0.12.3", path = "../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 # Used by the FPSS streaming callback silent-drop observability path
 # (see `tdx_fpss_dropped_events` / `tdx_unified_dropped_events`). Keep

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -232,7 +232,7 @@ auto client = tdx::Client::connect(creds, tdx::Config::production());
 ### Standalone Functions
 
 ```cpp
-// All 22 Greeks + IV. `right` accepts "C"/"P" or "call"/"put" (case-insensitive).
+// All 23 Greeks + IV. `right` accepts "C"/"P" or "call"/"put" (case-insensitive).
 auto g = tdx::all_greeks(spot, strike, rate, div_yield, tte, price, "C");
 // g.iv, g.delta, g.gamma, g.theta, g.vega, g.rho, g.vanna, g.charm, etc.
 

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -456,7 +456,7 @@ void tdx_string_free(char* s);
 /*  Greeks (standalone)                                                   */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
-/** Compute all 22 Greeks + IV. `right` accepts "C"/"P" or "call"/"put" (case-insensitive).
+/** Compute all 23 Greeks + IV. `right` accepts "C"/"P" or "call"/"put" (case-insensitive).
  *  Returns heap-allocated TdxGreeksResult (or NULL on error). Caller must free with tdx_greeks_result_free. */
 TdxGreeksResult* tdx_all_greeks(double spot, double strike, double rate, double div_yield,
                                 double tte, double option_price, const char* right);

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2310,7 +2310,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.21"
+version = "8.0.22"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ doc = false
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.2", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
 
 # Direct prost dep for decoding `thetadatadx::proto::ResponseData` bytes in
 # the `decode_response_bytes` hook. The main crate no longer re-exports

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -58,7 +58,7 @@ strikes = tdx.option_list_strikes("SPY", exps[0])
 
 ## Greeks Calculator
 
-Full Black-Scholes calculator with 22 Greeks, running in Rust:
+Full Black-Scholes calculator with 23 Greeks, running in Rust:
 
 ```python
 from thetadatadx import all_greeks, implied_volatility

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.21"
+version = "8.0.22"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.2", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
 
 napi = { version = "3.8.5", features = ["async", "tokio_rt", "serde-json", "napi6", "chrono_date"] }
 napi-derive = "3.5.4"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.21",
+  "version": "8.0.22",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.21",
+  "version": "8.0.22",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.21",
+  "version": "8.0.22",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.21",
+  "version": "8.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "8.0.21",
+      "version": "8.0.22",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2"
@@ -15,9 +15,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "8.0.21",
-        "thetadatadx-linux-x64-gnu": "8.0.21",
-        "thetadatadx-win32-x64-msvc": "8.0.21"
+        "thetadatadx-darwin-arm64": "8.0.22",
+        "thetadatadx-linux-x64-gnu": "8.0.22",
+        "thetadatadx-win32-x64-msvc": "8.0.22"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.21",
+  "version": "8.0.22",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.21",
-    "thetadatadx-darwin-arm64": "8.0.21",
-    "thetadatadx-win32-x64-msvc": "8.0.21"
+    "thetadatadx-linux-x64-gnu": "8.0.22",
+    "thetadatadx-darwin-arm64": "8.0.22",
+    "thetadatadx-win32-x64-msvc": "8.0.22"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.21"
+version = "8.0.22"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.2", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.5.8"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.21"
+version = "8.0.22"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.2", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 sonic-rs = "0.5.8"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.21"
+version = "8.0.22"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.21"
+version = "8.0.22"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23.38", features = ["ring"] }
-tdbe = { version = "0.12.2", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
 axum = { version = "0.8.9", features = ["ws"] }
 tokio = { version = "1.52.1", features = ["full"] }
 sonic-rs = "0.5.8"


### PR DESCRIPTION
Follow-up to PR #456 covering four engineering findings surfaced during
post-merge inspection.

## Summary

- **Finding 1 — `fpss::accumulator::change_price_type` JVM parity.** v8.0.21 widened the rescale through `i64` and returned the unscaled input on overflow. The JVM terminal's `PriceCalcUtils.changePriceType` does plain `int * int` which silently wraps under two's-complement; downstream consumers depend on the wrapped wire bits. Switched to `i32::wrapping_mul` so the SDK reproduces the JVM byte-for-byte (debug-safe in Rust, where plain `*` would panic in debug). Tests pin the wrapping output to manually-computed Java-equivalent values.
- **Finding 2 — FLATFILES decoder regression gate.** `flatfiles_byte_match.rs` self-skips when the env var is unset, and CI never sets it, so byte-match was effectively a no-op. Added `flatfiles_synthetic_golden.rs`, a deterministic decoder-only golden that builds a minimal blob (header + INDEX + FIT-encoded DATA) in Rust and asserts the CSV writer's output byte-for-byte against a hand-computed expectation. Runs in plain `cargo test` with no live wire and no env var. The live workflow still runs the real byte-match (still skipping until a vendor reference fixture is provisioned, tracked under #453).
- **Finding 3 — `decode::row_number_i64` clamp parity.** `row_price_f64` routes Price cells through `tdbe::Price::new`, which clamps `price_type` to `0..=19`. The new `row_number_i64` Price branch in v8.0.21 used the raw wire `type`, so the same wire cell decoded differently across the two accessors. Clamped `price_type` to `0..=19` matching `Price::new`. Under the clamp, scale-up cannot overflow `i64` (`i32::MAX * 10^9 ≈ 2.15e18` < `i64::MAX`), so the unreachable error branch is replaced by positive parity tests.
- **Finding 4 — Greek count doc drift.** `vera` was added in v8.0.21 but the headline "22 Greeks" was missed in six docs files. Bumped to 23 Greeks. (Historical CHANGELOG entries from earlier releases left intact so the history reflects what shipped at the time.)

## Versioning

Patch increment to **v8.0.22 / tdbe 0.12.3** across every Rust crate (workspace + sub-workspace tools + sdks + ffi), every `package.json`, and the npm lockfile. The v8 line is patch-only even on API-touching changes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo deny check`
- [x] `cargo run -p thetadatadx --bin generate_sdk_surfaces --features config-file -- --check`
- [x] Sub-workspace builds: `tools/server`, `tools/mcp`, `sdks/python`, `sdks/typescript` (`cargo build --release --locked`)
- [x] New `flatfiles_synthetic_golden` test passes locally
- [x] Updated `change_price_type_*` and `row_number_i64_*` tests pass with hand-computed pinned values