### PR TITLE
fix: align endpoint docs with upstream operations + interval normaliser

### DIFF
--- a/crates/thetadatadx/src/mdds/endpoints.rs
+++ b/crates/thetadatadx/src/mdds/endpoints.rs
@@ -99,24 +99,35 @@ impl From<&[String]> for SymbolInput {
 /// Convert an interval to the format the MDDS gRPC server accepts.
 ///
 /// Users can pass either:
-/// - Milliseconds as a string: `"60000"`, `"300000"`, `"900000"`
-/// - Shorthand directly: `"1m"`, `"5m"`, `"1h"`
+/// - Shorthand directly: `"tick"`, `"10ms"`, `"100ms"`, `"500ms"`,
+///   `"1s"`, `"5s"`, `"10s"`, `"15s"`, `"30s"`, `"1m"`, `"5m"`,
+///   `"10m"`, `"15m"`, `"30m"`, `"1h"`.
+/// - Milliseconds as a string (e.g. `"60000"` or `"300000"`). Values
+///   are snapped to the nearest documented preset.
 ///
-/// The server accepts these specific presets:
-/// `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`,
-/// `15m`, `30m`, `1h`.
+/// The full upstream enum is reproduced verbatim in
+/// `docs.thetadata.us/operations/option_history_quote.html` (and every
+/// other endpoint with an `interval` parameter).
 ///
-/// If milliseconds are passed, they're converted to the nearest matching
-/// preset. If already a valid shorthand (contains 's', 'm', or 'h'), the
-/// value is passed through as-is.
+/// The historical SDK accepted `"0"` and silently mapped it to
+/// `"100ms"`. That contradicted the previously-documented behaviour
+/// (`"0"` was advertised as "every quote change"), so `"0"` now snaps
+/// to `"tick"` — which is the upstream every-event vocabulary. Calls
+/// that depended on the silent-100ms behaviour should switch to an
+/// explicit preset.
 fn normalize_interval(interval: &str) -> String {
     if interval.ends_with('s') || interval.ends_with('m') || interval.ends_with('h') {
         return interval.to_string();
     }
+    if interval == "tick" {
+        return "tick".to_string();
+    }
 
     match interval.parse::<u64>() {
         Ok(ms) => match ms {
-            0..=100 => "100ms".to_string(),
+            0 => "tick".to_string(),
+            1..=10 => "10ms".to_string(),
+            11..=100 => "100ms".to_string(),
             101..=500 => "500ms".to_string(),
             501..=1000 => "1s".to_string(),
             1_001..=5_000 => "5s".to_string(),
@@ -269,6 +280,8 @@ mod tests {
 
     #[test]
     fn normalize_interval_passes_shorthand_through() {
+        assert_eq!(normalize_interval("tick"), "tick");
+        assert_eq!(normalize_interval("10ms"), "10ms");
         assert_eq!(normalize_interval("1m"), "1m");
         assert_eq!(normalize_interval("5m"), "5m");
         assert_eq!(normalize_interval("1h"), "1h");
@@ -280,5 +293,23 @@ mod tests {
         assert_eq!(normalize_interval("300000"), "5m");
         assert_eq!(normalize_interval("900000"), "15m");
         assert_eq!(normalize_interval("3600000"), "1h");
+    }
+
+    #[test]
+    fn normalize_interval_snaps_zero_to_tick() {
+        // The historical mapping was `0 -> 100ms`, which contradicted
+        // the previously-documented every-event semantics. The upstream
+        // `tick` keyword is the every-event vocabulary, so the zero
+        // sentinel snaps to it instead.
+        assert_eq!(normalize_interval("0"), "tick");
+    }
+
+    #[test]
+    fn normalize_interval_snaps_small_milliseconds_to_documented_presets() {
+        // 10ms-and-under -> 10ms; 11-100ms -> 100ms. The earlier
+        // 0..=100 -> 100ms mapping skipped the 10ms preset entirely.
+        assert_eq!(normalize_interval("10"), "10ms");
+        assert_eq!(normalize_interval("11"), "100ms");
+        assert_eq!(normalize_interval("100"), "100ms");
     }
 }

--- a/crates/thetadatadx/src/mdds/validate.rs
+++ b/crates/thetadatadx/src/mdds/validate.rs
@@ -88,13 +88,40 @@ pub(crate) fn validate_symbol(value: &str, param_name: &str) -> Result<(), Endpo
     Ok(())
 }
 
+/// The exact set of `interval` strings the v3 ThetaData server accepts.
+///
+/// Mirrors the upstream enum at
+/// `https://docs.thetadata.us/operations/option_history_quote.html`.
+/// The SDK additionally accepts decimal millisecond shorthand
+/// (`"60000"`, `"300000"`, ...) and snaps it to the nearest preset via
+/// [`crate::mdds::endpoints::normalize_interval`]; this validator
+/// recognises both shapes so the CLI / MCP layer rejects garbage
+/// before the gRPC dispatch.
+const VALID_INTERVAL_PRESETS: &[&str] = &[
+    "tick", "10ms", "100ms", "500ms", "1s", "5s", "10s", "15s", "30s", "1m", "5m", "10m", "15m",
+    "30m", "1h",
+];
+
 pub(crate) fn validate_interval(value: &str, param_name: &str) -> Result<(), EndpointError> {
-    if value.is_empty() || !value.bytes().all(|b| b.is_ascii_alphanumeric()) {
+    if value.is_empty() {
         return Err(EndpointError::InvalidParams(format!(
-            "'{param_name}' must be a non-empty alphanumeric string (e.g. '60000' or '1m'), got: '{value}'"
+            "'{param_name}' must be a non-empty string from the upstream enum ({}) or a millisecond value (e.g. '60000'), got empty string",
+            VALID_INTERVAL_PRESETS.join(", "),
         )));
     }
-    Ok(())
+    if VALID_INTERVAL_PRESETS.contains(&value) {
+        return Ok(());
+    }
+    if value.bytes().all(|b| b.is_ascii_digit()) {
+        // Millisecond shorthand: `normalize_interval` will snap to the
+        // nearest documented preset. Any positive integer is accepted
+        // here; the snap range covers `0` (-> "tick") through `1h`.
+        return Ok(());
+    }
+    Err(EndpointError::InvalidParams(format!(
+        "'{param_name}' must be one of the upstream presets ({}) or a millisecond value (e.g. '60000'), got: '{value}'",
+        VALID_INTERVAL_PRESETS.join(", "),
+    )))
 }
 
 pub(crate) fn validate_right(value: &str, param_name: &str) -> Result<(), EndpointError> {
@@ -239,6 +266,23 @@ mod tests {
         }
         for bad in ["abc", "-10", "1.5.3", "$500"] {
             assert!(validate_strike(bad, "strike").is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn interval_accepts_upstream_enum_and_ms_shorthand() {
+        for good in [
+            "tick", "10ms", "100ms", "500ms", "1s", "5s", "10s", "15s", "30s", "1m", "5m", "10m",
+            "15m", "30m", "1h", "0", "60000", "300000",
+        ] {
+            assert!(validate_interval(good, "interval").is_ok(), "{good}");
+        }
+    }
+
+    #[test]
+    fn interval_rejects_garbage() {
+        for bad in ["", "twosec", "2sec", "1minute", "-1", "1.5s", "1 s", "*"] {
+            assert!(validate_interval(bad, "interval").is_err(), "{bad}");
         }
     }
 }

--- a/docs-site/docs/historical/index-data/history/ohlc.md
+++ b/docs-site/docs/historical/index-data/history/ohlc.md
@@ -56,16 +56,16 @@ for (const auto& t : data) {
 <div class="param-desc">End date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time of day as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time of day as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/index-data/history/price.md
+++ b/docs-site/docs/historical/index-data/history/price.md
@@ -49,16 +49,16 @@ for (const auto& t : data) {
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time of day as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time of day as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/index-data/snapshot/market-value.md
+++ b/docs-site/docs/historical/index-data/snapshot/market-value.md
@@ -49,7 +49,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/index-data/snapshot/ohlc.md
+++ b/docs-site/docs/historical/index-data/snapshot/ohlc.md
@@ -49,7 +49,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/index-data/snapshot/price.md
+++ b/docs-site/docs/historical/index-data/snapshot/price.md
@@ -46,7 +46,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/at-time/quote.md
+++ b/docs-site/docs/historical/option/at-time/quote.md
@@ -49,15 +49,15 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
@@ -73,11 +73,11 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/at-time/trade.md
+++ b/docs-site/docs/historical/option/at-time/trade.md
@@ -47,15 +47,15 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
@@ -71,11 +71,11 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/eod.md
+++ b/docs-site/docs/historical/option/history/eod.md
@@ -49,31 +49,31 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Start date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format (inclusive)</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">End date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format (inclusive)</div>
+</div>
+<div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/eod.md
+++ b/docs-site/docs/historical/option/history/eod.md
@@ -79,7 +79,7 @@ for (const auto& t : data) {
 
 ## Response
 
-> `strike_range` filters a wildcard bulk request. If you pin `strike` to one contract, the response stays single-strike. Use `strike="0"` in ThetaDataDx SDK/MCP or `strike=*` in the v3 REST API when you want multi-strike EOD output.
+> `strike_range` filters a wildcard bulk request. If you pin `strike` to one contract, the response stays single-strike. Pass `strike="*"` (or omit `strike`, which now defaults to `*`) when you want multi-strike EOD output.
 
 <div class="param-list">
 <div class="param">

--- a/docs-site/docs/historical/option/history/greeks-all.md
+++ b/docs-site/docs/historical/option/history/greeks-all.md
@@ -49,43 +49,59 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 
@@ -194,4 +210,5 @@ for (const auto& t : data) {
 
 ## Notes
 
+- Multi-day requests are limited to one calendar month.
 - If you only need a subset of Greeks, use [greeks-first-order](./greeks-first-order), [greeks-second-order](./greeks-second-order), or [greeks-third-order](./greeks-third-order) to reduce payload size.

--- a/docs-site/docs/historical/option/history/greeks-eod.md
+++ b/docs-site/docs/historical/option/history/greeks-eod.md
@@ -70,6 +70,55 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format (inclusive)</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format (inclusive)</div>
+</div>
+<div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>underlyer_use_nbbo</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">When <code>true</code>, use the NBBO midpoint as the underlying price input; otherwise use the last trade. Default: <code>false</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike. Narrows a wildcard bulk query; it does not expand a pinned strike into neighbors.</div>
+</div>
+</div>
+<div class="param">
+<div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">

--- a/docs-site/docs/historical/option/history/greeks-eod.md
+++ b/docs-site/docs/historical/option/history/greeks-eod.md
@@ -117,57 +117,8 @@ for (const auto& t : data) {
 <div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike. Narrows a wildcard bulk query; it does not expand a pinned strike into neighbors.</div>
 </div>
 </div>
-<div class="param">
-<div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
-</div>
-<div class="param">
-<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Start date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">End date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
-</div>
-<div class="param">
-<div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
-</div>
-<div class="param">
-<div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
-</div>
-<div class="param">
-<div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
-</div>
-<div class="param">
-<div class="param-header"><code>underlyer_use_nbbo</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Use NBBO midpoint for underlying price instead of last trade</div>
-</div>
-<div class="param">
-<div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter. This only narrows a wildcard bulk query; it does not expand a pinned strike into neighboring strikes.</div>
-</div>
-</div>
 
-> For multi-strike EOD Greeks requests, use a wildcard strike selection first (`strike="0"` in ThetaDataDx SDK/MCP, `strike=*` in the v3 REST API), then apply `strike_range`.
+> For multi-strike EOD Greeks requests, use a wildcard strike selection first (`strike="*"` on the SDK builder or v3 REST surface), then apply `strike_range`.
 
 ## Response
 

--- a/docs-site/docs/historical/option/history/greeks-first-order.md
+++ b/docs-site/docs/historical/option/history/greeks-first-order.md
@@ -51,43 +51,59 @@ Parameters are identical to [option_history_greeks_all](./greeks-all#parameters)
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/greeks-iv.md
+++ b/docs-site/docs/historical/option/history/greeks-iv.md
@@ -51,43 +51,59 @@ Parameters are identical to [option_history_greeks_all](./greeks-all#parameters)
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/greeks-second-order.md
+++ b/docs-site/docs/historical/option/history/greeks-second-order.md
@@ -51,43 +51,59 @@ Parameters are identical to [option_history_greeks_all](./greeks-all#parameters)
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/greeks-third-order.md
+++ b/docs-site/docs/historical/option/history/greeks-third-order.md
@@ -51,43 +51,59 @@ Parameters are identical to [option_history_greeks_all](./greeks-all#parameters)
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/ohlc.md
+++ b/docs-site/docs/historical/option/history/ohlc.md
@@ -49,35 +49,43 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Bar size. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 
@@ -133,4 +141,5 @@ for (const auto& t : data) {
 
 ## Notes
 
+- Multi-day requests are limited to one calendar month and must specify an `expiration` value (a single expiration or `"*"`).
 - Shorthand is supported: `"1m"`, `"5m"`, `"15m"`, `"1h"`. Milliseconds (`"60000"`, `"300000"`, `"900000"`, `"3600000"`) are auto-converted to the nearest valid preset.

--- a/docs-site/docs/historical/option/history/open-interest.md
+++ b/docs-site/docs/historical/option/history/open-interest.md
@@ -46,27 +46,35 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/quote.md
+++ b/docs-site/docs/historical/option/history/quote.md
@@ -13,26 +13,26 @@ Retrieve NBBO quotes for an option contract, sampled at a specified interval.
 
 ::: code-group
 ```rust [Rust]
-let data = tdx.option_history_quote("SPY", "20260417", "550", "C", "20260315", "60000").await?;
+let data = tdx.option_history_quote("SPY", "20260417", "20260315").await?;
 for t in &data {
     println!("date={} ms_of_day={} bid={:.2} ask={:.2} bid_size={} ask_size={}",
         t.date, t.ms_of_day, t.bid, t.ask, t.bid_size, t.ask_size);
 }
 ```
 ```python [Python]
-data = tdx.option_history_quote("SPY", "20260417", "550", "C", "20260315", "60000")
+data = tdx.option_history_quote("SPY", "20260417", "20260315")
 for t in data:
     print(f"date={t.date} ms_of_day={t.ms_of_day} bid={t.bid:.2f} "
           f"ask={t.ask:.2f} bid_size={t.bid_size} ask_size={t.ask_size}")
 ```
 ```typescript [TypeScript]
-const data = tdx.optionHistoryQuote('SPY', '20260417', '550', 'C', '20260315', '60000');
+const data = tdx.optionHistoryQuote('SPY', '20260417', '20260315');
 for (const t of data) {
     console.log(`date=${t.date} ms_of_day=${t.ms_of_day} bid=${t.bid} ask=${t.ask} bid_size=${t.bid_size} ask_size=${t.ask_size}`);
 }
 ```
 ```cpp [C++]
-auto data = client.option_history_quote("SPY", "20260417", "550", "C", "20260315", "60000");
+auto data = client.option_history_quote("SPY", "20260417", "20260315");
 for (const auto& t : data) {
     printf("date=%d ms_of_day=%d bid=%.2f ask=%.2f bid_size=%d ask_size=%d\n",
         t.date, t.ms_of_day, t.bid, t.ask, t.bid_size, t.ask_size);
@@ -49,31 +49,47 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Use <code>"0"</code> for every quote change.</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings (e.g. <code>"34200000"</code>) are also accepted.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 
@@ -125,9 +141,10 @@ for (const auto& t : data) {
 ]
 ```
 
-> 1-minute NBBO quotes for SPY 2026-04-17 550 call.
+> 1-second NBBO quotes for SPY 2026-04-17. With wildcard `strike="*"`, every chain strike is returned at the chosen interval.
 
 ## Notes
 
-- Use `"0"` as the interval to get every quote change (tick-by-tick).
-- For liquid contracts with `"0"` interval, the response can be very large. In Rust, use the `_stream` variant.
+- Multi-day requests are limited to one calendar month and must specify an `expiration` value (a single expiration or `"*"`).
+- Wildcard requests (`expiration="*"`, `strike="*"`) can return very large responses. In Rust, use the `_stream` variant to process chunk-by-chunk without buffering the full result.
+- The smallest `interval` value upstream accepts is `tick`. Values below `1m` (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`) are accepted only for single-day requests.

--- a/docs-site/docs/historical/option/history/trade-greeks-all.md
+++ b/docs-site/docs/historical/option/history/trade-greeks-all.md
@@ -49,51 +49,59 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/trade-greeks-first-order.md
+++ b/docs-site/docs/historical/option/history/trade-greeks-first-order.md
@@ -51,51 +51,59 @@ Parameters are identical to [option_history_trade_greeks_all](./trade-greeks-all
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/trade-greeks-iv.md
+++ b/docs-site/docs/historical/option/history/trade-greeks-iv.md
@@ -51,51 +51,59 @@ Parameters are identical to [option_history_trade_greeks_all](./trade-greeks-all
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/trade-greeks-second-order.md
+++ b/docs-site/docs/historical/option/history/trade-greeks-second-order.md
@@ -51,51 +51,59 @@ Parameters are identical to [option_history_trade_greeks_all](./trade-greeks-all
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/trade-greeks-third-order.md
+++ b/docs-site/docs/historical/option/history/trade-greeks-third-order.md
@@ -51,51 +51,59 @@ Parameters are identical to [option_history_trade_greeks_all](./trade-greeks-all
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/history/trade-quote.md
+++ b/docs-site/docs/historical/option/history/trade-quote.md
@@ -49,39 +49,47 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>exclusive</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Use exclusive time bounds</div>
+<div class="param-desc">When <code>true</code>, only quotes with timestamp strictly before the trade timestamp are paired. Default: <code>true</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 
@@ -144,4 +152,5 @@ for (const auto& t : data) {
 
 ## Notes
 
+- Multi-day requests are limited to one calendar month and must specify an `expiration` value (a single expiration or `"*"`).
 - Useful for trade classification (e.g., determining if a trade hit the bid or lifted the offer).

--- a/docs-site/docs/historical/option/history/trade.md
+++ b/docs-site/docs/historical/option/history/trade.md
@@ -49,35 +49,43 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
-</div>
-<div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
-</div>
-<div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
+</div>
+<div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
+</div>
+<div class="param">
+<div class="param-header"><code>start_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Start date in <code>YYYYMMDD</code> format. Use with <code>end_date</code> for multi-day requests. The <code>date</code> argument overrides <code>start_date</code>/<code>end_date</code> when present.</div>
+</div>
+<div class="param">
+<div class="param-header"><code>end_date</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">End date in <code>YYYYMMDD</code> format.</div>
 </div>
 </div>
 
@@ -127,4 +135,5 @@ for (const auto& t : data) {
 
 ## Notes
 
+- Multi-day requests are limited to one calendar month and must specify an `expiration` value (a single expiration or `"*"`).
 - For liquid contracts, this can return hundreds of thousands of rows. In Rust, use the `_stream` variant to process in chunks.

--- a/docs-site/docs/historical/option/list/contracts.md
+++ b/docs-site/docs/historical/option/list/contracts.md
@@ -42,11 +42,11 @@ for (const auto& t : data) {
 <div class="param-list">
 <div class="param">
 <div class="param-header"><code>request_type</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Data type (e.g. <code>"TRADE"</code>, <code>"QUOTE"</code>)</div>
+<div class="param-desc">Data type. Upstream enum: <code>"trade"</code>, <code>"quote"</code>. SDK also accepts the legacy upper-case forms <code>"TRADE"</code> / <code>"QUOTE"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>symbol</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Underlying symbol</div>
+<div class="param-desc">Underlying symbol. Upstream additionally accepts a comma-separated list or <code>"*"</code> for all symbols; the SDK takes a single symbol per call and emits the wire-side enumeration internally.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>date</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
@@ -54,7 +54,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration filter</div>
+<div class="param-desc">Maximum days to expiration. Only contracts with DTE less than or equal to this value are returned.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/list/dates.md
+++ b/docs-site/docs/historical/option/list/dates.md
@@ -40,7 +40,7 @@ for (const auto& item : data) {
 <div class="param-list">
 <div class="param">
 <div class="param-header"><code>request_type</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Data type: <code>"TRADE"</code>, <code>"QUOTE"</code>, or <code>"OHLC"</code></div>
+<div class="param-desc">Data type. Upstream enum: <code>"trade"</code>, <code>"quote"</code>. SDK also accepts the legacy upper-case forms <code>"TRADE"</code> / <code>"QUOTE"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>symbol</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
@@ -48,15 +48,15 @@ for (const auto& item : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string (e.g. <code>"500"</code> or <code>"17.5"</code>)</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"500"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/greeks-all.md
+++ b/docs-site/docs/historical/option/snapshot/greeks-all.md
@@ -49,51 +49,51 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>stock_price</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override underlying price</div>
+<div class="param-desc">Override the underlying spot price used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>use_market_value</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Use market value instead of last trade price</div>
+<div class="param-desc">When <code>true</code>, use the market value bid/ask/price inputs for the Greeks calculation. Default: <code>false</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/greeks-first-order.md
+++ b/docs-site/docs/historical/option/snapshot/greeks-first-order.md
@@ -51,51 +51,51 @@ Parameters are identical to [option_snapshot_greeks_all](./greeks-all#parameters
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>stock_price</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override underlying price</div>
+<div class="param-desc">Override the underlying spot price used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>use_market_value</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Use market value instead of last trade price</div>
+<div class="param-desc">When <code>true</code>, use the market value bid/ask/price inputs for the Greeks calculation. Default: <code>false</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/greeks-iv.md
+++ b/docs-site/docs/historical/option/snapshot/greeks-iv.md
@@ -49,19 +49,19 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
@@ -69,31 +69,31 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>stock_price</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override underlying price</div>
+<div class="param-desc">Override the underlying spot price used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>use_market_value</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Use market value instead of last trade price</div>
+<div class="param-desc">When <code>true</code>, use the market value bid/ask/price inputs for the Greeks calculation. Default: <code>false</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/greeks-second-order.md
+++ b/docs-site/docs/historical/option/snapshot/greeks-second-order.md
@@ -51,51 +51,51 @@ Parameters are identical to [option_snapshot_greeks_all](./greeks-all#parameters
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>stock_price</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override underlying price</div>
+<div class="param-desc">Override the underlying spot price used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>use_market_value</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Use market value instead of last trade price</div>
+<div class="param-desc">When <code>true</code>, use the market value bid/ask/price inputs for the Greeks calculation. Default: <code>false</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/greeks-third-order.md
+++ b/docs-site/docs/historical/option/snapshot/greeks-third-order.md
@@ -51,51 +51,51 @@ Parameters are identical to [option_snapshot_greeks_all](./greeks-all#parameters
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>annual_dividend</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override annual dividend</div>
+<div class="param-desc">Annualized expected dividend amount used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_type</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Interest rate type</div>
+<div class="param-desc">Risk-free rate curve. Allowed values: <code>sofr</code>, <code>treasury_m1</code>, <code>treasury_m3</code>, <code>treasury_m6</code>, <code>treasury_y1</code>, <code>treasury_y2</code>, <code>treasury_y3</code>, <code>treasury_y5</code>, <code>treasury_y7</code>, <code>treasury_y10</code>, <code>treasury_y20</code>, <code>treasury_y30</code>. Default: <code>"sofr"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>rate_value</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override interest rate value</div>
+<div class="param-desc">Override the risk-free rate (as a percent). When set, takes precedence over <code>rate_type</code> for that call.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>stock_price</code><span class="param-type">float</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Override underlying price</div>
+<div class="param-desc">Override the underlying spot price used in the Greeks calculation.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>version</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Greeks calculation version</div>
+<div class="param-desc">Greeks methodology selector. Allowed values: <code>latest</code> (use real time-to-expiry), <code>1</code> (fix 0DTE to 0.15 days). Default: <code>"latest"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>use_market_value</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Use market value instead of last trade price</div>
+<div class="param-desc">When <code>true</code>, use the market value bid/ask/price inputs for the Greeks calculation. Default: <code>false</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/ohlc.md
+++ b/docs-site/docs/historical/option/snapshot/ohlc.md
@@ -49,27 +49,27 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Strike price in dollars as a string (e.g. <code>"500"</code> or <code>"17.5"</code>)</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/open-interest.md
+++ b/docs-site/docs/historical/option/snapshot/open-interest.md
@@ -49,27 +49,27 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/quote.md
+++ b/docs-site/docs/historical/option/snapshot/quote.md
@@ -49,27 +49,27 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
-<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Strike price in dollars as a string</div>
+<div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Strike price in dollars (e.g. <code>"550"</code> or <code>"17.5"</code>), or <code>"*"</code> for all strikes. Default: <code>"*"</code>.</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>max_dte</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Maximum days to expiration</div>
+<div class="param-desc">Maximum days to expiration. Filters contracts returned when <code>expiration="*"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/option/snapshot/trade.md
+++ b/docs-site/docs/historical/option/snapshot/trade.md
@@ -49,23 +49,23 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>expiration</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Expiration date in <code>YYYYMMDD</code> format</div>
+<div class="param-desc">Expiration date in <code>YYYYMMDD</code> or <code>YYYY-MM-DD</code> format, or <code>"*"</code> for all expirations</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
 <div class="param-desc">Strike price in dollars as a string (e.g. <code>"500"</code> or <code>"17.5"</code>)</div>
 </div>
 <div class="param">
-<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc"><code>"C"</code> for call, <code>"P"</code> for put</div>
+<div class="param-header"><code>right</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Option side: <code>"call"</code>, <code>"put"</code>, or <code>"both"</code>. SDK also accepts <code>"C"</code>/<code>"P"</code>. Default: <code>"both"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>strike_range</code><span class="param-type">int</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Strike range filter</div>
+<div class="param-desc">Returns <code>n</code> strikes above and below spot price plus one ATM strike (up to <code>2n + 1</code> strikes).</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/at-time/quote.md
+++ b/docs-site/docs/historical/stock/at-time/quote.md
@@ -63,7 +63,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/at-time/trade.md
+++ b/docs-site/docs/historical/stock/at-time/trade.md
@@ -61,7 +61,7 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/history/ohlc.md
+++ b/docs-site/docs/historical/stock/history/ohlc.md
@@ -86,20 +86,20 @@ for (const auto& t : data) {
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight ET</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight ET</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 </div>
 
@@ -119,8 +119,8 @@ for (const auto& t : data) {
 <div class="param-desc">End date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>.</div>
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Bar size. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/history/quote.md
+++ b/docs-site/docs/historical/stock/history/quote.md
@@ -5,7 +5,7 @@ description: NBBO quotes for a stock at a configurable sampling interval.
 
 # stock_history_quote
 
-NBBO quotes for a stock on a given date, sampled at a configurable interval. Use `"0"` as the interval to get every quote change.
+NBBO quotes for a stock on a given date, sampled at a configurable interval.
 
 <TierBadge tier="value" />
 
@@ -52,20 +52,20 @@ for (const auto& t : data) {
 <div class="param-desc">Date in <code>YYYYMMDD</code> format</div>
 </div>
 <div class="param">
-<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge required">required</span></div>
-<div class="param-desc">Accepts milliseconds (<code>"60000"</code>) or shorthand (<code>"1m"</code>). Valid presets: <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Use <code>"0"</code> to get every quote change.</div>
+<div class="param-header"><code>interval</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
+<div class="param-desc">Sampling interval. Allowed values: <code>tick</code>, <code>10ms</code>, <code>100ms</code>, <code>500ms</code>, <code>1s</code>, <code>5s</code>, <code>10s</code>, <code>15s</code>, <code>30s</code>, <code>1m</code>, <code>5m</code>, <code>10m</code>, <code>15m</code>, <code>30m</code>, <code>1h</code>. Millisecond strings (e.g. <code>"60000"</code>) are accepted and snapped to the nearest preset. Default: <code>"1s"</code>. Sub-minute intervals are available only for single-day requests.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight ET</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight ET</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 </div>
 
@@ -116,6 +116,6 @@ for (const auto& t : data) {
 
 ## Notes
 
-- Setting `interval` to `"0"` returns every NBBO change, which can produce hundreds of thousands of rows for active symbols. Use the Rust `_stream` variant for large responses.
+- Sub-minute intervals (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`) are accepted for single-day requests only.
 - Python users chain `.to_pandas()` on the return value: `tdx.stock_history_quote(...).to_pandas()`.
 - Shorthand is supported: `"1m"`, `"5m"`, `"1h"`. Milliseconds (`"60000"`, `"300000"`, `"3600000"`) are auto-converted to the nearest valid preset.

--- a/docs-site/docs/historical/stock/history/trade-quote.md
+++ b/docs-site/docs/historical/stock/history/trade-quote.md
@@ -53,19 +53,19 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight ET</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight ET</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>exclusive</code><span class="param-type">bool</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Use exclusive time bounds</div>
+<div class="param-desc">When <code>true</code>, only quotes with timestamp strictly before the trade timestamp are paired. Default: <code>true</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/history/trade.md
+++ b/docs-site/docs/historical/stock/history/trade.md
@@ -53,15 +53,15 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>start_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Start time as milliseconds from midnight ET</div>
+<div class="param-desc">Start time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"09:30:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>end_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">End time as milliseconds from midnight ET</div>
+<div class="param-desc">End time (inclusive) in <code>HH:MM:SS.SSS</code> ET wall-clock format. Default: <code>"16:00:00"</code>. Legacy millisecond strings are also accepted.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/snapshot/market-value.md
+++ b/docs-site/docs/historical/stock/snapshot/market-value.md
@@ -49,11 +49,11 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight ET</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/snapshot/ohlc.md
+++ b/docs-site/docs/historical/stock/snapshot/ohlc.md
@@ -49,11 +49,11 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight ET</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/snapshot/quote.md
+++ b/docs-site/docs/historical/stock/snapshot/quote.md
@@ -49,11 +49,11 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight ET</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 

--- a/docs-site/docs/historical/stock/snapshot/trade.md
+++ b/docs-site/docs/historical/stock/snapshot/trade.md
@@ -49,11 +49,11 @@ for (const auto& t : data) {
 </div>
 <div class="param">
 <div class="param-header"><code>venue</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Data venue filter</div>
+<div class="param-desc">Feed selector. Allowed values: <code>nqb</code> (Nasdaq Basic), <code>utp_cta</code> (merged UTP &amp; CTA). Default: <code>"nqb"</code>.</div>
 </div>
 <div class="param">
 <div class="param-header"><code>min_time</code><span class="param-type">string</span><span class="param-badge optional">optional</span></div>
-<div class="param-desc">Minimum time of day as milliseconds from midnight ET</div>
+<div class="param-desc">Filters snapshots to timestamps at or after this ET wall-clock time. Format <code>HH:MM:SS.SSS</code>; legacy millisecond strings are also accepted.</div>
 </div>
 </div>
 


### PR DESCRIPTION
## Summary

Audit the 60 hand-maintained `docs-site/docs/historical/**/*.md` doc pages against the upstream operation specs at `docs.thetadata.us/operations/*.html`, fix every doc-parity issue surfaced by the audit, and harden the SDK's `interval` handling so the runtime behaviour matches the doc.

Triggered by a user report: `tdx.option_history_quote("QQQ", "*", "20260507").strike("*").right("both").interval("0")` hung indefinitely. Two root causes were uncovered:

1. **Doc bug.** `docs-site/docs/historical/option/history/quote.md` claimed `interval="0"` returned every quote tick-by-tick. That value is not in the upstream enum (`tick`, `10ms`, `100ms`, ..., `1h`). The SDK silently mapped `"0"` to `"100ms"`, so the user's intent (every quote) was downgraded to a 100ms sample without warning.
2. **Wildcard-volume hang.** With `expiration="*"` on a liquid symbol the upstream MDDS server can take a long time to start emitting data. The TLS handshake completes, the gRPC stream opens, but no DATA frames arrive in the SDK's observation window. Root cause analysis in `/tmp/wildcard-hang-rootcause.md`: server-side query compilation latency (hypothesis H4). Out of scope for a hot fix in v10.0.0 — PR #524's in-house gRPC transport with per-call deadlines is the recommended landing place; the doc + validator changes here close the surface the user can hit immediately.

## Doc changes (47 markdown files)

### Universal alignment

Every option doc that documents `strike` / `right` now marks them optional with the upstream defaults (`*` / `both`). The SDK builder was already building the wire-side wildcards via `wire_strike_opt` / `wire_right_opt`; only the badge was wrong. `start_time` / `end_time` are documented as `HH:MM:SS.SSS` ET wall-clock with the upstream defaults (`09:30:00` / `16:00:00`), not as "milliseconds from midnight". `expiration` now documents the upstream wildcard (`*`) and the alternate `YYYY-MM-DD` form. `start_date` / `end_date` are added as builder optionals on every endpoint upstream documents them on. The one-month / must-specify-expiration multi-day ceiling is called out where upstream documents it.

### Interval enum

Every page with an `interval` parameter now lists the full upstream enum (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`) and marks `interval` optional with the upstream `1s` default. The historical "Use `\"0\"` to get every quote change" claim is removed across the board.

### Greeks inputs

The history/greeks and history/trade_greeks pages now document `annual_dividend`, `rate_type` (with the full Treasury enum and `sofr` default), `rate_value`, `version` (`latest` / `1`), and `underlyer_use_nbbo` / `use_market_value` with their upstream defaults. The snapshot/greeks pages add `stock_price`, `min_time`, and the same overrides.

### Misc

- `option_list_dates` / `option_list_contracts`: `request_type` now points to the upstream lower-case `trade` / `quote` enum (SDK keeps the historical upper-case casing for back-compat).
- `option_list_strikes`: upstream surface only has `symbol` + `expiration`; the SDK doc already matched — no change.
- `stock_history_*`: `venue` documented with the `nqb` / `utp_cta` enum and `nqb` default.
- `index_history_*`, `index_snapshot_*`, `index_at_time_*`: same alignment sweep applied.

## Code changes

`crates/thetadatadx/src/mdds/endpoints.rs::normalize_interval`:
- `"0"` now snaps to `"tick"` (every-event) instead of `"100ms"`. The historical mapping contradicted the previously-documented every-event semantics.
- The `0..=100` ms snap range now exposes the `10ms` upstream preset (`1..=10` → `10ms`, `11..=100` → `100ms`) instead of skipping it.
- Docstring documents the upstream enum and the rationale.

`crates/thetadatadx/src/mdds/validate.rs::validate_interval`:
- Strict enum check against the upstream presets; rejects garbage like `"twosec"` or `"1minute"` up front with a typed `InvalidParams` error that lists the accepted values.
- Decimal millisecond shorthand still accepted (the runtime normaliser snaps it to a preset).

Unit tests cover both the preset and ms-shorthand paths.

## Wildcard-hang investigation

Hypothesis H4 (server-side query compilation latency for full-chain wildcard requests) remains the working theory. Methodology and full hypothesis chain documented in `/tmp/wildcard-hang-rootcause.md` (kept out of the repo because it references the in-flight PR #524 transport work). The doc + validator changes here close the user-visible surface: callers no longer get the silent `"0"` → 100ms downgrade and the doc no longer promises behaviour the wire doesn't expose.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (411 lib tests + doc-tests pass; 6 new tests added)
- [x] `python3 scripts/check_docs_consistency.py` (api-reference, openapi, tier badges all ok)
- [x] `cd docs-site && npm run build` (15.69s, clean)

## Files changed

`crates/thetadatadx/src/mdds/{endpoints.rs, validate.rs}` (code, +tests) and 45 markdown files under `docs-site/docs/historical/`.