### PR TITLE
chore(deps): bump polars 0.52 -> 0.53 + adopt new DataFrame::new signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -102,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -118,6 +124,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
+]
+
+[[package]]
+name = "argminmax"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f13d10a41ac8d2ec79ee34178d61e6f47a29c2edfe7ef1721c7383b0359e65"
+dependencies = [
+ "half",
+ "num-traits",
 ]
 
 [[package]]
@@ -221,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "atoi_simd"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a49e05797ca52e312a0c658938b7d00693ef037799ef7187678f212d7684cf"
+checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
 dependencies = [
  "debug_unsafe",
 ]
@@ -411,13 +427,14 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -816,7 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -955,7 +972,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result",
 ]
 
@@ -1024,6 +1041,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -1688,7 +1706,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1715,6 +1733,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-integer"
@@ -1817,7 +1846,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1923,13 +1952,14 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc9ea901050c1bb8747ee411bc7fbb390f3b399931e7484719512965132a248"
+checksum = "899852b723e563dc3cbdc7ea833b14ec44e61309f55df29ba86d45cfd6bc141a"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-core",
  "polars-error",
@@ -1939,12 +1969,13 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d3fe43f8702cf7899ff3d516c2e5f7dc84ee6f6a3007e1a831a0ff87940704"
+checksum = "6f672743a042b72ace4f88b29f8205ab200b29c5ac976c0560899680c07d2d09"
 dependencies = [
  "bitflags",
  "bytemuck",
+ "bytes",
  "chrono",
  "chrono-tz",
  "dyn-clone",
@@ -1952,8 +1983,10 @@ dependencies = [
  "ethnum",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
+ "half",
  "hashbrown 0.16.1",
  "num-traits",
+ "polars-buffer",
  "polars-error",
  "polars-schema",
  "polars-utils",
@@ -1964,10 +1997,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-compute"
-version = "0.52.0"
+name = "polars-buffer"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29cc7497378dee3a002f117e0b4e16b7cbe6c8ed3da16a0229c89294af7c3bf"
+checksum = "5d7011424c3a79ca9c1272c7b4f5fe98695d3bed45595e37bb23c16a2978c80c"
+dependencies = [
+ "bytemuck",
+ "either",
+ "version_check",
+]
+
+[[package]]
+name = "polars-compute"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a32eca8e08ac4cc5de2ac3996d2b38567bba72cdb19bbfd94c370193ed51dd"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -1978,30 +2022,33 @@ dependencies = [
  "itoa",
  "num-traits",
  "polars-arrow",
+ "polars-buffer",
  "polars-error",
  "polars-utils",
  "rand",
- "ryu",
  "strength_reduce",
  "strum_macros",
  "version_check",
+ "zmij",
 ]
 
 [[package]]
 name = "polars-core"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48409b7440cb1a4aa84953fe3a4189dfbfb300a3298266a92a37363476641e40"
+checksum = "726296966d04268ee9679c2062af2d06c83c7a87379be471defe616b244c5029"
 dependencies = [
  "bitflags",
  "boxcar",
  "bytemuck",
  "either",
+ "getrandom 0.3.4",
  "hashbrown 0.16.1",
  "indexmap",
  "itoa",
  "num-traits",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-dtype",
  "polars-error",
@@ -2017,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "polars-dtype"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7007e9e8b7b657cbd339b65246af7e87f5756ee9a860119b9424ddffd2aaf133"
+checksum = "51976dc46d42cd1e7ca252a9e3bdc90c63b0bfa7030047ebaf5250c2b7838fa6"
 dependencies = [
  "boxcar",
  "hashbrown 0.16.1",
@@ -2031,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6be22566c89f6405f553bfdb7c8a6cb20ec51b35f3172de9a25fa3e252d85"
+checksum = "8c13126f8baebc13dadf26a80dcf69a607977fc8a67b18671ad2cefc713a7bdd"
 dependencies = [
  "parking_lot",
  "signal-hook",
@@ -2042,13 +2089,14 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18d232f25b83032e280a279a1f40beb8a6f8fc43907b13dc07b1c56f3b11eea"
+checksum = "d29ea1a4554fe06442db1d6229235cd358e8eacba96aed8718f612caf3e3a646"
 dependencies = [
  "bitflags",
  "bytemuck",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-dtype",
  "polars-error",
@@ -2057,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "polars-schema"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73e21d429ae1c23f442b0220ccfe773a9734a44e997b5062a741842909d9441"
+checksum = "d688e73f9156f93cb29350be144c8f1e84c1bc705f00ee7f15eb9706a7971273"
 dependencies = [
  "indexmap",
  "polars-error",
@@ -2069,18 +2117,21 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667c1bc2d2313f934d711f6e3b58d8d9f80351d14ea60af936a26b7dfb06e309"
+checksum = "c97cabf53eb8fbf6050cde3fef8f596c51cc25fd7d55fbde108d815ee6674abf"
 dependencies = [
+ "argminmax",
  "bytemuck",
  "bytes",
  "compact_str",
  "either",
  "foldhash 0.2.0",
+ "half",
  "hashbrown 0.16.1",
  "indexmap",
  "libc",
+ "num-derive",
  "num-traits",
  "polars-error",
  "rand",
@@ -2591,7 +2642,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2650,7 +2701,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2822,9 +2873,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2886,7 +2937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2944,7 +2995,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3038,7 +3089,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3793,7 +3844,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3810,7 +3861,7 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.2.1",
  "windows-result",
  "windows-strings",
 ]
@@ -3839,6 +3890,12 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -3849,7 +3906,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3858,7 +3915,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3894,7 +3951,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3934,7 +3991,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -101,7 +101,7 @@ disruptor = "4.1.0"
 # No lazy, no I/O, no parquet, no SQL, no compute kernels. `default-features = false`
 # avoids pulling the polars-plan / polars-sql / polars-parquet graph into dependents
 # that only want row-to-frame materialization.
-polars = { version = "0.52", optional = true, default-features = false }
+polars = { version = "0.53", optional = true, default-features = false }
 # arrow-array + arrow-schema cover RecordBatch construction for the
 # optional `frames` feature only. Kept optional so the default dep
 # graph stays slim — FLATFILES does not pull in arrow.

--- a/crates/thetadatadx/build_support/ticks/rust_frames.rs
+++ b/crates/thetadatadx/build_support/ticks/rust_frames.rs
@@ -278,10 +278,10 @@ fn render_polars_impl(type_name: &str, def: &TickTypeDef) -> String {
     }
     out.push_str("        }\n");
 
-    // polars 0.46+ requires `Series::new(PlSmallStr, ...)` and
-    // `DataFrame::new(Vec<Column>)`; call `.into()` on each `Series` to
-    // coerce it into a `Column` before handing the vector to `DataFrame::new`.
-    out.push_str("        DataFrame::new(vec![\n");
+    // polars 0.53+ takes `DataFrame::new(height, Vec<Column>)`; pass `n`
+    // (set above to `self.len()`) so an empty input still constructs a
+    // zero-row DataFrame with the typed columns intact.
+    out.push_str("        DataFrame::new(n, vec![\n");
     for column in &def.columns {
         writeln!(
             out,

--- a/crates/thetadatadx/src/frames_generated.rs
+++ b/crates/thetadatadx/src/frames_generated.rs
@@ -69,7 +69,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::CalendarDay] {
             col_close_time.push(t.close_time);
             col_status.push(t.status);
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("date"), col_date).into(),
             Series::new(PlSmallStr::from_static("is_open"), col_is_open).into(),
             Series::new(PlSmallStr::from_static("open_time"), col_open_time).into(),
@@ -221,7 +221,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::EodTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("ms_of_day2"), col_ms_of_day2).into(),
             Series::new(PlSmallStr::from_static("open"), col_open).into(),
@@ -454,7 +454,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::GreeksAllTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("bid"), col_bid).into(),
             Series::new(PlSmallStr::from_static("ask"), col_ask).into(),
@@ -614,7 +614,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::GreeksFirstOrderTick]
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("bid"), col_bid).into(),
             Series::new(PlSmallStr::from_static("ask"), col_ask).into(),
@@ -754,7 +754,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::GreeksSecondOrderTick
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("bid"), col_bid).into(),
             Series::new(PlSmallStr::from_static("ask"), col_ask).into(),
@@ -887,7 +887,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::GreeksThirdOrderTick]
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("bid"), col_bid).into(),
             Series::new(PlSmallStr::from_static("ask"), col_ask).into(),
