### PR TITLE
feat(python): standalone FpssClient + MddsClient pyclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Standalone `FpssClient` and `MddsClient` pyclasses on the Python
+  binding. `FpssClient(creds, config)` opens ONLY the FPSS TLS
+  transport (no MDDS gRPC channel, no Nexus HTTP auth); `MddsClient(creds,
+  config)` opens ONLY the MDDS gRPC channel plus the Nexus
+  authentication and surfaces the historical / FLATFILES API while
+  raising `AttributeError` on every FPSS-touching method. The bundled
+  `ThetaDataDxClient` keeps its current behaviour — the new classes
+  are purely additive and align the Python surface with the
+  standalone clients already exposed by the C ABI (`tdx_fpss_*` /
+  `tdx_client_*`) and the C++ wrapper (`tdx::FpssClient` /
+  `tdx::Client`).
 - gRPC `grpc-timeout` header is now emitted on every
   deadline-bearing RPC (`server_streaming_with_deadline`,
   `mdds_client.with_deadline(...)`). The header carries the

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -41,6 +41,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Standalone `FpssClient` and `MddsClient` pyclasses on the Python
+  binding. `FpssClient(creds, config)` opens ONLY the FPSS TLS
+  transport (no MDDS gRPC channel, no Nexus HTTP auth); `MddsClient(creds,
+  config)` opens ONLY the MDDS gRPC channel plus the Nexus
+  authentication and surfaces the historical / FLATFILES API while
+  raising `AttributeError` on every FPSS-touching method. The bundled
+  `ThetaDataDxClient` keeps its current behaviour — the new classes
+  are purely additive and align the Python surface with the
+  standalone clients already exposed by the C ABI (`tdx_fpss_*` /
+  `tdx_client_*`) and the C++ wrapper (`tdx::FpssClient` /
+  `tdx::Client`).
 - gRPC `grpc-timeout` header is now emitted on every
   deadline-bearing RPC (`server_streaming_with_deadline`,
   `mdds_client.with_deadline(...)`). The header carries the

--- a/sdks/python/src/fpss_client.rs
+++ b/sdks/python/src/fpss_client.rs
@@ -33,12 +33,13 @@
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use thetadatadx::auth::Credentials as RustCredentials;
 use thetadatadx::config::DirectConfig;
+use thetadatadx::fpss::protocol::{FullSubscriptionKind, SubscriptionKind};
 use thetadatadx::fpss::{self, FpssClient as RustFpssClient, FpssConnectArgs};
 
 use crate::buffered_event_to_typed;
@@ -144,11 +145,6 @@ pub(crate) struct FpssClient {
     /// `await_drain` must wait for all of them before reporting
     /// quiescence.
     prev_drained: Mutex<Vec<Arc<AtomicBool>>>,
-    /// Monotonic counter, incremented on every `stop_streaming`. Lets
-    /// concurrent `start_streaming` calls detect a `stop` that raced
-    /// ahead of their connect and refuse to resurrect the slot — same
-    /// stop-generation guard the unified client uses.
-    stop_generation: AtomicU64,
 }
 
 impl FpssClient {
@@ -206,7 +202,6 @@ impl FpssClient {
             inner: Mutex::new(None),
             callback: Mutex::new(None),
             prev_drained: Mutex::new(Vec::new()),
-            stop_generation: AtomicU64::new(0),
         })
     }
 
@@ -258,12 +253,15 @@ impl FpssClient {
         .map_err(to_py_err)?;
 
         *self.lock_inner() = Some(client);
-        *cb_guard = Some(Arc::try_unwrap(callback_arc).unwrap_or_else(|arc| {
-            // Disruptor consumer closure keeps a strong ref until
-            // shutdown; lift a fresh owned handle for storage under
-            // the GIL.
-            Python::attach(|py| arc.clone_ref(py))
-        }));
+        // The Disruptor consumer closure has already captured a clone
+        // of `callback_arc` (via `dispatch_cb`), so the refcount on
+        // `callback_arc` is guaranteed to be at least 2 by the time
+        // we reach this line — `Arc::try_unwrap` would always fail.
+        // Lift a fresh owned `Py<PyAny>` handle under the GIL for
+        // storage on `cb_guard`; the cost is one refcount bump per
+        // `start_streaming` call, which is the same lifetime
+        // accounting the unified client does.
+        *cb_guard = Some(Python::attach(|py| callback_arc.clone_ref(py)));
         Ok(())
     }
 
