### PR TITLE
fix: silence find_header warn on optional Greeks columns (#472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.26] - 2026-05-05
+
+### Fixed
+
+- **`option_*_greeks_*_order` no longer spams `expected column header
+  not found` warnings.** `crates/thetadatadx/src/decode.rs::find_header`
+  emitted a `tracing::warn!` every time a generated parser asked for an
+  optional column that was absent from the wire response. The Greeks
+  family splits the column set across the wire — `_greeks_first_order`
+  ships seven Greeks, `_greeks_second_order` ships five, and
+  `_greeks_third_order` ships four — but the shared `GreeksTick` schema
+  carries the full 23-Greek union. Calling
+  `option_snapshot_greeks_third_order` therefore produced eight warn
+  lines per response (zomma, color, ultima, d1, d2, dual_delta,
+  dual_gamma, vera, …) before any user-visible decoding finished. The
+  warn is now a `tracing::trace!` so the diagnostic is still reachable
+  via `RUST_LOG=thetadatadx=trace` for genuine schema-drift
+  investigations, but stays out of stderr on routine subset calls.
+  Required-column drift continues to surface as a typed
+  `Error::MissingRequiredHeader` from the generated parser. Closes #472.
+
+### Changed
+
+- Per-endpoint vendor-schema column lists for the four Greeks families
+  pinned and documented in `tick_schema.toml::GreeksTick` against the
+  upstream OpenAPI capture in `scripts/upstream_openapi.yaml`. The
+  `GreeksTick` struct itself is unchanged — every Greeks endpoint still
+  returns `Vec<GreeksTick>` and the union layout is the same — but the
+  schema doc-comment now spells out which Greeks each endpoint
+  publishes, why the others zero-default, and where the per-endpoint
+  vendor schema is captured. The codegen pickup is doc-only; no SDK
+  surface drift.
+- Three new unit tests in `crates/thetadatadx/src/decode.rs::tests`
+  drive `parse_greeks_ticks` against the `_first_order`,
+  `_second_order`, and `_third_order` wire shapes (column lists pinned
+  to upstream OpenAPI). Each test asserts bit-exact decoded values for
+  the wire-present columns and `0.0` defaults for the documented gaps,
+  so a future regression of `find_header` back to `tracing::warn!` —
+  or any column-list drift in either direction — surfaces as a
+  behavioural test failure rather than as live log spam.
+- `tdbe` 0.12.6 → 0.12.7.
+
 ## [8.0.25] - 2026-05-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.12.6"
+version = "0.12.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.25"
+version = "8.0.26"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -40,7 +40,7 @@ frames = ["polars", "arrow"]
 live-tests = []
 
 [dependencies]
-tdbe = { version = "0.12.6", path = "../tdbe" }
+tdbe = { version = "0.12.7", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }
@@ -132,7 +132,7 @@ prost-build = "=0.14.3"
 regex = "1.12.3"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
-tdbe = { version = "0.12.6", path = "../tdbe" }
+tdbe = { version = "0.12.7", path = "../tdbe" }
 
 [[bench]]
 name = "bench_decode"

--- a/crates/thetadatadx/src/decode.rs
+++ b/crates/thetadatadx/src/decode.rs
@@ -105,6 +105,14 @@ const HEADER_ALIASES: &[(&str, &str)] = &[
 ///
 /// The v3 MDDS server uses `timestamp` where the tick schema says `ms_of_day`.
 /// This function checks the primary name first, then falls back to known aliases.
+///
+/// Returns `None` silently when the header is absent — required-header
+/// guards in the generated parsers surface a typed
+/// [`Error::MissingRequiredHeader`] for the must-have columns; optional
+/// columns missing from a subset response (e.g. `option_snapshot_greeks_third_order`
+/// returning only the third-order Greek columns from the `GreeksTick`
+/// union schema) are by design. Header drift can be observed at the
+/// `trace` level via `RUST_LOG=thetadatadx=trace`.
 fn find_header(headers: &[&str], name: &str) -> Option<usize> {
     // Try exact match first.
     if let Some(pos) = headers.iter().position(|&s| s == name) {
@@ -118,9 +126,9 @@ fn find_header(headers: &[&str], name: &str) -> Option<usize> {
             }
         }
     }
-    tracing::warn!(
+    tracing::trace!(
         header = name,
-        "expected column header not found in DataTable"
+        "column header not present in DataTable (optional or subset response)"
     );
     None
 }
@@ -1751,5 +1759,180 @@ mod tests {
         let ticks = parse_greeks_ticks(&table).unwrap();
         assert_eq!(ticks.len(), 1);
         assert!(ticks[0].implied_volatility.abs() < 1e-10);
+    }
+
+    /// Vendor wire shape for `option_*_greeks_first_order`: only the seven
+    /// first-order columns plus IV pair — vanna/charm/vomma/veta/speed/
+    /// zomma/color/ultima/d1/d2/dual_delta/dual_gamma/vera are absent and
+    /// must default to `0.0` without surfacing any `find_header` warn.
+    /// Column layout pinned to `scripts/upstream_openapi.yaml` schema
+    /// `items_option_snapshot_greeks_first_order`.
+    #[test]
+    fn parse_greeks_ticks_decodes_first_order_subset_with_silent_gaps() {
+        let table = proto::DataTable {
+            headers: vec![
+                "ms_of_day".into(),
+                "implied_volatility".into(),
+                "delta".into(),
+                "theta".into(),
+                "vega".into(),
+                "rho".into(),
+                "epsilon".into(),
+                "lambda".into(),
+                "iv_error".into(),
+                "date".into(),
+            ],
+            data_table: vec![row_of(vec![
+                dv_number(34_200_000),
+                dv_price(2142, 6),  // implied_volatility = 0.2142
+                dv_price(5023, 6),  // delta = 0.5023
+                dv_price(-114, 6),  // theta = -0.0114
+                dv_price(8741, 6),  // vega = 0.8741
+                dv_price(13598, 6), // rho = 1.3598
+                dv_price(-1976, 6), // epsilon = -0.1976
+                dv_price(32052, 6), // lambda = 3.2052
+                dv_price(-3, 6),    // iv_error = -3 / 10^4 = -0.0003
+                dv_number(20_240_614),
+            ])],
+        };
+        let ticks = parse_greeks_ticks(&table).unwrap();
+        assert_eq!(ticks.len(), 1);
+        let t = &ticks[0];
+
+        // Wire-present columns: bit-exact against the input.
+        // `dv_price(value, 6)` decodes as `value * 10^(6-10) = value / 10000`
+        // (see `tdbe::types::price::Price::to_f64`).
+        assert_eq!(t.ms_of_day, 34_200_000);
+        assert!((t.implied_volatility - 0.2142).abs() < 1e-9);
+        assert!((t.delta - 0.5023).abs() < 1e-9);
+        assert!((t.theta - -0.0114).abs() < 1e-9);
+        assert!((t.vega - 0.8741).abs() < 1e-9);
+        assert!((t.rho - 1.3598).abs() < 1e-9);
+        assert!((t.epsilon - -0.1976).abs() < 1e-9);
+        assert!((t.lambda - 3.2052).abs() < 1e-9);
+        assert!((t.iv_error - -0.0003).abs() < 1e-9);
+        assert_eq!(t.date, 20_240_614);
+
+        // Wire-absent columns: zero-defaulted. These are the columns the
+        // server does NOT publish for `_greeks_first_order` — `find_header`
+        // returning `None` for each must NOT yield an error and must NOT
+        // warn (the pre-fix behaviour spammed eight warn lines per row).
+        assert_eq!(t.gamma, 0.0);
+        assert_eq!(t.vanna, 0.0);
+        assert_eq!(t.charm, 0.0);
+        assert_eq!(t.vomma, 0.0);
+        assert_eq!(t.veta, 0.0);
+        assert_eq!(t.speed, 0.0);
+        assert_eq!(t.zomma, 0.0);
+        assert_eq!(t.color, 0.0);
+        assert_eq!(t.ultima, 0.0);
+        assert_eq!(t.d1, 0.0);
+        assert_eq!(t.d2, 0.0);
+        assert_eq!(t.dual_delta, 0.0);
+        assert_eq!(t.dual_gamma, 0.0);
+        assert_eq!(t.vera, 0.0);
+    }
+
+    /// Vendor wire shape for `option_*_greeks_second_order`: gamma / vanna
+    /// / charm / vomma / veta plus IV pair. Column layout pinned to
+    /// upstream OpenAPI schema `items_option_snapshot_greeks_second_order`.
+    #[test]
+    fn parse_greeks_ticks_decodes_second_order_subset_with_silent_gaps() {
+        let table = proto::DataTable {
+            headers: vec![
+                "ms_of_day".into(),
+                "implied_volatility".into(),
+                "gamma".into(),
+                "vanna".into(),
+                "charm".into(),
+                "vomma".into(),
+                "veta".into(),
+                "iv_error".into(),
+                "date".into(),
+            ],
+            data_table: vec![row_of(vec![
+                dv_number(34_200_000),
+                dv_price(2142, 6), // implied_volatility = 0.2142
+                dv_price(120, 6),  // gamma = 0.012
+                dv_price(45, 6),   // vanna = 0.0045
+                dv_price(-12, 6),  // charm = -0.0012
+                dv_price(900, 6),  // vomma = 0.09
+                dv_price(-3, 6),   // veta = -0.0003
+                dv_price(-3, 6),   // iv_error = -0.0003
+                dv_number(20_240_614),
+            ])],
+        };
+        let ticks = parse_greeks_ticks(&table).unwrap();
+        assert_eq!(ticks.len(), 1);
+        let t = &ticks[0];
+
+        assert!((t.gamma - 0.012).abs() < 1e-9);
+        assert!((t.vanna - 0.0045).abs() < 1e-9);
+        assert!((t.charm - -0.0012).abs() < 1e-9);
+        assert!((t.vomma - 0.09).abs() < 1e-9);
+        assert!((t.veta - -0.0003).abs() < 1e-9);
+
+        // First-order, third-order, and `_all`-only columns are absent
+        // on the wire and default to 0.0.
+        assert_eq!(t.delta, 0.0);
+        assert_eq!(t.speed, 0.0);
+        assert_eq!(t.zomma, 0.0);
+        assert_eq!(t.d1, 0.0);
+        assert_eq!(t.vera, 0.0);
+    }
+
+    /// Vendor wire shape for `option_*_greeks_third_order`: speed / zomma /
+    /// color / ultima plus IV pair. This is the exact endpoint the Issue
+    /// #472 reporter was hitting — `option_snapshot_greeks_third_order`
+    /// previously emitted eight warn lines per row for the absent
+    /// first-order / second-order / `_all`-only columns. The test pins the
+    /// silent-gap behaviour so a future regression of `find_header` back
+    /// to `tracing::warn!` would surface here as a behavioural change.
+    /// Column layout pinned to upstream OpenAPI schema
+    /// `items_option_snapshot_greeks_third_order` (notably `vera` is NOT
+    /// in the third-order subset; it only ships in `_greeks_all`).
+    #[test]
+    fn parse_greeks_ticks_decodes_third_order_subset_with_silent_gaps() {
+        let table = proto::DataTable {
+            headers: vec![
+                "ms_of_day".into(),
+                "implied_volatility".into(),
+                "speed".into(),
+                "zomma".into(),
+                "color".into(),
+                "ultima".into(),
+                "iv_error".into(),
+                "date".into(),
+            ],
+            data_table: vec![row_of(vec![
+                dv_number(34_200_000),
+                dv_price(2142, 6), // implied_volatility = 0.2142
+                dv_price(7, 6),    // speed  = 0.0007
+                dv_price(15, 6),   // zomma  = 0.0015
+                dv_price(-2, 6),   // color  = -0.0002
+                dv_price(33, 6),   // ultima = 0.0033
+                dv_price(-3, 6),   // iv_error = -0.0003
+                dv_number(20_240_614),
+            ])],
+        };
+        let ticks = parse_greeks_ticks(&table).unwrap();
+        assert_eq!(ticks.len(), 1);
+        let t = &ticks[0];
+
+        assert!((t.speed - 0.0007).abs() < 1e-9);
+        assert!((t.zomma - 0.0015).abs() < 1e-9);
+        assert!((t.color - -0.0002).abs() < 1e-9);
+        assert!((t.ultima - 0.0033).abs() < 1e-9);
+
+        // Vera is NOT a third-order column on the wire even though the
+        // generic `GreeksTick` struct carries the field. It must default
+        // to 0.0 here without warning.
+        assert_eq!(t.vera, 0.0);
+        // First-order and second-order columns also absent.
+        assert_eq!(t.delta, 0.0);
+        assert_eq!(t.gamma, 0.0);
+        assert_eq!(t.vanna, 0.0);
+        assert_eq!(t.d1, 0.0);
+        assert_eq!(t.dual_gamma, 0.0);
     }
 }

--- a/crates/thetadatadx/tick_schema.toml
+++ b/crates/thetadatadx/tick_schema.toml
@@ -185,7 +185,27 @@ columns = [
 ]
 
 [types.GreeksTick]
-doc = "Greeks tick -- 24 fields. Full set of option greeks."
+doc = """
+Greeks tick -- 24 fields. Full union of every Greek the v3 server
+publishes across the `option_*_greeks_*` family.
+
+Endpoint-specific subsets reuse this struct; absent columns decode to
+`0.0` and the per-endpoint vendor schema is documented via the upstream
+OpenAPI capture (`scripts/upstream_openapi.yaml`):
+
+* `option_*_greeks_first_order`  -> delta / theta / vega / rho / epsilon / lambda + IV pair
+* `option_*_greeks_second_order` -> gamma / vanna / charm / vomma / veta + IV pair
+* `option_*_greeks_third_order`  -> speed / zomma / color / ultima + IV pair (no vera)
+* `option_*_greeks_all` / `option_*_greeks_eod` -> the full union below
+* `option_*_greeks_implied_volatility` -> handled by `IvTick`
+
+The wire-level `timestamp` -> `ms_of_day` and `implied_vol` ->
+`implied_volatility` mappings are applied through `HEADER_ALIASES`
+in `crates/thetadatadx/src/decode.rs`. Optional columns absent from a
+subset response (e.g. `zomma` on the first-order endpoint) are silently
+defaulted to `0.0`; the parser never warns on a documented subset gap
+(see `find_header` for the trace-level diagnostic path).
+"""
 copy = true
 align = 64
 contract_id = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.26] - 2026-05-05