@@ -947,7 +947,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::InterestRateTick] {
             col_rate.push(t.rate);
             col_date.push(t.date);
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("rate"), col_rate).into(),
             Series::new(PlSmallStr::from_static("date"), col_date).into(),
@@ -1019,7 +1019,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::IvTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("implied_volatility"), col_implied_volatility).into(),
             Series::new(PlSmallStr::from_static("iv_error"), col_iv_error).into(),
@@ -1101,7 +1101,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::MarketValueTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("market_bid"), col_market_bid).into(),
             Series::new(PlSmallStr::from_static("market_ask"), col_market_ask).into(),
@@ -1202,7 +1202,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::OhlcTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("open"), col_open).into(),
             Series::new(PlSmallStr::from_static("high"), col_high).into(),
@@ -1276,7 +1276,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::OpenInterestTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("open_interest"), col_open_interest).into(),
             Series::new(PlSmallStr::from_static("date"), col_date).into(),
@@ -1333,7 +1333,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::OptionContract] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("root"), col_root).into(),
             Series::new(PlSmallStr::from_static("expiration"), col_expiration).into(),
             Series::new(PlSmallStr::from_static("strike"), col_strike).into(),
@@ -1382,7 +1382,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::PriceTick] {
             col_price.push(t.price);
             col_date.push(t.date);
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("price"), col_price).into(),
             Series::new(PlSmallStr::from_static("date"), col_date).into(),
