### PR TITLE
docs(changelog): add exchange rename bullet under [8.0.26]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `#[repr(C, align(64))]` declared on the corresponding `tdbe` types --
   the schema-derived FFI size used to under-count by the alignment
   rounding (32/144 vs 64/192) before reaching the C++ layout assert.
+- Exchange code 0 in `crates/tdbe/src/exchange.rs` renamed from a
+  third-party product mark to neutral SIP terminology (`Composite`).
+  Symbol stays `COMP`; wire byte 0 still resolves to the same array
+  slot. Closes #476.
 
 ### Fixed
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -87,6 +87,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `#[repr(C, align(64))]` declared on the corresponding `tdbe` types --
   the schema-derived FFI size used to under-count by the alignment
   rounding (32/144 vs 64/192) before reaching the C++ layout assert.
+- Exchange code 0 in `crates/tdbe/src/exchange.rs` renamed from a
+  third-party product mark to neutral SIP terminology (`Composite`).
+  Symbol stays `COMP`; wire byte 0 still resolves to the same array
+  slot. Closes #476.
 
 ### Fixed
 


### PR DESCRIPTION
## What

Add a one-line CHANGELOG bullet under the [8.0.26] `### Changed` section noting the exchange code 0 rename from #477.

## Why

#477 merged after the [8.0.26] section was drafted by #475, so the section under-reports what shipped. Mirrors the entry into both `CHANGELOG.md` and `docs-site/docs/changelog.md` so they stay byte-identical.

## How

- Append one bullet under `### Changed` of [8.0.26]
- `cp CHANGELOG.md docs-site/docs/changelog.md` to keep the mirror identical

## Test plan

- [x] `diff CHANGELOG.md docs-site/docs/changelog.md` clean
- [x] `cargo fmt --all -- --check` (no Rust source changes)