+
+### Fixed
+
+- **`option_*_greeks_*_order` no longer spams `expected column header
+  not found` warnings.** `crates/thetadatadx/src/decode.rs::find_header`
+  emitted a `tracing::warn!` every time a generated parser asked for an
+  optional column that was absent from the wire response. The Greeks
+  family splits the column set across the wire — `_greeks_first_order`
+  ships seven Greeks, `_greeks_second_order` ships five, and
+  `_greeks_third_order` ships four — but the shared `GreeksTick` schema
+  carries the full 23-Greek union. Calling
+  `option_snapshot_greeks_third_order` therefore produced eight warn
+  lines per response (zomma, color, ultima, d1, d2, dual_delta,
+  dual_gamma, vera, …) before any user-visible decoding finished. The
+  warn is now a `tracing::trace!` so the diagnostic is still reachable
+  via `RUST_LOG=thetadatadx=trace` for genuine schema-drift
+  investigations, but stays out of stderr on routine subset calls.
+  Required-column drift continues to surface as a typed
+  `Error::MissingRequiredHeader` from the generated parser. Closes #472.
+
+### Changed
+
+- Per-endpoint vendor-schema column lists for the four Greeks families
+  pinned and documented in `tick_schema.toml::GreeksTick` against the
+  upstream OpenAPI capture in `scripts/upstream_openapi.yaml`. The
+  `GreeksTick` struct itself is unchanged — every Greeks endpoint still
+  returns `Vec<GreeksTick>` and the union layout is the same — but the
+  schema doc-comment now spells out which Greeks each endpoint
+  publishes, why the others zero-default, and where the per-endpoint
+  vendor schema is captured. The codegen pickup is doc-only; no SDK
+  surface drift.
+- Three new unit tests in `crates/thetadatadx/src/decode.rs::tests`
+  drive `parse_greeks_ticks` against the `_first_order`,
+  `_second_order`, and `_third_order` wire shapes (column lists pinned
+  to upstream OpenAPI). Each test asserts bit-exact decoded values for
+  the wire-present columns and `0.0` defaults for the documented gaps,
+  so a future regression of `find_header` back to `tracing::warn!` —
+  or any column-list drift in either direction — surfaces as a
+  behavioural test failure rather than as live log spam.
+- `tdbe` 0.12.6 → 0.12.7.
+
 ## [8.0.25] - 2026-05-05
 
 ### Fixed

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.25"
+version = "8.0.26"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -31,7 +31,7 @@ testing-panic-boundary = []
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.12.6", path = "../crates/tdbe" }
+tdbe = { version = "0.12.7", path = "../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 # Used by the FPSS streaming callback silent-drop observability path
 # (see `tdx_fpss_dropped_events` / `tdx_unified_dropped_events`). Keep

--- a/sdks/go/tick_structs.go
+++ b/sdks/go/tick_structs.go
@@ -38,7 +38,7 @@ type EodTick struct {
 	Right          string   `json:"right,omitempty"`
 }
 
-// GreeksTick — Greeks tick -- 24 fields. Full set of option greeks.
+// GreeksTick — Greeks tick -- 24 fields. Full union of every Greek the v3 server
 type GreeksTick struct {
 	MsOfDay        int      `json:"ms_of_day"`
 	IV             float64  `json:"implied_volatility"`

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2310,7 +2310,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.25"
+version = "8.0.26"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ doc = false
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.6", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.7", path = "../../crates/tdbe" }
 
 # Direct prost dep for decoding `thetadatadx::proto::ResponseData` bytes in
 # the `decode_response_bytes` hook. The main crate no longer re-exports

--- a/sdks/python/src/tick_classes.rs
+++ b/sdks/python/src/tick_classes.rs
@@ -101,7 +101,25 @@ impl EodTick {
     }
 }
 
