### PR TITLE
fix: bound WS queue, surface serialisation errors, fail explicit on partial reconnect

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -104,6 +104,17 @@ jobs:
           print(thetadatadx.__file__)
           print(round(iv, 6), round(err, 6))
           PY
+      # Run the Python pytest suite against the freshly-installed wheel. The
+      # `THETADX_TEST_CREDS`-gated tests skip cleanly without secrets so this
+      # step exercises the install path AND the public-API surface contracts
+      # that don't need a live FPSS handshake. Kept as a separate step from
+      # the import smoke above so a pytest regression points at the suite,
+      # not at the smoke output.
+      - name: Pytest suite (skipped tests stay skipped)
+        shell: bash
+        run: |
+          python -m pip install pytest
+          python -m pytest sdks/python/tests/ -v
       - uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ runner.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.23] - 2026-05-01
+
+### Fixed
+
+- **REST + MCP no longer return empty bodies on serialisation failure.**
+  `tools/server/src/handler.rs` and `tools/mcp/src/main.rs` previously
+  swallowed `sonic_rs::to_string` errors via `unwrap_or_default()`,
+  producing a `200 OK` with `""` (REST) or a successful but empty
+  `tools/call` result (MCP) when a tick payload contained a non-finite
+  f64 cell. The REST handler now surfaces the failure as a structured
+  `500` carrying the underlying error message in the existing JSON
+  envelope, and the MCP handler returns a JSON-RPC `-32603` Internal
+  Error. The cross-language non-finite f64 -> JSON `null`
+  canonicalisation rule (previously inlined in `tools/cli/src/main.rs`
+  as `raw_f64`) now lives in the new `crates/json_canon` crate and is
+  shared by CLI, REST, and MCP so all three frontends produce
+  byte-identical output for the same payload.
+- **FPSS WebSocket broadcast queue is now bounded.**
+  `tools/server/src/ws/broadcast.rs` previously used
+  `tokio::sync::mpsc::unbounded_channel`, which could grow without bound
+  if the broadcast task lagged behind the Disruptor consumer thread.
+  The channel is now bounded at 65_536 slots and the callback uses
+  `try_send` with explicit `Full` / `Closed` arms; drops are accounted
+  on a new `AppState::record_fpss_broadcast_drop` `AtomicU64` counter,
+  exposed via `GET /v3/system/fpss/status` as `broadcast_dropped`, and
+  warn-logged once per 1024 drops to surface back-pressure without
+  flooding stderr.
+- **`ThetaDataDx::reconnect_streaming` now fails explicitly on partial
+  re-subscription.** The re-subscribe loop in
+  `crates/thetadatadx/src/unified.rs` previously logged failures via
+  `tracing::warn!` and returned `Ok(())`, hiding partial reconnects
+  from programmatic callers. The loop now collects every failed
+  `(SubscriptionKind, Contract)` pair and, when the list is non-empty,
+  returns the new `Error::PartialReconnect { failed }` variant. The
+  per-failure `tracing::warn!` lines stay for operational visibility.
+- **Version metadata drift cleared.** `sdks/cpp/CMakeLists.txt`
+  (`8.0.9` -> `8.0.23`) and the workspace comment in `Cargo.toml`
+  (`7.x` -> `8.0.x`) now match the rest of the v8 line. Banned
+  vocabulary purged from `SECURITY.md`, the `[8.0.8]` changelog entry,
+  and the dropped-events Python test.
+
+### Added
+
+- `crates/json_canon` — a tiny shared crate exposing
+  `finite_or_null`, `canonicalize`, and `canonicalize_and_serialize`
+  for non-finite f64 -> JSON `null` collapse plus surfaced
+  `sonic_rs::Error` on serialisation failure. Pulled in by
+  `tools/cli`, `tools/server`, and `tools/mcp`.
+- New `Error::PartialReconnect { failed: Vec<(SubscriptionKind, Contract)> }`
+  variant in `thetadatadx::error` and a new
+  `Contract::full_type_marker(sec_type)` constructor used to encode a
+  failed full-type subscription inside the structured failure list.
+- `AppState::record_fpss_broadcast_drop` and
+  `AppState::fpss_broadcast_dropped` on the REST server, and a new
+  `broadcast_dropped` field on `GET /v3/system/fpss/status`.
+- A pytest CI step in `.github/workflows/python.yml` that runs
+  `pytest sdks/python/tests/` after the wheel install. The existing
+  import smoke is kept as a separate step.
+
+### Changed
+
+- `tools/cli/src/main.rs` `raw_f64` is now a thin delegation to
+  `json_canon::finite_or_null`.
+- `tools/server/src/format.rs` `render_csv_value` canonicalises before
+  serialising and emits a `<csv-render-error: …>` sentinel rather than
+  an empty cell on serialisation failure.
+- `tdbe` bumped to `0.12.4` to keep all member crates on a fresh
+  patch line for the 8.0.23 release.
+
 ## [8.0.22] - 2026-05-01
 
 ### Fixed
@@ -461,7 +530,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.0.8] - 2026-04-23
 
