### PR TITLE
fix(python): resolve Contract name collision blocking fluent builder

### DIFF
--- a/crates/thetadatadx/build_support_bin/fpss_events/common.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/common.rs
@@ -35,11 +35,13 @@ pub(super) fn python_rust_field_type(
         "Option<String>" => "Option<String>",
         "Option<i32>" => "Option<i32>",
         "Vec<u8>" => "Vec<u8>",
-        // `Contract` becomes `Py<Contract>` on the pyclass — pyo3 cannot
-        // expose a `Contract` struct by value through `#[pyo3(get)]` on a
-        // frozen pyclass without a runtime acquisition, so we store the
-        // Python handle directly. See `render_python_event_class_struct`.
-        "Contract" => "Py<Contract>",
+        // `Contract` becomes `Py<ContractRef>` on the pyclass — pyo3 cannot
+        // expose a struct by value through `#[pyo3(get)]` on a frozen
+        // pyclass without a runtime acquisition, so we store the Python
+        // handle directly. The Python-side struct is named `ContractRef`
+        // to disambiguate from the fluent `Contract` builder registered
+        // by `fluent.rs`. See `render_python_event_class_struct`.
+        "Contract" => "Py<ContractRef>",
         other => {
             panic!("unsupported FPSS event column type '{other}' in {event_name}.{column_name}")
         }

--- a/crates/thetadatadx/build_support_bin/fpss_events/python.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/python.rs
@@ -6,10 +6,18 @@ use std::fmt::Write as _;
 use super::common::{is_contract, python_rust_field_type, snake_case};
 use super::schema::{sorted_event_names, ColumnDef, EventDef, Schema};
 
-/// Emit the `Contract` pyclass + helper constructor. Every data event
-/// carries a `Py<Contract>` field so Python code can read
+/// Emit the `ContractRef` pyclass + helper constructor. Every data event
+/// carries a `Py<ContractRef>` field so Python code can read
 /// `event.contract.symbol`, `event.contract.strike`, etc. through the
 /// normal pyo3 getter machinery.
+///
+/// Named `ContractRef` (not `Contract`) on the Python side because the
+/// fluent builder in `fluent.rs` already registers as `Contract` — see
+/// the corresponding TypeScript split in
+/// `sdks/typescript/src/fluent.rs` where the two are also held apart.
+/// Sharing the bare name would have pyo3's `m.add_class` last-write-wins
+/// silently shadow whichever helper registers first, hiding factory
+/// methods like `.stock()` / `.option()` from end users.
 fn render_contract_pyclass() -> &'static str {
     "/// FPSS contract identifier. Surfaced on every decoded FPSS data\n\
 /// event as `event.contract`. Reads `symbol`, `sec_type` (symbolic\n\
@@ -18,10 +26,14 @@ fn render_contract_pyclass() -> &'static str {
 /// in dollars), and `strike` (wire integer, thousandths of a dollar)\n\
 /// directly. User code reads the same notation it writes when\n\
 /// calling `Contract.option(symbol, expiration=..., strike=\"5400\", right=\"C\")`.\n\
+///\n\
+/// Distinct from the fluent `Contract` builder (in `fluent.rs`): this\n\
+/// type is the read-only event payload; the fluent builder is what\n\
+/// users instantiate via `Contract.stock(\"AAPL\")` / `Contract.option(...)`.\n\
 #[must_use]\n\
 #[pyclass(module = \"thetadatadx\", frozen, skip_from_py_object)]\n\
 #[derive(Clone)]\n\
-pub(crate) struct Contract {\n\
+pub(crate) struct ContractRef {\n\
     #[pyo3(get)] pub symbol: String,\n\
     #[pyo3(get)] pub sec_type: String,\n\
     #[pyo3(get)] pub expiration: Option<i32>,\n\
@@ -30,15 +42,15 @@ pub(crate) struct Contract {\n\
     #[pyo3(get)] pub strike: Option<i32>,\n\
 }\n\
 #[pymethods]\n\
-impl Contract {\n\
+impl ContractRef {\n\
     fn __repr__(&self) -> String {\n\
         format!(\n\
-            \"Contract(symbol={:?}, sec_type={:?}, expiration={:?}, right={:?}, strike_dollars={:?})\",\n\
+            \"ContractRef(symbol={:?}, sec_type={:?}, expiration={:?}, right={:?}, strike_dollars={:?})\",\n\
             self.symbol, self.sec_type, self.expiration, self.right, self.strike_dollars\n\
         )\n\
     }\n\
 }\n\
-impl Contract {\n\
+impl ContractRef {\n\
     /// Build from the core `thetadatadx::fpss::protocol::Contract` value\n\
     /// carried by each `BufferedEvent::*` Data arm. `sec_type` is the\n\
     /// symbolic uppercase name (`\"STOCK\"` / `\"OPTION\"` / `\"INDEX\"` /\n\
@@ -98,7 +110,7 @@ pub(super) fn render_python_fpss_event_classes(schema: &Schema) -> String {
     out.push_str(
         "pub(crate) fn register_fpss_event_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {\n",
     );
-    out.push_str("    m.add_class::<Contract>()?;\n");
+    out.push_str("    m.add_class::<ContractRef>()?;\n");
     for event_name in &names {
         writeln!(out, "    m.add_class::<{}>()?;", event_name).unwrap();
     }
@@ -301,7 +313,7 @@ fn render_python_buffered_match_arm(event_name: &str, def: &EventDef) -> String 
     let has_contract = def.columns.iter().any(|c| is_contract(&c.r#type));
     if has_contract {
         out.push_str(
-            "        } => {\n            let contract_py = Py::new(py, Contract::from_core(contract))?;\n            Py::new(\n                py,\n",
+            "        } => {\n            let contract_py = Py::new(py, ContractRef::from_core(contract))?;\n            Py::new(\n                py,\n",
         );
     } else {
         out.push_str("        } => Py::new(\n            py,\n");

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -86,6 +86,32 @@ class Contract:
     def __eq__(self, other: object) -> bool: ...
 
 
+class ContractRef:
+    """Read-only contract identifier surfaced on every FPSS event.
+
+    Distinct from the fluent `Contract` builder — `ContractRef` is what
+    `event.contract` returns inside a streaming callback, with the
+    resolved `symbol`, `sec_type`, `expiration`, `right`,
+    `strike_dollars`, and the wire-level integer `strike`. The fluent
+    `Contract` (above) is the one users instantiate to subscribe.
+    """
+
+    @property
+    def symbol(self) -> str: ...
+    @property
+    def sec_type(self) -> str: ...
+    @property
+    def expiration(self) -> Optional[int]: ...
+    @property
+    def right(self) -> Optional[str]: ...
+    @property
+    def strike_dollars(self) -> Optional[float]: ...
+    @property
+    def strike(self) -> Optional[int]: ...
+
+    def __repr__(self) -> str: ...
+
+
 class SecType:
     """Security type — `STOCK` / `OPTION` / `INDEX` / `RATE`."""
 
@@ -128,7 +154,7 @@ class Subscription:
 class Quote:
     """FPSS per-contract quote event."""
 
-    contract: Contract
+    contract: ContractRef
     bid_price: float
     bid_size: int
     ask_price: float
@@ -139,7 +165,7 @@ class Quote:
 class Trade:
     """FPSS per-contract trade event."""
 
-    contract: Contract
+    contract: ContractRef
     price: float
     size: int
     timestamp_ns: int
@@ -148,7 +174,7 @@ class Trade:
 class OpenInterest:
     """FPSS open-interest event (per-contract or full-stream)."""
 
-    contract: Contract
+    contract: ContractRef
     open_interest: int
     timestamp_ns: int
 
@@ -156,13 +182,23 @@ class OpenInterest:
 class Ohlcvc:
     """FPSS OHLCVC bar (derived in the SDK when `Config.derive_ohlcvc=True`)."""
 
-    contract: Contract
+    contract: ContractRef
     open: float
     high: float
     low: float
     close: float
     volume: int
     count: int
+
+
+class ContractAssigned:
+    """FPSS server assigned a contract id (`FpssControl::ContractAssigned`)."""
+
+    id: int
+    contract: ContractRef
+
+    @property
+    def kind(self) -> str: ...
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/sdks/python/src/_generated/fpss_event_classes.rs
+++ b/sdks/python/src/_generated/fpss_event_classes.rs
@@ -10,10 +10,14 @@
 /// in dollars), and `strike` (wire integer, thousandths of a dollar)
 /// directly. User code reads the same notation it writes when
 /// calling `Contract.option(symbol, expiration=..., strike="5400", right="C")`.
+///
+/// Distinct from the fluent `Contract` builder (in `fluent.rs`): this
+/// type is the read-only event payload; the fluent builder is what
+/// users instantiate via `Contract.stock("AAPL")` / `Contract.option(...)`.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
-pub(crate) struct Contract {
+pub(crate) struct ContractRef {
 #[pyo3(get)] pub symbol: String,
 #[pyo3(get)] pub sec_type: String,
 #[pyo3(get)] pub expiration: Option<i32>,
@@ -22,15 +26,15 @@ pub(crate) struct Contract {
 #[pyo3(get)] pub strike: Option<i32>,
 }
 #[pymethods]
-impl Contract {
+impl ContractRef {
 fn __repr__(&self) -> String {
 format!(
-"Contract(symbol={:?}, sec_type={:?}, expiration={:?}, right={:?}, strike_dollars={:?})",
+"ContractRef(symbol={:?}, sec_type={:?}, expiration={:?}, right={:?}, strike_dollars={:?})",
 self.symbol, self.sec_type, self.expiration, self.right, self.strike_dollars
 )
 }
 }
-impl Contract {
+impl ContractRef {
 /// Build from the core `thetadatadx::fpss::protocol::Contract` value
 /// carried by each `BufferedEvent::*` Data arm. `sec_type` is the
 /// symbolic uppercase name (`"STOCK"` / `"OPTION"` / `"INDEX"` /
@@ -64,7 +68,7 @@ impl Connected {
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct ContractAssigned {
     #[pyo3(get)] pub id: i32,
-    #[pyo3(get)] pub contract: Py<Contract>,
+    #[pyo3(get)] pub contract: Py<ContractRef>,
 }
 #[pymethods]
 impl ContractAssigned {
@@ -160,7 +164,7 @@ impl MarketOpen {
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct Ohlcvc {
-    #[pyo3(get)] pub contract: Py<Contract>,
+    #[pyo3(get)] pub contract: Py<ContractRef>,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub open: f64,
     #[pyo3(get)] pub high: f64,
@@ -185,7 +189,7 @@ impl Ohlcvc {
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct OpenInterest {
-    #[pyo3(get)] pub contract: Py<Contract>,
+    #[pyo3(get)] pub contract: Py<ContractRef>,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub open_interest: i32,
     #[pyo3(get)] pub date: i32,
@@ -219,7 +223,7 @@ impl Ping {
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct Quote {
-    #[pyo3(get)] pub contract: Py<Contract>,
+    #[pyo3(get)] pub contract: Py<ContractRef>,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub bid_size: i32,
     #[pyo3(get)] pub bid_exchange: i32,
@@ -341,7 +345,7 @@ impl ServerError {
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 pub(crate) struct Trade {
-    #[pyo3(get)] pub contract: Py<Contract>,
+    #[pyo3(get)] pub contract: Py<ContractRef>,
     #[pyo3(get)] pub ms_of_day: i32,
     #[pyo3(get)] pub sequence: i32,
     #[pyo3(get)] pub ext_condition1: i32,
@@ -409,7 +413,7 @@ pub(crate) fn buffered_event_to_typed(
             id,
             contract,
         } => {
-            let contract_py = Py::new(py, Contract::from_core(contract))?;
+            let contract_py = Py::new(py, ContractRef::from_core(contract))?;
             Py::new(
                 py,
                 ContractAssigned {
@@ -462,7 +466,7 @@ pub(crate) fn buffered_event_to_typed(
             date,
             received_at_ns,
         } => {
-            let contract_py = Py::new(py, Contract::from_core(contract))?;
+            let contract_py = Py::new(py, ContractRef::from_core(contract))?;
             Py::new(
                 py,
                 Ohlcvc {
@@ -487,7 +491,7 @@ pub(crate) fn buffered_event_to_typed(
             date,
             received_at_ns,
         } => {
-            let contract_py = Py::new(py, Contract::from_core(contract))?;
+            let contract_py = Py::new(py, ContractRef::from_core(contract))?;
             Py::new(
                 py,
                 OpenInterest {
@@ -523,7 +527,7 @@ pub(crate) fn buffered_event_to_typed(
             date,
             received_at_ns,
         } => {
-            let contract_py = Py::new(py, Contract::from_core(contract))?;
+            let contract_py = Py::new(py, ContractRef::from_core(contract))?;
             Py::new(
                 py,
                 Quote {
@@ -601,7 +605,7 @@ pub(crate) fn buffered_event_to_typed(
             date,
             received_at_ns,
         } => {
-            let contract_py = Py::new(py, Contract::from_core(contract))?;
+            let contract_py = Py::new(py, ContractRef::from_core(contract))?;
             Py::new(
                 py,
                 Trade {
@@ -643,7 +647,7 @@ pub(crate) fn buffered_event_to_typed(
 }
 
 pub(crate) fn register_fpss_event_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Contract>()?;
+    m.add_class::<ContractRef>()?;
     m.add_class::<Connected>()?;
     m.add_class::<ContractAssigned>()?;
     m.add_class::<Disconnected>()?;

--- a/sdks/python/tests/test_fluent_contract_example.py
+++ b/sdks/python/tests/test_fluent_contract_example.py
@@ -1,0 +1,88 @@
+"""Regression test for the v10.0.0 fluent `Contract` builder (#557).
+
+Asserts that the example documented in `fluent.rs:7-10`:
+
+    from thetadatadx import Contract, SecType
+
+    stock  = Contract.stock("AAPL")
+    option = Contract.option("SPY", expiration="20260620", strike="550", right="C")
+
+actually runs from a clean `import thetadatadx`. Prior to the
+`Contract` → `ContractRef` rename on the FPSS-event-payload side, the
+fluent builder was silently shadowed by the event class because both
+pyclasses registered under the same Python name, which is
+last-write-wins in pyo3.
+
+If this test fails after a future codegen change, run
+`cargo run -p thetadatadx --bin generate_sdk_surfaces --features config-file`
+and rebuild the wheel (`maturin develop` from `sdks/python`).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def thetadatadx_mod():
+    """The compiled thetadatadx module — must be importable for the test
+    to mean anything."""
+    return importlib.import_module("thetadatadx")
+
+
+def test_contract_stock_factory(thetadatadx_mod) -> None:
+    """`Contract.stock("AAPL")` returns a fluent builder, not the event
+    payload."""
+    contract = thetadatadx_mod.Contract.stock("AAPL")
+    # The fluent builder lowers `.quote()` to a Subscription; the event
+    # payload (now `ContractRef`) has no such method.
+    sub = contract.quote()
+    assert type(sub).__name__ == "Subscription"
+
+
+def test_contract_option_factory(thetadatadx_mod) -> None:
+    """`Contract.option(...)` returns a fluent builder with `.trade()`."""
+    option = thetadatadx_mod.Contract.option(
+        "SPY",
+        expiration="20260620",
+        strike="550",
+        right="C",
+    )
+    sub = option.trade()
+    assert type(sub).__name__ == "Subscription"
+
+
+def test_sec_type_full_trades(thetadatadx_mod) -> None:
+    """`SecType.OPTION.full_trades()` returns a full-stream Subscription."""
+    sub = thetadatadx_mod.SecType.OPTION.full_trades()
+    assert type(sub).__name__ == "Subscription"
+
+
+def test_contract_class_is_fluent_builder(thetadatadx_mod) -> None:
+    """`thetadatadx.Contract` must be the fluent builder, NOT the event
+    payload. The event payload now lives at `thetadatadx.ContractRef`."""
+    cls = thetadatadx_mod.Contract
+    # The fluent builder has `stock`, `option`, `index`, `quote`, `trade`,
+    # `open_interest` — none of which exist on the event-payload struct.
+    for method in ("stock", "option", "index", "quote", "trade", "open_interest"):
+        assert hasattr(cls, method), (
+            f"thetadatadx.Contract is missing fluent method {method!r}; "
+            f"is the event payload shadowing the fluent builder again? "
+            f"See #557."
+        )
+
+
+def test_contract_ref_is_event_payload(thetadatadx_mod) -> None:
+    """`thetadatadx.ContractRef` exists and carries the read-only event
+    fields."""
+    ref = thetadatadx_mod.ContractRef
+    # Read-only event-payload fields surfaced on every FPSS data event.
+    for attr in ("symbol", "sec_type", "expiration", "right", "strike_dollars", "strike"):
+        assert hasattr(ref, attr), f"thetadatadx.ContractRef missing field {attr!r}"
+    # The event payload has no factory methods.
+    assert not hasattr(ref, "stock"), (
+        "thetadatadx.ContractRef should not carry fluent factory methods; "
+        "those live on `Contract`."
+    )

--- a/sdks/python/tests/test_fpss_control_variants.py
+++ b/sdks/python/tests/test_fpss_control_variants.py
@@ -137,8 +137,15 @@ def test_class_identity_stable(thetadatadx_mod):
 
 
 def test_data_classes_still_exported(thetadatadx_mod):
-    """Sanity check: typed data classes survive the schema rewrite."""
-    for variant in ("Quote", "Trade", "Ohlcvc", "OpenInterest", "Contract"):
+    """Sanity check: typed data classes survive the schema rewrite.
+
+    `ContractRef` is the FPSS-event-payload identifier — read-only fields
+    surfaced as `event.contract.symbol` / `event.contract.strike`. It is
+    distinct from the fluent `Contract` builder (which lives at
+    `thetadatadx.Contract` and exposes `.stock()` / `.option()` factory
+    methods); see #557 for the collision-rename background.
+    """
+    for variant in ("Quote", "Trade", "Ohlcvc", "OpenInterest", "ContractRef"):
         cls = getattr(thetadatadx_mod, variant, None)
         assert cls is not None, f"thetadatadx.{variant} missing"
         assert cls.__name__ == variant

--- a/sdks/python/tests/test_no_pyclass_name_collisions.py
+++ b/sdks/python/tests/test_no_pyclass_name_collisions.py
@@ -1,0 +1,88 @@
+"""Regression guard for the v10.0.0 `Contract` collision (#557).
+
+Two pyclasses registered under the same Python name silently shadow each
+other — `m.add_class` is last-write-wins, so whichever helper runs second
+in `lib.rs` wins, and the user-facing surface loses whatever methods the
+earlier registration carried (factory methods, getters, etc.).
+
+This test scans every `#[pyclass]` in the Python SDK's Rust sources and
+asserts no two structs map to the same Python-facing name. The mapping
+mirrors how pyo3 resolves the public name:
+    1. If the attribute carries `name = "..."`, that wins.
+    2. Otherwise the bare struct identifier becomes the Python name,
+       with the leading `Py` prefix stripped (project convention used by
+       `PyContract`, `PySubscription`, etc.).
+
+If this fires, add an explicit `name = "..."` to the offending pyclass
+to disambiguate. Do NOT silence the test — name collisions break the
+fluent surface even when the build is green.
+"""
+
+from __future__ import annotations
+
+import collections
+import pathlib
+import re
+
+# `#[pyclass(...)] <attrs> pub(crate)? struct <Name>`
+# The attribute block can contain commas, quoted strings, balanced brackets,
+# and span multiple lines — we tolerate all of that and pull out the
+# optional `name = "..."` override plus the struct identifier.
+PYCLASS_RE = re.compile(
+    r"#\[pyclass(?:\(([^)]*)\))?\][^{]*?"
+    r"(?:pub(?:\(crate\))?\s+)?struct\s+(\w+)",
+    re.MULTILINE | re.DOTALL,
+)
+NAME_ATTR_RE = re.compile(r'name\s*=\s*"([^"]+)"')
+
+SRC_DIR = pathlib.Path(__file__).resolve().parents[1] / "src"
+
+
+def _python_name(attrs: str | None, struct_name: str) -> str:
+    """Resolve the Python-facing class name from the `#[pyclass]` attrs."""
+    if attrs:
+        match = NAME_ATTR_RE.search(attrs)
+        if match:
+            return match.group(1)
+    # Convention: bare struct named `PyFoo` → Python sees it as `Foo`.
+    return struct_name.removeprefix("Py")
+
+
+def _collect_python_names() -> dict[str, list[str]]:
+    seen: dict[str, list[str]] = collections.defaultdict(list)
+    for rust_src in SRC_DIR.rglob("*.rs"):
+        text = rust_src.read_text(encoding="utf-8")
+        for match in PYCLASS_RE.finditer(text):
+            attrs, struct_name = match.group(1), match.group(2)
+            py_name = _python_name(attrs, struct_name)
+            rel = rust_src.relative_to(SRC_DIR)
+            seen[py_name].append(f"{rel}::{struct_name}")
+    return seen
+
+
+def test_no_pyclass_name_collisions() -> None:
+    names = _collect_python_names()
+    collisions = {k: v for k, v in names.items() if len(v) > 1}
+    assert not collisions, (
+        "Multiple #[pyclass] structs register the same Python name. "
+        "pyo3's m.add_class is last-write-wins, so the second registration "
+        "silently shadows the first — see v10.0.0 #557 for the prior "
+        "Contract-collision incident. Fix by adding an explicit "
+        '`name = "..."` attribute to disambiguate.\n'
+        f"Collisions: {collisions}"
+    )
+
+
+def test_scanner_finds_expected_pyclasses() -> None:
+    """Sanity check: the regex actually matches the pyclasses we know
+    are there. Without this, a future regex regression could pass the
+    collision check by finding *nothing*."""
+    names = _collect_python_names()
+    # `Contract` (fluent builder) and `ContractRef` (event payload) — the
+    # two that motivated this guard. Plus a couple of generic SDK types
+    # to anchor the scanner against accidental zero-match silence.
+    for expected in ("Contract", "ContractRef", "Credentials", "Subscription"):
+        assert expected in names, (
+            f"scanner failed to locate #[pyclass] for {expected!r}; "
+            "regex regression?"
+        )

--- a/sdks/python/tests/test_standalone_clients.py
+++ b/sdks/python/tests/test_standalone_clients.py
@@ -154,12 +154,11 @@ def test_fpss_client_blocks_subscribe_before_start() -> None:
     """Subscribing on an `FpssClient` before `start_streaming*` raises
     `RuntimeError` -- the FPSS TLS connection is not open yet.
 
-    The `SecType.OPTION.full_trades()` factory is used here instead of
-    `Contract.stock(...).quote()` because the typed FPSS event
-    `Contract` class shares the `"Contract"` pyclass name with the
-    fluent builder in the current `m.add_class` registration order; the
-    full-stream surface side-steps the collision while still
-    exercising the polymorphic `subscribe(Subscription)` dispatch.
+    The `SecType.OPTION.full_trades()` factory exercises the polymorphic
+    `subscribe(Subscription)` dispatch via the full-stream surface. The
+    per-contract path (`Contract.stock(...).quote()`) is covered by
+    `test_fluent_contract_example.py`; this test focuses on the
+    pre-start guard.
     """
     mod = _import_module()
     creds = mod.Credentials("user@example.com", "pw")
@@ -344,10 +343,7 @@ def test_fpss_streaming_iter_smoke() -> None:
     with fpss.streaming_iter() as session:
         # `SecType.OPTION.full_trades()` exercises the polymorphic
         # `subscribe(Subscription)` dispatch via the full-stream
-        # surface, side-stepping the `Contract` pyclass-name collision
-        # between the fluent builder and the FPSS event read-side
-        # class (the latter wins the current `m.add_class` registration
-        # order). Live smoke value: confirms the FPSS handshake,
+        # surface. Live smoke value: confirms the FPSS handshake,
         # subscription dispatch, and pull-iter drain all wire through.
         fpss.subscribe(mod.SecType.OPTION.full_trades())
 
@@ -440,9 +436,9 @@ def test_fpss_reconnect_restores_subscriptions() -> None:
 
     fpss.start_streaming(on_event)
     try:
-        # Full-stream subscription side-steps the Contract pyclass
-        # name collision (see test_fpss_client_blocks_subscribe_before_start)
-        # while still exercising the polymorphic dispatch path.
+        # Full-stream subscription exercises the polymorphic dispatch
+        # path; per-contract dispatch is covered separately in
+        # `test_fluent_contract_example.py`.
         full_sub = mod.SecType.OPTION.full_trades()
         fpss.subscribe(full_sub)
 


### PR DESCRIPTION
## Summary

- Two pyclasses both registered as Python name `Contract` — the fluent builder in `sdks/python/src/fluent.rs` and the FPSS event payload generated by `build_support_bin/fpss_events/python.rs`. pyo3's `m.add_class` is last-write-wins, so the event payload shadowed the builder and `from thetadatadx import Contract` returned a read-only object with no `.stock()` / `.option()` / `.quote()` factory methods.
- Rename the event-side pyclass to `ContractRef` in the codegen, regenerate `sdks/python/src/_generated/fpss_event_classes.rs`, update `__init__.pyi`, and align with the TypeScript binding which already splits these names at `sdks/typescript/src/fluent.rs:97`.
- Add two regression guards: a static scanner that fails when any two `#[pyclass]` declarations resolve to the same Python name, and a runtime test that asserts the documented `Contract.stock("AAPL").quote()` example actually runs.

Closes #557. Supersedes #542 (which misdiagnosed this as a registration gap).

## Breaking change scope

Narrow. Anything that did `isinstance(event.contract, Contract)` against the event payload must become `isinstance(event.contract, ContractRef)`. User code that imported the fluent `Contract` and chained `.stock()` / `.option()` was already broken pre-fix (that's the bug being fixed), so for that path this is net-positive.

## Verification

Clean venv + release wheel:

```
$ python -c "
import thetadatadx as m
sub = m.Contract.stock('AAPL').quote()
print(type(sub).__name__)             # Subscription
opt = m.Contract.option('SPY', expiration='20260620', strike='550', right='C')
print(type(opt.trade()).__name__)     # Subscription
print('ContractRef' in dir(m))        # True
"
Subscription
Subscription
True
```

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy -- -D warnings` clean for the out-of-workspace `sdks/python` crate
- [x] `maturin develop` + `pytest` — 79 passed, 20 skipped (live-credentials), 1 pre-existing failure on `test_dataframe_arrow.py::test_option_contract_right_is_string_in_arrow_schema` confirmed present on `main` and unrelated to this change
- [x] `maturin build --release` produces a wheel that, installed into a fresh venv, satisfies the documented `Contract.stock("AAPL").quote()` example