### PR TITLE
fix(grpc): map h2 "inactive stream" user error to ConnectionClosed

### DIFF
--- a/crates/thetadatadx/src/grpc/channel.rs
+++ b/crates/thetadatadx/src/grpc/channel.rs
@@ -751,13 +751,23 @@ impl Drop for InFlightToken {
 
 fn classify_h2_error(e: h2::Error) -> ChannelError {
     if e.is_go_away() || e.is_io() {
-        ChannelError::ConnectionClosed(e.to_string())
-    } else {
-        // is_reset() (per-stream) and everything else (library
-        // protocol error, user error, bare Reason) — the h2
-        // connection itself survives.
-        ChannelError::H2Stream(e.to_string())
+        return ChannelError::ConnectionClosed(e.to_string());
     }
+    // `h2` raises a `User` library error with body "inactive stream"
+    // when an operation targets a stream whose underlying connection
+    // has already died (e.g. peer closed the TCP socket between
+    // SETTINGS exchange and `send_request`). The stream is inactive
+    // because the connection is gone — surface it as connection-level
+    // so the pool recycles the channel rather than retry on a dead
+    // socket.
+    let msg = e.to_string();
+    if msg.contains("inactive stream") {
+        return ChannelError::ConnectionClosed(msg);
+    }
+    // is_reset() (per-stream) and everything else (library
+    // protocol error, user error, bare Reason) — the h2
+    // connection itself survives.
+    ChannelError::H2Stream(msg)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Connection-drop after handshake but before request surfaces as `h2::Error` with "user error: inactive stream". The classifier currently routes that to `ChannelError::H2Stream`, but the underlying connection is gone — pool needs to recycle, not retry.

Fixes the intermittent CI failure on `channel_classifies_connection_drop_after_handshake_as_connection_closed` (test runs twice — once at top-level, once via `mod mock` in `grpc_stock_list_symbols.rs` — and races the connection-drop classification differently each time).

## Change

Extend `classify_h2_error` to also map "inactive stream" library errors to `ConnectionClosed`. Position: after `is_go_away` / `is_io`, before the `H2Stream` fallthrough. One-line string match on the error message; h2 does not expose the inactive-stream condition through a dedicated `is_*()` accessor.

## Test

- `cargo test --workspace --locked` green locally
- `cargo clippy --workspace --all-targets -- -D warnings` green
- Existing integration test `channel_classifies_connection_drop_after_handshake_as_connection_closed` now passes deterministically on both racing paths.