### PR TITLE
fix(grpc): post-release residual bulletproofing

### DIFF
--- a/crates/thetadatadx/src/grpc/channel.rs
+++ b/crates/thetadatadx/src/grpc/channel.rs
@@ -644,10 +644,12 @@ impl Channel {
                     // Trailers-only OK is theoretically legal (a unary-
                     // shaped response with no payload). Drop the body
                     // and surface an already-closed stream so callers
-                    // observe the OK terminus. No in-flight counter
-                    // adjustment — the increment-on-decrement pairing
-                    // happens via `InFlightToken` which we never built
-                    // for this short-circuit path.
+                    // observe the OK terminus. The in-flight counter
+                    // settles via `token`'s `Drop` on return: the
+                    // local was built above (pre-`ready()`) and is
+                    // *not* moved into the returned stream on this
+                    // branch, so leaving scope here decrements the
+                    // channel's counter exactly once.
                     drop(response.into_body());
                     return Ok(ServerStreaming::<Resp>::already_closed());
                 }

--- a/crates/thetadatadx/src/grpc/codec.rs
+++ b/crates/thetadatadx/src/grpc/codec.rs
@@ -164,12 +164,15 @@ where
     /// - `Ok(Some(resp))` when one complete frame was consumed.
     /// - `Ok(None)` when `buf` does not yet hold a full frame; the
     ///   caller should append more wire bytes and try again.
-    /// - `Err(_)` on a malformed frame; `buf` is not consumed and the
-    ///   caller must drop the stream.
+    /// - `Err(_)` on a malformed frame; `buf` is **not** consumed and
+    ///   the caller must drop the stream. This invariant covers every
+    ///   error variant — header-level rejection (compressed flag,
+    ///   oversized length) and payload-level rejection
+    ///   ([`CodecError::Decode`]) alike.
     ///
     /// The decoder uses [`Bytes::split_to`] to take ownership of the
-    /// payload slice, so the payload survives even after `buf` is
-    /// reused for later frames.
+    /// payload slice on the success path, so the payload survives
+    /// even after `buf` is reused for later frames.
     pub fn decode(&self, buf: &mut Bytes) -> Result<Option<Resp>, CodecError> {
         if buf.remaining() < FRAME_HEADER_LEN {
             return Ok(None);
@@ -201,10 +204,16 @@ where
             return Ok(None);
         }
 
-        // Consume the header, then split off the payload slice.
-        buf.advance(FRAME_HEADER_LEN);
-        let payload = buf.split_to(payload_len);
-        let resp = Resp::decode(payload).map_err(|e| CodecError::Decode(e.to_string()))?;
+        // Decode against an immutable slice view first so a prost
+        // failure leaves `buf` untouched — the caller's contract
+        // ("Err(_) ⇒ buf is not consumed") then holds for every
+        // error variant, not only the header-level ones above.
+        let payload_slice = &buf[FRAME_HEADER_LEN..FRAME_HEADER_LEN + payload_len];
+        let resp = Resp::decode(payload_slice).map_err(|e| CodecError::Decode(e.to_string()))?;
+
+        // Decode succeeded — consume the header and payload bytes
+        // from `buf` so the next call sees the following frame.
+        buf.advance(FRAME_HEADER_LEN + payload_len);
         Ok(Some(resp))
     }
 }
