### PR TITLE
fix(exchange): rename code 0 to Composite

### DIFF
--- a/crates/tdbe/src/exchange.rs
+++ b/crates/tdbe/src/exchange.rs
@@ -14,7 +14,7 @@ pub struct Exchange {
 pub const EXCHANGES: [Exchange; 78] = [
     Exchange {
         code: 0,
-        name: "NanexComp",
+        name: "Composite",
         symbol: "COMP",
     },
     Exchange {
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn exchange_name_valid() {
-        assert_eq!(exchange_name(0), "NanexComp");
+        assert_eq!(exchange_name(0), "Composite");
         assert_eq!(exchange_name(3), "NewYorkStockExchange");
         assert_eq!(exchange_name(68), "InvestorsExchange");
         assert_eq!(exchange_name(77), "24XNationalExchange");


### PR DESCRIPTION
## What

Rename the `name` field of `EXCHANGES[0]` from a third-party product mark to neutral SIP terminology (`Composite`).

## Why

`crates/tdbe/src/exchange.rs:17` seeded code 0 from an upstream NxCore-style exchange dictionary that embeds a peer-vendor product mark. The published vendor exchange table at https://docs.thetadata.us/Articles/Errors-Exchanges-Conditions/Exchanges.html starts at code 1, so code 0 is internal-only and never appears in user-facing data. The authored source tree should not carry third-party product marks for an internal sentinel.

## How

`name: "NanexComp"` -> `name: "Composite"`. Symbol stays `COMP` (already generic for the consolidated tape). Test assertion at `:437` updated to match. Array length unchanged (78); wire byte 0 still resolves to the same slot.

Closes #476.

## Test plan

- [x] `cargo test -p tdbe exchange` (5 tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `rg 'Nanex'` returns no matches in tracked sources