### PR TITLE
chore(release): v10.0.0 (semver-honest major bump of v9.1.0 surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0] - 2026-05-09
+
+Semver-honest version bump for the v9.1.0 surface. The v9.0.x →
+v9.1.0 wave introduced 12 major API breaks per
+`cargo-semver-checks` (subscribe_*-family removal, polymorphic
+`subscribe(spec)`, `Contract::option` arity change, `Error` enum
+reshape, `FpssData::*` `contract_id` removal in favour of typed
+`Arc<Contract>`, `ThetaDataDx` → `ThetaDataDxClient` rename,
+`mdds::decode::v3` → `mdds::decode::dual_type_columns` module
+rename, `IntoOptionSpec` trait removal, `FpssConnectArgs` field
+additions, `FpssConfig.queue_depth` removal, flat
+`TdxFpssControl` → typed per-variant structs, Go SDK removal).
+Rust semver classifies that diff as a major bump.
+
+v10.0.0 is the v9.1.0 surface with no further code changes —
+bumping the version number to align with semver discipline. The
+audit chain on the v9.1.0 wave (cargo fmt, clippy --workspace
+-- -D warnings, test --workspace, deny check, generate_sdk_surfaces
+--check, npm test 19/19, C++ CMake build, Python wheel + pytest)
+all passed; no findings remain after the closeout chain.
+
+### Changed
+
+- Project version: 9.1.0 → 10.0.0 across `crates/thetadatadx`,
+  `crates/tdbe` dependents, `ffi`, `tools/{cli,mcp,server}`,
+  `sdks/{python,typescript}`. tdbe stays at 0.13.1 (no API change
+  in this bump). All standalone Cargo.lock files re-locked.
+
+### Migration from v9.1.0
+
+No source-level changes required. Update the version pin:
+
+| Surface | v9.1.0 | v10.0.0 |
+|---|---|---|
+| `Cargo.toml` | `thetadatadx = "9"` | `thetadatadx = "10"` |
+| `pyproject.toml` / `requirements.txt` | `thetadatadx>=9.1.0,<10` | `thetadatadx>=10.0.0,<11` |
+| `package.json` | `"thetadatadx": "^9.1.0"` | `"thetadatadx": "^10.0.0"` |
+| C++ pin | `cargo build --release -p thetadatadx-ffi` from `v9.1.0` tag | `v10.0.0` tag |
+
+
 ### Added
 
 - Fluent contract-first streaming API. `Contract::stock("AAPL")`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "9.1.0"
+version = "10.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0] - 2026-05-09
+
+Semver-honest version bump for the v9.1.0 surface. The v9.0.x →
+v9.1.0 wave introduced 12 major API breaks per
+`cargo-semver-checks` (subscribe_*-family removal, polymorphic
+`subscribe(spec)`, `Contract::option` arity change, `Error` enum
+reshape, `FpssData::*` `contract_id` removal in favour of typed
+`Arc<Contract>`, `ThetaDataDx` → `ThetaDataDxClient` rename,
+`mdds::decode::v3` → `mdds::decode::dual_type_columns` module
+rename, `IntoOptionSpec` trait removal, `FpssConnectArgs` field
+additions, `FpssConfig.queue_depth` removal, flat
+`TdxFpssControl` → typed per-variant structs, Go SDK removal).
+Rust semver classifies that diff as a major bump.
+
+v10.0.0 is the v9.1.0 surface with no further code changes —
+bumping the version number to align with semver discipline. The
+audit chain on the v9.1.0 wave (cargo fmt, clippy --workspace
+-- -D warnings, test --workspace, deny check, generate_sdk_surfaces
+--check, npm test 19/19, C++ CMake build, Python wheel + pytest)
+all passed; no findings remain after the closeout chain.
+
+### Changed
+
+- Project version: 9.1.0 → 10.0.0 across `crates/thetadatadx`,
+  `crates/tdbe` dependents, `ffi`, `tools/{cli,mcp,server}`,
+  `sdks/{python,typescript}`. tdbe stays at 0.13.1 (no API change
+  in this bump). All standalone Cargo.lock files re-locked.
+
+### Migration from v9.1.0
+
+No source-level changes required. Update the version pin:
+
+| Surface | v9.1.0 | v10.0.0 |
+|---|---|---|
+| `Cargo.toml` | `thetadatadx = "9"` | `thetadatadx = "10"` |
+| `pyproject.toml` / `requirements.txt` | `thetadatadx>=9.1.0,<10` | `thetadatadx>=10.0.0,<11` |
+| `package.json` | `"thetadatadx": "^9.1.0"` | `"thetadatadx": "^10.0.0"` |
+| C++ pin | `cargo build --release -p thetadatadx-ffi` from `v9.1.0` tag | `v10.0.0` tag |
+
+
 ### Added
 
 - Fluent contract-first streaming API. `Contract::stock("AAPL")`,

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "9.1.0"
+version = "10.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "9.1.0"
+version = "10.0.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "9.1.0"
+version = "10.0.0"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thetadatadx",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thetadatadx",
-      "version": "9.1.0",
+      "version": "10.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2"
@@ -15,9 +15,9 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "thetadatadx-darwin-arm64": "9.1.0",
-        "thetadatadx-linux-x64-gnu": "9.1.0",
-        "thetadatadx-win32-x64-msvc": "9.1.0"
+        "thetadatadx-darwin-arm64": "10.0.0",
+        "thetadatadx-linux-x64-gnu": "10.0.0",
+        "thetadatadx-win32-x64-msvc": "10.0.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "9.1.0",
-    "thetadatadx-darwin-arm64": "9.1.0",
-    "thetadatadx-win32-x64-msvc": "9.1.0"
+    "thetadatadx-linux-x64-gnu": "10.0.0",
+    "thetadatadx-darwin-arm64": "10.0.0",
+    "thetadatadx-win32-x64-msvc": "10.0.0"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "9.1.0"
+version = "10.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "arc-swap",
  "crossbeam-queue",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "9.1.0"
+version = "10.0.0"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "arc-swap",
  "crossbeam-queue",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "9.1.0"
+version = "10.0.0"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "9.1.0"
+version = "10.0.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

Semver-honest major version bump. The v9.0.x → v9.1.0 wave introduced 12 major API breaks per \`cargo-semver-checks\`; Rust semver classifies that diff as a major bump. v10.0.0 promotes the v9.1.0 surface to a semver-honest major version with no further code changes.

## Change

- Project version: 9.1.0 → 10.0.0 across \`crates/thetadatadx\`, \`ffi\`, \`tools/{cli,mcp,server}\`, \`sdks/{python,typescript}\`.
- All standalone Cargo.lock files re-locked.
- \`tdbe\` stays at 0.13.1 (no API change in this bump).
- CHANGELOG + docs-site mirror updated with \`[10.0.0]\` entry.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --locked -- -D warnings\`
- [x] \`cargo test --workspace --locked\`
- [x] \`cargo run -p thetadatadx --bin generate_sdk_surfaces -- --check\`
- [x] \`python3 scripts/check_docs_consistency.py\`
- [x] \`cargo semver-checks --baseline-rev v9.0.0\` — still fails with the same 12 major breaks; that is what the v10.0.0 bump exists to acknowledge.

## Follow-up

Once merged: tag \`v10.0.0\` on the new main HEAD; release-on-tag publish chain uploads thetadatadx 10.0.0 to crates.io alongside the existing 9.1.0.