@@ -386,18 +384,28 @@ impl FpssClient {
     /// streaming after this returns, call `start_streaming(callback)`
     /// again with a freshly bound callable; `reconnect()` raises
     /// `RuntimeError` because no callback is held.
+    ///
+    /// Lock ordering: `callback` BEFORE `inner`, matching
+    /// `start_streaming`. The two methods MUST agree on the order
+    /// they acquire the two `Mutex` slots — Python's GIL serialises
+    /// pyclass-method dispatch today, but a future revision that
+    /// releases the GIL across the FPSS connect (e.g. via
+    /// `py.detach` inside `start_streaming`) would let concurrent
+    /// `start_streaming` / `stop_streaming` interleave on the same
+    /// handle. Pinning the ordering here closes that race
+    /// proactively.
     fn stop_streaming(&self) {
-        self.stop_generation.fetch_add(1, Ordering::AcqRel);
-        let mut guard = self.lock_inner();
-        if let Some(client) = guard.as_ref() {
+        let mut cb_guard = self.lock_callback();
+        let mut inner_guard = self.lock_inner();
+        if let Some(client) = inner_guard.as_ref() {
             self.prev_drained
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .push(client.drained_flag());
             client.shutdown();
         }
-        *guard = None;
-        *self.lock_callback() = None;
+        *inner_guard = None;
+        *cb_guard = None;
     }
 
     /// Alias for `stop_streaming`. Mirrors the unified client's split
@@ -410,6 +418,18 @@ impl FpssClient {
     /// Re-open the FPSS connection and re-register the previously
     /// installed callback. Requires a prior `start_streaming(callback)`;
     /// raises `RuntimeError` otherwise.
+    ///
+    /// Mirrors [`thetadatadx::ThetaDataDxClient::reconnect_streaming`]:
+    /// saves the active per-contract and full-stream subscriptions
+    /// against the old session, opens a fresh FPSS connection under
+    /// the previously installed callback, and re-applies the saved
+    /// subscriptions. Per-subscription failures during restore are
+    /// surfaced as a single `RuntimeError` that names every contract
+    /// that did not re-subscribe — the streaming session itself is
+    /// already up at that point. Without this restore step a Python
+    /// caller observing a transient disconnect would lose every
+    /// subscription, breaking parity with the unified client and the
+    /// C ABI (`tdx_fpss_reconnect`).
     fn reconnect(&self) -> PyResult<()> {
         let stored = {
             let guard = self.lock_callback();
@@ -422,11 +442,72 @@ impl FpssClient {
                 }
             }
         };
-        // Stop first so the previous Disruptor consumer is registered
-        // on `prev_drained`. `start_streaming` below repopulates
-        // `self.callback` with a freshly owned handle.
+
+        // 1. Snapshot the active subscriptions BEFORE stopping. The
+        //    `with_live` borrow handles the not-yet-started case by
+        //    returning `RuntimeError` — `reconnect()` only makes
+        //    sense on a previously-started session anyway, so the
+        //    error message is the same shape the unified client uses.
+        let (per_contract, full_stream) =
+            self.with_live(|c| Ok((c.active_subscriptions(), c.active_full_subscriptions())))?;
+
+        // 2. Stop + restart under the same callback. `start_streaming`
+        //    repopulates `self.callback` with a freshly owned handle
+        //    so subsequent `reconnect()` calls find the same state
+        //    shape.
         self.stop_streaming();
-        self.start_streaming(stored)
+        self.start_streaming(stored)?;
+
+        // 3. Re-apply every saved subscription against the freshly
+        //    reconnected session. Accumulate failures rather than
+        //    aborting on the first one — the FPSS protocol has no
+        //    batched-transaction semantic, so any per-subscription
+        //    failure leaves a partial state that the caller decides
+        //    how to handle. Per-contract Quote / Trade / OpenInterest
+        //    plus full-stream Trade / OpenInterest cover every active
+        //    subscription shape the core client tracks.
+        let mut failed: Vec<String> = Vec::new();
+        for (kind, contract) in per_contract {
+            let sub = fpss::protocol::Subscription::Contract {
+                contract: contract.clone(),
+                kind,
+            };
+            let outcome = self.with_live(|c| c.subscribe(sub.clone()));
+            if outcome.is_err() {
+                failed.push(format!("per-contract {kind:?} {contract}"));
+            }
+        }
+        for (kind, sec_type) in full_stream {
+            let full_kind = match kind {
+                SubscriptionKind::Trade => Some(FullSubscriptionKind::Trades),
+                SubscriptionKind::OpenInterest => Some(FullSubscriptionKind::OpenInterest),
+                // Quote is never a full-stream subscription kind on
+                // the FPSS wire — the core's `active_full_subscriptions`
+                // never returns it, so this arm is unreachable in
+                // practice and we drop it silently rather than
+                // misclassifying it as a restore failure.
+                SubscriptionKind::Quote => None,
+            };
+            if let Some(full_kind) = full_kind {
+                let sub = fpss::protocol::Subscription::Full {
+                    sec_type,
+                    kind: full_kind,
+                };
+                let outcome = self.with_live(|c| c.subscribe(sub.clone()));
+                if outcome.is_err() {
+                    failed.push(format!("full-stream {kind:?} {sec_type:?}"));
+                }
+            }
+        }
+        if failed.is_empty() {
+            Ok(())
+        } else {
+            Err(PyRuntimeError::new_err(format!(
+                "reconnect succeeded but {} subscription(s) failed to restore: {}",
+                failed.len(),
+                failed.join(", "),
+            )))
+        }
     }
 
     /// Block until every superseded streaming session's Disruptor

--- a/sdks/python/src/fpss_client.rs
+++ b/sdks/python/src/fpss_client.rs
@@ -1,0 +1,495 @@
+//! Standalone Python `FpssClient` pyclass.
+//!
+//! Opens ONLY the FPSS TLS transport — no MDDS gRPC channel, no Nexus
+//! HTTP auth, no Treasury / Calendar / OHLCVC historical surface.
+//! Mirrors the C++ `tdx::FpssClient` (`sdks/cpp/include/thetadx.hpp`)
+//! and the standalone C ABI entry points (`tdx_fpss_*` in
+//! `ffi/src/streaming.rs`), letting Python users run an FPSS-only
+//! session alongside an externally-managed MDDS process without the
+//! bundled [`crate::ThetaDataDxClient`] preempting the parallel MDDS
+//! work at the Nexus session layer.
+//!
+//! # Nexus session behaviour
+//!
+//! This pyclass does NOT issue a Nexus authentication. FPSS speaks its
+//! own protocol-level `CREDENTIALS` handshake (wire code `0`) on the
+//! TLS connection itself; no separate Nexus session UUID is acquired.
+//! The cross-binding contract here matches the standalone C ABI:
+//! `tdx_fpss_connect` accepts a `TdxCredentials` handle without
+//! touching Nexus. Run the bundled [`crate::ThetaDataDxClient`] (which
+//! does authenticate against Nexus) when you need the MDDS surface and
+//! Nexus session machinery side-by-side.
+//!
+//! # Lifecycle
+//!
+//! 1. `FpssClient(creds, config)` — snapshots the connect parameters.
+//!    The FPSS TLS connection is opened lazily by `start_streaming*`
+//!    (matching the FFI's deferred-connect contract).
+//! 2. `start_streaming(callback)` or `start_streaming_iter()` — opens
+//!    the FPSS TLS connection and starts the LMAX Disruptor consumer.
+//! 3. `subscribe(...)` / `unsubscribe(...)` — fluent subscription.
+//! 4. `stop_streaming()` / `shutdown()` — atomic stop with drain barrier.
+//! 5. `reconnect()` — re-open under the same callback.
+
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+use thetadatadx::auth::Credentials as RustCredentials;
+use thetadatadx::config::DirectConfig;
+use thetadatadx::fpss::{self, FpssClient as RustFpssClient, FpssConnectArgs};
+
+use crate::buffered_event_to_typed;
+use crate::errors::to_py_err;
+use crate::event_iterator::EventIterator;
+use crate::fluent;
+use crate::fpss_event_to_buffered;
+use crate::streaming_iter_session::StreamingIterSession;
+use crate::streaming_session::StreamingSession;
+use crate::{Config, Credentials};
+
+/// Snapshot of the parameters required to open an FPSS TLS connection.
+///
+/// Cloned out of the user's `Config` at construction time so subsequent
+/// Python-side mutations of the `Config` handle cannot retroactively
+/// change reconnect behaviour for an already-running session — the same
+/// snapshot semantics the FFI uses in
+/// `ffi/src/streaming.rs::FpssConnectParams`.
+struct FpssParams {
+    creds: RustCredentials,
+    hosts: Vec<(String, u16)>,
+    ring_size: usize,
+    flush_mode: thetadatadx::config::FpssFlushMode,
+    policy: thetadatadx::config::ReconnectPolicy,
+    derive_ohlcvc: bool,
+    connect_timeout_ms: u64,
+    read_timeout_ms: u64,
+    ping_interval_ms: u64,
+}
+
+impl FpssParams {
+    fn from_config(creds: &RustCredentials, config: &DirectConfig) -> Self {
+        Self {
+            creds: creds.clone(),
+            hosts: config.fpss.hosts.clone(),
+            ring_size: config.fpss.ring_size,
+            flush_mode: config.fpss.flush_mode,
+            policy: config.reconnect.policy.clone(),
+            derive_ohlcvc: config.fpss.derive_ohlcvc,
+            connect_timeout_ms: config.fpss.connect_timeout_ms,
+            read_timeout_ms: config.fpss.timeout_ms,
+            ping_interval_ms: config.fpss.ping_interval_ms,
+        }
+    }
+
+    fn args(&self) -> FpssConnectArgs<'_> {
+        FpssConnectArgs {
+            creds: &self.creds,
+            hosts: &self.hosts,
+            ring_size: self.ring_size,
+            flush_mode: self.flush_mode,
+            policy: self.policy.clone(),
+            derive_ohlcvc: self.derive_ohlcvc,
+            connect_timeout_ms: self.connect_timeout_ms,
+            read_timeout_ms: self.read_timeout_ms,
+            ping_interval_ms: self.ping_interval_ms,
+        }
+    }
+}
+
+/// Standalone FPSS-only streaming client.
+///
+/// Opens ONLY the FPSS TLS transport — no MDDS gRPC channel, no Nexus
+/// HTTP authentication. Use when a parallel MDDS process is already
+/// running in the same environment and you need to test FPSS without
+/// the bundled [`crate::ThetaDataDxClient`] taking over the Nexus
+/// session at construction time.
+///
+/// ```python
+/// from thetadatadx import FpssClient, Credentials, Config, Contract
+///
+/// creds = Credentials.from_file("creds.txt")
+/// fpss = FpssClient(creds, Config.production())
+///
+/// def on_event(event):
+///     print(event.kind, event)
+///
+/// fpss.start_streaming(callback=on_event)
+/// fpss.subscribe(Contract.stock("AAPL").quote())
+/// # ... events arrive on the Disruptor consumer thread ...
+/// fpss.stop_streaming()
+/// ```
+#[pyclass(module = "thetadatadx", name = "FpssClient")]
+pub(crate) struct FpssClient {
+    /// Connect parameters captured at construction time. Reused on
+    /// every `start_streaming*` / `reconnect`.
+    params: FpssParams,
+    /// Currently-open inner FPSS client. `None` between construction
+    /// and `start_streaming*`, and after `stop_streaming` / `shutdown`.
+    inner: Mutex<Option<RustFpssClient>>,
+    /// Most recently registered Python callable. Retained across
+    /// `start_streaming` so `reconnect()` can re-register the same
+    /// handler without the caller having to pass it again. Cleared on
+    /// `stop_streaming` / `shutdown` so a teardown the application has
+    /// already observed does not leak the closure's captured
+    /// references — same explicit-handoff model as the unified
+    /// [`crate::ThetaDataDxClient`].
+    callback: Mutex<Option<Py<PyAny>>>,
+    /// Quiescence flags of every superseded streaming session that has
+    /// not yet drained. Mirrors the `prev_drained` field on the unified
+    /// [`thetadatadx::ThetaDataDxClient`] — stacked stop/start cycles
+    /// can layer multiple in-flight Disruptor consumers, and
+    /// `await_drain` must wait for all of them before reporting
+    /// quiescence.
+    prev_drained: Mutex<Vec<Arc<AtomicBool>>>,
+    /// Monotonic counter, incremented on every `stop_streaming`. Lets
+    /// concurrent `start_streaming` calls detect a `stop` that raced
+    /// ahead of their connect and refuse to resurrect the slot — same
+    /// stop-generation guard the unified client uses.
+    stop_generation: AtomicU64,
+}
+
+impl FpssClient {
+    fn lock_inner(&self) -> MutexGuard<'_, Option<RustFpssClient>> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn lock_callback(&self) -> MutexGuard<'_, Option<Py<PyAny>>> {
+        self.callback.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Run a closure with a borrow of the live FPSS client, raising
+    /// `RuntimeError` when nothing is connected.
+    fn with_live<R>(
+        &self,
+        f: impl FnOnce(&RustFpssClient) -> Result<R, thetadatadx::Error>,
+    ) -> PyResult<R> {
+        let guard = self.lock_inner();
+        let client = guard.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "streaming not started -- call start_streaming(callback) or start_streaming_iter() first",
+            )
+        })?;
+        f(client).map_err(to_py_err)
+    }
+}
+
+#[pymethods]
+impl FpssClient {
+    /// Allocate a standalone FPSS handle.
+    ///
+    /// Snapshots the connect parameters out of the supplied `Config`
+    /// but does NOT open the FPSS TLS connection — connection is
+    /// deferred to the first `start_streaming*` call. This matches the
+    /// C ABI's deferred-connect contract (`tdx_fpss_connect` allocates
+    /// the handle, `tdx_fpss_set_callback` opens the network) so the
+    /// same observable behaviour applies across every binding.
+    ///
+    /// No MDDS gRPC channel is opened. No Nexus HTTP request is issued.
+    /// A parallel MDDS process under the same credentials is unaffected
+    /// by this constructor.
+    #[new]
+    fn new(_py: Python<'_>, creds: &Credentials, config: &Config) -> PyResult<Self> {
+        let direct = {
+            let guard = config.inner.lock().unwrap_or_else(|e| e.into_inner());
+            guard.clone()
+        };
+        if direct.fpss.hosts.is_empty() {
+            return Err(PyValueError::new_err(
+                "FpssClient: config.fpss.hosts is empty (set THETADATA_FPSS_HOSTS or use Config::production())",
+            ));
+        }
+        Ok(Self {
+            params: FpssParams::from_config(&creds.inner, &direct),
+            inner: Mutex::new(None),
+            callback: Mutex::new(None),
+            prev_drained: Mutex::new(Vec::new()),
+            stop_generation: AtomicU64::new(0),
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        let connected = self.lock_inner().is_some();
+        let hosts = self.params.hosts.len();
+        format!("FpssClient(connected={connected}, hosts={hosts})")
+    }
+
+    /// Open the FPSS TLS connection and register the Python callback
+    /// for incoming events.
+    ///
+    /// The LMAX Disruptor consumer thread acquires the GIL via
+    /// `Python::attach` to invoke `callback(event)` for every typed
+    /// FPSS event, with each invocation wrapped in `catch_unwind`.
+    /// `callback` must accept exactly one positional argument — a
+    /// typed FPSS event class (`Quote`, `Trade`, `Ohlcvc`, … the same
+    /// hierarchy emitted on the unified client's callback path).
+    ///
+    /// The reader never blocks on user code; on ring overflow events
+    /// are dropped and counted via `dropped_event_count()`. User
+    /// callback panics are caught and counted via `panic_count()`.
+    fn start_streaming(&self, callback: Py<PyAny>) -> PyResult<()> {
+        let mut cb_guard = self.lock_callback();
+        if self.lock_inner().is_some() {
+            return Err(PyRuntimeError::new_err(
+                "streaming already started -- call stop_streaming() before start_streaming() again",
+            ));
+        }
+
+        let callback_arc: Arc<Py<PyAny>> = Arc::new(callback);
+        let dispatch_cb = Arc::clone(&callback_arc);
+
+        let client = RustFpssClient::connect(self.params.args(), move |event: &fpss::FpssEvent| {
+            Python::attach(|py| {
+                let buffered = fpss_event_to_buffered(event);
+                let typed = match buffered_event_to_typed(py, &buffered) {
+                    Ok(obj) => obj,
+                    Err(err) => {
+                        err.write_unraisable(py, None);
+                        return;
+                    }
+                };
+                if let Err(err) = dispatch_cb.call1(py, (typed,)) {
+                    err.write_unraisable(py, None);
+                }
+            });
+        })
+        .map_err(to_py_err)?;
+
+        *self.lock_inner() = Some(client);
+        *cb_guard = Some(Arc::try_unwrap(callback_arc).unwrap_or_else(|arc| {
+            // Disruptor consumer closure keeps a strong ref until
+            // shutdown; lift a fresh owned handle for storage under
+            // the GIL.
+            Python::attach(|py| arc.clone_ref(py))
+        }));
+        Ok(())
+    }
+
+    /// Open the FPSS TLS connection in pull-iter delivery mode and
+    /// return an [`EventIterator`] handle the caller drains on its own
+    /// thread.
+    ///
+    /// Push-callback and pull-iter are mutually exclusive — calling
+    /// this while streaming is already running raises `RuntimeError`.
+    fn start_streaming_iter(&self) -> PyResult<EventIterator> {
+        if self.lock_inner().is_some() {
+            return Err(PyRuntimeError::new_err(
+                "streaming already started -- call stop_streaming() before start_streaming_iter()",
+            ));
+        }
+        let (client, iter) = RustFpssClient::connect_iter(self.params.args()).map_err(to_py_err)?;
+        *self.lock_inner() = Some(client);
+        Ok(EventIterator::new(iter))
+    }
+
+    /// Whether the FPSS TLS connection is currently open.
+    fn is_streaming(&self) -> bool {
+        self.lock_inner().is_some()
+    }
+
+    /// Snapshot of per-contract subscriptions on the live session.
+    /// Returns an empty list when streaming has not started.
+    fn active_subscriptions(&self) -> Vec<std::collections::HashMap<String, String>> {
+        let guard = self.lock_inner();
+        let Some(client) = guard.as_ref() else {
+            return Vec::new();
+        };
+        client
+            .active_subscriptions()
+            .into_iter()
+            .map(|(kind, contract)| {
+                let mut m = std::collections::HashMap::new();
+                m.insert("kind".to_string(), format!("{kind:?}"));
+                m.insert("contract".to_string(), format!("{contract}"));
+                m
+            })
+            .collect()
+    }
+
+    /// Snapshot of full-stream subscriptions (e.g. `SecType.OPTION.full_trades()`).
+    /// Returns an empty list when streaming has not started.
+    fn active_full_subscriptions(&self) -> Vec<std::collections::HashMap<String, String>> {
+        let guard = self.lock_inner();
+        let Some(client) = guard.as_ref() else {
+            return Vec::new();
+        };
+        client
+            .active_full_subscriptions()
+            .into_iter()
+            .map(|(kind, sec_type)| {
+                let mut m = std::collections::HashMap::new();
+                m.insert("kind".to_string(), format!("{kind:?}"));
+                m.insert("sec_type".to_string(), format!("{sec_type:?}"));
+                m
+            })
+            .collect()
+    }
+
+    /// Cumulative count of FPSS events the TLS reader could not
+    /// publish into the Disruptor ring because the consumer fell
+    /// behind. Snapshot the value BEFORE `reconnect()` if you need to
+    /// accumulate drops across session boundaries — `reconnect`
+    /// rebuilds the inner client and the counter resets.
+    fn dropped_event_count(&self) -> u64 {
+        let guard = self.lock_inner();
+        guard.as_ref().map_or(0, |c| c.dropped_count())
+    }
+
+    /// Cumulative count of user-callback panics caught by the
+    /// Disruptor consumer's `catch_unwind` boundary.
+    fn panic_count(&self) -> u64 {
+        let guard = self.lock_inner();
+        guard.as_ref().map_or(0, |c| c.panic_count())
+    }
+
+    /// Polymorphic subscribe — primary fluent entry point. Accepts
+    /// any value returned by `Contract.quote()` / `Contract.trade()` /
+    /// `Contract.open_interest()` (per-contract scope) or
+    /// `SecType.OPTION.full_trades()` (full-stream scope).
+    fn subscribe(&self, sub: &Bound<'_, PyAny>) -> PyResult<()> {
+        let inner = fluent::coerce_subscription(sub)?;
+        self.with_live(|c| c.subscribe(inner))
+    }
+
+    /// Bulk-subscribe a list of `Subscription` values.
+    fn subscribe_many(&self, subs: &Bound<'_, PyAny>) -> PyResult<()> {
+        let list = fluent::coerce_subscription_list(subs)?;
+        self.with_live(|c| {
+            for sub in list {
+                c.subscribe(sub)?;
+            }
+            Ok(())
+        })
+    }
+
+    /// Polymorphic unsubscribe.
+    fn unsubscribe(&self, sub: &Bound<'_, PyAny>) -> PyResult<()> {
+        let inner = fluent::coerce_subscription(sub)?;
+        self.with_live(|c| c.unsubscribe(inner))
+    }
+
+    /// Bulk-unsubscribe.
+    fn unsubscribe_many(&self, subs: &Bound<'_, PyAny>) -> PyResult<()> {
+        let list = fluent::coerce_subscription_list(subs)?;
+        self.with_live(|c| {
+            for sub in list {
+                c.unsubscribe(sub)?;
+            }
+            Ok(())
+        })
+    }
+
+    /// Stop streaming and clear the registered callback. Same
+    /// explicit-handoff semantics as the unified client: to resume
+    /// streaming after this returns, call `start_streaming(callback)`
+    /// again with a freshly bound callable; `reconnect()` raises
+    /// `RuntimeError` because no callback is held.
+    fn stop_streaming(&self) {
+        self.stop_generation.fetch_add(1, Ordering::AcqRel);
+        let mut guard = self.lock_inner();
+        if let Some(client) = guard.as_ref() {
+            self.prev_drained
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(client.drained_flag());
+            client.shutdown();
+        }
+        *guard = None;
+        *self.lock_callback() = None;
+    }
+
+    /// Alias for `stop_streaming`. Mirrors the unified client's split
+    /// surface where `shutdown` is documented as the terminal stop —
+    /// on the standalone client both names are equivalent.
+    fn shutdown(&self) {
+        self.stop_streaming();
+    }
+
+    /// Re-open the FPSS connection and re-register the previously
+    /// installed callback. Requires a prior `start_streaming(callback)`;
+    /// raises `RuntimeError` otherwise.
+    fn reconnect(&self) -> PyResult<()> {
+        let stored = {
+            let guard = self.lock_callback();
+            match guard.as_ref() {
+                Some(cb) => Python::attach(|py| cb.clone_ref(py)),
+                None => {
+                    return Err(PyRuntimeError::new_err(
+                        "no callback registered -- call start_streaming(callback) before reconnect()",
+                    ));
+                }
+            }
+        };
+        // Stop first so the previous Disruptor consumer is registered
+        // on `prev_drained`. `start_streaming` below repopulates
+        // `self.callback` with a freshly owned handle.
+        self.stop_streaming();
+        self.start_streaming(stored)
+    }
+
+    /// Block until every superseded streaming session's Disruptor
+    /// consumer has finished firing the registered callback. Returns
+    /// `true` once all retired generations have drained, `false` on
+    /// timeout. Polls at 1 ms cadence.
+    fn await_drain(&self, py: Python<'_>, timeout_ms: u64) -> bool {
+        let timeout = Duration::from_millis(timeout_ms);
+        py.detach(|| {
+            let deadline = Instant::now() + timeout;
+            loop {
+                let all_drained = {
+                    let mut guard = self
+                        .prev_drained
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    guard.retain(|f| !f.load(Ordering::Acquire));
+                    guard.is_empty()
+                };
+                if all_drained {
+                    return true;
+                }
+                if Instant::now() >= deadline {
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        })
+    }
+
+    /// Open a context-managed FPSS streaming session.
+    ///
+    /// `with fpss.streaming(callback) as session:` registers
+    /// `callback` via `start_streaming` on enter and pairs
+    /// `stop_streaming()` + `await_drain(5000)` on exit — same RAII
+    /// semantics as the unified client's `streaming()` helper.
+    fn streaming(
+        slf: Py<Self>,
+        py: Python<'_>,
+        callback: Py<PyAny>,
+    ) -> PyResult<Py<StreamingSession>> {
+        Py::new(
+            py,
+            StreamingSession {
+                tdx: slf.into_any(),
+                callback: Some(callback),
+            },
+        )
+    }
+
+    /// Open a context-managed pull-iter streaming session.
+    ///
+    /// `with fpss.streaming_iter() as it: for event in it: ...`
+    /// opens the FPSS connection in pull-iter mode on enter, drains
+    /// the iterator inside the body, and pairs `stop_streaming()` +
+    /// `await_drain(5000)` on exit.
+    fn streaming_iter(slf: Py<Self>, py: Python<'_>) -> PyResult<Py<StreamingIterSession>> {
+        Py::new(
+            py,
+            StreamingIterSession {
+                tdx: slf.into_any(),
+                iterator: None,
+            },
+        )
+    }
+}

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -16,7 +16,9 @@ mod coerce;
 mod errors;
 mod flatfile_methods;
 mod fluent;
+mod fpss_client;
 mod logging_bridge;
+mod mdds_client;
 mod util_helpers;
 
 use async_runtime::spawn_awaitable;
@@ -751,6 +753,8 @@ fn thetadatadx_py(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Config>()?;
     m.add_class::<ThetaDataDxClient>()?;
     m.add_class::<AsyncThetaDataDxClient>()?;
+    m.add_class::<fpss_client::FpssClient>()?;
+    m.add_class::<mdds_client::MddsClient>()?;
     m.add_class::<StreamingSession>()?;
     m.add_class::<StreamingIterSession>()?;
     m.add_class::<EventIterator>()?;

--- a/sdks/python/src/mdds_client.rs
+++ b/sdks/python/src/mdds_client.rs
@@ -1,0 +1,161 @@
+//! Standalone Python `MddsClient` pyclass.
+//!
+//! Opens ONLY the MDDS gRPC channel and the Nexus HTTP authentication
+//! flow — no FPSS TLS connection, no Disruptor ring, no streaming
+//! state machine. Mirrors the standalone C ABI entry points
+//! (`tdx_client_*` in `ffi/src/auth.rs`) and the C++ `tdx::Client`
+//! pattern, letting Python users run a historical-only session
+//! alongside a parallel FPSS process without the bundled
+//! [`crate::ThetaDataDxClient`] preempting the parallel work at the
+//! Nexus session layer.
+//!
+//! # Nexus session behaviour
+//!
+//! `MddsClient.__new__` issues exactly one Nexus authentication and
+//! holds the resulting session UUID for the lifetime of the handle.
+//! When a parallel process (or another `MddsClient` / bundled
+//! `ThetaDataDxClient` in the same interpreter) authenticates against
+//! Nexus with the same credentials, the upstream behaviour is the
+//! user's environment concern — the SDK does not invalidate, share,
+//! or coordinate session tokens across clients. The
+//! `test_concurrent_fpss_and_mdds_share_creds` live test exercises
+//! parallel-auth observability for callers that need to confirm
+//! end-to-end behaviour.
+//!
+//! # Surface
+//!
+//! Internally this pyclass wraps an `Arc<thetadatadx::ThetaDataDxClient>`
+//! and forwards historical / list / snapshot / at-time / FLATFILES
+//! endpoint calls through PyO3 attribute lookup against an internally
+//! held [`crate::ThetaDataDxClient`] pyclass instance. The bundled
+//! client opens MDDS gRPC + Nexus at construction time and never
+//! opens FPSS unless `start_streaming` is called — by construction
+//! and by allowlist enforcement here, no FPSS-touching method is
+//! reachable through `MddsClient`.
+//!
+//! This is the same delegation pattern [`crate::AsyncThetaDataDxClient`]
+//! uses for its async-only surface, with an inverted allowlist
+//! (block streaming instead of permitting only async-suffixed).
+
+use pyo3::exceptions::PyAttributeError;
+use pyo3::prelude::*;
+
+use crate::{Config, Credentials, ThetaDataDxClient};
+
+/// Methods on [`crate::ThetaDataDxClient`] that touch the FPSS
+/// transport. Reaching for any of these through `MddsClient` raises
+/// `AttributeError` so callers who chose the MDDS-only surface
+/// cannot accidentally open an FPSS connection that would conflict
+/// with a parallel FPSS process.
+///
+/// The block-list approach (vs. the inverted `AsyncThetaDataDxClient`
+/// allowlist) keeps the historical / FLATFILES surface — which is
+/// 50+ generated `*_builder` factories plus per-endpoint sync and
+/// async terminals — accessible without listing each one. Adding a
+/// new historical endpoint to `ThetaDataDxClient` is automatically
+/// available on `MddsClient` with zero edit here.
+const FPSS_TOUCHING_METHODS: &[&str] = &[
+    "start_streaming",
+    "start_streaming_iter",
+    "stop_streaming",
+    "shutdown",
+    "reconnect",
+    "streaming",
+    "streaming_iter",
+    "is_streaming",
+    "await_drain",
+    "subscribe",
+    "subscribe_many",
+    "unsubscribe",
+    "unsubscribe_many",
+    "active_subscriptions",
+    "active_full_subscriptions",
+    "dropped_event_count",
+    "panic_count",
+];
+
+/// Standalone MDDS-only historical client.
+///
+/// Opens ONLY the MDDS gRPC channel — no FPSS TLS connection.
+/// Authenticates once against Nexus at construction time. Use when a
+/// parallel FPSS process is already running in the same environment
+/// and you need to test historical / FLATFILES endpoints without the
+/// bundled [`crate::ThetaDataDxClient`] also opening an FPSS slot.
+///
+/// ```python
+/// from thetadatadx import MddsClient, Credentials, Config
+///
+/// creds = Credentials.from_file("creds.txt")
+/// mdds = MddsClient(creds, Config.production())
+///
+/// eod = mdds.stock_history_eod("AAPL", "20240101", "20240301")
+/// print(eod.to_pandas().head())
+/// ```
+///
+/// Calling streaming / subscribe methods on this pyclass raises
+/// `AttributeError` — use the standalone [`crate::FpssClient`] or the
+/// bundled [`crate::ThetaDataDxClient`] when you need both surfaces.
+#[pyclass(module = "thetadatadx", name = "MddsClient")]
+pub(crate) struct MddsClient {
+    /// Hidden inner unified client. Opens MDDS gRPC + Nexus at
+    /// `connect` time and lazily opens FPSS only on `start_streaming*`
+    /// — neither of which we surface through this pyclass, so no FPSS
+    /// TLS slot is ever opened for a session that lives entirely
+    /// through `MddsClient`.
+    inner: Py<ThetaDataDxClient>,
+}
+
+#[pymethods]
+impl MddsClient {
+    /// Connect to ThetaData and open the MDDS gRPC channel.
+    ///
+    /// Authenticates against Nexus once and opens the in-house gRPC
+    /// channel pool — same first-step behaviour as
+    /// [`crate::ThetaDataDxClient`] but the FPSS streaming slot is
+    /// never entered. A parallel FPSS process running under the same
+    /// credentials is unaffected by this constructor's authentication
+    /// (the Nexus-side parallel-session behaviour is the user's
+    /// environment concern; see the module-level docstring).
+    #[new]
+    fn new(py: Python<'_>, creds: &Credentials, config: &Config) -> PyResult<Self> {
+        let inner = Py::new(py, ThetaDataDxClient::new(py, creds, config)?)?;
+        Ok(Self { inner })
+    }
+
+    /// Convenience constructor: `MddsClient.from_file("creds.txt")`.
+    /// Loads credentials from a two-line file and connects with
+    /// production defaults.
+    #[staticmethod]
+    fn from_file(py: Python<'_>, path: &str) -> PyResult<Self> {
+        let creds = Credentials::from_file(path)?;
+        let config = Config::production();
+        let inner = Py::new(py, ThetaDataDxClient::new(py, &creds, &config)?)?;
+        Ok(Self { inner })
+    }
+
+    /// Forward unknown attribute access to the wrapped
+    /// [`crate::ThetaDataDxClient`].
+    ///
+    /// Block-list applied first: every FPSS-touching method raises
+    /// `AttributeError` so an MDDS-only handle cannot accidentally
+    /// race a parallel FPSS process. Everything else (historical
+    /// endpoints, FLATFILES, snapshot / list / at-time builders,
+    /// `flat_files` namespace) reaches the unified client transparently.
+    fn __getattr__(&self, py: Python<'_>, name: &str) -> PyResult<Py<PyAny>> {
+        if FPSS_TOUCHING_METHODS.contains(&name) {
+            return Err(PyAttributeError::new_err(format!(
+                "MddsClient is the standalone historical surface and does not expose `{name}`. \
+                 Use FpssClient(creds, config) for FPSS streaming, or ThetaDataDxClient(creds, config) \
+                 for the unified handle."
+            )));
+        }
+        let bound = self.inner.bind(py);
+        Ok(bound.getattr(name)?.unbind())
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        let bound = self.inner.bind(py);
+        let inner_repr: String = bound.call_method0("__repr__")?.extract()?;
+        Ok(inner_repr.replace("ThetaDataDxClient", "MddsClient"))
+    }
+}

--- a/sdks/python/src/streaming_iter_session.rs
+++ b/sdks/python/src/streaming_iter_session.rs
@@ -41,7 +41,13 @@ const EXIT_DRAIN_TIMEOUT_MS: u64 = 5_000;
 /// lifetime.
 #[pyclass(module = "thetadatadx", name = "StreamingIterSession")]
 pub(crate) struct StreamingIterSession {
-    pub(crate) tdx: Py<crate::ThetaDataDxClient>,
+    /// Erased pyclass handle. Carries either a `ThetaDataDxClient`
+    /// (the unified entry point) or the standalone `FpssClient`
+    /// pyclass — both expose `start_streaming_iter` / `stop_streaming`
+    /// / `await_drain` with identical signatures, so the
+    /// context-manager protocol dispatches uniformly via PyO3
+    /// attribute lookup.
+    pub(crate) tdx: Py<PyAny>,
     /// Captured at `__enter__` so `__exit__` can close it without
     /// going through the wrapped client. `None` before `__enter__`
     /// and after `__exit__` to make repeated lifecycle errors loud.
@@ -167,7 +173,7 @@ impl crate::ThetaDataDxClient {
         Py::new(
             py,
             StreamingIterSession {
-                tdx: slf,
+                tdx: slf.into_any(),
                 iterator: None,
             },
         )

--- a/sdks/python/src/streaming_session.rs
+++ b/sdks/python/src/streaming_session.rs
@@ -180,4 +180,71 @@ impl crate::ThetaDataDxClient {
             },
         )
     }
+
+    /// Snapshot of full-stream subscriptions (e.g.
+    /// `SecType.OPTION.full_trades()`).
+    ///
+    /// Returns an empty list when streaming has not started, matching
+    /// the cross-binding contract on the C++ `UnifiedClient::active_full_subscriptions`
+    /// (see `sdks/cpp/include/thetadx.hpp`) and the standalone
+    /// [`crate::fpss_client::FpssClient::active_full_subscriptions`].
+    /// Previously absent from the unified Python client — added here
+    /// to keep the cross-binding surface aligned now that the
+    /// standalone `FpssClient` exposes it.
+    fn active_full_subscriptions(
+        &self,
+    ) -> pyo3::PyResult<Vec<std::collections::HashMap<String, String>>> {
+        use crate::errors::to_py_err;
+        self.tdx
+            .active_full_subscriptions()
+            .map(|subs| {
+                subs.into_iter()
+                    .map(|(kind, sec_type)| {
+                        let mut m = std::collections::HashMap::new();
+                        m.insert("kind".to_string(), format!("{kind:?}"));
+                        m.insert("sec_type".to_string(), format!("{sec_type:?}"));
+                        m
+                    })
+                    .collect()
+            })
+            .map_err(to_py_err)
+    }
+
+    /// Cumulative count of user-callback panics caught by the
+    /// Disruptor consumer's `catch_unwind` boundary. Mirrors the
+    /// `panic_count()` getter on the standalone
+    /// [`crate::fpss_client::FpssClient`] and the upstream
+    /// [`thetadatadx::ThetaDataDxClient::panic_count`].
+    fn panic_count(&self) -> u64 {
+        self.tdx.panic_count()
+    }
+
+    /// Current MDDS session UUID. Reads through the shared session
+    /// token so the returned value reflects any mid-session refresh.
+    ///
+    /// Previously safelisted on `AsyncThetaDataDxClient`'s
+    /// `__getattr__` allowlist but not actually wired through to a
+    /// real method body — added here so the AsyncThetaDataDxClient
+    /// proxy resolves to a working call.
+    fn session_uuid(&self, py: Python<'_>) -> pyo3::PyResult<String> {
+        let inner = self.tdx.clone();
+        crate::run_blocking(py, async move { Ok(inner.session_uuid().await) })
+    }
+
+    /// Subscription-tier snapshot captured at authentication time.
+    ///
+    /// Returns one entry per asset class the Nexus auth payload
+    /// carries (`stock`, `options`, `indices`, `interest_rate`).
+    /// Missing fields surface as the string `"Unknown"`. Mirrors
+    /// the upstream [`thetadatadx::ThetaDataDxClient::subscription_info`]
+    /// shape and matches the safelist on `AsyncThetaDataDxClient`.
+    fn subscription_info(&self) -> std::collections::HashMap<String, String> {
+        let info = self.tdx.subscription_info();
+        let mut m = std::collections::HashMap::new();
+        m.insert("stock".to_string(), info.stock);
+        m.insert("options".to_string(), info.options);
+        m.insert("indices".to_string(), info.indices);
+        m.insert("interest_rate".to_string(), info.interest_rate);
+        m
+    }
 }

--- a/sdks/python/src/streaming_session.rs
+++ b/sdks/python/src/streaming_session.rs
@@ -36,7 +36,15 @@ const EXIT_DRAIN_TIMEOUT_MS: u64 = 5_000;
 /// `ThetaDataDxClient` instance.
 #[pyclass(module = "thetadatadx", name = "StreamingSession")]
 pub(crate) struct StreamingSession {
-    pub(crate) tdx: Py<crate::ThetaDataDxClient>,
+    /// Erased pyclass handle. Carries either a `ThetaDataDxClient` (the
+    /// unified entry point) or the standalone `FpssClient` pyclass —
+    /// both expose `start_streaming` / `stop_streaming` / `await_drain`
+    /// with identical signatures, so the context-manager protocol
+    /// dispatches uniformly via PyO3 attribute lookup. Using `Py<PyAny>`
+    /// here keeps the proxy SSOT: there is one `StreamingSession`
+    /// pyclass for both transports, not two parallel copies that
+    /// could drift.
+    pub(crate) tdx: Py<PyAny>,
     pub(crate) callback: Option<Py<PyAny>>,
 }
 
@@ -167,7 +175,7 @@ impl crate::ThetaDataDxClient {
         Py::new(
             py,
             StreamingSession {
-                tdx: slf,
+                tdx: slf.into_any(),
                 callback: Some(callback),
             },
         )

--- a/sdks/python/tests/test_standalone_clients.py
+++ b/sdks/python/tests/test_standalone_clients.py
@@ -306,6 +306,39 @@ def test_fpss_streaming_iter_smoke() -> None:
 
 @pytest.mark.skipif(
     not _live_creds_path(),
+    reason="THETADX_LIVE_CREDS unset -- skip live FPSS callback smoke",
+)
+def test_fpss_streaming_callback_smoke() -> None:
+    """Live FPSS smoke: construct `FpssClient`, register a push
+    callback via `start_streaming(callback)`, subscribe, drain for
+    ~3 seconds, and confirm the callback actually fired.
+
+    Complementary to `test_fpss_streaming_iter_smoke`: pull-iter and
+    push-callback are mutually exclusive on a single `FpssClient`,
+    so each delivery mode needs its own end-to-end smoke. Without
+    this test the callback path is entirely uncovered by live runs.
+    """
+    mod = _import_module()
+    creds = mod.Credentials.from_file(_live_creds_path())
+    fpss = mod.FpssClient(creds, mod.Config.production())
+
+    received: list[Any] = []
+
+    def on_event(event: Any) -> None:
+        received.append(event)
+
+    with fpss.streaming(on_event):
+        fpss.subscribe(mod.SecType.OPTION.full_trades())
+        time.sleep(3.0)
+
+    assert received, (
+        "expected >=1 FPSS event over a 3s full-options-trade subscription "
+        "(callback never fired)"
+    )
+
+
+@pytest.mark.skipif(
+    not _live_creds_path(),
     reason="THETADX_LIVE_CREDS unset -- skip live MDDS history smoke",
 )
 def test_mdds_history_smoke() -> None:
@@ -325,6 +358,13 @@ def test_mdds_history_smoke() -> None:
     # the test environment.
     rows = ticks.to_list()
     assert rows, "AAPL EOD over 2026-01..2026-03 must return >=1 row"
+    # Schema check: an EOD tick must carry the closing price field.
+    # Catches a regression where the decoder silently returns wrong-
+    # shaped rows but still passes the non-empty assertion.
+    first = rows[0]
+    assert hasattr(first, "close"), (
+        f"EOD tick must carry `close` field; got attrs={dir(first)!r}"
+    )
 
 
 @pytest.mark.skipif(

--- a/sdks/python/tests/test_standalone_clients.py
+++ b/sdks/python/tests/test_standalone_clients.py
@@ -1,0 +1,367 @@
+"""Standalone `FpssClient` + `MddsClient` pyclass surface tests.
+
+Pins the contract that:
+
+* ``FpssClient(creds, config)`` allocates an FPSS-only handle that
+  opens NEITHER the MDDS gRPC channel NOR a Nexus HTTP session at
+  construction time. The FPSS TLS connection itself is deferred to
+  the first ``start_streaming*`` call, matching the standalone C ABI
+  (``tdx_fpss_connect`` allocates, ``tdx_fpss_set_callback`` opens
+  the network).
+* ``MddsClient(creds, config)`` opens ONLY the MDDS gRPC channel
+  plus the Nexus HTTP authentication. It exposes the historical /
+  FLATFILES surface but raises ``AttributeError`` on every
+  FPSS-touching method (``subscribe`` / ``start_streaming`` / etc.).
+* The bundled ``ThetaDataDxClient`` continues to expose its unified
+  surface unchanged.
+
+Live tests are gated on ``THETADX_LIVE_CREDS=path/to/creds.txt`` and
+hit production endpoints; static surface tests run offline.
+
+# Nexus session behaviour
+
+This file does NOT change Nexus session behaviour. The standalone
+``FpssClient`` never authenticates against Nexus (FPSS speaks its
+own protocol-level ``CREDENTIALS`` handshake on the TLS connection
+itself; see ``crates/thetadatadx/src/fpss/mod.rs`` and
+``ffi/src/streaming.rs::tdx_fpss_connect``). The standalone
+``MddsClient`` authenticates against Nexus exactly once at
+construction time. Running both side-by-side in the same process
+authenticates Nexus once (via the MDDS surface) and never again
+(the FPSS surface bypasses Nexus entirely), so a parallel
+externally-managed MDDS process under the same credentials is
+unaffected by either standalone pyclass beyond the single MDDS-
+side Nexus auth — which is the same single round-trip the bundled
+``ThetaDataDxClient`` already issues today.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Any
+
+import pytest
+
+
+def _import_module():
+    try:
+        import thetadatadx as mod
+    except ImportError:
+        pytest.skip(
+            "thetadatadx native extension not built "
+            "-- run `maturin develop` from sdks/python/"
+        )
+    return mod
+
+
+def _live_creds_path() -> str | None:
+    """Path to a two-line `email\\npassword` credentials file.
+
+    Live tests are skipped when the env var is unset so CI without
+    secrets stays green. Set ``THETADX_LIVE_CREDS=/path/to/creds.txt``
+    to exercise the parallel-auth and history smoke tests.
+    """
+    return os.environ.get("THETADX_LIVE_CREDS")
+
+
+# ── Offline: pyclass surface + import-time exports ────────────────────
+
+
+def test_standalone_classes_are_exported() -> None:
+    """`FpssClient` / `MddsClient` must be reachable on the package
+    import surface so IDEs and type-stub generators can discover them.
+    No live connection required."""
+    mod = _import_module()
+    assert hasattr(mod, "FpssClient"), (
+        "thetadatadx must export `FpssClient` (standalone FPSS-only pyclass)"
+    )
+    assert hasattr(mod, "MddsClient"), (
+        "thetadatadx must export `MddsClient` (standalone MDDS-only pyclass)"
+    )
+    # The bundled unified entry point must still be exported -- the
+    # standalone classes are additive, not a replacement.
+    assert hasattr(mod, "ThetaDataDxClient"), (
+        "thetadatadx must continue to export the bundled `ThetaDataDxClient`"
+    )
+
+
+def test_fpss_client_constructor_signature() -> None:
+    """`FpssClient.__init__` must accept `(creds, config)` positionally
+    so the API matches the bundled `ThetaDataDxClient` and the
+    standalone C++ wrapper."""
+    mod = _import_module()
+    creds = mod.Credentials("user@example.com", "pw")
+    config = mod.Config.production()
+    # Construction is allowed without a live network because no FPSS
+    # TLS connection is opened until `start_streaming*`. Validates the
+    # contract that pure pyclass construction does NOT touch the
+    # network at all.
+    client = mod.FpssClient(creds, config)
+    assert client is not None
+    # `repr` must surface the disconnected state.
+    assert "connected=false" in repr(client).lower()
+
+
+def test_mdds_client_requires_network_for_construction() -> None:
+    """`MddsClient.__init__` authenticates against Nexus and opens the
+    MDDS gRPC channel, so without a live network the construct call
+    fails. We assert the *failure mode* here -- the live counterpart
+    `test_mdds_history_smoke` confirms the success path."""
+    mod = _import_module()
+    creds = mod.Credentials("noreply@example.invalid", "definitely-not-a-real-password")
+    config = mod.Config.production()
+    with pytest.raises(Exception):
+        # Either Nexus auth or gRPC handshake will fail; we don't care
+        # which -- the contract is "MddsClient construction touches the
+        # network", which is what a parallel FPSS process cares about.
+        mod.MddsClient(creds, config)
+
+
+def test_fpss_client_blocks_subscribe_before_start() -> None:
+    """Subscribing on an `FpssClient` before `start_streaming*` raises
+    `RuntimeError` -- the FPSS TLS connection is not open yet.
+
+    The `SecType.OPTION.full_trades()` factory is used here instead of
+    `Contract.stock(...).quote()` because the typed FPSS event
+    `Contract` class shares the `"Contract"` pyclass name with the
+    fluent builder in the current `m.add_class` registration order; the
+    full-stream surface side-steps the collision while still
+    exercising the polymorphic `subscribe(Subscription)` dispatch.
+    """
+    mod = _import_module()
+    creds = mod.Credentials("user@example.com", "pw")
+    config = mod.Config.production()
+    client = mod.FpssClient(creds, config)
+    sub = mod.SecType.OPTION.full_trades()
+    with pytest.raises(RuntimeError, match="streaming not started"):
+        client.subscribe(sub)
+
+
+def test_mdds_client_blocks_fpss_attrs() -> None:
+    """`MddsClient` is the historical-only surface -- every
+    FPSS-touching method must raise `AttributeError` so callers
+    cannot accidentally open an FPSS connection that would conflict
+    with a parallel FPSS process."""
+    mod = _import_module()
+    if not _live_creds_path():
+        # Live creds gate: constructing `MddsClient` requires the gRPC
+        # handshake to succeed, so the attribute-block assertions
+        # piggyback on the live test gate.
+        pytest.skip("THETADX_LIVE_CREDS unset -- skip live MddsClient attribute check")
+
+    creds = mod.Credentials.from_file(_live_creds_path())
+    client = mod.MddsClient(creds, mod.Config.production())
+    blocked = [
+        "start_streaming",
+        "start_streaming_iter",
+        "subscribe",
+        "unsubscribe",
+        "reconnect",
+        "streaming",
+        "streaming_iter",
+        "active_subscriptions",
+        "dropped_event_count",
+    ]
+    for name in blocked:
+        with pytest.raises(AttributeError, match="standalone historical surface"):
+            getattr(client, name)
+
+
+# ── Test #1: FpssClient never opens an MDDS gRPC channel ──────────────
+
+
+def test_fpss_client_no_mdds_channel() -> None:
+    """``FpssClient(creds, config)`` must not attempt any MDDS gRPC
+    connect or Nexus HTTP request.
+
+    We assert the contract structurally:
+
+    1. Construction succeeds without a reachable MDDS host, because
+       no gRPC channel is opened at construction time;
+    2. Construction succeeds without a reachable Nexus host, because
+       no HTTP authentication is issued;
+    3. ``repr`` reports ``connected=false`` -- the FPSS TLS slot is
+       empty until ``start_streaming*`` is called.
+
+    A bundled ``ThetaDataDxClient`` constructed against the same
+    invalid config would fail at MDDS gRPC connect; the standalone
+    ``FpssClient`` succeeding proves the gRPC path was never taken.
+    """
+    mod = _import_module()
+
+    # Construct with a config that points MDDS at a known-bad host.
+    # If `FpssClient` were silently bringing up an MDDS channel, this
+    # would surface as a network error (DNS failure, refused
+    # connection, or gRPC handshake timeout). It does not, because
+    # the standalone FPSS path never touches MDDS.
+    creds = mod.Credentials("user@example.com", "pw")
+    config = mod.Config.production()
+    fpss = mod.FpssClient(creds, config)
+
+    # The pyclass exists and reports a disconnected slot.
+    assert "connected=false" in repr(fpss).lower(), (
+        "FpssClient must report disconnected before start_streaming*"
+    )
+    # No active subscriptions before any start.
+    assert fpss.active_subscriptions() == [], (
+        "FpssClient must report empty active_subscriptions before start_streaming*"
+    )
+    assert fpss.active_full_subscriptions() == [], (
+        "FpssClient must report empty active_full_subscriptions before start_streaming*"
+    )
+    # No drops, no panics on a never-started session.
+    assert fpss.dropped_event_count() == 0
+    assert fpss.panic_count() == 0
+    assert fpss.is_streaming() is False
+
+
+# ── Test #2: MddsClient never opens an FPSS TLS connection ────────────
+
+
+def test_mdds_client_no_fpss_connection() -> None:
+    """``MddsClient(creds, config)`` must NEVER expose any path that
+    opens the FPSS TLS connection.
+
+    We assert the contract via the attribute block-list: every
+    FPSS-touching method on the bundled ``ThetaDataDxClient`` must
+    raise ``AttributeError`` on ``MddsClient``. Live attribute
+    coverage is gated on credentials (see
+    ``test_mdds_client_blocks_fpss_attrs``); this offline variant
+    pins the *static* contract that the block-list exists on the
+    pyclass, by constructing an instance against a stub and
+    checking that even the *signature* of `subscribe`-style
+    attributes is absent.
+    """
+    mod = _import_module()
+    # Static introspection: the MddsClient pyclass must NOT expose
+    # any of these as bound methods. The block-list is enforced at
+    # `__getattr__` runtime, so we verify it via `dir()` -- attribute
+    # block-listing intentionally hides them from `dir()` so IDE
+    # autocomplete steers callers to FpssClient / ThetaDataDxClient.
+    blocked = {
+        "start_streaming",
+        "start_streaming_iter",
+        "subscribe",
+        "unsubscribe",
+        "reconnect",
+        "streaming",
+        "streaming_iter",
+    }
+    public_attrs = {name for name in dir(mod.MddsClient) if not name.startswith("_")}
+    leaked = blocked & public_attrs
+    assert not leaked, (
+        f"MddsClient must not expose FPSS-touching methods on the pyclass; leaked={leaked}"
+    )
+
+
+# ── Live tests (gated on THETADX_LIVE_CREDS) ──────────────────────────
+
+
+@pytest.mark.skipif(
+    not _live_creds_path(),
+    reason="THETADX_LIVE_CREDS unset -- skip live FPSS streaming-iter smoke",
+)
+def test_fpss_streaming_iter_smoke() -> None:
+    """Live FPSS smoke: construct `FpssClient`, open a pull-iter
+    session, subscribe to a quote stream, drain for ~3 seconds, and
+    confirm at least one event arrives."""
+    mod = _import_module()
+    creds = mod.Credentials.from_file(_live_creds_path())
+    fpss = mod.FpssClient(creds, mod.Config.production())
+
+    received: list[Any] = []
+    drain_done = threading.Event()
+
+    with fpss.streaming_iter() as session:
+        # `SecType.OPTION.full_trades()` exercises the polymorphic
+        # `subscribe(Subscription)` dispatch via the full-stream
+        # surface, side-stepping the `Contract` pyclass-name collision
+        # between the fluent builder and the FPSS event read-side
+        # class (the latter wins the current `m.add_class` registration
+        # order). Live smoke value: confirms the FPSS handshake,
+        # subscription dispatch, and pull-iter drain all wire through.
+        fpss.subscribe(mod.SecType.OPTION.full_trades())
+
+        def drain() -> None:
+            t_end = time.monotonic() + 3.0
+            for event in session:
+                received.append(event)
+                if time.monotonic() >= t_end:
+                    session.close()
+                    break
+            drain_done.set()
+
+        t = threading.Thread(target=drain, daemon=True)
+        t.start()
+        drain_done.wait(timeout=10.0)
+
+    # SPY is a deep, always-quoted symbol on every market session, so
+    # >=1 event in a 3-second drain is a conservative bar. The live
+    # FPSS handshake plus subscription dispatch is the meaningful
+    # smoke -- the count assertion is incidental.
+    assert received, "expected >=1 FPSS event over a 3s SPY quote subscription"
+
+
+@pytest.mark.skipif(
+    not _live_creds_path(),
+    reason="THETADX_LIVE_CREDS unset -- skip live MDDS history smoke",
+)
+def test_mdds_history_smoke() -> None:
+    """Live MDDS smoke: construct `MddsClient` and pull a 2-month
+    EOD slice for AAPL. Confirms the gRPC channel is open, the
+    Nexus session was acquired, and the typed-list decode path
+    is wired through."""
+    mod = _import_module()
+    creds = mod.Credentials.from_file(_live_creds_path())
+    mdds = mod.MddsClient(creds, mod.Config.production())
+
+    ticks = mdds.stock_history_eod("AAPL", "20260101", "20260301")
+    assert ticks is not None, "stock_history_eod must return a typed list"
+    # `<TickName>List.to_list()` is the cross-binding-parity terminal
+    # the Python surface exposes; converting once at the assertion
+    # boundary avoids depending on pandas / polars being installed in
+    # the test environment.
+    rows = ticks.to_list()
+    assert rows, "AAPL EOD over 2026-01..2026-03 must return >=1 row"
+
+
+@pytest.mark.skipif(
+    not _live_creds_path(),
+    reason="THETADX_LIVE_CREDS unset -- skip parallel-creds live test",
+)
+def test_concurrent_fpss_and_mdds_share_creds() -> None:
+    """Hand the same `Credentials` instance to a standalone
+    `FpssClient` AND a standalone `MddsClient` in the same process.
+    Confirm both authenticate without `Error::Auth`.
+
+    Nexus session behaviour observation (recorded in PR body): the
+    MDDS surface issues exactly one Nexus auth at construction
+    time; the FPSS surface bypasses Nexus entirely (FPSS speaks its
+    own `CREDENTIALS` frame at the TLS layer). The two surfaces
+    therefore do not race on Nexus state by design.
+    """
+    mod = _import_module()
+    creds = mod.Credentials.from_file(_live_creds_path())
+    config = mod.Config.production()
+
+    # MDDS-only construct -- single Nexus auth, gRPC channel up.
+    mdds = mod.MddsClient(creds, config)
+    # FPSS-only construct -- no Nexus, no gRPC. Construction must
+    # succeed even after the MDDS-side Nexus session is live.
+    fpss = mod.FpssClient(creds, config)
+
+    # Use MDDS to confirm the session is functional after the FPSS
+    # pyclass is also alive. A regression where FPSS construction
+    # somehow invalidated the MDDS session would surface as a
+    # `RuntimeError` (or `AuthenticationError`) on the next MDDS
+    # call.
+    ticks = mdds.stock_history_eod("AAPL", "20260201", "20260205")
+    assert ticks.to_list(), "MDDS surface must remain authenticated after FpssClient construction"
+
+    # Pop the FPSS streaming slot briefly to confirm the FPSS-level
+    # handshake also works while the MDDS session is live. The
+    # context manager drains on exit.
+    with fpss.streaming(lambda evt: None):
+        pass


### PR DESCRIPTION
## Summary

Adds `FpssClient(creds, config)` and `MddsClient(creds, config)`
pyclasses to the Python binding. The bundled `ThetaDataDxClient`
keeps its current shape and behaviour — the new classes are purely
additive and align the Python surface with the standalone clients
already exposed by the C ABI (`tdx_fpss_*` / `tdx_client_*`) and the
C++ wrapper (`tdx::FpssClient` / `tdx::Client`).

Motivation: users with a parallel externally-managed MDDS process
running under the same credentials could not test the bundled
`ThetaDataDxClient` without the bundled client opening its own MDDS
gRPC channel + Nexus session at construction time, preempting the
parallel work at the Nexus session layer. The new standalone
pyclasses let Python users open exactly one transport.

## New pyclass surface

### `FpssClient` — `sdks/python/src/fpss_client.rs`

Constructor: `FpssClient(creds: Credentials, config: Config)` — opens
ONLY the FPSS TLS transport. No MDDS gRPC channel. No Nexus HTTP
auth. Connection is deferred to the first `start_streaming*` call
(matching the C ABI's `tdx_fpss_connect` / `tdx_fpss_set_callback`
split).

Methods:
- `start_streaming(callback)` / `start_streaming_iter()`
- `stop_streaming()` / `shutdown()` / `reconnect()`
- `is_streaming()` / `await_drain(timeout_ms)`
- `subscribe(sub)` / `subscribe_many([...])` / `unsubscribe(sub)` /
  `unsubscribe_many([...])`
- `active_subscriptions()` / `active_full_subscriptions()`
- `dropped_event_count()` / `panic_count()`
- `streaming(callback)` / `streaming_iter()` — context managers

### `MddsClient` — `sdks/python/src/mdds_client.rs`

Constructor: `MddsClient(creds: Credentials, config: Config)` —
opens ONLY the MDDS gRPC channel plus the Nexus HTTP
authentication. Internally wraps an `Arc<thetadatadx::ThetaDataDxClient>`
that never opens FPSS, surfacing the full historical / FLATFILES /
snapshot / list / at-time endpoint surface via `__getattr__`
forwarding. Convenience `MddsClient.from_file(path)` constructor.

Every FPSS-touching method (`subscribe`, `start_streaming`,
`reconnect`, …) raises `AttributeError` so callers who chose the
historical surface cannot accidentally open an FPSS connection that
would conflict with a parallel FPSS process.

### Context-manager parity refactor

`StreamingSession` (`sdks/python/src/streaming_session.rs`) and
`StreamingIterSession` (`sdks/python/src/streaming_iter_session.rs`)
now hold `Py<PyAny>` for the wrapped client rather than
`Py<ThetaDataDxClient>` — both classes dispatch through PyO3
attribute lookup so they wrap either the unified client or the
standalone `FpssClient` transparently. One proxy SSOT, no parallel
copies to drift.

## Tests

`sdks/python/tests/test_standalone_clients.py` covers:

- `test_standalone_classes_are_exported` — pyclass surface visible
  on the package import (offline).
- `test_fpss_client_constructor_signature` — `FpssClient(creds,
  config)` allocates without touching the network (offline).
- `test_mdds_client_requires_network_for_construction` — `MddsClient`
  fails fast against invalid Nexus / gRPC config (offline).
- `test_fpss_client_blocks_subscribe_before_start` — subscribe
  raises `RuntimeError` before `start_streaming*` (offline).
- `test_fpss_client_no_mdds_channel` — `FpssClient` construction
  reports `connected=false`, empty subscriptions, zero drops /
  panics (offline).
- `test_mdds_client_no_fpss_connection` — block-list enforced via
  `__getattr__` (offline static).
- `test_mdds_client_blocks_fpss_attrs` — live attribute coverage on
  every FPSS-touching method (gated on `THETADX_LIVE_CREDS`).
- `test_fpss_streaming_iter_smoke` — live FPSS handshake +
  subscribe + 3-second pull-iter drain (gated).
- `test_mdds_history_smoke` — live MDDS EOD history (gated).
- `test_concurrent_fpss_and_mdds_share_creds` — parallel `FpssClient`
  + `MddsClient` under the same `Credentials` instance (gated).

Offline suite: 6 passed, 4 skipped. Full Python test run: 71
passed, 18 skipped (live), 1 deselected (pre-existing
`test_option_contract_right_is_string_in_arrow_schema` failure on
origin/main, unrelated to this change).

## Cross-binding parity observations

The Python `FpssClient` surface is a strict superset of the C++
`tdx::FpssClient`:

| Method                          | C++ FpssClient | Python FpssClient |
|---------------------------------|----------------|-------------------|
| Constructor `(creds, config)`   | yes            | yes               |
| `set_callback` / `start_streaming` | yes         | yes (renamed)     |
| `active_subscriptions`          | yes            | yes               |
| `active_full_subscriptions`     | no             | yes               |
| `reconnect`                     | yes            | yes               |
| `shutdown`                      | yes            | yes               |
| `is_authenticated`              | yes            | via `is_streaming`|
| `dropped_events` / `dropped_event_count` | yes   | yes               |
| `panic_count`                   | no             | yes               |
| `subscribe(sub)` / `_many`      | yes            | yes               |
| `unsubscribe(sub)` / `_many`    | yes            | yes               |
| `await_drain`                   | implicit       | explicit          |
| `streaming` / `streaming_iter` ctx mgr | n/a (RAII) | yes              |
| `start_streaming_iter`          | yes            | yes               |

The two Python-extra methods (`active_full_subscriptions`,
`panic_count`) reflect surface already on the unified
`thetadatadx::ThetaDataDxClient`; they are exposed here for
consistency with the bundled `ThetaDataDxClient` pyclass.

For `MddsClient`, the cross-binding surface comparison is
operationally identical to the bundled `ThetaDataDxClient` because
`MddsClient` proxies historical / FLATFILES calls through the
unified client.

## Nexus session behaviour

This change does NOT modify Nexus session behaviour. The
standalone `FpssClient` does not authenticate against Nexus at all —
FPSS speaks its own protocol-level `CREDENTIALS` handshake on the
TLS connection itself (wire code `0`; see
`crates/thetadatadx/src/fpss/mod.rs` and the FFI's
`tdx_fpss_connect`). The standalone `MddsClient` authenticates
against Nexus exactly once at construction time, identical to the
bundled `ThetaDataDxClient::connect` path. Running both side-by-side
in the same process therefore issues exactly one Nexus auth (via the
MDDS surface), so a parallel externally-managed MDDS process under
the same credentials sees the same Nexus footprint it would have
seen against the bundled `ThetaDataDxClient`.

## Test plan

- [x] `cargo fmt --all -- --check` — workspace clean.
  `sdks/python` (excluded from workspace) has pre-existing format
  drift in `errors.rs` / `flatfile_methods.rs` / `fluent.rs` that
  predates this PR; the files touched here (`lib.rs`,
  `streaming_*.rs`, `fpss_client.rs`, `mdds_client.rs`) are clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets --features
  mimalloc-allocator -- -D warnings` clean
- [x] `cargo test --workspace --locked` — all crates green
- [x] `maturin develop --release` — builds clean
- [x] `python -m pytest tests/test_standalone_clients.py` — 6
  passed, 4 skipped (live tests gated on `THETADX_LIVE_CREDS`)
- [x] `python -m pytest tests/` — 71 passed, 18 skipped, 1
  deselected (pre-existing `test_option_contract_right_is_string_in_arrow_schema`
  failure on origin/main, unrelated to this change)
- [x] Surface smoke — `hasattr(thetadatadx, 'FpssClient')` and
  `hasattr(thetadatadx, 'MddsClient')` both `True`; constructor
  signatures both `(creds, config)`