@@ -1496,7 +1496,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::QuoteTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("bid_size"), col_bid_size).into(),
             Series::new(PlSmallStr::from_static("bid_exchange"), col_bid_exchange).into(),
@@ -1699,7 +1699,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::TradeQuoteTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("sequence"), col_sequence).into(),
             Series::new(PlSmallStr::from_static("ext_condition1"), col_ext_condition1).into(),
@@ -1861,7 +1861,7 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::TradeTick] {
             col_strike.push(t.strike);
             col_right.push(if t.is_call() { "C".to_string() } else if t.is_put() { "P".to_string() } else { String::new() });
         }
-        DataFrame::new(vec![
+        DataFrame::new(n, vec![
             Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
             Series::new(PlSmallStr::from_static("sequence"), col_sequence).into(),
             Series::new(PlSmallStr::from_static("ext_condition1"), col_ext_condition1).into(),


### PR DESCRIPTION
## What

Bump polars 0.52.0 -> 0.53.0 and migrate generated frame code to the new `DataFrame::new(height, Vec<Column>)` signature.

Supersedes #464 (dependabot's bare bump alone fails to compile because polars 0.53 changed the signature).

## Why

polars 0.53 reshapes the public `DataFrame::new` constructor from `(Vec<Column>) -> PolarsResult<Self>` to `(usize, Vec<Column>) -> PolarsResult<Self>`, where the new `usize` argument is the declared row count. The old signature is gone, so the bare bump produced 16 compile errors in `crates/thetadatadx/src/frames_generated.rs`.

## How

- Bump polars to 0.53 in `crates/thetadatadx/Cargo.toml` (cherry-picked from #464)
- Update the generator template at `crates/thetadatadx/build_support/ticks/rust_frames.rs:284` to emit `DataFrame::new(n, vec![...])` (where `n = self.len()` is already in scope)
- Regenerate `frames_generated.rs` via `generate_sdk_surfaces`

## Test plan

- [x] `cargo test -p thetadatadx --features polars --test test_frames_polars` (9 passing)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo run -p thetadatadx --bin generate_sdk_surfaces --features config-file -- --check`

Closes #464.