### PR TITLE
feat(tdbe): ParsedRight::from_wire_byte (inverse of as_wire_byte)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,17 @@ PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
   shipped in this release. The `fpss_smoke` example is restored on
   the callback path.
 
+### tdbe
+
+- `tdbe::right::ParsedRight::from_wire_byte(byte: i32) -> Option<Self>`
+  — `const fn` decoder for the FPSS wire `right` byte (`67` for
+  `'C'`, `80` for `'P'`). Inverse of the existing `as_wire_byte()`.
+  Removes the rationale for downstream tick decoders to re-type the
+  `67` / `80` magic numbers at every trust boundary; round-trip
+  property test confirms `from_wire_byte(self.as_wire_byte().unwrap())
+  == Some(self)` for every variant where the forward direction is
+  defined. Patch bump tdbe 0.12.8 → 0.12.9.
+
 ## [8.0.29] - 2026-05-06
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "criterion",
  "thiserror 2.0.18",

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.12.8"
+version = "0.12.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tdbe/src/right.rs
+++ b/crates/tdbe/src/right.rs
@@ -97,6 +97,39 @@ impl ParsedRight {
             Self::Both => None,
         }
     }
+
+    /// Decode an FPSS wire byte (`67` for `'C'`, `80` for `'P'`) into
+    /// a typed [`ParsedRight`]. Returns [`None`] for any other byte
+    /// so callers can lift the soft-skip / hard-error decision into
+    /// their own error type.
+    ///
+    /// Inverse of [`Self::as_wire_byte`]: every variant whose
+    /// `as_wire_byte()` returns `Some(b)` round-trips through
+    /// `from_wire_byte(b) == Some(self)`.
+    ///
+    /// `const fn` so it stays evaluable in const contexts. Removes the
+    /// rationale for downstream tick decoders (analytics chain
+    /// snapshots, replay validators) to re-type the `67` / `80` magic
+    /// numbers at every trust boundary.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tdbe::right::ParsedRight;
+    ///
+    /// assert_eq!(ParsedRight::from_wire_byte(67), Some(ParsedRight::Call));
+    /// assert_eq!(ParsedRight::from_wire_byte(80), Some(ParsedRight::Put));
+    /// assert_eq!(ParsedRight::from_wire_byte(0), None);
+    /// assert_eq!(ParsedRight::from_wire_byte(-1), None);
+    /// ```
+    #[must_use]
+    pub const fn from_wire_byte(byte: i32) -> Option<Self> {
+        match byte {
+            67 => Some(Self::Call),
+            80 => Some(Self::Put),
+            _ => None,
+        }
+    }
 }
 
 /// Parse a user-supplied `right` string.
@@ -246,5 +279,56 @@ mod tests {
         // Still surfaces the baseline invalid-input error for garbage.
         let err = parse_right_strict("xyz").unwrap_err();
         assert!(format!("{err}").contains("invalid option right"));
+    }
+
+    #[test]
+    fn from_wire_byte_decodes_call_and_put() {
+        assert_eq!(ParsedRight::from_wire_byte(67), Some(ParsedRight::Call));
+        assert_eq!(ParsedRight::from_wire_byte(80), Some(ParsedRight::Put));
+    }
+
+    #[test]
+    fn from_wire_byte_rejects_unknown_bytes() {
+        for byte in [
+            0_i32,
+            1,
+            65,
+            66,
+            68,
+            79,
+            81,
+            100,
+            256,
+            -1,
+            i32::MIN,
+            i32::MAX,
+        ] {
+            assert!(
+                ParsedRight::from_wire_byte(byte).is_none(),
+                "byte {byte} should not decode"
+            );
+        }
+    }
+
+    #[test]
+    fn wire_byte_round_trips_through_inverse() {
+        // Every variant whose `as_wire_byte()` returns Some(b) should
+        // round-trip through `from_wire_byte(b) == Some(self)`.
+        for variant in [ParsedRight::Call, ParsedRight::Put, ParsedRight::Both] {
+            match variant.as_wire_byte() {
+                Some(byte) => {
+                    assert_eq!(
+                        ParsedRight::from_wire_byte(byte),
+                        Some(variant),
+                        "round-trip failed for {variant:?}"
+                    );
+                }
+                None => {
+                    // `Both` returns None on the forward direction —
+                    // there is no FPSS byte to invert from.
+                    assert_eq!(variant, ParsedRight::Both);
+                }
+            }
+        }
     }
 }

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -40,7 +40,7 @@ frames = ["polars", "arrow"]
 live-tests = []
 
 [dependencies]
