### PR TITLE
fix(ts): sync npm package.json versions to 8.0.29 + CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
       - run: python3 scripts/check_docs_consistency.py
+      - run: python3 scripts/check_version_sync.py
       - run: python3 scripts/validate_agreement_test.py
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       - run: cargo check --manifest-path tools/mcp/Cargo.toml --locked

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Bump every user-visible version pin in lockstep.
+
+Usage:
+    scripts/bump_version.py 8.0.30
+
+Reads the canonical version from ``crates/thetadatadx/Cargo.toml`` (only
+to print "from -> to" for context), then walks every file that pins a
+version of the published artifact and rewrites it. All four npm
+``package.json`` files, the seven workspace Cargo.toml files (workspace +
+ffi + tools/cli + tools/mcp + tools/server + sdks/python +
+sdks/typescript), and the three ``optionalDependencies`` pins inside
+``sdks/typescript/package.json``. Cargo.lock files are refreshed via
+``cargo update --workspace`` against every manifest that carries its own
+lockfile. ``crates/tdbe/Cargo.toml`` is NOT touched -- tdbe ships its
+own version cadence; bump it separately if its surface changed.
+
+After the bump, ``scripts/check_version_sync.py`` runs to verify nothing
+got missed. Exits non-zero if anything is out of sync.
+
+This is the only supported way to bump the SDK version. Doing it by
+hand reliably misses ``sdks/typescript/`` files (lesson from npm being
+stuck at v8.0.26 across v8.0.27 / v8.0.28 / v8.0.29 releases).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+WORKSPACE_CARGOS = [
+    ROOT / "crates" / "thetadatadx" / "Cargo.toml",
+    ROOT / "ffi" / "Cargo.toml",
+    ROOT / "tools" / "cli" / "Cargo.toml",
+    ROOT / "tools" / "mcp" / "Cargo.toml",
+    ROOT / "tools" / "server" / "Cargo.toml",
+    ROOT / "sdks" / "python" / "Cargo.toml",
+    ROOT / "sdks" / "typescript" / "Cargo.toml",
+]
+
+SUB_LOCK_MANIFESTS = [
+    ROOT / "tools" / "mcp" / "Cargo.toml",
+    ROOT / "tools" / "server" / "Cargo.toml",
+    ROOT / "sdks" / "python" / "Cargo.toml",
+    ROOT / "sdks" / "typescript" / "Cargo.toml",
+]
+
+
+def parse_semver(value: str) -> tuple[int, int, int]:
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", value)
+    if not match:
+        sys.exit(f"not a semver MAJOR.MINOR.PATCH: '{value}'")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def current_canonical() -> str:
+    text = (ROOT / "crates" / "thetadatadx" / "Cargo.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        sys.exit("could not parse current version from crates/thetadatadx/Cargo.toml")
+    return match.group(1)
+
+
+def bump_cargo(path: Path, current: str, target: str) -> None:
+    text = path.read_text()
+    pattern = re.compile(rf'^version\s*=\s*"{re.escape(current)}"', re.MULTILINE)
+    new_text, count = pattern.subn(f'version = "{target}"', text, count=1)
+    if count != 1:
+        sys.exit(
+            f"{path.relative_to(ROOT)}: expected one `version = \"{current}\"` line, "
+            f"found {count}"
+        )
+    path.write_text(new_text)
+
+
+def bump_root_package_json(path: Path, current: str, target: str) -> None:
+    data = json.loads(path.read_text())
+    if data.get("version") != current:
+        sys.exit(
+            f"{path.relative_to(ROOT)}: version is {data.get('version')!r}, "
+            f"expected {current!r}"
+        )
+    data["version"] = target
+    deps = data.get("optionalDependencies", {})
+    for name, pinned in list(deps.items()):
+        if pinned == current:
+            deps[name] = target
+        else:
+            sys.exit(
+                f"{path.relative_to(ROOT)} optionalDependencies['{name}'] is "
+                f"{pinned!r}, expected {current!r}"
+            )
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def bump_platform_package_json(path: Path, current: str, target: str) -> None:
+    data = json.loads(path.read_text())
+    if data.get("version") != current:
+        sys.exit(
+            f"{path.relative_to(ROOT)}: version is {data.get('version')!r}, "
+            f"expected {current!r}"
+        )
+    data["version"] = target
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def cargo_update(manifest: Path) -> None:
+    subprocess.run(
+        ["cargo", "update", "--manifest-path", str(manifest), "--workspace"],
+        cwd=ROOT,
+        check=True,
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.exit("usage: scripts/bump_version.py <new-version>")
+    target = argv[1]
+    parse_semver(target)
+    current = current_canonical()
+    if current == target:
+        sys.exit(f"current version is already {current}; nothing to bump")
+    print(f"bumping {current} -> {target}")
+
+    for cargo in WORKSPACE_CARGOS:
+        bump_cargo(cargo, current, target)
+        print(f"  bumped {cargo.relative_to(ROOT)}")
+
+    bump_root_package_json(
+        ROOT / "sdks" / "typescript" / "package.json", current, target
+    )
+    print("  bumped sdks/typescript/package.json (+ optionalDependencies)")
+
+    for platform_pkg in (ROOT / "sdks" / "typescript" / "npm").glob("*/package.json"):
+        bump_platform_package_json(platform_pkg, current, target)
+        print(f"  bumped {platform_pkg.relative_to(ROOT)}")
+
+    print("refreshing Cargo.lock files ...")
+    cargo_update(WORKSPACE_CARGOS[0])
+    for manifest in SUB_LOCK_MANIFESTS:
+        cargo_update(manifest)
+
+    print("verifying with scripts/check_version_sync.py ...")
+    subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "check_version_sync.py")],
+        cwd=ROOT,
+        check=True,
+    )
+    print(f"version bump to {target} complete; review `git diff` before committing")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Verify that user-visible package metadata stays in lockstep with Cargo.toml.
+
+The TypeScript SDK ships through npm and pins its version in
+``sdks/typescript/package.json`` plus three per-platform packages under
+``sdks/typescript/npm/`` plus three ``optionalDependencies`` entries.
+The Rust workspace bumps its Cargo.toml independently. When any of those
+fall out of sync (which happened across v8.0.27 / v8.0.28 / v8.0.29 and
+left npm stuck on v8.0.26 because the publish workflow keys off
+``package.json`` rather than ``Cargo.toml``), the npm package silently
+ages while git tags advance.
+
+This script fails CI when any tracked version disagrees with the
+canonical ``crates/thetadatadx/Cargo.toml`` version.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CANONICAL_CARGO = ROOT / "crates" / "thetadatadx" / "Cargo.toml"
+
+
+def cargo_version(path: Path) -> str:
+    text = path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        sys.exit(f"could not parse `version` from {path}")
+    return match.group(1)
+
+
+def package_json_version(path: Path) -> str:
+    return json.loads(path.read_text())["version"]
+
+
+def package_json_optional_deps(path: Path) -> dict[str, str]:
+    return json.loads(path.read_text()).get("optionalDependencies", {})
+
+
+def main() -> int:
+    canonical = cargo_version(CANONICAL_CARGO)
+    print(f"canonical version (Cargo.toml): {canonical}")
+
+    failures: list[str] = []
+
+    ts_root = ROOT / "sdks" / "typescript" / "package.json"
+    if package_json_version(ts_root) != canonical:
+        failures.append(
+            f"{ts_root.relative_to(ROOT)} version is "
+            f"{package_json_version(ts_root)}, expected {canonical}"
+        )
+
+    for name, pinned in package_json_optional_deps(ts_root).items():
+        if pinned != canonical:
+            failures.append(
+                f"{ts_root.relative_to(ROOT)} optionalDependencies['{name}'] "
+                f"is {pinned}, expected {canonical}"
+            )
+
+    for platform_pkg in (ts_root.parent / "npm").glob("*/package.json"):
+        if package_json_version(platform_pkg) != canonical:
+            failures.append(
+                f"{platform_pkg.relative_to(ROOT)} version is "
+                f"{package_json_version(platform_pkg)}, expected {canonical}"
+            )
+
+    if failures:
+        print("version-sync errors:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("version sync: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.26",
+  "version": "8.0.29",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.26",
+  "version": "8.0.29",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.26",
+  "version": "8.0.29",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.26",
+  "version": "8.0.29",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.26",
-    "thetadatadx-darwin-arm64": "8.0.26",
-    "thetadatadx-win32-x64-msvc": "8.0.26"
+    "thetadatadx-linux-x64-gnu": "8.0.29",
+    "thetadatadx-darwin-arm64": "8.0.29",
+    "thetadatadx-win32-x64-msvc": "8.0.29"
   },
   "engines": {
     "node": ">= 20"


### PR DESCRIPTION
## What

1. Bump every \`package.json\` under \`sdks/typescript/\` to 8.0.29 to match Cargo.toml.
2. Add \`scripts/check_version_sync.py\` CI guard so this drift never happens silently again.
3. Add \`scripts/bump_version.py\` — single command that touches every version pin in lockstep so future bumps cannot miss a file.

## Why

\`sdks/typescript/package.json\` was last bumped on v8.0.26 and never moved across v8.0.27 / v8.0.28 / v8.0.29. The publish workflow at \`.github/workflows/typescript.yml\` keys off \`package.json\`'s version, hits \`npm view thetadatadx@8.0.26\` (already published), and silently skips. Result: **npm is stuck on v8.0.26** while git tags advance.

The Cargo.toml workspace bump only covers \`thetadatadx-napi\`'s Rust-side version pin; the npm registry name + version come from \`package.json\`, which the maturin/napi-rs build doesn't auto-sync.

## How

### One-time fix (this PR)

- Bump \`sdks/typescript/package.json\` \`version\` 8.0.26 -> 8.0.29
- Bump the three \`optionalDependencies\` pins (\`thetadatadx-linux-x64-gnu\`, \`thetadatadx-darwin-arm64\`, \`thetadatadx-win32-x64-msvc\`) to 8.0.29
- Bump each per-platform \`sdks/typescript/npm/*/package.json\` to 8.0.29

### Permanent fix (this PR)

\`scripts/bump_version.py 8.0.30\` updates everything atomically:

- 7 workspace Cargo.toml files
- 1 root \`sdks/typescript/package.json\` + 3 platform \`sdks/typescript/npm/*/package.json\`
- 3 \`optionalDependencies\` pins inside the root package.json
- 5 Cargo.lock files (workspace + tools/mcp + tools/server + sdks/python + sdks/typescript) via \`cargo update --workspace\`

After bumping, the script invokes \`check_version_sync.py\` and exits non-zero if anything is out of sync.

\`scripts/check_version_sync.py\` runs in the CI Lint job alongside \`check_docs_consistency.py\` and \`validate_agreement_test.py\`. Any PR that drifts the package.json version off the canonical Cargo.toml fails CI before merge.

## Test plan

- [x] \`python3 scripts/check_version_sync.py\` reports \`version sync: ok\` on the bumped tree
- [x] Manual flip of one \`version\` field makes the script exit 1 with a precise file/field error
- [x] \`python3 scripts/bump_version.py 8.0.30\` bumps everything and re-running it reports \`version sync: ok\` (then reverted via \`bump_version.py 8.0.29\` for the actual PR)

## Follow-up

After merge + tag the next release, the npm publish workflow sees 8.0.29 != already-published 8.0.26 and actually publishes. From that point on, every release uses \`scripts/bump_version.py <version>\` as the only supported way to bump.