-/// Greeks tick. Full set of option greeks.
+/// Greeks tick. Full union of every Greek the v3 server
+/// publishes across the `option_*_greeks_*` family.
+/// 
+/// Endpoint-specific subsets reuse this struct; absent columns decode to
+/// `0.0` and the per-endpoint vendor schema is documented via the upstream
+/// OpenAPI capture (`scripts/upstream_openapi.yaml`):
+/// 
+/// * `option_*_greeks_first_order`  -> delta / theta / vega / rho / epsilon / lambda + IV pair
+/// * `option_*_greeks_second_order` -> gamma / vanna / charm / vomma / veta + IV pair
+/// * `option_*_greeks_third_order`  -> speed / zomma / color / ultima + IV pair (no vera)
+/// * `option_*_greeks_all` / `option_*_greeks_eod` -> the full union below
+/// * `option_*_greeks_implied_volatility` -> handled by `IvTick`
+/// 
+/// The wire-level `timestamp` -> `ms_of_day` and `implied_vol` ->
+/// `implied_volatility` mappings are applied through `HEADER_ALIASES`
+/// in `crates/thetadatadx/src/decode.rs`. Optional columns absent from a
+/// subset response (e.g. `zomma` on the first-order endpoint) are silently
+/// defaulted to `0.0`; the parser never warns on a documented subset gap
+/// (see `find_header` for the trace-level diagnostic path).
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.25"
+version = "8.0.26"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.6", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.7", path = "../../crates/tdbe" }
 
 napi = { version = "3.8.5", features = ["async", "tokio_rt", "serde-json", "napi6", "chrono_date"] }
 napi-derive = "3.5.4"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.25",