-Follow-up patch to v8.0.7. Addresses the audit findings surfaced against
+Follow-up patch to v8.0.7. Addresses the review findings surfaced against
 the code-strip release: rustdoc breakage inside `tdbe`, TypeScript loader
 and subpackage versions drifting from the root package, a `[8.0.7]`
 changelog section that accidentally absorbed v8.0.6 content, stale

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_canon"
+version = "0.1.0"
+dependencies = [
+ "sonic-rs",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",
@@ -3036,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3075,10 +3082,11 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "clap",
  "comfy-table",
+ "json_canon",
  "sonic-rs",
  "tdbe",
  "thetadatadx",
@@ -3087,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tdbe", "crates/thetadatadx", "tools/cli", "ffi"]
+members = ["crates/json_canon", "crates/tdbe", "crates/thetadatadx", "tools/cli", "ffi"]
 exclude = ["sdks/python", "sdks/typescript", "tools/mcp", "tools/server"]
 resolver = "2"
 
@@ -9,7 +9,7 @@ resolver = "2"
 #
 # `version` is intentionally NOT hoisted because the workspace ships two
 # independent semver tracks: `tdbe` (0.x encoding crate) and everything
-# else (the 7.x SDK line). Each member keeps its own `version = "..."`.
+# else (the 8.0.x SDK line). Each member keeps its own `version = "..."`.
 [workspace.package]
 edition = "2021"
 rust-version = "1.85"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -109,7 +109,7 @@ unbounded memory allocation.
 
 ### Dependencies
 
-We audit dependencies for:
+We review dependencies for:
 - Known vulnerabilities (RustSec advisory database)
 - License compliance
 - Duplicate crate versions

--- a/crates/json_canon/Cargo.toml
+++ b/crates/json_canon/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "json_canon"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "JSON canonicalisation for non-finite f64 (NaN / +Inf / -Inf -> null) shared by cli, server, and mcp."
+
+[lints]
+workspace = true
+
+[dependencies]
+sonic-rs = "0.5.8"

--- a/crates/json_canon/src/lib.rs
+++ b/crates/json_canon/src/lib.rs
@@ -1,0 +1,155 @@
+//! JSON canonicalisation helpers shared by the CLI, REST server, and MCP tools.
+//!
+//! Standards-compliant JSON encoders refuse `NaN`, `+Infinity`, and
+//! `-Infinity` because the JSON spec has no representation for them. The
+//! `sonic_rs` encoder writes JSON `null` in their place, but the cross-language
+//! SDK contract (see `scripts/validate_agreement.py` and the `raw_f64` helper
+//! in `tools/cli/src/main.rs`) requires every frontend — REST, MCP, CLI — to
+//! canonicalise non-finite f64 to `null` BEFORE the value tree leaves the
+//! frontend, so callers cannot observe a backend-specific drift.
+//!
+//! This crate owns the canonicalisation pass so all three frontends share one
+//! implementation.
+
+#![forbid(unsafe_code)]
+
+use sonic_rs::{JsonNumberTrait, JsonValueMutTrait, JsonValueTrait, Number, Value};
+
+/// Convert a single f64 to a JSON-safe value: finite passthrough, non-finite
+/// becomes JSON null. Mirrors the behaviour of `tools/cli/src/main.rs`
+/// `raw_f64` exactly so all three frontends produce byte-identical output for
+/// the same tick payload.
+#[must_use]
+pub fn finite_or_null(value: f64) -> Value {
+    Number::from_f64(value).map_or_else(Value::new_null, Value::from)
+}
+
+/// Walk `value` in place and replace every non-finite f64 inside numbers,
+/// arrays, and objects with JSON `null`.
+///
+/// After this call returns, every leaf number in the tree is either a JSON
+/// integer or a finite f64. The walk is non-allocating in the steady state —
+/// only the non-finite leaves are replaced.
+pub fn canonicalize(value: &mut Value) {
+    if let Some(arr) = value.as_array_mut() {
+        for item in arr.iter_mut() {
+            canonicalize(item);
+        }
+        return;
+    }
+    if let Some(obj) = value.as_object_mut() {
+        for (_, v) in obj.iter_mut() {
+            canonicalize(v);
+        }
+        return;
+    }
+    if let Some(num) = value.as_number() {
+        if let Some(f) = num.as_f64() {
+            if !f.is_finite() {
+                *value = Value::new_null();
+            }
+        }
+    }
+}
+
+/// Canonicalise the value tree in place and serialise it.
+///
+/// # Errors
+///
+/// Forwards any `sonic_rs::Error` from the serialiser. Callers MUST translate
+/// this into a structured error response — never an empty body.
+pub fn canonicalize_and_serialize(value: &mut Value) -> Result<String, sonic_rs::Error> {
+    canonicalize(value);
+    sonic_rs::to_string(&*value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nan_becomes_null() {
+        let v = finite_or_null(f64::NAN);
+        assert!(v.is_null(), "NaN must canonicalise to null, got {v:?}");
+    }
+
+    #[test]
+    fn pos_inf_becomes_null() {
+        let v = finite_or_null(f64::INFINITY);
+        assert!(v.is_null(), "+Inf must canonicalise to null, got {v:?}");
+    }
+
+    #[test]
+    fn neg_inf_becomes_null() {
+        let v = finite_or_null(f64::NEG_INFINITY);
+        assert!(v.is_null(), "-Inf must canonicalise to null, got {v:?}");
+    }
+
+    #[test]
+    fn finite_passthrough_42_5() {
+        let v = finite_or_null(42.5);
+        assert_eq!(v.as_f64(), Some(42.5));
+    }
+
+    #[test]
+    fn finite_zero_passthrough() {
+        let v = finite_or_null(0.0);
+        assert_eq!(v.as_f64(), Some(0.0));
+    }
+
+    #[test]
+    fn finite_negative_passthrough() {
+        let v = finite_or_null(-1234.5678);
+        assert_eq!(v.as_f64(), Some(-1234.5678));
+    }
+
+    #[test]
+    fn canonicalize_walks_arrays() {
+        // `Value::from(f64::NAN)` is not callable directly (no `From<f64>`).
+        // We seed the array with three slots — a finite f64, a pre-collapsed
+        // NaN, and another finite f64 — then run the canonicaliser to prove
+        // the walk does not corrupt the surrounding finite values.
+        let mut arr = sonic_rs::array![
+            sonic_rs::to_value(&1.0_f64).expect("finite ok"),
+            finite_or_null(f64::NAN),
+            sonic_rs::to_value(&3.0_f64).expect("finite ok"),
+        ]
+        .into_value();
+        canonicalize(&mut arr);
+        let s = sonic_rs::to_string(&arr).expect("serialises after canonicalise");
+        assert_eq!(s, "[1.0,null,3.0]");
+    }
+
+    #[test]
+    fn canonicalize_walks_objects() {
+        let mut obj = sonic_rs::json!({
+            "ok": 1.5_f64,
+            "bad": Value::new_null(),
+            "nested": {
+                "deep": Value::new_null(),
+            }
+        });
+        if let Some(o) = obj.as_object_mut() {
+            o.insert(&"bad", finite_or_null(f64::NAN));
+            if let Some(nested) = o.get_mut(&"nested").and_then(|v| v.as_object_mut()) {
+                nested.insert(&"deep", finite_or_null(f64::INFINITY));
+            }
+        }
+        canonicalize(&mut obj);
+        let s = sonic_rs::to_string(&obj).expect("serialises");
+        assert!(s.contains("\"bad\":null"), "got {s}");
+        assert!(s.contains("\"deep\":null"), "got {s}");
+        assert!(s.contains("\"ok\":1.5"), "got {s}");
+    }
+
+    #[test]
+    fn canonicalize_and_serialize_succeeds_after_nan() {
+        let mut v = sonic_rs::array![
+            finite_or_null(f64::NAN),
+            sonic_rs::to_value(&2.0_f64).expect("finite"),
+        ]
+        .into_value();
+        let s = canonicalize_and_serialize(&mut v).expect("must serialise");
+        assert_eq!(s, "[null,2.0]");
+    }
+}

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.12.3"
+version = "0.12.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.22"
+version = "8.0.23"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -40,7 +40,7 @@ frames = ["polars", "arrow"]
 live-tests = []
 
 [dependencies]
-tdbe = { version = "0.12.3", path = "../tdbe" }
+tdbe = { version = "0.12.4", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }
@@ -132,7 +132,7 @@ prost-build = "=0.14.3"
 regex = "1.12.3"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
-tdbe = { version = "0.12.3", path = "../tdbe" }
+tdbe = { version = "0.12.4", path = "../tdbe" }
 
 [[bench]]
 name = "bench_decode"

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -128,6 +128,27 @@ pub enum Error {
     /// the underlying server error to the user.
     #[error("FLATFILES unavailable: {0}")]
     FlatFilesUnavailable(crate::flatfiles::FlatFilesUnavailableReason),
+
+    /// `reconnect_streaming` succeeded in re-establishing the FPSS session
+    /// but failed to restore one or more of the previously active
+    /// subscriptions. The streaming connection itself is healthy; the listed
+    /// subscriptions need to be re-issued by the caller (or the caller may
+    /// choose to retry the whole `reconnect_streaming` call).
+    ///
+    /// Each entry is `(SubscriptionKind, Contract)` describing the
+    /// subscription that could not be restored. The original per-failure
+    /// error has already been logged at `warn` level via `tracing` so
+    /// operators can see the underlying cause; the caller-facing surface is
+    /// the structured list so programmatic recovery is possible without
+    /// log scraping.
+    #[error("partial reconnect: {} subscription(s) failed to restore", .failed.len())]
+    PartialReconnect {
+        /// The subscriptions that failed to restore.
+        failed: Vec<(
+            crate::fpss::protocol::SubscriptionKind,
+            crate::fpss::protocol::Contract,
+        )>,
+    },
 }
 
 impl From<tdbe::error::Error> for Error {

--- a/crates/thetadatadx/src/fpss/protocol.rs
+++ b/crates/thetadatadx/src/fpss/protocol.rs
@@ -202,6 +202,27 @@ impl Contract {
         }
     }
 
+    /// Synthetic marker used by `reconnect_streaming` to represent a failed
+    /// full-type subscription inside [`crate::Error::PartialReconnect::failed`].
+    ///
+    /// Full-type subscriptions are not addressed by a real `Contract`, but the
+    /// failure list keeps a homogeneous `(SubscriptionKind, Contract)` shape
+    /// so callers can iterate the list with one match arm. `root` is empty
+    /// and option fields are `None`, which mirrors the lack of per-contract
+    /// addressability for a full-type subscription. Operators see the
+    /// original `SecType` via the per-failure `tracing::warn!` line emitted
+    /// at the call site.
+    #[must_use]
+    pub fn full_type_marker(sec_type: SecType) -> Self {
+        Self {
+            root: String::new(),
+            sec_type,
+            exp_date: None,
+            is_call: None,
+            strike: None,
+        }
+    }
+
     /// OCC-21 option identifier length (6 root + 6 YYMMDD + 1 side + 8 strike).
     const OCC21_LEN: usize = 21;
 

--- a/crates/thetadatadx/src/unified.rs
+++ b/crates/thetadatadx/src/unified.rs
@@ -321,10 +321,21 @@ impl ThetaDataDx {
     /// 1. Save active per-contract and full-type subscriptions
     /// 2. Stop the current streaming connection
     /// 3. Start a new streaming connection with the provided handler
-    /// 4. Re-subscribe all saved subscriptions
+    /// 4. Re-subscribe all saved subscriptions, collecting per-subscription
+    ///    failures rather than aborting on the first error
+    ///
     /// # Errors
     ///
-    /// Returns an error on network, authentication, or parsing failure.
+    /// Returns [`Error::Fpss`], [`Error::Auth`], etc. when the underlying
+    /// streaming session cannot be re-established (steps 1–3).
+    ///
+    /// Returns [`Error::PartialReconnect`] when the streaming session was
+    /// re-established successfully but one or more saved subscriptions
+    /// failed to restore. The variant carries the structured list of failed
+    /// `(SubscriptionKind, Contract)` pairs so the caller can retry just
+    /// those subscriptions or surface the partial failure to the operator.
+    /// Per-subscription `tracing::warn!` lines are still emitted for
+    /// operational visibility.
     pub fn reconnect_streaming<F>(&self, handler: F) -> Result<(), Error>
     where
         F: FnMut(&FpssEvent) + Send + 'static,
@@ -351,45 +362,28 @@ impl ThetaDataDx {
         // 3. Start a new streaming connection
         self.start_streaming(handler)?;
 
-        // 4. Re-subscribe all saved subscriptions
+        // 4. Re-subscribe all saved subscriptions, accumulating failures
         let (per_contract, full_type) = saved_subs;
-
-        for (kind, contract) in &per_contract {
-            let result = match kind {
+        let failed = restore_subscriptions(
+            &per_contract,
+            &full_type,
+            |kind, contract| match kind {
                 SubscriptionKind::Quote => self.subscribe_quotes(contract),
                 SubscriptionKind::Trade => self.subscribe_trades(contract),
                 SubscriptionKind::OpenInterest => self.subscribe_open_interest(contract),
-            };
-            if let Err(e) = result {
-                tracing::warn!(
-                    kind = ?kind,
-                    contract = %contract,
-                    error = %e,
-                    "failed to re-subscribe after reconnect"
-                );
-            }
-        }
+            },
+            |kind, sec_type| match kind {
+                SubscriptionKind::Trade => Some(self.subscribe_full_trades(sec_type)),
+                SubscriptionKind::OpenInterest => Some(self.subscribe_full_open_interest(sec_type)),
+                SubscriptionKind::Quote => None,
+            },
+        );
 
-        for (kind, sec_type) in &full_type {
-            let result = match kind {
-                SubscriptionKind::Trade => self.subscribe_full_trades(*sec_type),
-                SubscriptionKind::OpenInterest => self.subscribe_full_open_interest(*sec_type),
-                SubscriptionKind::Quote => {
-                    tracing::warn!("full-type Quote subscription is not supported, skipping");
-                    continue;
-                }
-            };
-            if let Err(e) = result {
-                tracing::warn!(
-                    kind = ?kind,
-                    sec_type = ?sec_type,
-                    error = %e,
-                    "failed to re-subscribe full-type after reconnect"
-                );
-            }
+        if failed.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::PartialReconnect { failed })
         }
-
-        Ok(())
     }
 
     /// Get the current streaming connection status.
@@ -690,5 +684,210 @@ impl std::ops::Deref for ThetaDataDx {
     type Target = MddsClient;
     fn deref(&self) -> &MddsClient {
         &self.historical
+    }
+}
+
+/// Replay every saved subscription against the freshly reconnected
+/// streaming client and return the list of subscriptions that failed to
+/// restore.
+///
+/// The two callbacks decouple the loop from the live `ThetaDataDx`
+/// streaming methods so the resubscription logic is unit-testable with
+/// in-memory fakes — the [`reconnect_streaming`] caller in production
+/// passes through to the real `subscribe_quotes` / `subscribe_trades` /
+/// `subscribe_open_interest` and `subscribe_full_*` methods, while the
+/// regression test below injects closures that return canned `Err` for a
+/// specific subscription pair to prove the failure list carries the right
+/// structured contents.
+///
+/// Per-failure operational visibility is preserved: every error path emits a
+/// `tracing::warn!` line carrying `kind`, `contract` (or `sec_type`), and
+/// the underlying error, identical to the single-call-site loop this
+/// helper replaces.
+///
+/// `full_subscribe` returns `Some(Result<()>)` for kinds that are valid
+/// full-type subscriptions, and `None` for kinds that are not (currently
+/// only `SubscriptionKind::Quote` is excluded). A `None` triggers the same
+/// "skipping" warning the previous in-line loop emitted.
+fn restore_subscriptions<P, F>(
+    per_contract: &[(SubscriptionKind, Contract)],
+    full_type: &[(SubscriptionKind, SecType)],
+    mut per_subscribe: P,
+    mut full_subscribe: F,
+) -> Vec<(SubscriptionKind, Contract)>
+where
+    P: FnMut(SubscriptionKind, &Contract) -> Result<(), Error>,
+    F: FnMut(SubscriptionKind, SecType) -> Option<Result<(), Error>>,
+{
+    let mut failed: Vec<(SubscriptionKind, Contract)> = Vec::new();
+
+    for (kind, contract) in per_contract {
+        if let Err(e) = per_subscribe(*kind, contract) {
+            tracing::warn!(
+                kind = ?kind,
+                contract = %contract,
+                error = %e,
+                "failed to re-subscribe after reconnect"
+            );
+            failed.push((*kind, contract.clone()));
+        }
+    }
+
+    for (kind, sec_type) in full_type {
+        match full_subscribe(*kind, *sec_type) {
+            Some(Ok(())) => {}
+            Some(Err(e)) => {
+                tracing::warn!(
+                    kind = ?kind,
+                    sec_type = ?sec_type,
+                    error = %e,
+                    "failed to re-subscribe full-type after reconnect"
+                );
+                // Full-type subscriptions are encoded as a synthetic
+                // `Contract` with an empty `root` so the structured failure
+                // list stays homogeneous. Operators see the original
+                // `sec_type` via the `tracing::warn!` line above.
+                failed.push((*kind, Contract::full_type_marker(*sec_type)));
+            }
+            None => {
+                tracing::warn!(
+                    kind = ?kind,
+                    sec_type = ?sec_type,
+                    "full-type subscription is not supported for this kind, skipping"
+                );
+            }
+        }
+    }
+
+    failed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Inject a single failing per-contract subscribe call and prove the
+    /// returned failure list contains exactly the failed `(kind, contract)`
+    /// pair — not a count, not a boolean, the real structured contents.
+    #[test]
+    fn restore_subscriptions_collects_failed_per_contract() {
+        let aapl = Contract::stock("AAPL");
+        let msft = Contract::stock("MSFT");
+        let per_contract = vec![
+            (SubscriptionKind::Quote, aapl.clone()),
+            (SubscriptionKind::Quote, msft.clone()),
+        ];
+        let full_type: Vec<(SubscriptionKind, SecType)> = Vec::new();
+
+        let failed = restore_subscriptions(
+            &per_contract,
+            &full_type,
+            |_kind, contract| {
+                if contract.root == "MSFT" {
+                    Err(Error::Fpss {
+                        kind: crate::error::FpssErrorKind::Disconnected,
+                        message: "injected: MSFT subscribe rejected".to_string(),
+                    })
+                } else {
+                    Ok(())
+                }
+            },
+            |_, _| None,
+        );
+
+        assert_eq!(failed.len(), 1, "exactly one subscription must have failed");
+        assert_eq!(failed[0].0, SubscriptionKind::Quote);
+        assert_eq!(failed[0].1, msft);
+    }
+
+    /// A successful run must return an empty failure list — no false
+    /// positives, no spurious entries.
+    #[test]
+    fn restore_subscriptions_empty_on_full_success() {
+        let aapl = Contract::stock("AAPL");
+        let per_contract = vec![(SubscriptionKind::Trade, aapl)];
+        let full_type = vec![(SubscriptionKind::Trade, SecType::Stock)];
+
+        let failed = restore_subscriptions(
+            &per_contract,
+            &full_type,
+            |_, _| Ok(()),
+            |_, _| Some(Ok(())),
+        );
+
+        assert!(failed.is_empty(), "no failures expected, got {failed:?}");
+    }
+
+    /// A full-type subscription failure must show up in the list with the
+    /// `full_type_marker` synthetic contract carrying the right `SecType`,
+    /// so callers can pattern-match the failure without losing the
+    /// originally failed sec_type.
+    #[test]
+    fn restore_subscriptions_records_full_type_failure() {
+        let per_contract: Vec<(SubscriptionKind, Contract)> = Vec::new();
+        let full_type = vec![(SubscriptionKind::OpenInterest, SecType::Option)];
+
+        let failed = restore_subscriptions(
+            &per_contract,
+            &full_type,
+            |_, _| Ok(()),
+            |_, _| {
+                Some(Err(Error::Fpss {
+                    kind: crate::error::FpssErrorKind::TooManyRequests,
+                    message: "injected: full-type subscribe rate-limited".to_string(),
+                }))
+            },
+        );
+
+        assert_eq!(failed.len(), 1);
+        let (kind, contract) = &failed[0];
+        assert_eq!(*kind, SubscriptionKind::OpenInterest);
+        assert_eq!(contract.sec_type, SecType::Option);
+        assert!(
+            contract.root.is_empty(),
+            "full-type marker carries empty root, got {:?}",
+            contract.root
+        );
+    }
+
+    /// `reconnect_streaming` returns `Error::PartialReconnect` carrying the
+    /// failed list when subscriptions cannot be restored — the regression
+    /// test for issue #461. The variant payload is asserted by pattern-
+    /// match, not just `is_err()`, so a future refactor that changes the
+    /// payload shape breaks this test loudly.
+    #[test]
+    fn partial_reconnect_error_carries_failed_subscriptions() {
+        let aapl = Contract::stock("AAPL");
+        let per_contract = vec![(SubscriptionKind::Quote, aapl.clone())];
+        let full_type: Vec<(SubscriptionKind, SecType)> = Vec::new();
+
+        let failed = restore_subscriptions(
+            &per_contract,
+            &full_type,
+            |_, _| {
+                Err(Error::Fpss {
+                    kind: crate::error::FpssErrorKind::Disconnected,
+                    message: "injected".to_string(),
+                })
+            },
+            |_, _| None,
+        );
+
+        // This is exactly the path `reconnect_streaming` takes when failed
+        // is non-empty: build the structured `PartialReconnect` error.
+        let err = if failed.is_empty() {
+            None
+        } else {
+            Some(Error::PartialReconnect { failed })
+        };
+
+        match err {
+            Some(Error::PartialReconnect { failed }) => {
+                assert_eq!(failed.len(), 1);
+                assert_eq!(failed[0].0, SubscriptionKind::Quote);
+                assert_eq!(failed[0].1, aapl);
+            }
+            other => panic!("expected PartialReconnect, got {other:?}"),
+        }
     }
 }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -20,42 +20,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `500` carrying the underlying error message in the existing JSON
   envelope, and the MCP handler returns a JSON-RPC `-32603` Internal
   Error. The cross-language non-finite f64 -> JSON `null`
-  canonicalisation rule now lives in the new `crates/json_canon` crate
-  and is shared by CLI, REST, and MCP.
-- **FPSS WebSocket broadcast queue is now bounded** at 65_536 slots,
-  using `try_send` with explicit `Full` / `Closed` arms. Drops are
-  accounted on a new `AppState::fpss_broadcast_dropped()` counter,
-  exposed via `GET /v3/system/fpss/status` as `broadcast_dropped`,
-  and warn-logged once per 1024 drops.
+  canonicalisation rule (previously inlined in `tools/cli/src/main.rs`
+  as `raw_f64`) now lives in the new `crates/json_canon` crate and is
+  shared by CLI, REST, and MCP so all three frontends produce
+  byte-identical output for the same payload.
+- **FPSS WebSocket broadcast queue is now bounded.**
+  `tools/server/src/ws/broadcast.rs` previously used
+  `tokio::sync::mpsc::unbounded_channel`, which could grow without bound
+  if the broadcast task lagged behind the Disruptor consumer thread.
+  The channel is now bounded at 65_536 slots and the callback uses
+  `try_send` with explicit `Full` / `Closed` arms; drops are accounted
+  on a new `AppState::record_fpss_broadcast_drop` `AtomicU64` counter,
+  exposed via `GET /v3/system/fpss/status` as `broadcast_dropped`, and
+  warn-logged once per 1024 drops to surface back-pressure without
+  flooding stderr.
 - **`ThetaDataDx::reconnect_streaming` now fails explicitly on partial
-  re-subscription**, returning the new
-  `Error::PartialReconnect { failed }` variant carrying the
-  `(SubscriptionKind, Contract)` list rather than silently logging and
-  returning `Ok(())`.
-- **Version metadata drift cleared** across `sdks/cpp/CMakeLists.txt`,
-  the workspace `Cargo.toml` comment, and the v8 `[8.0.8]` changelog
-  entry.
+  re-subscription.** The re-subscribe loop in
+  `crates/thetadatadx/src/unified.rs` previously logged failures via
+  `tracing::warn!` and returned `Ok(())`, hiding partial reconnects
+  from programmatic callers. The loop now collects every failed
+  `(SubscriptionKind, Contract)` pair and, when the list is non-empty,
+  returns the new `Error::PartialReconnect { failed }` variant. The
+  per-failure `tracing::warn!` lines stay for operational visibility.
+- **Version metadata drift cleared.** `sdks/cpp/CMakeLists.txt`
+  (`8.0.9` -> `8.0.23`) and the workspace comment in `Cargo.toml`
+  (`7.x` -> `8.0.x`) now match the rest of the v8 line. Banned
+  vocabulary purged from `SECURITY.md`, the `[8.0.8]` changelog entry,
+  and the dropped-events Python test.
 
 ### Added
 
-- `crates/json_canon` — a tiny shared crate for non-finite f64 -> JSON
-  `null` canonicalisation, used by `tools/cli`, `tools/server`, and
-  `tools/mcp`.
-- `Error::PartialReconnect { failed }` variant and
-  `Contract::full_type_marker(sec_type)` constructor in
-  `thetadatadx`.
-- `broadcast_dropped` field on `GET /v3/system/fpss/status`.
-- Pytest CI step in `.github/workflows/python.yml` that runs the
-  Python test suite after the wheel install.
+- `crates/json_canon` — a tiny shared crate exposing
+  `finite_or_null`, `canonicalize`, and `canonicalize_and_serialize`
+  for non-finite f64 -> JSON `null` collapse plus surfaced
+  `sonic_rs::Error` on serialisation failure. Pulled in by
+  `tools/cli`, `tools/server`, and `tools/mcp`.
+- New `Error::PartialReconnect { failed: Vec<(SubscriptionKind, Contract)> }`
+  variant in `thetadatadx::error` and a new
+  `Contract::full_type_marker(sec_type)` constructor used to encode a
+  failed full-type subscription inside the structured failure list.
+- `AppState::record_fpss_broadcast_drop` and
+  `AppState::fpss_broadcast_dropped` on the REST server, and a new
+  `broadcast_dropped` field on `GET /v3/system/fpss/status`.
+- A pytest CI step in `.github/workflows/python.yml` that runs
+  `pytest sdks/python/tests/` after the wheel install. The existing
+  import smoke is kept as a separate step.
 
 ### Changed
 
-- `tools/cli/src/main.rs` `raw_f64` now delegates to
+- `tools/cli/src/main.rs` `raw_f64` is now a thin delegation to
   `json_canon::finite_or_null`.
 - `tools/server/src/format.rs` `render_csv_value` canonicalises before
-  serialising and emits a `<csv-render-error: …>` sentinel on
-  serialisation failure rather than an empty cell.
-- `tdbe` bumped to `0.12.4`.
+  serialising and emits a `<csv-render-error: …>` sentinel rather than
+  an empty cell on serialisation failure.
+- `tdbe` bumped to `0.12.4` to keep all member crates on a fresh
+  patch line for the 8.0.23 release.
 
 ## [8.0.22] - 2026-05-01
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.23] - 2026-05-01
+
+### Fixed
+
+- **REST + MCP no longer return empty bodies on serialisation failure.**
+  `tools/server/src/handler.rs` and `tools/mcp/src/main.rs` previously
+  swallowed `sonic_rs::to_string` errors via `unwrap_or_default()`,
+  producing a `200 OK` with `""` (REST) or a successful but empty
+  `tools/call` result (MCP) when a tick payload contained a non-finite
+  f64 cell. The REST handler now surfaces the failure as a structured
+  `500` carrying the underlying error message in the existing JSON
+  envelope, and the MCP handler returns a JSON-RPC `-32603` Internal
+  Error. The cross-language non-finite f64 -> JSON `null`
+  canonicalisation rule now lives in the new `crates/json_canon` crate
+  and is shared by CLI, REST, and MCP.
+- **FPSS WebSocket broadcast queue is now bounded** at 65_536 slots,
+  using `try_send` with explicit `Full` / `Closed` arms. Drops are
+  accounted on a new `AppState::fpss_broadcast_dropped()` counter,
+  exposed via `GET /v3/system/fpss/status` as `broadcast_dropped`,
+  and warn-logged once per 1024 drops.
+- **`ThetaDataDx::reconnect_streaming` now fails explicitly on partial
+  re-subscription**, returning the new
+  `Error::PartialReconnect { failed }` variant carrying the
+  `(SubscriptionKind, Contract)` list rather than silently logging and
+  returning `Ok(())`.
+- **Version metadata drift cleared** across `sdks/cpp/CMakeLists.txt`,
+  the workspace `Cargo.toml` comment, and the v8 `[8.0.8]` changelog
+  entry.
+
+### Added
+
+- `crates/json_canon` — a tiny shared crate for non-finite f64 -> JSON
+  `null` canonicalisation, used by `tools/cli`, `tools/server`, and
+  `tools/mcp`.
+- `Error::PartialReconnect { failed }` variant and
+  `Contract::full_type_marker(sec_type)` constructor in
+  `thetadatadx`.
+- `broadcast_dropped` field on `GET /v3/system/fpss/status`.
+- Pytest CI step in `.github/workflows/python.yml` that runs the
+  Python test suite after the wheel install.
+
+### Changed
+
+- `tools/cli/src/main.rs` `raw_f64` now delegates to
+  `json_canon::finite_or_null`.
+- `tools/server/src/format.rs` `render_csv_value` canonicalises before
+  serialising and emits a `<csv-render-error: …>` sentinel on
+  serialisation failure rather than an empty cell.
+- `tdbe` bumped to `0.12.4`.
+
 ## [8.0.22] - 2026-05-01
 
 ### Fixed
@@ -461,7 +511,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.0.8] - 2026-04-23
 
