### PR TITLE
chore(release): 8.0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.31] - 2026-05-06
+
+### tdbe
+
+- `tdbe::right::ParsedRight::from_wire_byte(byte: i32) -> Option<Self>`
+  — `const fn` decoder for the FPSS wire `right` byte (`67` for
+  `'C'`, `80` for `'P'`). Inverse of the existing `as_wire_byte()`.
+  Removes the rationale for downstream tick decoders to re-type the
+  `67` / `80` magic numbers at every trust boundary; round-trip
+  property test confirms `from_wire_byte(self.as_wire_byte().unwrap())
+  == Some(self)` for every variant where the forward direction is
+  defined. Patch bump tdbe 0.12.8 → 0.12.9.
+
 ## [8.0.30] - 2026-05-06
 
 This release closes #482: the entire FPSS streaming stack — Rust core,
@@ -123,17 +136,6 @@ PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
   `tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback`
   shipped in this release. The `fpss_smoke` example is restored on
   the callback path.
-
-### tdbe
-
-- `tdbe::right::ParsedRight::from_wire_byte(byte: i32) -> Option<Self>`
-  — `const fn` decoder for the FPSS wire `right` byte (`67` for
-  `'C'`, `80` for `'P'`). Inverse of the existing `as_wire_byte()`.
-  Removes the rationale for downstream tick decoders to re-type the
-  `67` / `80` magic numbers at every trust boundary; round-trip
-  property test confirms `from_wire_byte(self.as_wire_byte().unwrap())
-  == Some(self)` for every variant where the forward direction is
-  defined. Patch bump tdbe 0.12.8 → 0.12.9.
 
 ## [8.0.29] - 2026-05-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.30"
+version = "8.0.31"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.31] - 2026-05-06
+
+### tdbe
+
+- `tdbe::right::ParsedRight::from_wire_byte(byte: i32) -> Option<Self>`
+  — `const fn` decoder for the FPSS wire `right` byte (`67` for
+  `'C'`, `80` for `'P'`). Inverse of the existing `as_wire_byte()`.
+  Removes the rationale for downstream tick decoders to re-type the
+  `67` / `80` magic numbers at every trust boundary; round-trip
+  property test confirms `from_wire_byte(self.as_wire_byte().unwrap())
+  == Some(self)` for every variant where the forward direction is
+  defined. Patch bump tdbe 0.12.8 → 0.12.9.
+
 ## [8.0.30] - 2026-05-06
 
 This release closes #482: the entire FPSS streaming stack — Rust core,
@@ -123,17 +136,6 @@ PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
   `tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback`
   shipped in this release. The `fpss_smoke` example is restored on
   the callback path.
-
-### tdbe
-
-- `tdbe::right::ParsedRight::from_wire_byte(byte: i32) -> Option<Self>`
-  — `const fn` decoder for the FPSS wire `right` byte (`67` for
-  `'C'`, `80` for `'P'`). Inverse of the existing `as_wire_byte()`.
-  Removes the rationale for downstream tick decoders to re-type the
-  `67` / `80` magic numbers at every trust boundary; round-trip
-  property test confirms `from_wire_byte(self.as_wire_byte().unwrap())
-  == Some(self)` for every variant where the forward direction is
-  defined. Patch bump tdbe 0.12.8 → 0.12.9.
 
 ## [8.0.29] - 2026-05-06
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.30"
+version = "8.0.31"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.30"
+version = "8.0.31"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.30"
+version = "8.0.31"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.30",
+  "version": "8.0.31",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.30",
+  "version": "8.0.31",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.30",
+  "version": "8.0.31",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.30",
+  "version": "8.0.31",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.30",
-    "thetadatadx-darwin-arm64": "8.0.30",
-    "thetadatadx-win32-x64-msvc": "8.0.30"
+    "thetadatadx-linux-x64-gnu": "8.0.31",
+    "thetadatadx-darwin-arm64": "8.0.31",
+    "thetadatadx-win32-x64-msvc": "8.0.31"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.30"
+version = "8.0.31"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "json_canon",
  "serde",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.30"
+version = "8.0.31"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.30"
+version = "8.0.31"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.30"
+version = "8.0.31"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

Patch bump 8.0.30 → 8.0.31 for the additive `tdbe::right::ParsedRight::from_wire_byte` landed in #496 (which itself patch-bumped tdbe 0.12.8 → 0.12.9).

Per the v8 patch-only policy. No SDK behaviour change beyond the new public surface on `tdbe::right`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] All extended-surface manifests (`tools/{cli,server,mcp}`, `sdks/{python,typescript}`) refreshed; `cargo check --locked` passes for each
- [x] npm `package.json` versions in `sdks/typescript/{,npm/*}` synced to 8.0.31
- [x] CHANGELOG `[8.0.31]` section + docs-site mirror