+  "version": "8.0.26",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.25",
+  "version": "8.0.26",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.25",
+  "version": "8.0.26",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.25",
+  "version": "8.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "8.0.25",
+      "version": "8.0.26",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2"
@@ -15,9 +15,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "8.0.25",
-        "thetadatadx-linux-x64-gnu": "8.0.25",
-        "thetadatadx-win32-x64-msvc": "8.0.25"
+        "thetadatadx-darwin-arm64": "8.0.26",
+        "thetadatadx-linux-x64-gnu": "8.0.26",
+        "thetadatadx-win32-x64-msvc": "8.0.26"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.25",
+  "version": "8.0.26",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.25",
-    "thetadatadx-darwin-arm64": "8.0.25",
-    "thetadatadx-win32-x64-msvc": "8.0.25"
+    "thetadatadx-linux-x64-gnu": "8.0.26",
+    "thetadatadx-darwin-arm64": "8.0.26",
+    "thetadatadx-win32-x64-msvc": "8.0.26"
   },
   "engines": {
     "node": ">= 20"

--- a/sdks/typescript/src/tick_classes.rs
+++ b/sdks/typescript/src/tick_classes.rs
@@ -43,7 +43,7 @@ pub struct EodTick {
     pub right: String,
 }
 
-/// Greeks tick. Full set of option greeks.
+/// Greeks tick. Full union of every Greek the v3 server
 #[must_use]
 #[napi(object)]
 #[derive(Clone)]

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.25"
+version = "8.0.26"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.6", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.7", path = "../../crates/tdbe" }
 json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "json_canon",
  "serde",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.25"