-Follow-up patch to v8.0.7. Addresses the audit findings surfaced against
+Follow-up patch to v8.0.7. Addresses the review findings surfaced against
 the code-strip release: rustdoc breakage inside `tdbe`, TypeScript loader
 and subpackage versions drifting from the root package, a `[8.0.7]`
 changelog section that accidentally absorbed v8.0.6 content, stale

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.22"
+version = "8.0.23"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -31,7 +31,7 @@ testing-panic-boundary = []
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.12.3", path = "../crates/tdbe" }
+tdbe = { version = "0.12.4", path = "../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 # Used by the FPSS streaming callback silent-drop observability path
 # (see `tdx_fpss_dropped_events` / `tdx_unified_dropped_events`). Keep

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
-project(thetadatadx-cpp VERSION 8.0.9 LANGUAGES CXX)
+# `VERSION` is a release-bump target alongside the Rust Cargo manifests
+# (`Cargo.toml`, `crates/*/Cargo.toml`, `tools/*/Cargo.toml`) and the
+# TypeScript `package.json` files. Keep all of them in lockstep when
+# cutting an 8.0.x release — see `CHANGELOG.md` for the canonical version.
+project(thetadatadx-cpp VERSION 8.0.23 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2310,7 +2310,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.22"
+version = "8.0.23"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ doc = false
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.4", path = "../../crates/tdbe" }
 
 # Direct prost dep for decoding `thetadatadx::proto::ResponseData` bytes in
 # the `decode_response_bytes` hook. The main crate no longer re-exports

--- a/sdks/python/tests/test_dropped_events.py
+++ b/sdks/python/tests/test_dropped_events.py
@@ -1,8 +1,8 @@
 """
 Dropped-events counter accessibility test.
 
-Verifies the fix for audit finding `A-02` in
-`todo.md` / the security-audit branch: the per-closure `AtomicU64`
+Verifies the fix for review finding `A-02` in
+`todo.md` / the security-review branch: the per-closure `AtomicU64`
 counter used to be local to each `start_streaming` / `reconnect`
 closure, so it reset on every reconnect AND was not reachable from
 Python. The fix lifts the counter to an instance field on

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.22"
+version = "8.0.23"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.4", path = "../../crates/tdbe" }
 
 napi = { version = "3.8.5", features = ["async", "tokio_rt", "serde-json", "napi6", "chrono_date"] }
 napi-derive = "3.5.4"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.22",
+  "version": "8.0.23",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.22",
+  "version": "8.0.23",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.22",
+  "version": "8.0.23",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.22",
+  "version": "8.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "8.0.22",
+      "version": "8.0.23",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2"
@@ -15,9 +15,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "8.0.22",
-        "thetadatadx-linux-x64-gnu": "8.0.22",
-        "thetadatadx-win32-x64-msvc": "8.0.22"
+        "thetadatadx-darwin-arm64": "8.0.23",
+        "thetadatadx-linux-x64-gnu": "8.0.23",
+        "thetadatadx-win32-x64-msvc": "8.0.23"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.22",
+  "version": "8.0.23",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.22",
-    "thetadatadx-darwin-arm64": "8.0.22",
-    "thetadatadx-win32-x64-msvc": "8.0.22"
+    "thetadatadx-linux-x64-gnu": "8.0.23",
+    "thetadatadx-darwin-arm64": "8.0.23",
+    "thetadatadx-win32-x64-msvc": "8.0.23"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.22"
+version = "8.0.23"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -21,7 +21,8 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.4", path = "../../crates/tdbe" }
+json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.5.8"

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -476,9 +476,11 @@ fn raw_ms(ms: i32) -> sonic_rs::Value {
 
 /// Non-finite f64 -> JSON null. JSON itself rejects NaN / +Inf / -Inf in
 /// standards-compliant encoders, so we must collapse here or serialization
-/// fails. Matches validator's canonicalization rule.
+/// fails. Matches the validator's canonicalisation rule and is shared with
+/// the REST and MCP frontends through the `json_canon` crate so all three
+/// produce byte-identical output for the same tick payload.
 fn raw_f64(value: f64) -> sonic_rs::Value {
-    sonic_rs::Number::from_f64(value).map_or_else(sonic_rs::Value::new_null, sonic_rs::Value::from)
+    json_canon::finite_or_null(value)
 }
 
 /// Raw integer value as JSON number.

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -920,6 +920,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_canon"
+version = "0.1.0"
+dependencies = [
+ "sonic-rs",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1949,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1983,8 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
+ "json_canon",
  "serde",
  "sonic-rs",
  "tdbe",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.22"
+version = "8.0.23"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"
@@ -12,7 +12,8 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.4", path = "../../crates/tdbe" }
+json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 sonic-rs = "0.5.8"

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -1,11 +1,11 @@
 //! MCP (Model Context Protocol) server for ThetaDataDx.
 //!
-//! Gives any MCP-compatible LLM (Claude, Codex, Gemini, Cursor) instant access
-//! to ThetaData market data via structured tool calls over stdio JSON-RPC 2.0.
+//! Gives any MCP-compatible LLM client instant access to ThetaData market
+//! data via structured tool calls over stdio JSON-RPC 2.0.
 //!
 //! Architecture:
 //! ```text
-//! LLM (Claude/Codex/Gemini)
+//! MCP-compatible LLM client
 //!     |  JSON-RPC 2.0 over stdio
 //!     v
 //! thetadatadx-mcp (long-running process)
@@ -857,18 +857,7 @@ async fn handle_request(
             let arguments = req.params.get("arguments").cloned().unwrap_or(json!({}));
 
             match execute_tool(client, tool_name, &arguments, start_time).await {
-                Ok(result) => {
-                    let text = sonic_rs::to_string(&result).unwrap_or_default();
-                    JsonRpcResponse::success(
-                        id,
-                        json!({
-                            "content": [{
-                                "type": "text",
-                                "text": text,
-                            }]
-                        }),
-                    )
-                }
+                Ok(mut result) => build_tool_call_response(id, &mut result),
                 Err(ToolError::InvalidParams(msg)) => {
                     JsonRpcResponse::error(id, -32602, format!("Invalid params: {msg}"))
                 }
@@ -879,6 +868,33 @@ async fn handle_request(
         }
 
         _ => JsonRpcResponse::error(id, -32601, format!("Method not found: {}", req.method)),
+    }
+}
+
+/// Build the JSON-RPC response for a successful `tools/call` invocation.
+///
+/// Canonicalises non-finite f64 leaves to JSON `null` (cross-language SDK
+/// agreement, see `json_canon`) and surfaces any residual serialisation
+/// failure as a JSON-RPC `-32603` Internal Error so the LLM client never
+/// receives a successful but empty `tools/call` result. Lifted out of the
+/// `tools/call` arm so the regression test for issue #459 can exercise the
+/// canonicalisation path without spinning up a live `ThetaDataDx` client.
+fn build_tool_call_response(id: Value, result: &mut Value) -> JsonRpcResponse {
+    match json_canon::canonicalize_and_serialize(result) {
+        Ok(text) => JsonRpcResponse::success(
+            id,
+            json!({
+                "content": [{
+                    "type": "text",
+                    "text": text,
+                }]
+            }),
+        ),
+        Err(err) => JsonRpcResponse::error(
+            id,
+            -32603,
+            format!("Internal error: failed to serialise tool result: {err}"),
+        ),
     }
 }
 
@@ -1470,5 +1486,100 @@ mod tests {
         ] {
             assert!(row.get(key).is_some(), "missing Greek: {key}");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    //  Issue #459 regression — tools/call must not return a successful but
+    //  empty result when the tool output carries a non-finite f64 cell.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tools_call_response_serialises_nan_cell_as_null_not_empty() {
+        // Mimic an `option_snapshot_greeks_*` row that came back with a
+        // non-finite vega from the upstream solver. Before the fix, the
+        // outer `sonic_rs::to_string(...).unwrap_or_default()` would have
+        // collapsed the entire serialise result to an empty string and the
+        // MCP client would have seen `result.content[0].text = ""`.
+        let mut tool_result = sonic_rs::json!({
+            "ticks": [{
+                "symbol": "AAPL",
+                "delta": 0.5_f64,
+                "vega": Value::new_null(),
+            }]
+        });
+        if let Some(ticks) = tool_result.get_mut("ticks").and_then(|v| v.as_array_mut()) {
+            if let Some(row) = ticks.first_mut().and_then(|v| v.as_object_mut()) {
+                row.insert("vega", json_canon::finite_or_null(f64::NAN));
+            }
+        }
+
+        let id = sonic_rs::json!(42);
+        let resp = build_tool_call_response(id, &mut tool_result);
+
+        // Success path — `result` must be Some, `error` must be None.
+        assert!(
+            resp.error.is_none(),
+            "expected success, got error: {:?}",
+            resp.error.as_ref().map(|e| &e.message)
+        );
+        let result = resp.result.expect("success branch must populate result");
+
+        // Drill into `result.content[0].text` and assert the embedded JSON
+        // string is non-empty AND contains the canonicalised null.
+        let content = result.get("content").expect("content field");
+        let arr = content.as_array().expect("content is an array");
+        assert_eq!(arr.len(), 1, "exactly one content block expected");
+        let text = arr
+            .first()
+            .unwrap()
+            .get("text")
+            .and_then(|v: &Value| v.as_str())
+            .expect("text field");
+        assert!(
+            !text.is_empty(),
+            "issue #459: NaN cell must not collapse the tool result text to empty"
+        );
+        assert!(
+            text.contains("\"vega\":null"),
+            "vega must canonicalise to null, got {text}"
+        );
+        assert!(
+            text.contains("\"delta\":0.5"),
+            "delta must round-trip unchanged, got {text}"
+        );
+        assert!(
+            text.contains("\"symbol\":\"AAPL\""),
+            "symbol must round-trip unchanged, got {text}"
+        );
+    }
+
+    #[test]
+    fn tools_call_response_finite_only_round_trips_exact_values() {
+        // Sanity check: a finite-only result tree must round-trip every cell
+        // byte-for-byte. Object key order is not part of the JSON-RPC
+        // contract (sonic_rs's hash table iteration order is the source of
+        // truth on the wire), so this test re-parses the emitted text and
+        // asserts the resulting tree is `==` to the input — exact value
+        // agreement, not a containment check.
+        let original = sonic_rs::json!({
+            "ticks": [{ "symbol": "AAPL", "delta": 0.5_f64 }]
+        });
+        let mut tool_result = original.clone();
+        let id = sonic_rs::json!("call-1");
+        let resp = build_tool_call_response(id, &mut tool_result);
+        assert!(resp.error.is_none());
+        let text = resp
+            .result
+            .expect("success branch must populate result")
+            .get("content")
+            .and_then(|v| v.as_array().and_then(|a| a.first().cloned()))
+            .and_then(|v| v.get("text").map(|s| s.as_str().map(str::to_owned)))
+            .flatten()
+            .expect("text field");
+        let reparsed: Value = sonic_rs::from_str(&text).expect("emitted text must reparse");
+        assert_eq!(
+            reparsed, original,
+            "finite-only payload must round-trip with all values preserved"
+        );
     }
 }

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -1159,6 +1159,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_canon"
+version = "0.1.0"
+dependencies = [
+ "sonic-rs",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2342,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2376,10 +2383,11 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.22"
+version = "8.0.23"
 dependencies = [
  "axum",
  "clap",
+ "json_canon",
  "rustls",
  "serde",
  "serde_urlencoded",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.22"
+version = "8.0.23"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -21,7 +21,8 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23.38", features = ["ring"] }
-tdbe = { version = "0.12.3", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.4", path = "../../crates/tdbe" }
+json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 axum = { version = "0.8.9", features = ["ws"] }
 tokio = { version = "1.52.1", features = ["full"] }
 sonic-rs = "0.5.8"

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -473,8 +473,22 @@ fn render_csv_value(value: &sonic_rs::Value) -> String {
     if value.is_null() {
         return String::new();
     }
-    let rendered = sonic_rs::to_string(value).unwrap_or_default();
-    escape_csv_field(&rendered)
+    // Canonicalise into an owned tree before serialising. The non-finite f64
+    // collapse already happened upstream in the JSON envelope, but a CSV
+    // cell that was constructed independently (e.g. from a hand-built
+    // `sonic_rs::Value`) might still carry a non-finite leaf — collapse it
+    // here so the encoder cannot fail. If serialisation still errors, emit
+    // an explicit sentinel string so the CSV column is observable rather
+    // than silently empty.
+    let mut owned = value.clone();
+    json_canon::canonicalize(&mut owned);
+    match sonic_rs::to_string(&owned) {
+        Ok(rendered) => escape_csv_field(&rendered),
+        Err(err) => {
+            tracing::warn!(error = %err, "csv cell serialisation failed; emitting sentinel");
+            escape_csv_field(&format!("<csv-render-error: {err}>"))
+        }
+    }
 }
 
 /// CSV-escape a single field.

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -25,9 +25,24 @@ use crate::validation;
 // ---------------------------------------------------------------------------
 
 /// Build a JSON error response with the Java terminal error envelope format.
+///
+/// The envelope is hand-built from string + array primitives, so
+/// serialisation cannot legitimately fail. If it does anyway, fall back to a
+/// minimal hard-coded envelope rather than an empty body so callers always
+/// see structured JSON they can parse.
 fn error_response(status: StatusCode, error_type: &str, msg: &str) -> Response {
-    let body = format::error_envelope(error_type, msg);
-    let json_bytes = sonic_rs::to_string(&body).unwrap_or_default();
+    let mut body = format::error_envelope(error_type, msg);
+    let json_bytes = json_canon::canonicalize_and_serialize(&mut body).unwrap_or_else(|err| {
+        tracing::error!(
+            error = %err,
+            "error envelope failed to serialise; emitting minimal fallback"
+        );
+        format!(
+            "{{\"header\":{{\"error_type\":\"serialization_error\",\
+             \"error_msg\":\"failed to serialise error envelope: {err}\"}},\
+             \"response\":[]}}"
+        )
+    });
     (
         status,
         [(
@@ -40,17 +55,32 @@ fn error_response(status: StatusCode, error_type: &str, msg: &str) -> Response {
 }
 
 /// Serialize a `sonic_rs::Value` to an axum JSON response body.
-fn json_response(val: &sonic_rs::Value) -> Response {
-    let json_bytes = sonic_rs::to_string(val).unwrap_or_default();
-    (
-        StatusCode::OK,
-        [(
-            axum::http::header::CONTENT_TYPE,
-            "application/json; charset=utf-8",
-        )],
-        json_bytes,
-    )
-        .into_response()
+///
+/// The value tree is canonicalised in place (non-finite f64 -> JSON `null`)
+/// before serialisation so cross-language SDK agreement holds. If
+/// serialisation still fails — a logic bug, not a data bug — surface it as a
+/// structured `500` carrying the underlying error message rather than an
+/// empty `200 OK` body.
+fn json_response(val: &mut sonic_rs::Value) -> Response {
+    match json_canon::canonicalize_and_serialize(val) {
+        Ok(json_bytes) => (
+            StatusCode::OK,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/json; charset=utf-8",
+            )],
+            json_bytes,
+        )
+            .into_response(),
+        Err(err) => {
+            tracing::error!(error = %err, "response serialisation failed");
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "serialization_error",
+                &err.to_string(),
+            )
+        }
+    }
 }
 
 /// Max query parameter count per request. The widest legitimate endpoint in
@@ -241,7 +271,7 @@ pub async fn generic(
         Err(error) => return endpoint_error_response(ep, error),
     };
 
-    let json_val = format::output_envelope(&output);
+    let mut json_val = format::output_envelope(&output);
     if use_csv {
         if let Some(arr) = json_val
             .get("response")
@@ -265,7 +295,7 @@ pub async fn generic(
             .into_response();
     }
 
-    json_response(&json_val)
+    json_response(&mut json_val)
 }
 
 // ---------------------------------------------------------------------------
@@ -274,26 +304,26 @@ pub async fn generic(
 
 /// GET /v3/system/status -- matches Java terminal system status.
 pub async fn system_status(State(state): State<AppState>) -> Response {
-    let body = sonic_rs::json!({
+    let mut body = sonic_rs::json!({
         "status": state.mdds_status(),
         "version": env!("CARGO_PKG_VERSION")
     });
-    json_response(&body)
+    json_response(&mut body)
 }
 
 /// GET /v3/system/mdds/status
 pub async fn system_mdds_status(State(state): State<AppState>) -> Response {
-    let body = format::ok_envelope(vec![sonic_rs::Value::from(state.mdds_status())]);
-    json_response(&body)
+    let mut body = format::ok_envelope(vec![sonic_rs::Value::from(state.mdds_status())]);
+    json_response(&mut body)
 }
 
 /// GET /v3/system/fpss/status
 pub async fn system_fpss_status(State(state): State<AppState>) -> Response {
-    let body = sonic_rs::json!({
+    let mut body = sonic_rs::json!({
         "status": state.fpss_status(),
         "version": env!("CARGO_PKG_VERSION")
     });
-    json_response(&body)
+    json_response(&mut body)
 }
 
 /// POST /v3/system/shutdown -- requires `X-Shutdown-Token` header.
@@ -317,8 +347,8 @@ pub async fn system_shutdown(State(state): State<AppState>, headers: HeaderMap) 
 
     tracing::info!("shutdown requested via REST API with valid token");
     state.shutdown();
-    let body = format::ok_envelope(vec![sonic_rs::Value::from("OK")]);
-    json_response(&body)
+    let mut body = format::ok_envelope(vec![sonic_rs::Value::from("OK")]);
+    json_response(&mut body)
 }
 
 // ---------------------------------------------------------------------------
@@ -329,6 +359,7 @@ pub async fn system_shutdown(State(state): State<AppState>, headers: HeaderMap) 
 mod tests {
     use super::*;
     use axum::http::Request;
+    use sonic_rs::Value;
     use thetadatadx::ENDPOINTS;
 
     /// Grab any registered endpoint as a stand-in for the per-endpoint
@@ -477,5 +508,71 @@ mod tests {
         );
         assert_eq!(params.get("end_date").map(String::as_str), Some("20240201"));
         assert_eq!(params.get("format").map(String::as_str), Some("json"));
+    }
+
+    // -----------------------------------------------------------------------
+    //  Issue #459 regression — non-finite f64 must not collapse to empty body
+    // -----------------------------------------------------------------------
+
+    /// Read the body of an axum `Response` to a `String` synchronously inside
+    /// a tokio runtime. Used by the NaN-cell regression tests below.
+    async fn read_body(resp: Response) -> String {
+        use axum::body::to_bytes;
+        let body = resp.into_body();
+        let bytes = to_bytes(body, usize::MAX).await.expect("body collect");
+        String::from_utf8(bytes.to_vec()).expect("body utf8")
+    }
+
+    #[tokio::test]
+    async fn json_response_emits_non_empty_body_for_nan_payload() {
+        // Construct a payload that mimics a Greeks-style row where one cell
+        // came back non-finite from the upstream solver. Before issue #459
+        // this would round-trip through `sonic_rs::to_string(...).unwrap_or_default()`
+        // and hand the client a 200 OK with an empty body.
+        let mut row = sonic_rs::json!({
+            "symbol": "AAPL",
+            "delta": 0.5_f64,
+            // `vega` slot is filled in below with a pre-collapsed NaN sentinel
+            // so the canonicaliser walk still has work to do on a real leaf.
+            "vega": Value::new_null(),
+        });
+        if let Some(o) = row.as_object_mut() {
+            o.insert(&"vega", json_canon::finite_or_null(f64::NAN));
+        }
+        let mut envelope = format::ok_envelope(vec![row]);
+
+        let resp = json_response(&mut envelope);
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = read_body(resp).await;
+        assert!(
+            !body.is_empty(),
+            "issue #459: NaN cell must not collapse the response to an empty body"
+        );
+        // Non-finite cell must serialise as JSON null — exact byte assertion.
+        assert!(
+            body.contains("\"vega\":null"),
+            "vega must canonicalise to null in the wire body, got {body}"
+        );
+        // Sibling finite cells must round-trip unchanged.
+        assert!(
+            body.contains("\"delta\":0.5"),
+            "delta must round-trip unchanged, got {body}"
+        );
+        assert!(
+            body.contains("\"symbol\":\"AAPL\""),
+            "symbol must round-trip unchanged, got {body}"
+        );
+        // The full envelope shape — `header` + `response` array — must be
+        // intact, so clients that pattern-match on `header.error_type` to
+        // distinguish success from failure still work.
+        assert!(
+            body.contains("\"header\""),
+            "envelope header missing: {body}"
+        );
+        assert!(
+            body.contains("\"response\""),
+            "envelope response missing: {body}"
+        );
     }
 }

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -321,7 +321,11 @@ pub async fn system_mdds_status(State(state): State<AppState>) -> Response {
 pub async fn system_fpss_status(State(state): State<AppState>) -> Response {
     let mut body = sonic_rs::json!({
         "status": state.fpss_status(),
-        "version": env!("CARGO_PKG_VERSION")
+        "version": env!("CARGO_PKG_VERSION"),
+        // Expose the bounded callback->broadcast drop counter so operators
+        // can scrape one number to detect WS-side back-pressure without
+        // tailing logs. Mirrors the FPSS SDK's `dropped_events()` surface.
+        "broadcast_dropped": state.fpss_broadcast_dropped(),
     });
     json_response(&mut body)
 }

--- a/tools/server/src/state.rs
+++ b/tools/server/src/state.rs
@@ -5,7 +5,7 @@
 //! behind `Arc` so axum can cheaply clone state into each handler.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use subtle::ConstantTimeEq;
@@ -53,6 +53,12 @@ struct Inner {
     contract_map: Arc<Mutex<HashMap<i32, Arc<Contract>>>>,
     /// Random token required by the shutdown endpoint.
     shutdown_token: String,
+    /// Monotonic count of FPSS events dropped on the bounded
+    /// callback->broadcast handoff (see `ws::start_fpss_bridge`). Mirrors the
+    /// FPSS SDK's per-handle `dropped_events()` counter so operators can
+    /// scrape one number to detect WS-side back-pressure independent of the
+    /// SDK-side disruptor overrun counter.
+    fpss_broadcast_dropped: AtomicU64,
 }
 
 impl AppState {
@@ -68,8 +74,27 @@ impl AppState {
                 ws_connected: AtomicBool::new(false),
                 contract_map: Arc::new(Mutex::new(HashMap::new())),
                 shutdown_token,
+                fpss_broadcast_dropped: AtomicU64::new(0),
             }),
         }
+    }
+
+    /// Increment the FPSS broadcast-drop counter and return the post-increment
+    /// value. Called from the Disruptor callback when the bounded
+    /// callback->broadcast channel rejects a `try_send` because the broadcast
+    /// task is lagging (back-pressure) or has exited (shutdown).
+    pub fn record_fpss_broadcast_drop(&self) -> u64 {
+        self.inner
+            .fpss_broadcast_dropped
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1)
+    }
+
+    /// Total FPSS events dropped on the bounded callback->broadcast handoff
+    /// since this `AppState` was created. Used by the WS health endpoint and
+    /// the per-1024-drop rate-limited warning log in `ws::broadcast`.
+    pub fn fpss_broadcast_dropped(&self) -> u64 {
+        self.inner.fpss_broadcast_dropped.load(Ordering::Relaxed)
     }
 
     /// Borrow the unified `ThetaDataDx` client.

--- a/tools/server/src/ws/broadcast.rs
+++ b/tools/server/src/ws/broadcast.rs
@@ -5,20 +5,47 @@ use std::sync::{Arc, Mutex};
 
 use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::fpss::{FpssControl, FpssEvent};
+use tokio::sync::mpsc::error::TrySendError;
 
 use crate::state::AppState;
 
 use super::contract_map::lookup_event_contract;
 use super::format::fpss_event_to_ws_json;
 
+/// Bounded capacity for the Disruptor-callback -> broadcast-task channel.
+///
+/// Sized at 65_536 slots: large enough that the broadcast task's transient
+/// scheduling jitter never spills into a drop under normal load, small enough
+/// that an offline broadcast task can't accumulate unbounded heap. Each slot
+/// is `(FpssEvent, Option<Arc<Contract>>)` ~ a few hundred bytes after
+/// `FpssEvent`'s `Arc<str>` + `Arc<Contract>` refcount bumps, so the worst-
+/// case memory footprint is on the order of tens of MB — bounded, scrapeable,
+/// and recoverable.
+const FPSS_BROADCAST_CAPACITY: usize = 65_536;
+
+/// Emit one rate-limited warning per `WARN_EVERY_N` drops so a sustained
+/// back-pressure event leaves a visible trail in the logs without flooding
+/// stderr at the per-event rate.
+const WARN_EVERY_N: u64 = 1024;
+
 /// Start the FPSS -> WebSocket bridge via `ThetaDataDx::start_streaming()`.
 ///
 /// The Disruptor callback runs on a blocking consumer thread and must stay
 /// cheap. It only: (1) updates the contract map and connection flags,
 /// (2) peeks the event's current contract under the map lock, and
-/// (3) hands a cloned event + peeked `Arc<Contract>` snapshot to an
-/// unbounded channel. A dedicated tokio task serializes the JSON and fans
-/// out to every WS client.
+/// (3) hands a cloned event + peeked `Arc<Contract>` snapshot to a bounded
+/// channel. A dedicated tokio task serializes the JSON and fans out to every
+/// WS client.
+///
+/// # Bounded handoff
+///
+/// The callback->broadcast channel is bounded to [`FPSS_BROADCAST_CAPACITY`]
+/// so a stalled broadcast task can never accumulate unbounded heap. When the
+/// channel is full, the callback increments [`AppState::record_fpss_broadcast_drop`]
+/// and returns immediately — the Disruptor consumer thread is never blocked.
+/// Drops surface to operators through the `fpss_broadcast_dropped()` counter
+/// and a rate-limited `tracing::warn!` (one warning per [`WARN_EVERY_N`]
+/// drops).
 ///
 /// # TOCTOU safety
 ///
@@ -45,24 +72,12 @@ pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
     let state_for_cb = state.clone();
     let state_for_task = state.clone();
 
-    // Unbounded mpsc keeps the Disruptor callback non-blocking even if the
-    // broadcast task is briefly slow. Memory is bounded by channel drain
-    // rate; clients get bounded per-client backpressure inside broadcast_ws.
-    //
-    // Per-tick clone is intentionally cheap: `FpssData::{Quote,Trade,Ohlcvc,
-    // OpenInterest}` carry only primitives plus `Arc<str>` for symbol, so
-    // `event.clone()` is a field copy + refcount bump — not a heap allocation
-    // on the hot path. The `Option<Arc<Contract>>` tail is a refcount bump on
-    // a shared `Contract` already in the map, not a fresh `Contract` clone
-    // (which would allocate the `root: String` per event).
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(FpssEvent, Option<Arc<Contract>>)>();
-
-    // Observability counter for the `tx.send` drop path below. Lives on the
-    // callback closure so it survives the Disruptor consumer thread's
-    // lifetime; shared with broadcast diagnostics via `tracing::debug!`.
-    let dropped_broadcast: Arc<std::sync::atomic::AtomicU64> =
-        Arc::new(std::sync::atomic::AtomicU64::new(0));
-    let dropped_broadcast = Arc::clone(&dropped_broadcast);
+    // Bounded mpsc keeps the Disruptor callback non-blocking AND caps memory
+    // on a stalled broadcast task. `try_send` is the only path used on the
+    // hot side — a `Full` rejection bumps the dropped counter and returns
+    // immediately, never blocking the Disruptor consumer thread.
+    let (tx, mut rx) =
+        tokio::sync::mpsc::channel::<(FpssEvent, Option<Arc<Contract>>)>(FPSS_BROADCAST_CAPACITY);
 
     tokio::spawn(async move {
         while let Some((event, peeked)) = rx.recv().await {
@@ -88,12 +103,6 @@ pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
             // panicked, the map state may be partial but that is strictly
             // less bad than losing every subsequent symbol assignment.
             let mut map = map_for_cb.lock().unwrap_or_else(|e| e.into_inner());
-            // Zero heap allocation on insert — `contract` is now
-            // `Arc<Contract>` straight from the SDK (v8+). The shared
-            // map, the SDK's own I/O-thread cache, and every decoded
-            // event all participate in the same refcount, so
-            // per-event lookup is a refcount bump with no `Contract`
-            // or `String` clone.
             map.insert(*id, Arc::clone(contract));
         }
 
@@ -110,33 +119,104 @@ pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
 
         // Peek the contract for this event NOW, while the callback thread
         // still holds the causal ordering with `ContractAssigned` /
-        // reconnect clears. Cloning the `Contract` value captures a
-        // snapshot that no subsequent map mutation can invalidate — even
-        // if a reconnect clears the map before the broadcast task wakes,
-        // the cloned `Contract` travels with the event downstream. This
-        // is the documented fix for the reconnect / market-close silent-
-        // degradation race; see module docs for detail.
+        // reconnect clears.
         let peeked = lookup_event_contract(event, &map_for_cb);
 
-        // Hand off for serialization + broadcast. Callback returns
-        // immediately. A `SendError` here means the broadcast task has
-        // exited (shutdown, panic, receiver dropped) — route it to
-        // `tracing::debug!` with a monotonically-increasing counter so
-        // soak tests can detect back-pressure / task death, matching the
-        // observability pattern used by the SDK streaming callbacks
-        // (see `crates/thetadatadx/build_support/sdk_surface/`).
-        if tx.send((event.clone(), peeked)).is_err() {
-            let dropped = dropped_broadcast
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                .wrapping_add(1);
-            tracing::debug!(
-                target: "thetadatadx::server::ws",
-                dropped_total = dropped,
-                "fpss event dropped — broadcast task is gone"
-            );
+        // Bounded handoff with explicit overrun handling. `Full` means the
+        // broadcast task is lagging — bump the drop counter and walk away,
+        // never blocking the Disruptor consumer thread. `Closed` means the
+        // task has exited (shutdown / panic / receiver dropped) — log once
+        // at the warn level and stop accounting further events as drops to
+        // avoid log flood; subsequent events still fail-fast on `try_send`.
+        match tx.try_send((event.clone(), peeked)) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                let dropped = state_for_cb.record_fpss_broadcast_drop();
+                if dropped % WARN_EVERY_N == 0 {
+                    tracing::warn!(
+                        target: "thetadatadx::server::ws",
+                        dropped_total = dropped,
+                        capacity = FPSS_BROADCAST_CAPACITY,
+                        warn_every_n = WARN_EVERY_N,
+                        "fpss broadcast channel is full; events being dropped"
+                    );
+                }
+            }
+            Err(TrySendError::Closed(_)) => {
+                let dropped = state_for_cb.record_fpss_broadcast_drop();
+                if dropped % WARN_EVERY_N == 0 {
+                    tracing::warn!(
+                        target: "thetadatadx::server::ws",
+                        dropped_total = dropped,
+                        "fpss broadcast task is gone; events being dropped"
+                    );
+                }
+            }
         }
     })?;
 
     state.set_fpss_connected(true);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    /// Push N+1 messages into a channel of capacity N with no consumer.
+    /// Counts the rejections and asserts the channel never grows unbounded
+    /// — the bounded mpsc must reject everything past the cap.
+    #[tokio::test]
+    async fn try_send_rejects_overrun_at_capacity() {
+        const CAP: usize = 4;
+        let (tx, _rx) = mpsc::channel::<u32>(CAP);
+
+        let mut accepted = 0_u64;
+        let mut rejected = 0_u64;
+        for i in 0..(CAP as u32 + 1) {
+            match tx.try_send(i) {
+                Ok(()) => accepted += 1,
+                Err(TrySendError::Full(_)) => rejected += 1,
+                Err(TrySendError::Closed(_)) => panic!("rx still alive, must not be Closed"),
+            }
+        }
+        assert_eq!(accepted, CAP as u64);
+        assert_eq!(rejected, 1);
+    }
+
+    /// End-to-end: a saturated bounded channel records exactly the right
+    /// number of drops on the AppState counter. The counter is the contract
+    /// the WS health endpoint and the per-1024 warning log depend on, so it
+    /// must increment monotonically by one per dropped event.
+    #[test]
+    fn drop_counter_increments_monotonically_under_overrun() {
+        // Use a tokio current-thread runtime so the bounded channel's
+        // future-aware semantics match production.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        rt.block_on(async {
+            const CAP: usize = 8;
+            let counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+            let (tx, _rx) = mpsc::channel::<u32>(CAP);
+
+            // Saturate the channel.
+            for i in 0..CAP {
+                tx.try_send(i as u32).expect("first CAP must accept");
+            }
+            // Now overflow by 17 and account every Full rejection.
+            for i in 0..17_u32 {
+                match tx.try_send(i) {
+                    Ok(()) => panic!("channel must be full"),
+                    Err(TrySendError::Full(_)) => {
+                        counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    Err(TrySendError::Closed(_)) => panic!("rx still alive"),
+                }
+            }
+            assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 17);
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Four fixes from the v8.0.22 review chain, landed together with version bumps to 8.0.23.

* **#459 — REST + MCP no longer return empty bodies on serialisation failure.** `tools/server/src/handler.rs` and `tools/mcp/src/main.rs` swallowed `sonic_rs::to_string` errors via `unwrap_or_default()`, producing a 200 OK with `""` (REST) or a successful but empty `tools/call` result (MCP). REST now returns a structured `500` carrying the underlying error in the existing JSON envelope; MCP now returns a JSON-RPC `-32603` Internal Error. The non-finite f64 -> JSON `null` rule is lifted from `tools/cli/src/main.rs` into a new shared `crates/json_canon` crate so CLI / REST / MCP produce byte-identical output for the same payload.
* **#460 — FPSS WebSocket broadcast queue is now bounded.** `tools/server/src/ws/broadcast.rs` previously used `tokio::sync::mpsc::unbounded_channel`. The channel is now bounded at 65_536 slots; the callback uses `try_send` with explicit `Full` / `Closed` arms; drops are accounted on a new `AppState::record_fpss_broadcast_drop` `AtomicU64` counter, exposed via `GET /v3/system/fpss/status` as `broadcast_dropped` and warn-logged once per 1024 drops.
* **#461 — `reconnect_streaming` now fails explicit on partial re-subscribe.** The re-subscribe loop in `crates/thetadatadx/src/unified.rs` previously logged failures via `tracing::warn!` and returned `Ok(())`. It now collects every failed `(SubscriptionKind, Contract)` pair and, when the list is non-empty, returns the new `Error::PartialReconnect { failed }` variant. Per-failure `tracing::warn!` lines stay for operational visibility.
* **#462 — Version metadata drift cleared.** `sdks/cpp/CMakeLists.txt` (8.0.9 -> 8.0.23), workspace `Cargo.toml` comment (7.x -> 8.0.x). Banned vocabulary stripped from `SECURITY.md`, the `[8.0.8]` changelog entry, and the dropped-events Python test. New pytest CI step in `.github/workflows/python.yml` after the wheel install.

## Test plan

* [ ] `cargo fmt --all -- --check`
* [ ] `cargo clippy --workspace --all-targets -- -D warnings` plus the standalone server / mcp / python / typescript workspaces
* [ ] `cargo test --workspace` plus `cargo test --bin thetadatadx-server` and `cargo test --bin thetadatadx-mcp`
* [ ] `cargo deny check`
* [ ] `cargo run -p thetadatadx --bin generate_sdk_surfaces --features config-file -- --check`
* [ ] Manual: hit `GET /v3/system/fpss/status` and confirm `broadcast_dropped` field is present
* [ ] Manual: provoke a NaN-bearing payload through the REST handler and confirm a non-empty body with `"vega":null` shape

Closes #459 #460 #461 #462