### PR TITLE
chore(release): 8.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.27] - 2026-05-06
+
+### Changed
+
+- **polars 0.52 -> 0.53.** Adopts the new
+  `DataFrame::new(height: usize, columns: Vec<Column>)` signature in
+  `crates/thetadatadx/build_support/ticks/rust_frames.rs` (the existing
+  `n = self.len()` binding feeds the new `height` argument). Re-runs of
+  `generate_sdk_surfaces` produce `frames_generated.rs` with the
+  updated call form. Closes #464.
+
+### Fixed
+
+- **`crates/tdbe/src/conditions.rs` trade condition 61 renamed from
+  a third-party product mark to `PRICEVOLUMEADJ`.** Same scrub pattern
+  as the v8.0.26 exchange-code-0 rename. Single tracked-source
+  occurrence; `rg 'NANEX'` now clean. Description unchanged. Closes
+  #476's sibling, filed as #480.
+
 ## [8.0.26] - 2026-05-05
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.26"
+version = "8.0.27"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.27] - 2026-05-06
+
+### Changed
+
+- **polars 0.52 -> 0.53.** Adopts the new
+  `DataFrame::new(height: usize, columns: Vec<Column>)` signature in
+  `crates/thetadatadx/build_support/ticks/rust_frames.rs` (the existing
+  `n = self.len()` binding feeds the new `height` argument). Re-runs of
+  `generate_sdk_surfaces` produce `frames_generated.rs` with the
+  updated call form. Closes #464.
+
+### Fixed
+
+- **`crates/tdbe/src/conditions.rs` trade condition 61 renamed from
+  a third-party product mark to `PRICEVOLUMEADJ`.** Same scrub pattern
+  as the v8.0.26 exchange-code-0 rename. Single tracked-source
+  occurrence; `rg 'NANEX'` now clean. Description unchanged. Closes
+  #476's sibling, filed as #480.
+
 ## [8.0.26] - 2026-05-05
 
 ### Breaking

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.26"
+version = "8.0.27"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.26"
+version = "8.0.27"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.26"
+version = "8.0.27"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.26"
+version = "8.0.27"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "disruptor",
  "metrics",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "json_canon",
  "serde",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.26"
+version = "8.0.27"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "disruptor",
  "metrics",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.26"
+version = "8.0.27"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.26"
+version = "8.0.27"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## What

Bump version to 8.0.27 to release the polars 0.53 migration (#479) and the conditions code 61 scrub (#480).

## Why

Both PRs landed on main without their own version bumps; this PR closes the release boundary so users on 8.0.26 can pull a clean tag once it merges.

## How

- Bump `thetadatadx`, `thetadatadx-ffi`, `thetadatadx-cli`, `thetadatadx-mcp`, `thetadatadx-server`, `thetadatadx-py`, `thetadatadx-napi` to 8.0.27
- Add [8.0.27] section to CHANGELOG.md and mirror to docs-site
- `cargo update --workspace` to refresh Cargo.lock

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `diff CHANGELOG.md docs-site/docs/changelog.md` clean