### PR TITLE
feat!: C++ callback wrapper + v8.0.30 release (closes #482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [8.0.30] - 2026-05-06
+
+This release closes #482: the entire FPSS streaming stack — Rust core,
+C ABI, Python, TypeScript, and C++ — moves to a callback-driven
+delivery model backed by a single `StreamingDispatcher` SSOT. Bundles
+PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
+(TypeScript), and #494 (C++ wrapper).
 
 ### Breaking
 
@@ -86,9 +92,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and connect are atomic). All `std::sync::mpsc` usage and the
   poll-based receive path have been removed from `ffi/src/streaming.rs`.
 
-  The C++ wrapper's `next_event` / `FpssEventDeleter` / `FpssEventPtr`
-  are also gone; the wrapper migrates to the callback API in a
-  follow-up.
+- **C++ wrapper**: the poll-based `tdx::FpssClient::next_event` and the
+  owning `FpssEventPtr` / `FpssEventDeleter` types are gone. Event
+  delivery is now exclusively callback-driven through the new
+  `set_callback` / `set_inline_callback` methods (see Added).
 
 ### Changed
 
@@ -109,6 +116,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for the dispatcher path) but slow callbacks block the reader and
   cause vendor disconnects. Documented contract: callback must
   return within microseconds.
+- **C++ wrapper callback API.** `tdx::FpssClient::set_callback
+  (std::function<void(const FpssEvent&)>)` for the default queued
+  path; `set_inline_callback` for power-user opt-in directly on
+  the FPSS reader thread. Both wrap the C ABI
+  `tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback`
+  shipped in this release. The `fpss_smoke` example is restored on
+  the callback path.
 
 ## [8.0.29] - 2026-05-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.29"
+version = "8.0.30"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [8.0.30] - 2026-05-06
+
+This release closes #482: the entire FPSS streaming stack — Rust core,
+C ABI, Python, TypeScript, and C++ — moves to a callback-driven
+delivery model backed by a single `StreamingDispatcher` SSOT. Bundles
+PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
+(TypeScript), and #494 (C++ wrapper).
 
 ### Breaking
 
@@ -86,9 +92,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and connect are atomic). All `std::sync::mpsc` usage and the
   poll-based receive path have been removed from `ffi/src/streaming.rs`.
 
-  The C++ wrapper's `next_event` / `FpssEventDeleter` / `FpssEventPtr`
-  are also gone; the wrapper migrates to the callback API in a
-  follow-up.
+- **C++ wrapper**: the poll-based `tdx::FpssClient::next_event` and the
+  owning `FpssEventPtr` / `FpssEventDeleter` types are gone. Event
+  delivery is now exclusively callback-driven through the new
+  `set_callback` / `set_inline_callback` methods (see Added).
 
 ### Changed
 
@@ -109,6 +116,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for the dispatcher path) but slow callbacks block the reader and
   cause vendor disconnects. Documented contract: callback must
   return within microseconds.