@@ -377,6 +386,47 @@ mod tests {
             CodecError::InvalidCompressedFlag(0xFF) => {}
             other => panic!("expected InvalidCompressedFlag(0xFF), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn decode_leaves_buf_unchanged_on_payload_decode_error() {
+        // A legal 5-byte header followed by payload bytes that are
+        // not valid protobuf for `DataValueList`. Production callers
+        // rely on `Err(_) ⇒ buf is not consumed` so a corrupt frame
+        // can be inspected (or simply dropped together with the
+        // stream) without losing the framing offset.
+        let codec = Codec::<StockListSymbolsRequest, DataValueList>::new();
+
+        // Build a frame that announces 4 bytes of payload but whose
+        // payload is `[0xFF, 0xFF, 0xFF, 0xFF]` — every byte sets a
+        // reserved wire tag, so `prost` rejects it as a malformed
+        // message.
+        let mut framed = BytesMut::new();
+        framed.put_u8(0);
+        framed.put_u32(4);
+        framed.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+        let mut buf = framed.freeze();
+
+        let pre = buf.clone();
+        let pre_len = buf.remaining();
+
+        let err = codec
+            .decode(&mut buf)
+            .expect_err("malformed protobuf payload rejected");
+        assert!(
+            matches!(err, CodecError::Decode(_)),
+            "expected CodecError::Decode, got {err:?}"
+        );
+
+        // Documented invariant: on Err the buffer is not consumed.
+        // The caller drops the stream, but the framing offset and
+        // every byte remain untouched.
+        assert_eq!(
+            buf.remaining(),
+            pre_len,
+            "buf length is unchanged after CodecError::Decode"
+        );
+        assert_eq!(buf, pre, "buf bytes are unchanged after CodecError::Decode");
     }
 
     #[test]

--- a/crates/thetadatadx/src/grpc/decoder_pool.rs
+++ b/crates/thetadatadx/src/grpc/decoder_pool.rs
@@ -369,6 +369,13 @@ impl DecoderHandle {
         if self.is_poisoned() {
             return Err(DecoderSubmitError::Poisoned);
         }
+        // Detect the runtime flavor once per submit and pass the
+        // resolved value into the retry loop. `Handle::try_current`
+        // is thread-local but still ~10 ns per call; under sustained
+        // ring saturation the loop would otherwise re-detect on
+        // every iteration even though the result is invariant for
+        // the lifetime of this call.
+        let backoff_mode = BackoffMode::detect();
         let (tx, rx) = oneshot::channel();
         // Both the work closure and the reply sender ride together
         // in a single `Option` so the bounded retry loop can take
@@ -421,33 +428,68 @@ impl DecoderHandle {
                     // runtime can migrate queued tasks to a sibling
                     // worker for the duration of the sleep — without
                     // it the calling task would stall its worker.
-                    backoff_ring_full(PUBLISH_RETRY_BACKOFF);
+                    backoff_ring_full(backoff_mode, PUBLISH_RETRY_BACKOFF);
                 }
             }
         }
     }
 }
 