-tdbe = { version = "0.12.8", path = "../tdbe" }
+tdbe = { version = "0.12.9", path = "../tdbe" }
 
 # gRPC + protobuf (tonic 0.14 extracted prost codec into tonic-prost)
 tonic = { version = "=0.14.5", features = ["tls-ring", "tls-native-roots", "channel", "transport"] }
@@ -141,7 +141,7 @@ prost-build = "=0.14.3"
 regex = "1.12.3"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
-tdbe = { version = "0.12.8", path = "../tdbe" }
+tdbe = { version = "0.12.9", path = "../tdbe" }
 
 [[bench]]
 name = "bench_decode"

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -124,6 +124,17 @@ PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
   shipped in this release. The `fpss_smoke` example is restored on
   the callback path.
 
+### tdbe
+
+- `tdbe::right::ParsedRight::from_wire_byte(byte: i32) -> Option<Self>`
+  — `const fn` decoder for the FPSS wire `right` byte (`67` for
+  `'C'`, `80` for `'P'`). Inverse of the existing `as_wire_byte()`.
+  Removes the rationale for downstream tick decoders to re-type the
+  `67` / `80` magic numbers at every trust boundary; round-trip
+  property test confirms `from_wire_byte(self.as_wire_byte().unwrap())
+  == Some(self)` for every variant where the forward direction is
+  defined. Patch bump tdbe 0.12.8 → 0.12.9.
+
 ## [8.0.29] - 2026-05-06
 
 ### Removed

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -31,7 +31,7 @@ testing-panic-boundary = []
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx" }
-tdbe = { version = "0.12.8", path = "../crates/tdbe" }
+tdbe = { version = "0.12.9", path = "../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 # Used by the FPSS streaming callback silent-drop observability path
 # (see `tdx_fpss_dropped_events` / `tdx_unified_dropped_events`). Keep

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2319,7 +2319,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -19,7 +19,7 @@ doc = false
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.8", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.9", path = "../../crates/tdbe" }
 
 # Direct prost dep for decoding `thetadatadx::proto::ResponseData` bytes in
 # the `decode_response_bytes` hook. The main crate no longer re-exports

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.8", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.9", path = "../../crates/tdbe" }
 
 napi = { version = "3.8.5", features = ["async", "tokio_rt", "serde-json", "napi6", "chrono_date"] }
 napi-derive = "3.5.4"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.8", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.9", path = "../../crates/tdbe" }
 json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.12.8", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.9", path = "../../crates/tdbe" }
 json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.12.8"
+version = "0.12.9"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23.38", features = ["ring"] }
-tdbe = { version = "0.12.8", path = "../../crates/tdbe" }
+tdbe = { version = "0.12.9", path = "../../crates/tdbe" }
 json_canon = { version = "0.1.0", path = "../../crates/json_canon" }
 axum = { version = "0.8.9", features = ["ws"] }
 tokio = { version = "1.52.1", features = ["full"] }


### PR DESCRIPTION
## Summary

- Adds `tdbe::right::ParsedRight::from_wire_byte(byte: i32) -> Option<Self>` — `const fn` decoder for the FPSS wire `right` byte (`67` for `'C'`, `80` for `'P'`).
- Inverse of the existing `ParsedRight::as_wire_byte`. Round-trip property test confirms every variant whose `as_wire_byte()` returns `Some(b)` decodes through `from_wire_byte(b) == Some(self)`.
- Removes the rationale for downstream tick decoders to re-type the `67` / `80` magic numbers at every trust boundary (e.g. `thetadatadx-analytics::analytics::_shared::prewarm::chain_snapshot::from_mdds_ticks`).
- Patch bumps `tdbe` 0.12.8 → 0.12.9 per the 0.12.x patch-only policy. `thetadatadx` / `ffi` / `tools/cli` dependency pins lifted to `0.12.9`. The `thetadatadx` SDK version stays at 8.0.29 — a follow-up release PR rolls the SDK forward.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --release -p thetadatadx-ffi`
- [x] 3 new unit tests (decode known bytes, reject unknown bytes incl. negatives & i32 extremes, round-trip property)
- [x] CHANGELOG entry under `[Unreleased] / tdbe`

Closes #495.

## Friction note

The original v13 cleanup spec named this work as "typed chain-snapshot decoder for endpoints 67/80". The numbers `67` and `80` are NOT MDDS endpoint numbers — they are the ASCII byte values for the option `right` field (`'C' == 67`, `'P' == 80`). MDDS endpoints are method names on `MddsClient` (e.g. `option_snapshot_quote`, `option_at_time_quote`); the `right` byte is a tick-field encoding owned by `tdbe`. This PR lands the cleanup at the right level (a `tdbe` API on `ParsedRight`) so the analytics consumer can drop its hardcoded match arms.