+- **C++ wrapper callback API.** `tdx::FpssClient::set_callback
+  (std::function<void(const FpssEvent&)>)` for the default queued
+  path; `set_inline_callback` for power-user opt-in directly on
+  the FPSS reader thread. Both wrap the C ABI
+  `tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback`
+  shipped in this release. The `fpss_smoke` example is restored on
+  the callback path.
 
 ## [8.0.29] - 2026-05-06
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.29"
+version = "8.0.30"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -280,21 +280,35 @@ int main() {
     // Create a streaming client (separate from the historical Client)
     tdx::FpssClient fpss(creds, config);
 
-    // Subscribe to real-time quotes
-    int req_id = fpss.subscribe_quotes("AAPL");
-    std::cout << "Subscribed (req_id=" << req_id << ")" << std::endl;
+    // Register a queued callback. The dispatcher drain thread invokes
+    // `fn` for every event; the FPSS reader thread never blocks on
+    // user code.
+    fpss.set_callback([](const tdx::FpssEvent& event) {
+        if (event.kind == TDX_FPSS_QUOTE) {
+            std::cout << "quote bid=" << event.quote.bid
+                      << " ask=" << event.quote.ask << std::endl;
+        }
+    });
 
-    // The C++ wrapper migrates to the new callback C ABI in a follow-up
-    // PR (refs #482). Until that lands, drive the streaming connection
-    // by calling the C symbols `tdx_fpss_set_callback` (queued, default)
-    // or `tdx_fpss_set_inline_callback` (inline, microsecond-budget)
-    // directly with an `extern "C" fn(const TdxFpssEvent*, void*)`.
+    fpss.subscribe_quotes("AAPL");
+
+    // ... let the callback run ...
 
     fpss.shutdown();
 }
 ```
 
-All prices in streaming events are `double` (f64) -- decoded during parsing. Access them directly: `event->quote.bid`, `event->trade.price`, etc. No `price_type` decoding needed.
+All prices in streaming events are `double` (f64) -- decoded during parsing. Access them directly: `event.quote.bid`, `event.trade.price`, etc. No `price_type` decoding needed.
+
+### Inline callback (power user)
+
+`set_inline_callback` is the opt-in alternative. Instead of routing events through the bounded crossbeam queue and dispatcher drain thread, the callback fires directly from the FPSS reader thread. This skips the queueing overhead but inverts the safety contract: the callback MUST return within microseconds. Any allocation, lock acquisition, syscall, or blocking I/O stalls the reader, fills the kernel TCP receive buffer, and causes the vendor to disconnect. Reach for this path only inside provably wait-free trading loops.
+
+```cpp
+fpss.set_inline_callback([](const tdx::FpssEvent& event) {
+    // wait-free hot loop -- no allocation, no locks, no I/O
+});
+```
 
 ### FpssClient API
 
@@ -321,7 +335,9 @@ All prices in streaming events are `double` (f64) -- decoded during parsing. Acc
 | `contract_lookup(id)` | `optional<string>` | Look up a contract by server-assigned ID |
 | `contract_map()` | `map<int32_t, string>` | Get the full contract ID mapping |
 | `active_subscriptions()` | `vector<Subscription>` | Get active subscriptions as typed structs |
-| (callback registration) | `int` | The C++ wrapper migrates to the new callback C ABI in a follow-up PR (#482); until then call `tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback` from C directly |
+| `set_callback(std::function<void(const FpssEvent&)>)` | `void` | Queued path: dispatcher drain thread invokes `fn`, reader never blocks |
+| `set_inline_callback(std::function<void(const FpssEvent&)>)` | `void` | Inline path: `fn` fires on the FPSS reader thread (microsecond-budget contract) |
+| `dropped_events()` | `uint64_t` | Cumulative count of events the dispatcher dropped on queue overflow (0 for inline path) |
 | `reconnect()` | `void` | Reconnect streaming and restore subscriptions |
 | `shutdown()` | `void` | Shut down the FPSS client |
 

--- a/sdks/cpp/examples/fpss_smoke.cpp
+++ b/sdks/cpp/examples/fpss_smoke.cpp
@@ -1,13 +1,118 @@
-// fpss_smoke.cpp -- C++ FPSS smoke test.
+// fpss_smoke.cpp -- C++ FPSS smoke test driven by the callback C ABI.
 //
-// The poll-based `tdx::FpssClient::next_event` API was removed in
-// issue #482 (PR B) along with the underlying `tdx_fpss_next_event`
-// C ABI symbol. This example will be rewritten to drive the new
-// callback API (`tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback`)
-// when the C++ wrapper migration ships in PR E.
-//
-// Compiling this file in its current form is intentional only after
-// the C++ wrapper migration lands; until then it is a static breakage
-// signal so downstream consumers do not silently miss the API change.
+// Subscribes to a stock and an option contract, registers a queued
+// callback, prints every event for a few seconds, then exits cleanly.
 
-#error "fpss_smoke.cpp depends on the removed `next_event` poll API. Re-enable when the C++ wrapper migrates to the callback C ABI in PR E (refs #482)."
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "thetadx.hpp"
+
+namespace {
+
+constexpr const char* kSymbol = "AAPL";
+constexpr const char* kOptionSymbol = "SPY";
+constexpr const char* kExpiration = "20260417";
+constexpr const char* kStrike = "550";
+constexpr const char* kRight = "C";
+
+constexpr auto kCollectFor = std::chrono::seconds(5);
+constexpr int kMaxEventsPrinted = 25;
+
+const char* event_kind_name(tdx::FpssEventKind kind) {
+    switch (kind) {
+        case TDX_FPSS_QUOTE: return "quote";
+        case TDX_FPSS_TRADE: return "trade";
+        case TDX_FPSS_OPEN_INTEREST: return "open_interest";
+        case TDX_FPSS_OHLCVC: return "ohlcvc";
+        case TDX_FPSS_CONTROL: return "control";
+        case TDX_FPSS_RAW_DATA: return "raw_data";
+    }
+    return "unknown";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    const std::string creds_path = (argc > 1) ? argv[1] : "creds.txt";
+    try {
+        auto creds = tdx::Credentials::from_file(creds_path);
+        auto config = tdx::Config::production();
+
+        tdx::FpssClient fpss(creds, config);
+
+        std::atomic<int> total_events{0};
+        std::atomic<int> data_events{0};
+        std::mutex print_mtx;
+
+        fpss.set_callback([&](const tdx::FpssEvent& event) {
+            const int seq = total_events.fetch_add(1, std::memory_order_relaxed);
+            if (event.kind != TDX_FPSS_CONTROL && event.kind != TDX_FPSS_RAW_DATA) {
+                data_events.fetch_add(1, std::memory_order_relaxed);
+            }
+            if (seq >= kMaxEventsPrinted) return;
+            std::lock_guard<std::mutex> guard(print_mtx);
+            std::cout << "[" << seq << "] kind=" << event_kind_name(event.kind);
+            switch (event.kind) {
+                case TDX_FPSS_QUOTE:
+                    std::cout << " contract_id=" << event.quote.contract_id
+                              << " bid=" << event.quote.bid
+                              << " ask=" << event.quote.ask;
+                    break;
+                case TDX_FPSS_TRADE:
+                    std::cout << " contract_id=" << event.trade.contract_id
+                              << " price=" << event.trade.price
+                              << " size=" << event.trade.size;
+                    break;
+                case TDX_FPSS_OPEN_INTEREST:
+                    std::cout << " contract_id=" << event.open_interest.contract_id
+                              << " open_interest=" << event.open_interest.open_interest;
+                    break;
+                case TDX_FPSS_OHLCVC:
+                    std::cout << " contract_id=" << event.ohlcvc.contract_id
+                              << " close=" << event.ohlcvc.close;
+                    break;
+                case TDX_FPSS_CONTROL:
+                    std::cout << " control_kind=" << event.control.kind;
+                    if (event.control.detail) std::cout << " detail=" << event.control.detail;
+                    break;
+                case TDX_FPSS_RAW_DATA:
+                    std::cout << " code=" << static_cast<int>(event.raw_data.code)
+                              << " len=" << event.raw_data.payload_len;
+                    break;
+            }
+            std::cout << std::endl;
+        });
+
+        if (fpss.subscribe_quotes(kSymbol) < 0) {
+            throw std::runtime_error("subscribe_quotes failed");
+        }
+        if (fpss.subscribe_trades(kSymbol) < 0) {
+            throw std::runtime_error("subscribe_trades failed");
+        }
+        if (fpss.subscribe_option_quotes(kOptionSymbol, kExpiration, kStrike, kRight) < 0) {
+            throw std::runtime_error("subscribe_option_quotes failed");
+        }
+
+        std::this_thread::sleep_for(kCollectFor);
+
+        const int total = total_events.load(std::memory_order_relaxed);
+        const int data = data_events.load(std::memory_order_relaxed);
+        const uint64_t dropped = fpss.dropped_events();
+
+        std::cout << "summary: total=" << total
+                  << " data=" << data
+                  << " dropped=" << dropped << std::endl;
+
+        fpss.shutdown();
+        return data > 0 ? 0 : 1;
+    } catch (const std::exception& e) {
+        std::cerr << "fpss_smoke error: " << e.what() << std::endl;
+        return 2;
+    }
+}

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -324,14 +325,24 @@ using FpssEvent = TdxFpssEvent;
 
 // ── FPSS real-time streaming client ──
 //
-// The poll-based `next_event` API and its `FpssEventPtr` owning unique_ptr
-// are gone in the C ABI as of issue #482 (PR B). The C++ wrapper migrates
-// to the new `tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback`
-// surface in PR E. Until that lands, `FpssClient` exposes only the
-// configuration / subscription / lifecycle methods that don't touch
-// event delivery, plus a `dropped_events()` accessor whose semantics
-// changed (now reports queue overflow drops, not channel-disconnect
-// drops).
+// Event delivery is callback-driven. Two paths are available:
+//
+// * `set_callback(fn)` — default queued path. Events flow
+//   `FPSS reader -> bounded(8192) crossbeam queue -> dispatcher drain
+//   thread -> user fn`. The reader thread never blocks on user code; on
+//   queue overflow events are dropped and counted via `dropped_events()`.
+//
+// * `set_inline_callback(fn)` — power-user opt-in. `fn` fires directly
+//   from the FPSS reader thread. The caller MUST guarantee `fn` returns
+//   within microseconds; a slow `fn` blocks the reader, fills the kernel
+//   TCP receive buffer, and causes the vendor to disconnect.
+//
+// The Client owns the `std::function`. A free `extern "C"` shim retrieves
+// the stored function from the registered `void* ctx` and invokes it with
+// the event reference. The shim converts `const TdxFpssEvent*` (the C ABI
+// payload type) to `const FpssEvent&` (the C++ alias) at the boundary.
+// Callback storage outlives any FPSS reader / dispatcher thread because
+// `~FpssClient` calls `tdx_fpss_shutdown` before the storage is freed.
 
 class FpssClient {
 public:
@@ -340,10 +351,41 @@ public:
 
     FpssClient(const FpssClient&) = delete;
     FpssClient& operator=(const FpssClient&) = delete;
-    FpssClient(FpssClient&& other) noexcept : handle_(std::move(other.handle_)) {}
+    FpssClient(FpssClient&& other) noexcept
+        : handle_(std::move(other.handle_)),
+          callback_(std::move(other.callback_)) {}
     FpssClient& operator=(FpssClient&& other) noexcept {
         handle_ = std::move(other.handle_);
+        callback_ = std::move(other.callback_);
         return *this;
+    }
+
+    /** Register a queued FPSS callback and open the FPSS connection.
+     *  `fn` runs on the dispatcher drain thread, never on the FPSS
+     *  reader. The reader thread cannot be blocked by user code: on
+     *  overflow events are dropped and counted via `dropped_events()`.
+     *  Throws on registration failure. */
+    void set_callback(std::function<void(const FpssEvent&)> fn) {
+        callback_ = std::make_unique<std::function<void(const FpssEvent&)>>(std::move(fn));
+        int rc = tdx_fpss_set_callback(handle_.get(), &FpssClient::callback_shim, callback_.get());
+        if (rc < 0) {
+            callback_.reset();
+            throw std::runtime_error("thetadatadx: " + detail::last_ffi_error());
+        }
+    }
+
+    /** Register an inline FPSS callback and open the FPSS connection.
+     *  `fn` fires directly from the FPSS reader thread. Caller MUST
+     *  guarantee `fn` returns within microseconds; a slow `fn` stalls
+     *  the reader and the vendor will drop the session. Throws on
+     *  registration failure. */
+    void set_inline_callback(std::function<void(const FpssEvent&)> fn) {
+        callback_ = std::make_unique<std::function<void(const FpssEvent&)>>(std::move(fn));
+        int rc = tdx_fpss_set_inline_callback(handle_.get(), &FpssClient::callback_shim, callback_.get());
+        if (rc < 0) {
+            callback_.reset();
+            throw std::runtime_error("thetadatadx: " + detail::last_ffi_error());
+        }
     }
 
     /** Cumulative count of FPSS events dropped by the streaming dispatcher
@@ -356,7 +398,24 @@ public:
     }
 
 private:
+    // Free C-ABI shim that the Rust dispatcher invokes. `ctx` is the
+    // `std::function*` we registered alongside the callback. The event
+    // pointer is non-null and valid only for the duration of this call.
+    static void callback_shim(const TdxFpssEvent* event, void* ctx) noexcept {
+        auto* fn = static_cast<std::function<void(const FpssEvent&)>*>(ctx);
+        if (fn == nullptr || event == nullptr) return;
+        try {
+            (*fn)(*event);
+        } catch (...) {
+            // User callbacks must not propagate exceptions across the
+            // C ABI boundary — Rust would unwind into UB. Swallow.
+        }
+    }
+
     std::unique_ptr<TdxFpssHandle, FpssHandleDeleter> handle_;
+    // `unique_ptr` so the address handed to the C ABI as `ctx` is stable
+    // across moves of the owning `FpssClient`.
+    std::unique_ptr<std::function<void(const FpssEvent&)>> callback_;
 };
 
 // ── Standalone Greeks functions ──

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -354,9 +354,25 @@ public:
     FpssClient(FpssClient&& other) noexcept
         : handle_(std::move(other.handle_)),
           callback_(std::move(other.callback_)) {}
+    /** Move-assign. The receiver may already hold a live FPSS handle
+     *  with a registered callback whose `ctx` points into our existing
+     *  `callback_` storage. We must drain that wiring on the C ABI side
+     *  BEFORE destroying the old `callback_`, otherwise the Rust
+     *  dispatcher / inline reader could invoke through a dangling
+     *  `void*` ctx. `tdx_fpss_shutdown` drops the FPSS reader and joins
+     *  the dispatcher drain thread before returning, so once it
+     *  completes no thread observes the old ctx. */
     FpssClient& operator=(FpssClient&& other) noexcept {
-        handle_ = std::move(other.handle_);
-        callback_ = std::move(other.callback_);
+        if (this != &other) {
+            if (handle_) {
+                tdx_fpss_shutdown(handle_.get());
+            }
+            // Now safe to drop the old callback storage; no Rust thread
+            // can still be holding its address.
+            callback_.reset();
+            handle_ = std::move(other.handle_);
+            callback_ = std::move(other.callback_);
+        }
         return *this;
     }
 
@@ -364,28 +380,42 @@ public:
      *  `fn` runs on the dispatcher drain thread, never on the FPSS
      *  reader. The reader thread cannot be blocked by user code: on
      *  overflow events are dropped and counted via `dropped_events()`.
-     *  Throws on registration failure. */
+     *  Throws on registration failure.
+     *
+     *  The C ABI permits exactly one successful callback registration
+     *  per handle; a second call returns -1 and KEEPS the previously
+     *  installed (callback, ctx) wired into the Rust dispatcher. We
+     *  therefore stage the new `std::function` into a local
+     *  `unique_ptr`, attempt the FFI registration with the staged
+     *  address, and only adopt it into `callback_` after the FFI
+     *  reports success. On failure the existing `callback_` is left
+     *  untouched so the still-live Rust registration keeps pointing at
+     *  valid storage. */
     void set_callback(std::function<void(const FpssEvent&)> fn) {
-        callback_ = std::make_unique<std::function<void(const FpssEvent&)>>(std::move(fn));
-        int rc = tdx_fpss_set_callback(handle_.get(), &FpssClient::callback_shim, callback_.get());
+        auto staged = std::make_unique<std::function<void(const FpssEvent&)>>(std::move(fn));
+        int rc = tdx_fpss_set_callback(handle_.get(), &FpssClient::callback_shim, staged.get());
         if (rc < 0) {
-            callback_.reset();
             throw std::runtime_error("thetadatadx: " + detail::last_ffi_error());
         }
+        callback_ = std::move(staged);
     }
 
     /** Register an inline FPSS callback and open the FPSS connection.
      *  `fn` fires directly from the FPSS reader thread. Caller MUST
      *  guarantee `fn` returns within microseconds; a slow `fn` stalls
      *  the reader and the vendor will drop the session. Throws on
-     *  registration failure. */
+     *  registration failure.
+     *
+     *  Same staged-then-adopt discipline as `set_callback`: only swap
+     *  into `callback_` after the FFI reports success, so a rejected
+     *  re-registration cannot dangle the still-active Rust ctx. */
     void set_inline_callback(std::function<void(const FpssEvent&)> fn) {
-        callback_ = std::make_unique<std::function<void(const FpssEvent&)>>(std::move(fn));
-        int rc = tdx_fpss_set_inline_callback(handle_.get(), &FpssClient::callback_shim, callback_.get());
+        auto staged = std::make_unique<std::function<void(const FpssEvent&)>>(std::move(fn));
+        int rc = tdx_fpss_set_inline_callback(handle_.get(), &FpssClient::callback_shim, staged.get());
         if (rc < 0) {
-            callback_.reset();
             throw std::runtime_error("thetadatadx: " + detail::last_ffi_error());
         }
+        callback_ = std::move(staged);
     }
 
     /** Cumulative count of FPSS events dropped by the streaming dispatcher

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.29"
+version = "8.0.30"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.29"
+version = "8.0.30"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.29",
+  "version": "8.0.30",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.29",
+  "version": "8.0.30",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.29",
+  "version": "8.0.30",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.29",
+  "version": "8.0.30",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.29",
-    "thetadatadx-darwin-arm64": "8.0.29",
-    "thetadatadx-win32-x64-msvc": "8.0.29"
+    "thetadatadx-linux-x64-gnu": "8.0.30",
+    "thetadatadx-darwin-arm64": "8.0.30",
+    "thetadatadx-win32-x64-msvc": "8.0.30"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.29"
+version = "8.0.30"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "json_canon",
  "serde",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.29"
+version = "8.0.30"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.29"
+version = "8.0.30"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.29"
+version = "8.0.30"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

Final binding migration for #482. The C++ wrapper moves to the callback C ABI shipped in #490, the `fpss_smoke` example is restored on the callback path, and the `[Unreleased]` CHANGELOG block becomes the v8.0.30 release that bundles the entire #482 stack.

## New C++ surface

`sdks/cpp/include/thetadx.hpp`, header-only on `tdx::FpssClient`:

```cpp
void set_callback(std::function<void(const FpssEvent&)> fn);
void set_inline_callback(std::function<void(const FpssEvent&)> fn);
uint64_t dropped_events() const;  // already shipped in #490
```

`set_callback` wires `tdx_fpss_set_callback` (queued: dispatcher drain thread invokes `fn`, reader never blocks). `set_inline_callback` wires `tdx_fpss_set_inline_callback` (inline: `fn` fires on the FPSS reader thread, microsecond-budget contract). The client owns a `unique_ptr<std::function<...>>` so the address handed to the C ABI as `ctx` is stable across moves; a free `extern "C"` shim recovers the function from `ctx` and swallows any propagating exception so unwinding cannot cross the Rust/C boundary.

## Release-note table — what v8.0.30 bundles

| PR | Layer | What ships |
|----|-------|------------|
| #489 | Rust core | `StreamingDispatcher` + bounded crossbeam queue + `start_streaming_inline` |
| #490 | C ABI | `tdx_*_set_callback` / `tdx_*_set_inline_callback`; `next_event` / `start_streaming` removed |
| #492 | Python (in flight) | PyO3 callback API; `next_event` / `next_event_typed` removed |
| #493 | TypeScript (in flight) | NAPI callback API; `nextEvent` removed |
| this PR | C++ wrapper | `tdx::FpssClient::set_callback` / `set_inline_callback`; `fpss_smoke` example restored |

## Version bump

```
$ python3 scripts/check_version_sync.py
canonical version (Cargo.toml): 8.0.30
version sync: ok
```

`scripts/bump_version.py 8.0.30` updated every Cargo.toml, every `package.json`, every `optionalDependencies` entry, and every `Cargo.lock` in lockstep.

## Heads-up

`[Unreleased]` was promoted to `## [8.0.30] - 2026-05-06` on a state that includes only PR #489 + #490 in-tree. PR #492 (Python) and PR #493 (TypeScript) currently target the same `[Unreleased]` block; once they merge they will conflict on this CHANGELOG section. Per the staged plan they fold into the same v8.0.30 release notes — the merge order needs to be resolved by the maintainer.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo deny check`
- [x] `cargo run -p thetadatadx --bin generate_sdk_surfaces --features config-file -- --check`
- [x] `cargo check / clippy / test --no-run` on `tools/mcp`
- [x] `cargo check --locked` on `tools/server`, `sdks/python`, `sdks/typescript`
- [x] `python3 scripts/check_version_sync.py` → `version sync: ok`
- [x] `cmake -S sdks/cpp -B build/cpp && cmake --build build/cpp` — every target (`thetadatadx_cpp`, `thetadatadx_example`, `thetadatadx_validate`, `thetadatadx_fpss_smoke`) builds clean
- [ ] Live FPSS smoke run (requires creds; `./build/cpp/thetadatadx_fpss_smoke creds.txt`)

Closes #482.