### PR TITLE
fix(conditions): scrub third-party product mark from trade condition 61

### DIFF
--- a/crates/tdbe/src/conditions.rs
+++ b/crates/tdbe/src/conditions.rs
@@ -822,7 +822,7 @@ pub const TRADE_CONDITIONS: [TradeCondition; 149] = [
     },
     TradeCondition {
         code: 61,
-        name: "NANEXADMIN",
+        name: "PRICEVOLUMEADJ",
         description: "Used to make volume and price corrections to match official exchange values.",
         cancel: false,
         late_report: false,


### PR DESCRIPTION
## What

Rename trade condition 61's display name in `crates/tdbe/src/conditions.rs:825`.

## Why

Condition 61's display name embeds a third-party product mark inherited from the upstream condition dictionary. Same pattern as #477 (exchange code 0). The description ("Used to make volume and price corrections to match official exchange values") already captures purpose; the renamed constant matches intent without the vendor reference.

## How

`"NANEXADMIN"` -> `"PRICEVOLUMEADJ"` (matches existing ALLCAPS condition-name convention). Single tracked-source occurrence, no downstream string match (`rg 'NANEXADMIN'` clean post-rename). Description unchanged.

## Test plan

- [x] `cargo test -p tdbe conditions` (18 tests pass)
- [x] `rg 'Nanex|NANEX'` returns no matches
- [x] `cargo fmt --all -- --check`