-/// Brief back-off invoked when the Disruptor ring is full. Aware of the
-/// active runtime so it does not stall a tokio worker thread under
-/// decoder saturation: on a multi-thread tokio runtime the wait runs
-/// inside [`tokio::task::block_in_place`] so the runtime can steal
-/// queued work onto a sibling worker; on a current-thread tokio runtime
-/// or outside tokio entirely the wait is a plain sync sleep.
-fn backoff_ring_full(duration: Duration) {
-    use tokio::runtime::{Handle, RuntimeFlavor};
-    let on_multi_thread = matches!(
-        Handle::try_current().map(|h| h.runtime_flavor()),
-        Ok(RuntimeFlavor::MultiThread)
-    );
+/// Resolved back-off strategy for [`backoff_ring_full`].
+///
+/// Detected once at [`DecoderHandle::submit_work`] entry rather than
+/// on every retry: under sustained ring saturation the publish loop
+/// would otherwise call [`tokio::runtime::Handle::try_current`] (and
+/// the subsequent `runtime_flavor` query) on every iteration even
+/// though the runtime flavor is invariant for the lifetime of the
+/// `submit_work` call. Hoisting the detection collapses that cost to
+/// one resolution per submit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BackoffMode {
+    /// Calling thread is on a multi-thread tokio runtime worker —
+    /// the back-off sleep must be wrapped in
+    /// [`tokio::task::block_in_place`] so the runtime can steal
+    /// queued work onto a sibling worker rather than stalling the
+    /// current worker.
+    TokioMultiThread,
+    /// Calling thread is on a current-thread tokio runtime or
+    /// outside tokio entirely — a plain sync sleep is correct.
+    /// `block_in_place` would panic on a current-thread runtime
+    /// and is meaningless off-runtime.
+    SyncSleep,
+}
+
+impl BackoffMode {
+    /// Resolve once for the lifetime of a `submit_work` call. Thread-
+    /// local on a tokio worker; the detection cost is small but the
+    /// caller-side hoist still pays for itself under sustained ring
+    /// saturation where the retry loop would otherwise re-detect on
+    /// every iteration.
+    fn detect() -> Self {
+        use tokio::runtime::{Handle, RuntimeFlavor};
+        match Handle::try_current().map(|h| h.runtime_flavor()) {
+            Ok(RuntimeFlavor::MultiThread) => Self::TokioMultiThread,
+            _ => Self::SyncSleep,
+        }
+    }
+}
+
+/// Brief back-off invoked when the Disruptor ring is full.
+///
+/// The caller is expected to have resolved [`BackoffMode`] *outside*
+/// the retry loop and pass it in here, so a saturated ring does not
+/// re-query [`tokio::runtime::Handle::try_current`] on every spin —
+/// the resolution is invariant for the lifetime of one publish
+/// attempt and the caller-side hoist keeps the cost to one
+/// detection per submit rather than O(retries).
+fn backoff_ring_full(mode: BackoffMode, duration: Duration) {
     let wait = || {
         thread::yield_now();
         thread::sleep(duration);
     };
-    if on_multi_thread {
-        tokio::task::block_in_place(wait);
-    } else {
-        wait();
+    match mode {
+        BackoffMode::TokioMultiThread => tokio::task::block_in_place(wait),
+        BackoffMode::SyncSleep => wait(),
     }
 }
 

--- a/crates/thetadatadx/src/grpc/decoder_pool.rs
+++ b/crates/thetadatadx/src/grpc/decoder_pool.rs
@@ -1051,19 +1051,24 @@ mod tests {
         }
 
         // Step 4: spawn overflow submitters. Each will park in the
-        // publish retry loop because the ring is now saturated.
+        // publish retry loop because the ring is now saturated. Each
+        // thread records the instant `submit_work` returns so the
+        // main thread can measure the *post-poison* reaction window
+        // (finish - poison_at) instead of the wall-clock distance
+        // from thread spawn — which would otherwise include the 50ms
+        // settle sleep below and inflate the measurement.
         let mut overflow_handles = Vec::with_capacity(OVERFLOW_SUBMITTERS);
         for _ in 0..OVERFLOW_SUBMITTERS {
             let producer_handle = handle.clone();
             overflow_handles.push(thread::spawn(move || {
-                let started_at = Instant::now();
                 let outcome = producer_handle.submit_work(Box::new(move || {
                     Ok(proto::DataTable {
                         headers: vec!["x".into()],
                         data_table: Vec::new(),
                     })
                 }));
-                (started_at.elapsed(), outcome)
+                let finished_at = Instant::now();
+                (finished_at, outcome)
             }));
         }
 
@@ -1081,20 +1086,26 @@ mod tests {
         handle.poisoned.store(true, Ordering::Release);
 
         // Step 6: every overflow submitter returns Poisoned within
-        // the budget. The budget is strict — a regression that
-        // restored busy-wait `publish()` would block here forever
-        // (consumer never advances, ring never frees, no Poisoned).
+        // the budget *measured from the poison flip*. The budget is
+        // strict — a regression that restored busy-wait `publish()`
+        // would block here forever (consumer never advances, ring
+        // never frees, no Poisoned).
         for (idx, join) in overflow_handles.into_iter().enumerate() {
-            let (elapsed, outcome) = join.join().expect("overflow submitter joins");
+            let (finished_at, outcome) = join.join().expect("overflow submitter joins");
             match outcome {
                 Err(DecoderSubmitError::Poisoned) => { /* expected */ }
                 other => panic!("overflow submitter {idx} did not observe poison: {other:?}"),
             }
-            let reaction = elapsed.saturating_sub(poison_at.elapsed());
+            // `saturating_duration_since` returns 0 if the submitter
+            // somehow finished before the poison flip — impossible
+            // on the happy path (poison flip is the only event that
+            // unblocks the parked retry loop) but defensive against
+            // future restructuring.
+            let reaction = finished_at.saturating_duration_since(poison_at);
             assert!(
-                elapsed < POISON_PROPAGATION_BUDGET + Duration::from_millis(100),
-                "overflow submitter {idx} took {elapsed:?} to observe poison \
-                 (budget {POISON_PROPAGATION_BUDGET:?} from poison flip; reaction window {reaction:?})"
+                reaction < POISON_PROPAGATION_BUDGET,
+                "overflow submitter {idx} took {reaction:?} to observe poison \
+                 after the flag flipped (budget {POISON_PROPAGATION_BUDGET:?})"
             );
         }
 

--- a/crates/thetadatadx/src/mdds/validate.rs
+++ b/crates/thetadatadx/src/mdds/validate.rs
@@ -17,9 +17,72 @@
 
 use crate::error::Error;
 use crate::mdds::endpoint_args::EndpointError;
-use crate::mdds::wire_semantics::is_iso_date;
 
 // -- Canonical validators (two-arg, take a parameter name for diagnostics) --
+
+/// Calendar-correct error message shared by every public date input.
+///
+/// Centralised so `YYYYMMDD` and `YYYY-MM-DD` paths cannot drift on
+/// the bounds they document. Bounds match
+/// [`tdbe::time::is_valid_gregorian_date`].
+const GREGORIAN_BOUNDS_MSG: &str =
+    "valid Gregorian date (year 1900-2100, month 1-12, day-of-month including 4/100/400 leap rule)";
+
+/// Calendar-correct check shared by every public date entry point.
+///
+/// Both the `YYYYMMDD` and `YYYY-MM-DD` parsers feed the parsed
+/// components through this single helper, so the surface accepts
+/// exactly the same set of real dates regardless of which textual
+/// form the caller used. The check itself lives in `tdbe::time` so
+/// MDDS, FPSS, and `tdbe` consumers all use one canonical Gregorian
+/// validator.
+fn check_gregorian(
+    year: i32,
+    month: u32,
+    day: u32,
+    value: &str,
+    param_name: &str,
+) -> Result<(), EndpointError> {
+    if tdbe::time::is_valid_gregorian_date(year, month, day) {
+        Ok(())
+    } else {
+        Err(EndpointError::InvalidParams(format!(
+            "'{param_name}' is not a {GREGORIAN_BOUNDS_MSG}, got: '{value}'"
+        )))
+    }
+}
+
+/// Parse `YYYY-MM-DD` into `(year, month, day)`.
+///
+/// Returns `None` if the textual shape is not exactly `4-2-2` digits.
+/// Calendar correctness is left to [`check_gregorian`] so the shape
+/// check and the calendar check stay independent of each other and
+/// can be composed by callers that already know which form they hold.
+fn parse_iso_date_components(value: &str) -> Option<(i32, u32, u32)> {
+    let mut parts = value.splitn(3, '-');
+    let (y, m, d) = match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some(y), Some(m), Some(d), None) => (y, m, d),
+        _ => return None,
+    };
+    if y.len() != 4 || m.len() != 2 || d.len() != 2 {
+        return None;
+    }
+    if !y.bytes().all(|b| b.is_ascii_digit())
+        || !m.bytes().all(|b| b.is_ascii_digit())
+        || !d.bytes().all(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+    // Parses cannot fail: every char is ASCII digit and the lengths
+    // (4 / 2 / 2) fit comfortably in i32 / u32. The `ok()?` chain
+    // keeps the function total in case prose-level reasoning ever
+    // misses an edge case (e.g. a future tweak to accept negative
+    // years).
+    let year: i32 = y.parse().ok()?;
+    let month: u32 = m.parse().ok()?;
+    let day: u32 = d.parse().ok()?;
+    Some((year, month, day))
+}
 
 pub(crate) fn validate_date(value: &str, param_name: &str) -> Result<(), EndpointError> {
     if value.len() != 8 || !value.bytes().all(|b| b.is_ascii_digit()) {
@@ -30,27 +93,34 @@ pub(crate) fn validate_date(value: &str, param_name: &str) -> Result<(), Endpoin
     // Shape passed; now apply the calendar check. Rejects the
     // `00000000` sentinel and impossible dates like `20260230` or
     // `19990431` that the shape-only check used to silently accept.
-    // The leap-year / month-length logic lives in `tdbe::time` so MDDS
-    // and FPSS share one canonical Gregorian validator (H3 + H4).
     let yyyymmdd: i32 = value.parse().map_err(|_| {
         EndpointError::InvalidParams(format!(
             "'{param_name}' must be 8 digits (YYYYMMDD), got: '{value}'"
         ))
     })?;
-    if !tdbe::time::is_valid_yyyymmdd(yyyymmdd) {
-        return Err(EndpointError::InvalidParams(format!(
-            "'{param_name}' is not a valid Gregorian date (YYYYMMDD with year 1900-2100, valid month, day-of-month including 4/100/400 leap rule), got: '{value}'"
-        )));
-    }
-    Ok(())
+    let year = yyyymmdd / 10_000;
+    let month = ((yyyymmdd / 100) % 100) as u32;
+    let day = (yyyymmdd % 100) as u32;
+    check_gregorian(year, month, day, value, param_name)
 }
 
 /// Validate `expiration`: accepts `YYYY-MM-DD`, `YYYYMMDD`, `*`, or the
 /// legacy `"0"` wildcard (translated to `*` in
 /// [`crate::mdds::wire_semantics::normalize_expiration`]).
+///
+/// Both dated forms are calendar-checked — `2026-02-30`,
+/// `2026-13-01`, and `2026-04-31` are rejected on every public input
+/// regardless of which textual shape the caller used.
 pub(crate) fn validate_expiration(value: &str, param_name: &str) -> Result<(), EndpointError> {
-    if matches!(value, "*" | "0") || is_iso_date(value) {
+    if matches!(value, "*" | "0") {
         return Ok(());
+    }
+    // ISO-dashed shape: parse components and run the same calendar
+    // check the `YYYYMMDD` path uses, so the two surface forms accept
+    // exactly the same set of dates. A shape mismatch falls through
+    // to the digits-only path which may still recognise the input.
+    if let Some((year, month, day)) = parse_iso_date_components(value) {
+        return check_gregorian(year, month, day, value, param_name);
     }
     validate_date(value, param_name).map_err(|_| {
         EndpointError::InvalidParams(format!(
@@ -249,13 +319,61 @@ mod tests {
             "abc",
             "202604175",
             "2026/04/17",
-            // H3: shape-only validation used to accept these. The
-            // Gregorian check now rejects them on every public input.
+            // Calendar-impossible dates on the digits-only path. The
+            // Gregorian check rejects them on every public input.
             "20260230",
             "19990431",
             "00000000",
         ] {
             assert!(validate_expiration(bad, "expiration").is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn expiration_iso_dashed_form_enforces_calendar_bounds() {
+        // The previous code path checked only the textual shape of
+        // `YYYY-MM-DD` and accepted calendar-impossible inputs. Both
+        // forms now flow through the same Gregorian validator, so
+        // these inputs are rejected.
+        for bad in [
+            "2026-02-30", // Feb 30 — no such day
+            "2026-13-01", // month 13 — out of range
+            "2026-04-31", // Apr 31 — only 30 days
+            "1899-12-31", // year < 1900
+            "2101-01-01", // year > 2100
+            "0000-00-00", // sentinel — every component invalid
+            "1900-02-29", // year /100 non-leap
+        ] {
+            assert!(
+                validate_expiration(bad, "expiration").is_err(),
+                "expected calendar rejection on dashed form: {bad}"
+            );
+        }
+        // Sanity: real leap-year boundaries still pass on the dashed
+        // form. Two complementary cases.
+        for good in [
+            "2024-02-29", // /4 leap
+            "2000-02-29", // /400 leap
+        ] {
+            assert!(
+                validate_expiration(good, "expiration").is_ok(),
+                "expected acceptance: {good}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_date_yyyymmdd_path_rejects_same_impossibles_as_dashed_form() {
+        // Symmetry guard: the two surface forms accept exactly the
+        // same set of real dates. The dashed form is checked above;
+        // the digits-only form rejects the corresponding inputs.
+        for bad in [
+            "20260230", "20261301", "20260431", "18991231", "21010101", "00000000", "19000229",
+        ] {
+            assert!(
+                validate_date(bad, "date").is_err(),
+                "expected calendar rejection on digits-only form: {bad}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Five residual correctness / clarity fixes on top of v10.0.0..3a999b14.

### 1. `Codec::decode` preserves `buf` on payload decode failure

`crates/thetadatadx/src/grpc/codec.rs` advanced and split the header/payload off `buf` *before* invoking `Resp::decode`. A prost failure therefore left the buffer mutated, contradicting the documented `Err(_) ⇒ buf is not consumed` invariant. Decode against an immutable slice view first; only call `buf.advance` once `Resp::decode` succeeds.

Test added: `decode_leaves_buf_unchanged_on_payload_decode_error`.

### 2. Trailers-only in-flight counter comment corrected

`crates/thetadatadx/src/grpc/channel.rs` ~L644 claimed no in-flight counter adjustment ran because the `InFlightToken` was "never built for this short-circuit path". The token *is* built above (just before `ready()`) and decrements via `Drop` when the function returns. Comment rewritten to describe the actual drop-on-return mechanism. No behaviour change.

### 3. Poison-propagation test measures reaction from the poison flip

`poison_flag_unblocks_publishers_on_full_ring` in `crates/thetadatadx/src/grpc/decoder_pool.rs` asserted the propagation budget against `started_at.elapsed()`, where `started_at` was captured at thread spawn — before the 50 ms settle sleep and the poison flip. The wall-clock distance included ~50 ms of pre-poison prelude, leaving the effective regression budget ~5x looser than the comment claimed.

Each spawned thread now records its `finished_at` instant; main computes `reaction = finished_at - poison_at` and asserts against the documented 250 ms budget.

### 4. Runtime detection hoisted out of the publish retry loop

`backoff_ring_full` called `tokio::runtime::Handle::try_current` and queried `runtime_flavor()` on every iteration of the retry loop. The result is invariant for the lifetime of one `submit_work` call. Resolved once at `submit_work` entry into a `BackoffMode` enum and passed down. The helper now takes the resolved mode as an argument; its doc comment documents the caller-side detection contract.

Regression covered by existing `poison_flag_unblocks_publishers_on_full_ring` plus the new tighter budget.

### 5. `YYYY-MM-DD` inputs are calendar-checked

`validate_expiration` in `crates/thetadatadx/src/mdds/validate.rs` accepted any `YYYY-MM-DD` whose textual shape parsed without consulting the calendar, while the parallel `YYYYMMDD` path enforced full Gregorian bounds. Inputs like `2026-02-30`, `2026-13-01`, and `2026-04-31` flowed through.

Extracted a shared `check_gregorian` helper; both textual forms parse their components and route through it. The two surface forms now accept exactly the same set of real dates.

Tests added: `expiration_iso_dashed_form_enforces_calendar_bounds` (Feb 30, month 13, Apr 31, year < 1900, year > 2100, `0000-00-00`, 1900-02-29 century non-leap) and a symmetry guard on the digits-only path.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --features mimalloc-allocator -- -D warnings`
- [x] `cargo test --workspace --locked` — all green
- [x] `cargo clippy` on `tools/cli`, `tools/server`, `tools/mcp` — all green