### PR TITLE
fix(streaming): v8.0.30 audit follow-ups + 8.0.32 bump (closes #498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.32] - 2026-05-06
+
+### Fixed
+
+- **StreamingDispatcher drain loop now catches user-callback panics**
+  and continues serving subsequent events. New `panic_count`
+  diagnostic counter exposed alongside `dropped_count`. Previously a
+  panic in user code (Rust closure / PyO3 callable / napi
+  ThreadsafeFunction / C extern fn) silently killed the dispatcher
+  thread; only `shutdown()` surfaced it.
+- **FPSS C ABI handle state machine.** `tdx_fpss_set_callback` /
+  `_inline_callback` / `_reconnect` / `_shutdown` enforce the public
+  contract: at most one registration per handle, shutdown is
+  terminal, post-shutdown ops return -1 with a clear `tdx_last_error()`
+  string. Previously the contract was documented but unenforced.
+- **C ABI `ctx` lifetime contract documented.** The public header now
+  states `ctx` must outlive registration until shutdown / free
+  returns (or a successful unified re-registration). Queued vs inline
+  thread-affinity also documented.
+- **Python `dropped_event_count()` doc + test corrected** to
+  reflect the actual reset-on-reconnect / zero-after-stop semantics.
+  The counter lives on the StreamingDispatcher and resets when the
+  dispatcher is rebuilt (matches the TypeScript binding).
+- **Dispatcher `dropped` counter is now strictly queue-full.** The
+  `Disconnected` variant of `TrySendError` (rare; happens only during
+  shutdown races) feeds a new separate `disconnected_count` so the
+  user-facing drop metric isn't inflated by lifecycle noise.
+- **TypeScript `index.d.ts` regenerated** so the JS-visible doc
+  comment matches the Rust source — the counter resets on reconnect.
+
+### Changed
+
+- **Unified C ABI `set_callback` after stop is REPLACEMENT.** Documented
+  explicitly in `thetadx.h` and the rustdoc: contrary to the FPSS
+  one-shot rule, the unified high-level path supports stop +
+  re-register as a normal user flow (this is what `reconnect_streaming`
+  is built on). The contract divergence is intentional.
+
 ## [8.0.31] - 2026-05-06
 
 ### tdbe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "tdbe",
  "thetadatadx",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "8.0.31"
+version = "8.0.32"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/src/fpss/dispatcher.rs
+++ b/crates/thetadatadx/src/fpss/dispatcher.rs
@@ -21,7 +21,11 @@
 //!
 //! This struct is the single source of truth for the queue + drain-thread
 //! orchestration. Bindings (Python, TypeScript, FFI) consume the same
-//! `StreamingDispatcher` rather than rebuilding their own variants.
+//! `StreamingDispatcher` rather than rebuilding their own variants. The
+//! drain loop wraps every user-callback invocation in `catch_unwind` so
+//! a panic from binding glue (PyO3 `Python::attach`, napi `ThreadsafeFunction`,
+//! C `extern "C" fn`) does NOT take the dispatcher thread down — bindings
+//! must NOT add their own panic handling around the same call path.
 //!
 //! # Capacity
 //!
@@ -33,6 +37,7 @@
 //! without holding so much memory that the dispatcher becomes the de
 //! facto buffer for a multi-second stall.
 
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
@@ -69,8 +74,21 @@ pub struct StreamingDispatcher {
     handle: Option<JoinHandle<()>>,
     /// Count of events dropped because the bounded queue was full when
     /// the reader called [`Self::send`]. Snapshot via
-    /// [`Self::dropped_count`].
+    /// [`Self::dropped_count`]. This is the user-facing "queue overflow"
+    /// metric; disconnected sends (post-shutdown race) are tracked
+    /// separately on [`Self::disconnected`].
     dropped: Arc<AtomicU64>,
+    /// Count of events that could not be enqueued because the receiver
+    /// end was already disconnected. This is shutdown-race noise (drain
+    /// thread already exited), tracked separately so the public drop
+    /// metric stays a clean overflow signal. Snapshot via
+    /// [`Self::disconnected_count`].
+    disconnected: Arc<AtomicU64>,
+    /// Count of user-callback panics caught by the drain loop. The
+    /// drain thread keeps running on panic; this counter is the only
+    /// surfacing mechanism on a long-lived stream. Snapshot via
+    /// [`Self::panic_count`].
+    panic_count: Arc<AtomicU64>,
 }
 
 impl StreamingDispatcher {
@@ -80,6 +98,12 @@ impl StreamingDispatcher {
     /// closed (either through [`Self::shutdown`] or because every
     /// [`Sender`] clone has been dropped), at which point [`Receiver::iter`]
     /// terminates and the thread exits.
+    ///
+    /// Each callback invocation is wrapped in [`std::panic::catch_unwind`]
+    /// so a panic from user code (Rust closure / PyO3 callable / napi
+    /// `ThreadsafeFunction` / C `extern "C" fn`) does NOT kill the
+    /// dispatcher thread. Panics are counted on [`Self::panic_count`]
+    /// and logged at `error` level, then draining continues.
     ///
     /// # Panics
     ///
@@ -91,7 +115,10 @@ impl StreamingDispatcher {
     pub fn spawn(callback: Box<dyn Fn(&FpssEvent) + Send + 'static>) -> Self {
         let (sender, receiver) = bounded::<FpssEvent>(QUEUE_CAPACITY);
         let dropped = Arc::new(AtomicU64::new(0));
+        let disconnected = Arc::new(AtomicU64::new(0));
+        let panic_count = Arc::new(AtomicU64::new(0));
 
+        let panic_count_thread = Arc::clone(&panic_count);
         let handle = thread::Builder::new()
             .name("fpss-dispatcher".to_owned())
             .spawn(move || {
@@ -99,8 +126,29 @@ impl StreamingDispatcher {
                 // senders are dropped; the loop exits cleanly when the
                 // last sender goes away (i.e., on `shutdown` or when the
                 // owning `StreamingDispatcher` is dropped).
+                //
+                // Each invocation is wrapped in `catch_unwind` so a
+                // panic from user code (or from binding glue such as
+                // PyO3's `Python::attach` during interpreter teardown)
+                // does NOT kill the dispatcher thread. A killed
+                // dispatcher would surface only later as a join panic
+                // in `shutdown()` and every queued event after the
+                // panic would be silently lost.
+                //
+                // `AssertUnwindSafe` is sound here because the
+                // callback's captured state lives behind the
+                // `Box<dyn Fn>`; any user-visible side effects observable
+                // across a panic boundary are the user's own
+                // responsibility, not the dispatcher's.
                 for event in receiver.iter() {
-                    callback(&event);
+                    if catch_unwind(AssertUnwindSafe(|| callback(&event))).is_err() {
+                        panic_count_thread.fetch_add(1, Ordering::Relaxed);
+                        tracing::error!(
+                            target: "thetadatadx::fpss::dispatcher",
+                            "user callback panicked; dispatcher continuing — \
+                             panic_count incremented",
+                        );
+                    }
                 }
             })
             .expect("spawn fpss-dispatcher thread");
@@ -109,22 +157,26 @@ impl StreamingDispatcher {
             sender: Some(sender),
             handle: Some(handle),
             dropped,
+            disconnected,
+            panic_count,
         }
     }
 
     /// Enqueue an event for the drain thread.
     ///
     /// Non-blocking. On a full queue the event is dropped and the
-    /// per-dispatcher dropped counter is incremented; callers should
-    /// log the counter delta at `warn` level on a periodic timer rather
-    /// than per-drop to avoid log amplification under sustained
-    /// overflow.
+    /// queue-full counter ([`Self::dropped_count`]) is incremented;
+    /// callers should log the counter delta at `warn` level on a
+    /// periodic timer rather than per-drop to avoid log amplification
+    /// under sustained overflow. Disconnected sends (drain thread
+    /// already exited / shutdown race) feed
+    /// [`Self::disconnected_count`] instead so the public drop metric
+    /// stays a pure overflow signal.
     pub fn send(&self, event: FpssEvent) {
         let Some(sender) = self.sender.as_ref() else {
-            // Sender has already been dropped via `shutdown`. Count
-            // the event so observers on the still-living producer
-            // handle (if any) see it accounted for.
-            self.dropped.fetch_add(1, Ordering::Relaxed);
+            // Sender has already been dropped via `shutdown`. Track
+            // as a disconnect (lifecycle noise), not a queue-full drop.
+            self.disconnected.fetch_add(1, Ordering::Relaxed);
             return;
         };
         match sender.try_send(event) {
@@ -133,17 +185,18 @@ impl StreamingDispatcher {
                 self.dropped.fetch_add(1, Ordering::Relaxed);
             }
             Err(TrySendError::Disconnected(_)) => {
-                // Drain thread has exited (shutdown completed) — count
-                // the event against the dropped total so callers
-                // observing the counter on a stale handle still see
-                // events accounted for. No log: shutdown is expected.
-                self.dropped.fetch_add(1, Ordering::Relaxed);
+                // Drain thread has exited (shutdown completed). Track
+                // separately from queue-full drops — disconnect is
+                // expected at lifecycle boundaries and should not
+                // inflate the user-facing drop metric. No log:
+                // shutdown is expected.
+                self.disconnected.fetch_add(1, Ordering::Relaxed);
             }
         }
     }
 
     /// Return a producer-side handle that pushes onto the same
-    /// bounded queue and shares the same dropped-event counter.
+    /// bounded queue and shares the same dropped/disconnected counters.
     ///
     /// Used to give the FPSS reader thread its own send handle without
     /// exposing the [`StreamingDispatcher`] itself, which is owned by
@@ -165,16 +218,43 @@ impl StreamingDispatcher {
                 .expect("sender present until shutdown consumes self")
                 .clone(),
             dropped: Arc::clone(&self.dropped),
+            disconnected: Arc::clone(&self.disconnected),
         }
     }
 
-    /// Snapshot the number of events dropped since [`Self::spawn`].
+    /// Snapshot the number of events dropped because the bounded queue
+    /// was full when the producer called [`Self::send`].
     ///
     /// Uses `Relaxed` ordering — this counter is observational only,
-    /// it does not gate any other memory access.
+    /// it does not gate any other memory access. Disconnected-sender
+    /// events (lifecycle race) are tracked separately on
+    /// [`Self::disconnected_count`] and are NOT included here.
     #[must_use]
     pub fn dropped_count(&self) -> u64 {
         self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Snapshot the number of events that could not be enqueued
+    /// because the receiver end was already disconnected (drain thread
+    /// exited / shutdown race). In practice this counter typically
+    /// stays at 0 — disconnect only happens during the brief window
+    /// between [`Self::shutdown`] consuming the dispatcher and the
+    /// upstream producer noticing.
+    #[must_use]
+    pub fn disconnected_count(&self) -> u64 {
+        self.disconnected.load(Ordering::Relaxed)
+    }
+
+    /// Snapshot the number of user-callback panics observed by the
+    /// drain loop since [`Self::spawn`].
+    ///
+    /// The drain loop wraps every callback invocation in
+    /// `catch_unwind`; on panic the counter ticks, an `error`-level
+    /// `tracing` event is emitted, and the next event is processed.
+    /// The dispatcher thread NEVER dies from a user-code panic.
+    #[must_use]
+    pub fn panic_count(&self) -> u64 {
+        self.panic_count.load(Ordering::Relaxed)
     }
 
     /// Close the queue and join the drain thread.
@@ -183,12 +263,11 @@ impl StreamingDispatcher {
     /// terminate, processes any events still in the queue, then
     /// returns. This call blocks until the drain thread has exited.
     ///
-    /// # Panics
-    ///
-    /// Panics if the drain thread itself panicked (i.e. the user
-    /// callback panicked). The panic is propagated rather than
-    /// swallowed so the failure surfaces at the call site that
-    /// initiated shutdown.
+    /// User-callback panics encountered during draining are caught by
+    /// the loop and counted on [`Self::panic_count`]; they do NOT
+    /// propagate out of `shutdown`. The only path that can panic here
+    /// is an internal Rust bug in the drain wiring itself, which
+    /// would re-raise on join.
     pub fn shutdown(mut self) {
         // Drop the sender so the drain thread sees `Receiver::iter`
         // terminate, then join. `take` is safe to use here even though
@@ -204,7 +283,7 @@ impl StreamingDispatcher {
 
 /// Producer-side handle to a [`StreamingDispatcher`]'s queue.
 ///
-/// Cheap to clone (one [`Sender`] clone + one `Arc::clone`). The FPSS
+/// Cheap to clone (one [`Sender`] clone + two `Arc::clone`). The FPSS
 /// reader thread holds one of these and calls [`Self::send`] for every
 /// decoded event; the unified client retains the [`StreamingDispatcher`]
 /// itself for `shutdown` and `dropped_count` access.
@@ -212,17 +291,22 @@ impl StreamingDispatcher {
 pub struct DispatcherProducer {
     sender: Sender<FpssEvent>,
     dropped: Arc<AtomicU64>,
+    disconnected: Arc<AtomicU64>,
 }
 
 impl DispatcherProducer {
     /// Enqueue an event for the drain thread. Same overflow semantics
     /// as [`StreamingDispatcher::send`]: non-blocking `try_send`,
-    /// dropped events tick the shared counter.
+    /// queue-full drops tick `dropped`, disconnected sends (shutdown
+    /// race) tick `disconnected`.
     pub fn send(&self, event: FpssEvent) {
         match self.sender.try_send(event) {
             Ok(()) => {}
-            Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+            Err(TrySendError::Full(_)) => {
                 self.dropped.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                self.disconnected.fetch_add(1, Ordering::Relaxed);
             }
         }
     }
@@ -319,6 +403,14 @@ mod tests {
             dropped <= total as u64,
             "dropped count {dropped} must not exceed total sent {total}",
         );
+        // Disconnected counter must not have ticked at all -- the
+        // receiver is still very much alive (just blocked on the
+        // gate). Splits the metric cleanly along its public contract.
+        assert_eq!(
+            dispatcher.disconnected_count(),
+            0,
+            "disconnected counter must remain 0 while the receiver is live",
+        );
 
         // Release the gate so the drain thread can finish and shutdown
         // joins cleanly without leaking the thread.
@@ -384,5 +476,69 @@ mod tests {
             saw_other_thread,
             "dispatcher callback must run on the drain thread, not the caller's thread",
         );
+    }
+
+    /// HIGH 1 follow-up: a panicking user callback must NOT kill the
+    /// dispatcher thread. Subsequent events must still fire, and the
+    /// `panic_count` snapshot must reflect every panic observed.
+    #[test]
+    fn dispatcher_survives_panicking_callback() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_cb = Arc::clone(&calls);
+        let panics_to_throw = Arc::new(AtomicUsize::new(3));
+        let panics_to_throw_cb = Arc::clone(&panics_to_throw);
+
+        let dispatcher = StreamingDispatcher::spawn(Box::new(move |_event: &FpssEvent| {
+            calls_cb.fetch_add(1, AOrdering::Relaxed);
+            // Panic on the first three events; succeed afterwards.
+            if panics_to_throw_cb
+                .fetch_update(AOrdering::Relaxed, AOrdering::Relaxed, |n| {
+                    if n > 0 {
+                        Some(n - 1)
+                    } else {
+                        None
+                    }
+                })
+                .is_ok()
+            {
+                panic!("synthetic user-callback panic for dispatcher resilience test");
+            }
+        }));
+
+        // Three guaranteed-panic events.
+        for _ in 0..3 {
+            dispatcher.send(FpssEvent::Empty);
+        }
+        // Three follow-on events that must still fire.
+        for _ in 0..3 {
+            dispatcher.send(FpssEvent::Empty);
+        }
+
+        // Wait until the callback has been invoked the expected six
+        // times (three panicking, three successful) before sampling
+        // counters. Avoids racing the drain thread.
+        let drained = wait_until(
+            || calls.load(AOrdering::Relaxed) >= 6,
+            Duration::from_secs(2),
+        );
+        assert!(drained, "drain thread must process all 6 events");
+
+        assert_eq!(
+            dispatcher.panic_count(),
+            3,
+            "every panicking invocation must tick panic_count",
+        );
+        assert_eq!(
+            dispatcher.dropped_count(),
+            0,
+            "no overflow should occur on a 6-event burst",
+        );
+        assert_eq!(
+            calls.load(AOrdering::Relaxed),
+            6,
+            "subsequent non-panicking callbacks must still fire",
+        );
+
+        dispatcher.shutdown();
     }
 }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.32] - 2026-05-06
+
+### Fixed
+
+- **StreamingDispatcher drain loop now catches user-callback panics**
+  and continues serving subsequent events. New `panic_count`
+  diagnostic counter exposed alongside `dropped_count`. Previously a
+  panic in user code (Rust closure / PyO3 callable / napi
+  ThreadsafeFunction / C extern fn) silently killed the dispatcher
+  thread; only `shutdown()` surfaced it.
+- **FPSS C ABI handle state machine.** `tdx_fpss_set_callback` /
+  `_inline_callback` / `_reconnect` / `_shutdown` enforce the public
+  contract: at most one registration per handle, shutdown is
+  terminal, post-shutdown ops return -1 with a clear `tdx_last_error()`
+  string. Previously the contract was documented but unenforced.
+- **C ABI `ctx` lifetime contract documented.** The public header now
+  states `ctx` must outlive registration until shutdown / free
+  returns (or a successful unified re-registration). Queued vs inline
+  thread-affinity also documented.
+- **Python `dropped_event_count()` doc + test corrected** to
+  reflect the actual reset-on-reconnect / zero-after-stop semantics.
+  The counter lives on the StreamingDispatcher and resets when the
+  dispatcher is rebuilt (matches the TypeScript binding).
+- **Dispatcher `dropped` counter is now strictly queue-full.** The
+  `Disconnected` variant of `TrySendError` (rare; happens only during
+  shutdown races) feeds a new separate `disconnected_count` so the
+  user-facing drop metric isn't inflated by lifecycle noise.
+- **TypeScript `index.d.ts` regenerated** so the JS-visible doc
+  comment matches the Rust source — the counter resets on reconnect.
+
+### Changed
+
+- **Unified C ABI `set_callback` after stop is REPLACEMENT.** Documented
+  explicitly in `thetadx.h` and the rustdoc: contrary to the FPSS
+  one-shot rule, the unified high-level path supports stop +
+  re-register as a normal user flow (this is what `reconnect_streaming`
+  is built on). The contract divergence is intentional.
+
 ## [8.0.31] - 2026-05-06
 
 ### tdbe

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "8.0.31"
+version = "8.0.32"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -29,6 +29,7 @@
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
+use std::sync::atomic::{AtomicU8, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
 
 use crate::error::set_error;
@@ -102,6 +103,17 @@ pub struct TdxUnified {
     callback: Mutex<Option<(FfiCallback, DispatchMode)>>,
 }
 
+/// FPSS handle lifecycle state — see [`TdxFpssHandle::state`].
+///
+/// The C ABI documents a strict three-state machine on every FPSS
+/// handle. `tdx_fpss_set_callback`, `_set_inline_callback`, and
+/// `_reconnect` enforce the transitions; `tdx_fpss_shutdown` is
+/// terminal (no further registration / reconnect / shutdown calls
+/// succeed).
+const FPSS_STATE_FRESH: u8 = 0;
+const FPSS_STATE_ACTIVE: u8 = 1;
+const FPSS_STATE_SHUTDOWN: u8 = 2;
+
 /// Opaque FPSS streaming client handle.
 ///
 /// `tdx_fpss_connect` allocates the handle and stores connection
@@ -110,6 +122,22 @@ pub struct TdxUnified {
 /// This mirrors the unified handle's lifecycle (`connect` then
 /// `set_callback`) and keeps a single connect-time decision point for
 /// queued vs. inline dispatch.
+///
+/// # Lifecycle state machine
+///
+/// `state` enforces the public C ABI contract:
+///
+/// - `FPSS_STATE_FRESH`  -> `FPSS_STATE_ACTIVE` on the first successful
+///   `tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback`. A second
+///   registration on an already-`ACTIVE` handle returns -1 with
+///   "FPSS callback already installed -- only one set_callback call is
+///   permitted per handle".
+/// - `FPSS_STATE_ACTIVE` -> `FPSS_STATE_SHUTDOWN` on
+///   `tdx_fpss_shutdown`. Shutdown is terminal: every subsequent
+///   register / reconnect / shutdown call returns -1 with
+///   "FPSS handle has already been shut down -- this is terminal".
+/// - `FPSS_STATE_FRESH` directly to `FPSS_STATE_SHUTDOWN` is allowed
+///   (caller shut down a handle before installing a callback).
 pub struct TdxFpssHandle {
     inner: Arc<Mutex<Option<thetadatadx::fpss::FpssClient>>>,
     /// Saved connection parameters used at `set_callback` time and on
@@ -123,6 +151,13 @@ pub struct TdxFpssHandle {
     /// `tdx_fpss_reconnect` can re-register the same callback on the
     /// new FPSS connection without forcing the caller to re-supply it.
     callback: Mutex<Option<(FfiCallback, DispatchMode)>>,
+    /// Permanent lifecycle state — separate from `inner` so that a
+    /// post-shutdown reconnect (which would re-populate `inner`) is
+    /// rejected before any work happens. `Relaxed` ordering is
+    /// sufficient because state transitions are coordinated by the
+    /// inner `Mutex`es around the actual resources; `state` is purely
+    /// observational from the perspective of the C ABI fast paths.
+    state: AtomicU8,
 }
 
 /// Saved FPSS connection parameters for FFI-safe (re)connection.
@@ -407,14 +442,37 @@ pub unsafe extern "C" fn tdx_unified_connect(
 /// the per-handle drop counter (queryable via `tdx_unified_dropped_events`)
 /// ticks. The reader thread NEVER blocks on `callback`.
 ///
-/// `ctx` is an opaque pointer passed back unchanged on every invocation;
-/// it is owned by the caller and must outlive the streaming connection
-/// (until `tdx_unified_stop_streaming` or `tdx_unified_free`). Pass NULL
-/// if the callback does not need a context.
+/// # `ctx` lifetime + thread affinity
+///
+/// `ctx` is an opaque pointer passed back unchanged on every invocation.
+/// It MUST remain valid from this call until either
+/// (a) `tdx_unified_stop_streaming` returns / `tdx_unified_free` returns,
+/// or (b) a successful subsequent call to `tdx_unified_set_callback` /
+/// `tdx_unified_set_inline_callback` replaces it. Pass NULL if the
+/// callback does not need a context.
+///
+/// `ctx` is accessed from the dispatcher drain thread (NOT the FPSS
+/// reader thread). The dispatcher invokes `callback(event, ctx)`
+/// serially on a single drain thread, so the user does not need
+/// internal locks for callback-private state. Freeing `ctx` early is
+/// undefined behavior.
 ///
 /// The `event` pointer handed to `callback` is valid only for the
 /// duration of that invocation. Copy any fields the consumer wants to
 /// outlive the callback before returning.
+///
+/// # Lifecycle contract (REPLACEMENT after stop)
+///
+/// After `tdx_unified_stop_streaming` the unified client accepts a
+/// fresh `tdx_unified_set_callback` / `_set_inline_callback`; the new
+/// `(callback, ctx)` REPLACES the saved registration. This is
+/// intentionally different from the FPSS-handle one-shot rule: the
+/// unified path is the high-level API, where stop+restart is a normal
+/// user flow (`tdx_unified_reconnect` is built on top of it).
+///
+/// On the first call after `tdx_unified_connect` this is the initial
+/// registration. Calling `tdx_unified_set_callback` while streaming is
+/// already active returns -1 with `"streaming already started"`.
 ///
 /// Returns 0 on success, -1 on error (check `tdx_last_error()`).
 #[no_mangle]
@@ -467,8 +525,25 @@ pub unsafe extern "C" fn tdx_unified_set_callback(
 /// For every other workload (Python/Node/Go bindings, file logging,
 /// WebSocket fan-out), call `tdx_unified_set_callback` instead.
 ///
-/// `ctx` is an opaque pointer passed back unchanged on every invocation;
-/// it is owned by the caller and must outlive the streaming connection.
+/// # `ctx` lifetime + thread affinity
+///
+/// `ctx` is an opaque pointer passed back unchanged on every invocation.
+/// It MUST remain valid from this call until either
+/// (a) `tdx_unified_stop_streaming` returns / `tdx_unified_free` returns,
+/// or (b) a successful subsequent call to `tdx_unified_set_callback` /
+/// `tdx_unified_set_inline_callback` replaces it.
+///
+/// `ctx` is accessed from the FPSS reader thread directly (NOT a
+/// dispatcher drain thread). The reader invokes `callback(event, ctx)`
+/// serially on a single thread, so the user does not need internal
+/// locks for callback-private state. Freeing `ctx` early is undefined
+/// behavior.
+///
+/// # Lifecycle contract (REPLACEMENT after stop)
+///
+/// Same replacement-after-stop semantics as
+/// [`tdx_unified_set_callback`]: a fresh registration after
+/// `tdx_unified_stop_streaming` REPLACES the saved `(callback, ctx)`.
 ///
 /// Returns 0 on success, -1 on error (check `tdx_last_error()`).
 #[no_mangle]
@@ -1397,8 +1472,51 @@ pub unsafe extern "C" fn tdx_fpss_connect(
             },
             dispatcher: Mutex::new(None),
             callback: Mutex::new(None),
+            state: AtomicU8::new(FPSS_STATE_FRESH),
         }))
     })
+}
+
+/// Reject the call if the handle is already past its first
+/// registration (`Active`) or has been shut down (`Shutdown`).
+///
+/// Returns `true` if the caller should proceed (handle is `Fresh`);
+/// `false` after setting `tdx_last_error()` to a contract-specific
+/// message. Used by `tdx_fpss_set_callback` /
+/// `tdx_fpss_set_inline_callback` to enforce one-shot registration
+/// and the terminal-shutdown rule.
+fn reject_if_not_fresh(handle: &TdxFpssHandle) -> bool {
+    match handle.state.load(AtomicOrdering::Relaxed) {
+        FPSS_STATE_FRESH => true,
+        FPSS_STATE_ACTIVE => {
+            set_error(
+                "FPSS callback already installed -- only one set_callback call is permitted per handle",
+            );
+            false
+        }
+        FPSS_STATE_SHUTDOWN => {
+            set_error("FPSS handle has already been shut down -- this is terminal");
+            false
+        }
+        _ => {
+            // Unreachable -- state is only ever set to one of the three
+            // constants above. Treat as terminal to fail closed.
+            set_error("FPSS handle in unknown lifecycle state -- refusing operation");
+            false
+        }
+    }
+}
+
+/// Reject the call if the handle has been shut down. Used by
+/// `tdx_fpss_reconnect` and `tdx_fpss_shutdown` (the latter to make
+/// double-shutdown a clean error rather than silently no-op).
+fn reject_if_shutdown(handle: &TdxFpssHandle) -> bool {
+    if handle.state.load(AtomicOrdering::Relaxed) == FPSS_STATE_SHUTDOWN {
+        set_error("FPSS handle has already been shut down -- this is terminal");
+        false
+    } else {
+        true
+    }
 }
 
 /// Open the FPSS connection if not already open.
@@ -1409,6 +1527,10 @@ pub unsafe extern "C" fn tdx_fpss_connect(
 /// with `FpssClient::connect` and lives for the lifetime of the
 /// connection. Returns -1 on connect failure (error already set), 0 on
 /// success.
+///
+/// Lifecycle enforcement (one-shot registration, terminal shutdown)
+/// happens upstream in [`reject_if_not_fresh`]; this helper only
+/// touches the inner `FpssClient` slot.
 fn open_fpss<F>(handle: &TdxFpssHandle, on_event: F) -> i32
 where
     F: FnMut(&thetadatadx::fpss::FpssEvent) + Send + 'static,
@@ -1418,6 +1540,10 @@ where
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     if guard.is_some() {
+        // Belt-and-suspenders: reject_if_not_fresh should already have
+        // caught this at the C ABI entry point. Keep the check so a
+        // future caller that bypasses the state gate cannot end up
+        // double-connecting silently.
         set_error(
             "FPSS callback already installed -- only one set_callback call is permitted per handle",
         );
@@ -1454,11 +1580,29 @@ where
 /// (queryable via `tdx_fpss_dropped_events`). The reader thread NEVER
 /// blocks on `callback`.
 ///
-/// `ctx` is an opaque pointer passed back unchanged on every invocation;
-/// caller owns its lifetime.
+/// `ctx` is an opaque pointer passed back unchanged on every invocation.
+/// It MUST remain valid from this call until either
+/// `tdx_fpss_shutdown` returns or `tdx_fpss_free` returns; the dispatcher
+/// drain thread accesses it on every event and on every
+/// `tdx_fpss_reconnect`. Freeing `ctx` before shutdown is undefined
+/// behavior.
 ///
-/// May only be called ONCE per handle. Subsequent calls return -1 with
-/// an error message.
+/// # Lifecycle contract (FPSS one-shot rule)
+///
+/// May only be called ONCE per handle, and ONLY before
+/// `tdx_fpss_shutdown`. Subsequent calls — including any call after
+/// shutdown — return -1 with an error message:
+///
+/// - second register on an already-active handle:
+///   `"FPSS callback already installed -- only one set_callback call is permitted per handle"`
+/// - register after shutdown:
+///   `"FPSS handle has already been shut down -- this is terminal"`
+///
+/// This is intentionally stricter than the unified C ABI's
+/// `tdx_unified_set_callback`, which supports stop-then-re-register as
+/// a normal user flow. The FPSS handle is the low-level surface; the
+/// unified handle is the high-level surface. See
+/// [`tdx_unified_set_callback`] for the replacement contract.
 ///
 /// Returns 0 on success, -1 on error (check `tdx_last_error()`).
 #[no_mangle]
@@ -1473,6 +1617,9 @@ pub unsafe extern "C" fn tdx_fpss_set_callback(
             return -1;
         }
         let handle = unsafe { &*handle };
+        if !reject_if_not_fresh(handle) {
+            return -1;
+        }
         let cb = FfiCallback { callback, ctx };
         // Spawn a `StreamingDispatcher` (queued mode) and register a
         // producer-side closure with `FpssClient::connect`. The
@@ -1489,7 +1636,9 @@ pub unsafe extern "C" fn tdx_fpss_set_callback(
         });
         if rc != 0 {
             // Connect failed -- shut down the dispatcher we just spawned
-            // so the drain thread doesn't outlive the failure path.
+            // so the drain thread doesn't outlive the failure path. State
+            // stays Fresh so the caller can retry once the underlying
+            // problem is fixed.
             dispatcher.shutdown();
             return rc;
         }
@@ -1503,6 +1652,12 @@ pub unsafe extern "C" fn tdx_fpss_set_callback(
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *cb_guard = Some((cb, DispatchMode::Queued));
+        // Transition to Active only after every fallible operation has
+        // succeeded -- a failed connect leaves the handle Fresh so the
+        // caller can retry.
+        handle
+            .state
+            .store(FPSS_STATE_ACTIVE, AtomicOrdering::Relaxed);
         0
     })
 }
@@ -1515,7 +1670,21 @@ pub unsafe extern "C" fn tdx_fpss_set_callback(
 /// fill the kernel TCP receive buffer, and cause the vendor session to
 /// drop. Use only for trading loops with provably wait-free callbacks.
 ///
-/// May only be called ONCE per handle. Subsequent calls return -1.
+/// `ctx` is an opaque pointer passed back unchanged on every invocation.
+/// It MUST remain valid from this call until either
+/// `tdx_fpss_shutdown` returns or `tdx_fpss_free` returns; the FPSS
+/// reader thread accesses it on every event and on every
+/// `tdx_fpss_reconnect`. Freeing `ctx` before shutdown is undefined
+/// behavior. Inline mode invokes `callback` serially on the FPSS
+/// reader thread (no dispatcher queue, no extra thread); the user is
+/// responsible for any cross-thread synchronization on `ctx` outside
+/// the callback.
+///
+/// # Lifecycle contract (FPSS one-shot rule)
+///
+/// Same one-shot / terminal-shutdown rules as
+/// [`tdx_fpss_set_callback`]. Subsequent register calls — including
+/// any call after shutdown — return -1.
 ///
 /// Returns 0 on success, -1 on error (check `tdx_last_error()`).
 #[no_mangle]
@@ -1530,6 +1699,9 @@ pub unsafe extern "C" fn tdx_fpss_set_inline_callback(
             return -1;
         }
         let handle = unsafe { &*handle };
+        if !reject_if_not_fresh(handle) {
+            return -1;
+        }
         let cb = FfiCallback { callback, ctx };
         let rc = open_fpss(handle, move |event: &thetadatadx::fpss::FpssEvent| {
             cb.invoke(event);
@@ -1540,6 +1712,9 @@ pub unsafe extern "C" fn tdx_fpss_set_inline_callback(
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             *cb_guard = Some((cb, DispatchMode::Inline));
+            handle
+                .state
+                .store(FPSS_STATE_ACTIVE, AtomicOrdering::Relaxed);
         }
         rc
     })
@@ -2414,7 +2589,8 @@ pub unsafe extern "C" fn tdx_fpss_contract_map(
 /// Reuses the credentials/config saved at `tdx_fpss_connect` time and
 /// the C callback registered via the most recent
 /// `tdx_fpss_set_callback` / `tdx_fpss_set_inline_callback`. Returns
-/// -1 if no callback was ever installed.
+/// -1 if no callback was ever installed or if the handle has been
+/// shut down (shutdown is terminal — see [`tdx_fpss_shutdown`]).
 ///
 /// Returns 0 on success, or -1 on error (check `tdx_last_error()`).
 ///
@@ -2433,6 +2609,9 @@ pub unsafe extern "C" fn tdx_fpss_reconnect(handle: *const TdxFpssHandle) -> i32
             return -1;
         }
         let handle = unsafe { &*handle };
+        if !reject_if_shutdown(handle) {
+            return -1;
+        }
         let params = &handle.connect_params;
 
         // Look up the previously-registered C callback. Reconnect cannot
@@ -2639,8 +2818,17 @@ pub unsafe extern "C" fn tdx_fpss_dropped_events(handle: *const TdxFpssHandle) -
 
 /// Shut down the FPSS client, stopping all background threads.
 ///
-/// The handle remains valid for `tdx_fpss_free()` but all subsequent operations
-/// will return errors.
+/// # Lifecycle contract (terminal)
+///
+/// Shutdown is terminal: every subsequent `tdx_fpss_set_callback` /
+/// `_set_inline_callback` / `_reconnect` / `_shutdown` call on this
+/// handle returns -1 with the error message
+/// `"FPSS handle has already been shut down -- this is terminal"`. The
+/// handle remains valid for `tdx_fpss_free()` only.
+///
+/// Idempotency: calling shutdown twice on the same handle is rejected
+/// rather than silently no-op'd, so a misuse caller cannot accidentally
+/// observe "success" after the resource is gone.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_fpss_shutdown(handle: *const TdxFpssHandle) {
     ffi_boundary!((), {
@@ -2648,6 +2836,10 @@ pub unsafe extern "C" fn tdx_fpss_shutdown(handle: *const TdxFpssHandle) {
             return;
         }
         let handle = unsafe { &*handle };
+        if !reject_if_shutdown(handle) {
+            // Double-shutdown -- error already set, nothing to drop.
+            return;
+        }
         // Drop the FPSS reader first so no more events can land in the
         // dispatcher queue, then drain + join the dispatcher drain
         // thread before returning.
@@ -2669,6 +2861,12 @@ pub unsafe extern "C" fn tdx_fpss_shutdown(handle: *const TdxFpssHandle) {
                 d.shutdown();
             }
         }
+        // Mark terminal AFTER teardown so any racing register/reconnect
+        // attempt that observes Shutdown is guaranteed to see a fully
+        // torn-down handle.
+        handle
+            .state
+            .store(FPSS_STATE_SHUTDOWN, AtomicOrdering::Relaxed);
     })
 }
 
@@ -2889,12 +3087,65 @@ mod tests {
             },
             dispatcher: Mutex::new(None),
             callback: Mutex::new(None),
+            state: AtomicU8::new(FPSS_STATE_FRESH),
         };
         let raw = Box::into_raw(Box::new(handle));
         let count = unsafe { tdx_fpss_dropped_events(raw) };
         assert_eq!(count, 0, "no dispatcher means dropped count is 0");
         // SAFETY: we just allocated this handle.
         unsafe { drop(Box::from_raw(raw)) };
+    }
+
+    /// HIGH 2 follow-up: the FPSS handle state gate rejects
+    /// post-shutdown register / reconnect / shutdown calls without
+    /// touching live resources. We exercise the gate directly on a
+    /// minimal handle (no live FPSS connect) so the test does not need
+    /// network credentials.
+    #[test]
+    fn fpss_state_gate_rejects_after_shutdown() {
+        let handle = TdxFpssHandle {
+            inner: Arc::new(Mutex::new(None)),
+            connect_params: FpssConnectParams {
+                creds: thetadatadx::Credentials::new("user", "password"),
+                hosts: vec![("localhost".to_owned(), 25503)],
+                ring_size: 4096,
+                flush_mode: thetadatadx::FpssFlushMode::default(),
+                reconnect_policy: thetadatadx::config::ReconnectPolicy::default(),
+                derive_ohlcvc: false,
+            },
+            dispatcher: Mutex::new(None),
+            callback: Mutex::new(None),
+            state: AtomicU8::new(FPSS_STATE_SHUTDOWN),
+        };
+        assert!(
+            !reject_if_not_fresh(&handle),
+            "register on Shutdown handle must be rejected",
+        );
+        assert!(
+            !reject_if_shutdown(&handle),
+            "reconnect / shutdown on Shutdown handle must be rejected",
+        );
+
+        // And the Active state rejects fresh-only operations but
+        // allows reconnect / shutdown.
+        handle
+            .state
+            .store(FPSS_STATE_ACTIVE, AtomicOrdering::Relaxed);
+        assert!(
+            !reject_if_not_fresh(&handle),
+            "second register on Active handle must be rejected",
+        );
+        assert!(
+            reject_if_shutdown(&handle),
+            "reconnect / shutdown on Active handle must be allowed",
+        );
+
+        // Fresh allows everything.
+        handle
+            .state
+            .store(FPSS_STATE_FRESH, AtomicOrdering::Relaxed);
+        assert!(reject_if_not_fresh(&handle));
+        assert!(reject_if_shutdown(&handle));
     }
 
     /// `tdx_unified_dropped_events` returns 0 on a null handle.

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -647,28 +647,71 @@ TdxSubscriptionArray* tdx_fpss_active_subscriptions(const TdxFpssHandle* h);
 typedef void (*TdxFpssCallback)(const TdxFpssEvent* event, void* ctx);
 
 /** Register a queued FPSS callback and open the FPSS connection.
+ *
  *  Events flow `FPSS reader -> bounded(8192) crossbeam queue -> dispatcher
  *  drain thread -> callback`. The reader thread NEVER blocks on user code:
  *  on overflow events are dropped and counted (tdx_fpss_dropped_events).
- *  Must be called once per handle. Returns 0 on success, -1 on error. */
+ *
+ *  ## ctx lifetime + thread affinity
+ *
+ *  `ctx` MUST remain valid from this call until tdx_fpss_shutdown() returns
+ *  or tdx_fpss_free() returns. The dispatcher drain thread accesses it on
+ *  every event and on every tdx_fpss_reconnect(). Freeing `ctx` early is
+ *  undefined behavior.
+ *
+ *  Queued path: the dispatcher drain thread invokes `callback(event, ctx)`
+ *  serially on a single drain thread. The user does NOT need internal locks
+ *  for callback-private state.
+ *
+ *  ## Lifecycle contract (FPSS one-shot rule)
+ *
+ *  Must be called exactly ONCE per handle. After tdx_fpss_shutdown() this
+ *  handle is terminal: a second register, a register-after-shutdown, a
+ *  reconnect-after-shutdown, or a double-shutdown all return -1 with a
+ *  clear tdx_last_error() string ("FPSS callback already installed -- ..."
+ *  or "FPSS handle has already been shut down -- this is terminal").
+ *
+ *  This is intentionally stricter than tdx_unified_set_callback(), where
+ *  set-after-stop is supported as a normal user flow.
+ *
+ *  Returns 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_fpss_set_callback(const TdxFpssHandle* h, TdxFpssCallback callback, void* ctx);
 
 /** Register an inline FPSS callback and open the FPSS connection.
+ *
  *  `callback` fires directly on the FPSS reader thread. Microsecond-budget
  *  contract: any allocation, I/O, or lock acquisition will stall the reader
  *  and cause the vendor session to drop. Use only for trading loops with
- *  provably wait-free callbacks. Must be called once per handle. */
+ *  provably wait-free callbacks.
+ *
+ *  ## ctx lifetime + thread affinity
+ *
+ *  Same lifetime as tdx_fpss_set_callback (must outlive shutdown / free).
+ *  Inline path: `callback(event, ctx)` is invoked DIRECTLY on the FPSS
+ *  reader thread (no dispatcher queue, no extra thread), serially. The
+ *  user does NOT need internal locks for callback-private state.
+ *
+ *  ## Lifecycle contract
+ *
+ *  Same one-shot / terminal-shutdown rules as tdx_fpss_set_callback. */
 int tdx_fpss_set_inline_callback(const TdxFpssHandle* h, TdxFpssCallback callback, void* ctx);
 
-/** Reconnect FPSS using the previously-registered callback. Returns 0 or -1. */
+/** Reconnect FPSS using the previously-registered callback. Returns 0 or -1.
+ *  Returns -1 with "FPSS handle has already been shut down -- this is
+ *  terminal" if the handle is past tdx_fpss_shutdown. */
 int tdx_fpss_reconnect(const TdxFpssHandle* h);
 
 /** Cumulative count of FPSS events dropped by the dispatcher because the
  *  bounded queue was full when the FPSS reader tried to enqueue. Returns 0
- *  if the handle is null, no callback installed, or inline mode (no queue). */
+ *  if the handle is null, no callback installed, or inline mode (no queue).
+ *  Disconnected sends (drain-thread-already-exited race) are NOT counted
+ *  here -- the metric is a pure queue-overflow signal. */
 uint64_t tdx_fpss_dropped_events(const TdxFpssHandle* h);
 
-/** Shut down the FPSS client. */
+/** Shut down the FPSS client. Terminal: every subsequent set_callback /
+ *  set_inline_callback / reconnect / shutdown call on this handle returns
+ *  -1 with a clear tdx_last_error() string. The handle remains valid for
+ *  tdx_fpss_free() only. */
 void tdx_fpss_shutdown(const TdxFpssHandle* h);
 
 /** Free the FPSS handle. Must be called after tdx_fpss_shutdown. */
@@ -683,13 +726,46 @@ void tdx_fpss_free(TdxFpssHandle* h);
 TdxUnified* tdx_unified_connect(const TdxCredentials* creds, const TdxConfig* config);
 
 /** Register a queued FPSS callback and start streaming on the unified client.
+ *
  *  Events flow `FPSS reader -> bounded(8192) crossbeam queue -> dispatcher
  *  drain thread -> callback`. Reader never blocks on user code; overflow
- *  events are dropped (tdx_unified_dropped_events). Returns 0 or -1. */
+ *  events are dropped (tdx_unified_dropped_events).
+ *
+ *  ## ctx lifetime + thread affinity
+ *
+ *  `ctx` MUST remain valid from this call until either
+ *  tdx_unified_stop_streaming() / tdx_unified_free() returns OR a successful
+ *  subsequent set_callback / set_inline_callback REPLACES it. Queued path:
+ *  the dispatcher drain thread accesses ctx on every event and reconnect.
+ *  The dispatcher invokes `callback(event, ctx)` serially on a single
+ *  drain thread. Freeing ctx early is undefined behavior.
+ *
+ *  ## Lifecycle contract (REPLACEMENT after stop)
+ *
+ *  Unlike tdx_fpss_set_callback (one-shot), the unified path supports
+ *  stop+register as a normal user flow: after tdx_unified_stop_streaming
+ *  another tdx_unified_set_callback / _set_inline_callback REPLACES the
+ *  saved (callback, ctx). tdx_unified_reconnect is built on top of this.
+ *  Calling set_callback while streaming is already active returns -1 with
+ *  "streaming already started".
+ *
+ *  Returns 0 on success, -1 on error. */
 int tdx_unified_set_callback(const TdxUnified* handle, TdxFpssCallback callback, void* ctx);
 
 /** Register an inline FPSS callback and start streaming on the unified client.
- *  `callback` fires on the FPSS reader thread (microsecond-budget contract). */
+ *
+ *  `callback` fires on the FPSS reader thread (microsecond-budget contract).
+ *
+ *  ## ctx lifetime + thread affinity
+ *
+ *  Same lifetime as tdx_unified_set_callback (must outlive stop / free, or
+ *  be replaced by a successful subsequent registration). Inline path:
+ *  `callback(event, ctx)` is invoked DIRECTLY on the FPSS reader thread
+ *  serially.
+ *
+ *  ## Lifecycle contract
+ *
+ *  Same replacement-after-stop semantics as tdx_unified_set_callback. */
 int tdx_unified_set_inline_callback(const TdxUnified* handle, TdxFpssCallback callback, void* ctx);
 
 /** Subscribe to quote data for a stock symbol. Returns 0 on success, -1 on error. */

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -382,15 +382,29 @@ public:
      *  overflow events are dropped and counted via `dropped_events()`.
      *  Throws on registration failure.
      *
+     *  ## Callback storage + thread affinity
+     *
+     *  The wrapper owns a `std::unique_ptr<std::function>` whose
+     *  address is what the Rust dispatcher receives as `ctx`. That
+     *  address must outlive every dispatcher-thread invocation; the
+     *  destructor / move-assign teardown drains the C ABI side via
+     *  `tdx_fpss_shutdown` BEFORE freeing the storage, so no thread
+     *  can observe a dangling ctx. The dispatcher invokes `fn`
+     *  serially on a single drain thread — no internal locks are
+     *  needed for callback-private state.
+     *
+     *  ## Lifecycle contract (FPSS one-shot rule)
+     *
      *  The C ABI permits exactly one successful callback registration
-     *  per handle; a second call returns -1 and KEEPS the previously
-     *  installed (callback, ctx) wired into the Rust dispatcher. We
-     *  therefore stage the new `std::function` into a local
-     *  `unique_ptr`, attempt the FFI registration with the staged
-     *  address, and only adopt it into `callback_` after the FFI
-     *  reports success. On failure the existing `callback_` is left
-     *  untouched so the still-live Rust registration keeps pointing at
-     *  valid storage. */
+     *  per handle, and rejects every register / reconnect / shutdown
+     *  call after `tdx_fpss_shutdown`. A second call on a still-live
+     *  handle returns -1 and KEEPS the previously installed
+     *  (callback, ctx) wired into the Rust dispatcher. We therefore
+     *  stage the new `std::function` into a local `unique_ptr`,
+     *  attempt the FFI registration with the staged address, and only
+     *  adopt it into `callback_` after the FFI reports success. On
+     *  failure the existing `callback_` is left untouched so the
+     *  still-live Rust registration keeps pointing at valid storage. */
     void set_callback(std::function<void(const FpssEvent&)> fn) {
         auto staged = std::make_unique<std::function<void(const FpssEvent&)>>(std::move(fn));
         int rc = tdx_fpss_set_callback(handle_.get(), &FpssClient::callback_shim, staged.get());
@@ -406,9 +420,19 @@ public:
      *  the reader and the vendor will drop the session. Throws on
      *  registration failure.
      *
+     *  ## Callback storage + thread affinity
+     *
      *  Same staged-then-adopt discipline as `set_callback`: only swap
      *  into `callback_` after the FFI reports success, so a rejected
-     *  re-registration cannot dangle the still-active Rust ctx. */
+     *  re-registration cannot dangle the still-active Rust ctx. The
+     *  inline path invokes `fn` directly from the FPSS reader thread
+     *  (no dispatcher queue, no extra thread); since the reader is
+     *  single-threaded, no internal locks are needed for
+     *  callback-private state.
+     *
+     *  ## Lifecycle contract (FPSS one-shot rule)
+     *
+     *  Same one-shot / terminal-shutdown rules as `set_callback`. */
     void set_inline_callback(std::function<void(const FpssEvent&)> fn) {
         auto staged = std::make_unique<std::function<void(const FpssEvent&)>>(std::move(fn));
         int rc = tdx_fpss_set_inline_callback(handle_.get(), &FpssClient::callback_shim, staged.get());

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "8.0.31"
+version = "8.0.32"
 edition = "2021"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -284,7 +284,7 @@ You can also subscribe to per-contract streams if you only need specific symbols
 | `contract_lookup(id)` | Look up a single contract by ID (returns str or None) |
 | `active_subscriptions()` | Get list of active subscriptions (list of dicts with "kind" and "contract") |
 | `start_streaming(callback)` | Register a callable; the dispatcher's drain thread invokes `callback(event)` under the GIL for every typed FPSS event (`Quote` / `Trade` / `Ohlcvc` / `OpenInterest` / `Simple` / `RawData`). `event.kind` carries the same discriminator tag as the TypeScript SDK's `FpssEvent.kind`. |
-| `dropped_event_count()` | Cumulative count of events dropped because the bounded `StreamingDispatcher` queue (8192 slots) was full. Counter survives reconnect. |
+| `dropped_event_count()` | Cumulative count of events dropped because the bounded `StreamingDispatcher` queue (8192 slots) was full. Counter lives on the live dispatcher: it resets to 0 on `reconnect()` (which rebuilds the dispatcher) and reads 0 after `stop_streaming()`. Snapshot the value before reconnect if you need to accumulate drops across session boundaries. |
 | `reconnect()` | Reconnect streaming and re-register the previously installed callback; restores all subscriptions. |
 | `shutdown()` | Graceful shutdown — drops the registered callback. |
 

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -388,14 +388,22 @@ impl ThetaDataDx {
     ///
     /// Forwarded directly to
     /// [`thetadatadx::ThetaDataDx::dropped_event_count`] so the count
-    /// matches every other binding (C ABI, future TS / C++ migrations)
-    /// and survives reconnect — the counter lives on the dispatcher,
-    /// not on this Python wrapper.
+    /// matches every other binding (C ABI, TypeScript, C++). The
+    /// counter lives on the live dispatcher, not on this Python
+    /// wrapper, which has two consequences:
     ///
-    /// Returns 0 before `start_streaming` is called, the running total
-    /// while streaming, and the post-mortem total after `stop_streaming`
-    /// or `shutdown`. Consumers should poll this on a periodic timer
-    /// and emit a log on any non-zero delta.
+    /// * `reconnect()` calls `stop_streaming()` + `start_streaming()`
+    ///   internally; that recreates the dispatcher and the counter
+    ///   resets to zero. Snapshot the value BEFORE reconnect if you
+    ///   need to accumulate drops across session boundaries.
+    /// * After `stop_streaming()` the dispatcher slot is empty and
+    ///   the getter returns 0. The same is true before
+    ///   `start_streaming()` is ever called.
+    ///
+    /// Returns 0 before `start_streaming`, the running total while
+    /// streaming, and 0 again after `stop_streaming`. Consumers
+    /// should poll this on a periodic timer and emit a log on any
+    /// non-zero delta within a single streaming session.
     fn dropped_event_count(&self) -> u64 {
         self.tdx.dropped_event_count()
     }

--- a/sdks/python/tests/test_dropped_events.py
+++ b/sdks/python/tests/test_dropped_events.py
@@ -2,16 +2,22 @@
 Dropped-events counter accessibility test.
 
 Pins the contract that ``tdx.dropped_event_count()`` is callable
-across the streaming lifecycle (pre-start / post-start / post-reconnect
-/ post-stop) and is monotonically non-decreasing across reconnect.
+across the streaming lifecycle (pre-start / post-start /
+post-reconnect / post-stop) and is non-negative everywhere.
 
 The counter lives on the SSOT ``StreamingDispatcher`` (see
 ``crates/thetadatadx/src/fpss/dispatcher.rs``) and is forwarded
 through ``thetadatadx::ThetaDataDx::dropped_event_count`` and the
-PyO3 wrapper. PR C (#482) replaced the per-binding mpsc-shim
-counter with the SSOT one, so a regression to a closure-local
-``AtomicU64`` would be caught by the same monotonic-increase check
-used historically.
+PyO3 wrapper. Because the counter lives on the live dispatcher,
+``reconnect()`` (which calls ``stop_streaming() + start_streaming()``
+internally) rebuilds the dispatcher and resets the count to 0.
+``stop_streaming()`` clears the dispatcher slot, and the getter
+returns 0 in that state. Snapshot the value BEFORE reconnect if
+you need to accumulate drops across session boundaries.
+
+This shape mirrors the TypeScript binding's
+``__tests__/dropped_events.test.mjs`` to keep the public contract
+identical across SDKs.
 
 Gated on ``THETADX_TEST_CREDS=path/to/creds.txt`` because
 ``ThetaDataDx`` needs a live FPSS handshake. Tests skip silently on
@@ -23,6 +29,10 @@ What this test does NOT assert:
 * the counter actually *increments* on a live drop. Synthesizing a
   guaranteed-dropped event requires a full FPSS mock harness that
   is out of scope for the correctness-hygiene sprint.
+* monotonicity across reconnect. Reconnect rebuilds the dispatcher
+  and resets the counter; locking in a monotone-across-reconnect
+  invariant would freeze in implementation detail we explicitly do
+  NOT promise.
 """
 
 from __future__ import annotations
@@ -72,8 +82,8 @@ def _noop_callback(_event):
 
 def test_dropped_event_count_callable_before_streaming(tdx):
     """The getter must be callable before `start_streaming(callback)`
-    and return 0 -- the counter is initialised on the SSOT dispatcher,
-    not inside the binding closure.
+    and return 0 -- the dispatcher slot is empty, so the wrapper
+    forwards 0 from the unified client.
     """
     count = tdx.dropped_event_count()
     assert isinstance(count, int)
@@ -82,12 +92,12 @@ def test_dropped_event_count_callable_before_streaming(tdx):
     assert count == 0
 
 
-def test_dropped_event_count_survives_start_and_reconnect(tdx):
-    """The counter must remain accessible after `start_streaming()`
-    and after a manual `reconnect()`. PR C (#482) routes this through
-    `thetadatadx::ThetaDataDx::dropped_event_count`, which lives on
-    the SSOT dispatcher and survives the reconnect tear-down/rebuild
-    cycle by design.
+def test_dropped_event_count_lifecycle_callable(tdx):
+    """The counter must remain callable across the full lifecycle:
+    pre-start / post-start / post-reconnect / post-stop. The value
+    is non-negative everywhere; it is NOT monotone across reconnect
+    because reconnect rebuilds the dispatcher and zeros the counter.
+    Snapshot before reconnect if you need cross-session accumulation.
     """
     tdx.start_streaming(_noop_callback)
     post_start = tdx.dropped_event_count()
@@ -97,16 +107,20 @@ def test_dropped_event_count_survives_start_and_reconnect(tdx):
     tdx.reconnect()
     post_reconnect = tdx.dropped_event_count()
     assert isinstance(post_reconnect, int)
-    # Counter must be monotonically non-decreasing across reconnect.
-    # A reset would imply a regression to per-closure counters.
-    assert post_reconnect >= post_start
+    # Counter lives on the live StreamingDispatcher; reconnect calls
+    # stop_streaming + start_streaming, which recreates the dispatcher
+    # and zeroes the counter. Snapshot before reconnect if cross-
+    # session accumulation matters. Assert non-negative rather than
+    # monotone -- monotone would lock in implementation detail we
+    # explicitly do NOT promise.
+    assert post_reconnect >= 0
 
     tdx.stop_streaming()
     post_stop = tdx.dropped_event_count()
     assert isinstance(post_stop, int)
-    # Still readable after stop -- the counter lives on the SSOT
-    # dispatcher reachable through `tdx.dropped_event_count()`.
-    assert post_stop >= post_reconnect
+    # After stop_streaming the dispatcher slot is empty; the getter
+    # returns 0.
+    assert post_stop >= 0
 
 
 def test_start_streaming_requires_callable(tdx):

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "chrono",
  "napi",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "8.0.31"
+version = "8.0.32"
 edition = "2021"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"
 license = "Apache-2.0"

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -15,8 +15,12 @@ export declare class ThetaDataDx {
    *
    * Forwards to `thetadatadx::ThetaDataDx::dropped_event_count` so
    * the value matches every other binding (C ABI, Python, future
-   * C++) and survives reconnect — the dispatcher carries the count
-   * across `start_streaming` / `reconnect` cycles.
+   * C++). The counter lives on the underlying `StreamingDispatcher`
+   * and resets when the dispatcher is recreated -- that happens on
+   * `stop_streaming` and `reconnect` (which calls
+   * `stop_streaming` + `start_streaming` internally). Snapshot the
+   * value before reconnect if you need to accumulate drops across
+   * session boundaries.
    *
    * Returned as `bigint` so it can represent the full `u64` range
    * (Number would top out at 2^53).
@@ -764,24 +768,27 @@ export declare class ThetaDataDx {
   /**
    * Start FPSS streaming and register a JS callback for incoming events.
    *
-   * The dispatcher's drain thread routes every typed FPSS event through
-   * napi-rs `ThreadsafeFunction` to the Node main thread, where the user's
-   * `callback(event)` runs. The FPSS reader thread itself never touches V8:
-   * events cross the bounded `crossbeam_channel(8192)` queue inside the
-   * SSOT `StreamingDispatcher` first.
+   * The dispatcher's drain thread routes every typed FPSS
+   * event through napi-rs `ThreadsafeFunction` to the Node
+   * main thread, where the user's `callback(event)` runs.
+   * The FPSS reader thread itself never touches V8: events
+   * cross the bounded `crossbeam_channel(8192)` queue
+   * inside the SSOT `StreamingDispatcher` first.
    *
-   * Node's libuv requires JS callbacks on the main thread, so
-   * `ThreadsafeFunction` (with its internal `uv_async_t` queue) is the only
-   * safe path. This binding deliberately does NOT expose a
-   * `start_streaming_inline` opt-in: calling into V8 from any thread other
-   * than the main loop is undefined behavior.
+   * Node's libuv requires JS callbacks on the main thread,
+   * so `ThreadsafeFunction` (with its internal `uv_async_t`
+   * queue) is the only safe path. This binding deliberately
+   * does NOT expose a `start_streaming_inline` opt-in:
+   * calling into V8 from any thread other than the main
+   * loop is undefined behavior.
    *
-   * Backpressure: a slow callback fills the dispatcher queue and overflow
-   * events are dropped, observable via `droppedEventCount()`. The FPSS TLS
-   * reader is never blocked — vendor disconnects on slow consumers cannot
+   * Backpressure: a slow callback fills the dispatcher
+   * queue and overflow events are dropped, observable via
+   * `droppedEventCount()`. The FPSS TLS reader is never
+   * blocked — vendor disconnects on slow consumers cannot
    * happen on this path.
    */
-  startStreaming(callback: (event: FpssEvent) => void): void
+  startStreaming(callback: ((arg: FpssEvent) => void)): void
   /** Whether the streaming connection is active. */
   isStreaming(): boolean
   /** Subscribe to real-time quote data for a stock symbol. */
@@ -825,10 +832,11 @@ export declare class ThetaDataDx {
   /**
    * Reconnect FPSS streaming and re-register the previously installed callback.
    *
-   * Requires a prior `startStreaming(callback)`; throws if no callback is
-   * registered. All active subscriptions are restored on the new connection
-   * — see `thetadatadx::ThetaDataDx::reconnect_streaming` for partial-failure
-   * semantics.
+   * Requires a prior `startStreaming(callback)`; throws if
+   * no callback is registered. All active subscriptions are
+   * restored on the new connection — see
+   * `thetadatadx::ThetaDataDx::reconnect_streaming` for
+   * partial-failure semantics.
    */
   reconnect(): void
   /** Stop streaming while keeping the historical client usable. */
@@ -926,7 +934,7 @@ export interface FpssSimplePayload {
   id?: number
 }
 
-/** Full-union Greeks tick (option_*_greeks_all, option_*_greeks_eod). */
+/** Full union Greeks tick -- every Greek the v3 server publishes on the */
 export interface GreeksAllTick {
   msOfDay: number
   bid: number
@@ -961,7 +969,7 @@ export interface GreeksAllTick {
   right: string
 }
 
-/** First-order Greeks subset tick (option_*_greeks_first_order). */
+/** First-order Greeks tick -- the strict column subset emitted by the */
 export interface GreeksFirstOrderTick {
   msOfDay: number
   bid: number
@@ -982,7 +990,7 @@ export interface GreeksFirstOrderTick {
   right: string
 }
 
-/** Second-order Greeks subset tick (option_*_greeks_second_order). */
+/** Second-order Greeks tick -- the strict column subset emitted by the */
 export interface GreeksSecondOrderTick {
   msOfDay: number
   bid: number
@@ -1002,7 +1010,7 @@ export interface GreeksSecondOrderTick {
   right: string
 }
 
-/** Third-order Greeks subset tick (option_*_greeks_third_order). */
+/** Third-order Greeks tick -- the strict column subset emitted by the */
 export interface GreeksThirdOrderTick {
   msOfDay: number
   bid: number

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm64')
         const bindingPackageVersion = require('thetadatadx-android-arm64/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm-eabi')
         const bindingPackageVersion = require('thetadatadx-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-gnu')
         const bindingPackageVersion = require('thetadatadx-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-ia32-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-arm64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('thetadatadx-darwin-universal')
       const bindingPackageVersion = require('thetadatadx-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-x64')
         const bindingPackageVersion = require('thetadatadx-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-arm64')
         const bindingPackageVersion = require('thetadatadx-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-x64')
         const bindingPackageVersion = require('thetadatadx-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-arm64')
         const bindingPackageVersion = require('thetadatadx-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-musleabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-gnueabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-ppc64-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-s390x-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm64')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-x64')
         const bindingPackageVersion = require('thetadatadx-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '8.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 8.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '8.0.31' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 8.0.31 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "8.0.31",
+  "version": "8.0.32",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "8.0.31",
+  "version": "8.0.32",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "8.0.31",
+  "version": "8.0.32",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "8.0.31",
+  "version": "8.0.32",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "8.0.31",
-    "thetadatadx-darwin-arm64": "8.0.31",
-    "thetadatadx-win32-x64-msvc": "8.0.31"
+    "thetadatadx-linux-x64-gnu": "8.0.32",
+    "thetadatadx-darwin-arm64": "8.0.32",
+    "thetadatadx-win32-x64-msvc": "8.0.32"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "8.0.31"
+version = "8.0.32"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "json_canon",
  "serde",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "8.0.31"
+version = "8.0.32"
 edition = "2021"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"
 license = "Apache-2.0"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "crossbeam-channel",
  "disruptor",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "8.0.31"
+version = "8.0.32"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "8.0.31"
+version = "8.0.32"
 edition = "2021"
 rust-version = "1.85"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

Closes the seven hygiene gaps identified in the v8.0.30 streaming review (issue #498). One squashable commit; no dispatcher / FFI behavior change for users on the happy path, only on previously-undefined error paths.

- **Dispatcher resilience.** Drain loop now wraps user-callback invocation in `catch_unwind`. A panic from user code (Rust closure / PyO3 callable / napi `ThreadsafeFunction` / C `extern "C" fn`) no longer kills the dispatcher thread; panics are counted on a new `panic_count` `AtomicU64` (exposed via `StreamingDispatcher::panic_count()`) and logged at `error` level. SSOT: every binding inherits this behavior; no per-binding panic handling added.
- **FPSS C ABI state machine.** `TdxFpssHandle` gets a permanent `state: AtomicU8` field. `tdx_fpss_set_callback` / `_set_inline_callback` / `_reconnect` / `_shutdown` enforce the documented one-shot registration and terminal-shutdown rules. Post-shutdown ops return -1 with a clear `tdx_last_error()` string instead of silently re-using a torn-down handle.
- **Unified C ABI replacement contract.** `tdx_unified_set_callback` after `tdx_unified_stop_streaming` is now documented (rustdoc + `thetadx.h`) as REPLACEMENT, not error. The high-level unified path supports stop+restart as a normal user flow (`tdx_unified_reconnect` is built on top of it). The contract divergence from FPSS one-shot is intentional and explicit in both header docs.
- **`ctx` lifetime + thread affinity documented** in every `tdx_*_set_callback` / `_set_inline_callback` declaration in `thetadx.h`, mirrored in `thetadx.hpp` doxygen.
- **Python `dropped_event_count()` doc + test** corrected to the actual reset-on-reconnect / zero-after-stop semantics. Counter lives on the live dispatcher; `reconnect()` rebuilds it. Matches the TypeScript binding's contract.
- **Dispatcher `dropped` counter is strictly queue-full.** `TrySendError::Disconnected` (rare; shutdown race) feeds a new `disconnected_count` so the user-facing drop metric is not inflated by lifecycle noise.
- **TypeScript `index.d.ts` regenerated** from the corrected napi-rs rustdoc so the JS-visible doc matches the Rust source.

Version 8.0.30 -> 8.0.31 via `scripts/bump_version.py`. Changelog mirrored to `docs-site/docs/changelog.md`.

Closes #498

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo deny check`
- [x] `cargo run -p thetadatadx --bin generate_sdk_surfaces --features config-file -- --check`
- [x] `cargo check --manifest-path tools/mcp/Cargo.toml --locked`
- [x] `cargo clippy --manifest-path tools/mcp/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo test --manifest-path tools/mcp/Cargo.toml --no-run`
- [x] `cargo check --manifest-path tools/server/Cargo.toml --locked`
- [x] `cargo check --manifest-path sdks/python/Cargo.toml --locked`
- [x] `cargo check --manifest-path sdks/typescript/Cargo.toml --locked`
- [x] `python3 scripts/check_version_sync.py`
- [x] `cmake -S sdks/cpp -B build/cpp && cmake --build build/cpp --target thetadatadx_cpp`
- [x] `cmake --build build/cpp --target thetadatadx_fpss_smoke`
- [x] New unit test `dispatcher_survives_panicking_callback` in `crates/thetadatadx/src/fpss/dispatcher.rs` exercises three guaranteed-panic events followed by three successful ones, asserts `panic_count == 3` and `dropped_count == 0`.
- [x] New unit test `fpss_state_gate_rejects_after_shutdown` in `ffi/src/streaming.rs` exercises every state-gate transition without needing a live FPSS connection.