### PR TITLE
docs(option): rename /list/roots → /list/symbols

### DIFF
--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -128,7 +128,7 @@ export default withMermaid(defineConfig({
                 text: 'List',
                 collapsed: true,
                 items: [
-                  { text: 'Roots', link: '/historical/option/list/roots' },
+                  { text: 'Symbols', link: '/historical/option/list/symbols' },
                   { text: 'Dates', link: '/historical/option/list/dates' },
                   { text: 'Strikes', link: '/historical/option/list/strikes' },
                   { text: 'Expirations', link: '/historical/option/list/expirations' },

--- a/docs-site/docs/historical/option/index.md
+++ b/docs-site/docs/historical/option/index.md
@@ -22,11 +22,11 @@ Option contracts are identified by four parameters:
 
 ## Endpoint Categories
 
-### [List](./list/roots) (5 endpoints)
+### [List](./list/symbols) (5 endpoints)
 
 Discover available symbols, expirations, strikes, dates, and contracts.
 
-- [List Roots](./list/roots) - all option underlying symbols
+- [List Symbols](./list/symbols) - all option underlying symbols
 - [List Dates](./list/dates) - available dates for a contract
 - [List Strikes](./list/strikes) - strike prices for an expiration
 - [List Expirations](./list/expirations) - expiration dates for an underlying

--- a/docs-site/docs/historical/option/list/symbols.md
+++ b/docs-site/docs/historical/option/list/symbols.md
@@ -1,13 +1,13 @@
 ---
-title: option_list_roots
+title: option_list_symbols
 description: List all available option underlying symbols.
 ---
 
-# option_list_roots
+# option_list_symbols
 
 <TierBadge tier="free" />
 
-List all available option underlying symbols (roots). Use this to discover which tickers have option chains available in ThetaData.
+List all available option underlying symbols. Use this to discover which tickers have option chains available in ThetaData.
 
 ## Code Example
 
@@ -60,4 +60,4 @@ None.
 ## Notes
 
 - Returns all underlying symbols, not individual contracts. Use [option_list_expirations](./expirations) and [option_list_strikes](./strikes) to drill into a specific chain.
-- The Rust SDK method is `option_list_symbols`. The legacy "roots" term is preserved in this page's URL slug for inbound-link stability; the SDK and protobuf surface use `symbol` exclusively.
+- The Rust SDK method is `option_list_symbols`. The SDK and protobuf surface use `symbol` exclusively.


### PR DESCRIPTION
## Summary

Page URL slug stayed \`roots\` after the SDK rename to \`option_list_symbols\` — https://userfrm.github.io/ThetaDataDx/historical/option/list/roots showed \`option_list_roots\` H1 / title with \`option_list_symbols\` code examples in the body. Fix the URL slug, the H1, the title, the prose, and the nav-bar label.

## Change

- \`docs-site/docs/historical/option/list/roots.md\` → \`symbols.md\` (git mv preserves history).
- H1 + frontmatter title + description: \`option_list_roots\` → \`option_list_symbols\`.
- Page prose: dropped the \`(roots)\` parenthetical from the first paragraph and the "legacy 'roots' term preserved in URL slug" note.
- \`docs-site/docs/historical/option/index.md\`: \`./list/roots\` → \`./list/symbols\` link + "List Roots" → "List Symbols" label.
- \`docs-site/docs/.vitepress/config.ts\`: nav-bar label \`Roots\` → \`Symbols\`.

## Test plan

- [x] \`cargo run -p thetadatadx --bin generate_sdk_surfaces -- --check\`
- [x] \`python3 scripts/check_docs_consistency.py\`
- [x] \`grep -rn "option_list_roots\\|/list/roots\\|List Roots" docs-site/docs/ docs/\` returns 0 (excluding \`.vitepress/dist/\` and historical changelog entries).