+version = "8.0.26"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.6", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.7", path = "../../crates/tdbe" }
 json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.25"
+version = "8.0.26"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.25"
+version = "8.0.26"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23.38", features = ["ring"] }
-tdbe = { version = "0.12.6", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.7", path = "../../crates/tdbe" }
 json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 axum = { version = "0.8.9", features = ["ws"] }
 tokio = { version = "1.52.1", features = ["full"] }


### PR DESCRIPTION
## Summary

Closes #472.

`crates/thetadatadx/src/decode.rs::find_header` emitted a
`tracing::warn!("expected column header not found in DataTable", header=…)`
on every optional column missing from a wire response. The Greeks family
splits the column set across endpoints — `_first_order` ships seven Greeks,
`_second_order` ships five, `_third_order` ships four — but the shared
`GreeksTick` schema carries the full 23-Greek union. The reporter saw
eight warn lines per row on a single `option_snapshot_greeks_first_order`
call from Python. Demote the diagnostic to `tracing::trace!` so genuine
schema-drift investigations are still reachable via
`RUST_LOG=thetadatadx=trace` while routine subset calls stay clean.

Required-column drift continues to surface as a typed
`Error::MissingRequiredHeader` from the generated parser, so the
silenced path is strictly the documented optional-column case.

Pin the per-endpoint vendor column lists for the four Greeks families
in the `GreeksTick` schema doc-comment, against the upstream OpenAPI
capture in `scripts/upstream_openapi.yaml`. The struct layout itself
is unchanged — every Greeks endpoint still returns `Vec<GreeksTick>` —
so the SSOT pickup is doc-only and there is zero generated-SDK drift.

Add three regression tests in `decode.rs::tests` driving
`parse_greeks_ticks` against `_first_order`, `_second_order`, and
`_third_order` wire shapes. Each asserts bit-exact decoded values for
the wire-present columns and `0.0` defaults for the documented gaps,
so a future regression of `find_header` back to `tracing::warn!` —
or any column-list drift in either direction — surfaces as a
behavioural test failure rather than as live log spam.

Per-endpoint vendor schemas pinned to:
* `_first_order`: items_option_snapshot_greeks_first_order — delta, theta, vega, rho, epsilon, lambda + IV pair
* `_second_order`: items_option_snapshot_greeks_second_order — gamma, vanna, charm, vomma, veta + IV pair
* `_third_order`: items_option_snapshot_greeks_third_order — speed, zomma, color, ultima + IV pair (vera not in third-order)
* `_all`: items_option_snapshot_greeks_all — full 23-Greek union
* `_implied_volatility`: items_option_snapshot_greeks_implied_volatility — handled by IvTick

Workspace 8.0.25 → 8.0.26, tdbe 0.12.6 → 0.12.7. CHANGELOG +
`docs-site/docs/changelog.md` kept byte-identical.

## Follow-up: per-endpoint typed structs

The bug-report comment thread also asked for per-endpoint typed
return structs (`GreeksFirstOrderTick`, `GreeksSecondOrderTick`,
`GreeksThirdOrderTick`) so the type system reflects the wire schema.
Surveying the surface, that change ripples through ~30 codegen
tables (build_support helpers, FFI macros with hand-tuned padding,
hand-written C++ headers, Go FFI mirrors, three SDK regenerations,
the `EndpointOutput` enum + every consumer in CLI / MCP / server /
ffi). It deserves its own issue + PR rather than being bolted onto a
warn-silence fix; the schema doc-comment in this PR is the
prerequisite that nails down the column lists per endpoint, so the
follow-up can map each subset to a typed struct without re-deriving
the wire shape from scratch.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` 0 failures across all crates
- [x] `cargo deny check` clean (advisories + bans + licenses + sources)
- [x] `cargo run -p thetadatadx --bin generate_sdk_surfaces --features config-file -- --check` no drift
- [x] Three new regression tests in `decode::tests` exercising the
  three Greeks subset wire shapes
- [ ] Reporter on Issue #472 confirms log spam is gone after pulling
  v8.0.26