### PR TITLE
fix: address 2 SERIOUS + 3 MINOR findings from final audit (close v10.x audit cycle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,10 +92,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `streaming_async_batches(max_queue_depth=, backpressure=)`.
 - `ThetaDataDxClient.streaming_async_batches()` /
   `FpssClient.streaming_async_batches()` (#564). Arrow IPC zero-copy
-  surface: each `async for batch in session` yields a `pyarrow.Table`
-  whose column buffers alias the Disruptor consumer's pre-grouped
-  Arrow `RecordBatch` — no per-event Python object construction on
-  the reader path. Same self-pipe wake-FD signalling as
+  surface: each `async for batch in session` yields a
+  `pyarrow.RecordBatch` whose column buffers alias the Disruptor
+  consumer's pre-grouped Arrow `RecordBatch` — no per-event Python
+  object construction on the reader path. Same self-pipe wake-FD
+  signalling as
   `streaming_async()`; the column-shape SSOT (`tick_schema.toml`)
   guarantees schema parity with the per-event variant.
 - `queue_depth()` and `dropped_event_count()` getters on

--- a/crates/thetadatadx/src/auth/session.rs
+++ b/crates/thetadatadx/src/auth/session.rs
@@ -177,6 +177,18 @@ impl SessionToken {
     pub async fn current_uuid(&self) -> String {
         self.state.read().await.uuid.clone()
     }
+
+    /// Test-only: bump the in-memory token version and swap the UUID
+    /// without going through Nexus. Lets retry / refresh tests
+    /// simulate "another task already refreshed past stale" so a
+    /// subsequent `refresh(&stale)` call takes the fast-path return
+    /// without an HTTP round-trip to an unreachable URL.
+    #[cfg(test)]
+    pub(crate) async fn bump_for_test(&self, new_uuid: &str) {
+        let mut guard = self.state.write().await;
+        guard.uuid = new_uuid.to_string();
+        guard.version = guard.version.wrapping_add(1);
+    }
 }
 
 impl std::fmt::Debug for SessionToken {

--- a/crates/thetadatadx/src/grpc/endpoints.rs
+++ b/crates/thetadatadx/src/grpc/endpoints.rs
@@ -253,15 +253,13 @@ pub mod bench_support {
 
 /// Lift a [`ChannelError`] into the crate's umbrella [`Error`] type.
 ///
-/// Wire-level failures (`Rpc`, `Codec`, `H2Stream`, ...) flow through
-/// [`Error::config_internal`] with the underlying message preserved in
-/// the carried `String`. Callers that need structured discrimination
-/// match on the [`ChannelError`] directly via [`Channel::server_streaming`].
+/// Delegates to the canonical `From<ChannelError> for Error` impl in
+/// [`crate::error`], which preserves the structured taxonomy:
+/// `Rpc` becomes `Error::Grpc { kind: GrpcStatusKind::*, .. }`,
+/// `DeadlineExceeded` becomes `Error::Timeout`, and every transport
+/// fault folds into `Error::Transport { kind: TransportErrorKind::*, .. }`.
+/// The retry classifier in [`crate::mdds::macros`] then dispatches on
+/// the typed `kind` rather than parsing `Display` strings.
 fn map_channel_error(err: ChannelError) -> Error {
-    match err {
-        ChannelError::Rpc { status } => Error::config_internal(format!(
-            "in-house grpc rpc returned non-ok status: {status}"
-        )),
-        other => Error::config_internal(format!("in-house grpc transport: {other}")),
-    }
+    Error::from(err)
 }

--- a/crates/thetadatadx/src/mdds/client.rs
+++ b/crates/thetadatadx/src/mdds/client.rs
@@ -326,16 +326,25 @@ async fn open_channel_pool(
 ) -> Result<ChannelPool, Error> {
     let connect_timeout = Duration::from_secs(config.mdds.connect_timeout_secs);
     let max_message_size = config.mdds.max_message_size;
+    // `rustls::ClientConfig` is designed for `Arc` sharing across
+    // connections — the root store + ALPN list are immutable after
+    // construction. Build once and clone the `Arc` into every
+    // channel in the pool rather than rebuilding the webpki roots
+    // and the cipher-suite tables on each iteration.
+    let tls_config = if tls {
+        Some(build_rustls_config()?)
+    } else {
+        None
+    };
     let mut channels = Vec::with_capacity(pool_size);
     for idx in 0..pool_size {
-        let channel = if tls {
-            let tls_config = build_rustls_config()?;
+        let channel = if let Some(tls_config) = tls_config.as_ref() {
             tokio::time::timeout(
                 connect_timeout,
                 Channel::connect_tls_with_max_message_size(
                     host,
                     port,
-                    tls_config,
+                    tls_config.clone(),
                     max_message_size,
                 ),
             )

--- a/crates/thetadatadx/src/mdds/macros.rs
+++ b/crates/thetadatadx/src/mdds/macros.rs
@@ -282,54 +282,68 @@ macro_rules! list_endpoint {
                 let policy = self.config().retry;
                 let budget = policy.max_attempts.max(1);
                 let mut refreshed_already = false;
-                let mut last_err: Option<Error> = None;
-                let table: proto::DataTable = 'retry: loop {
-                    for attempt in 1..=budget {
-                        let snap = self.session().snapshot().await;
-                        let qi = self.build_query_info(snap.uuid.clone());
-                        let request = proto::$req {
-                            query_info: Some(qi),
-                            params: Some(proto::$query { $($field : $val),* }),
-                        };
-                        let attempt_result: Result<proto::DataTable, Error> = async {
-                            // Bind the lease to a local so it lives
-                            // across the await — the pre-dispatch
-                            // reservation must outlive `server_streaming`
-                            // for the picker fix (Finding 4) to count
-                            // pending opens correctly under burst
-                            // contention. Deref coercion from
-                            // `&ChannelLease` to `&Channel` satisfies
-                            // the generated stub signature.
-                            let lease = self.channel();
-                            let stream = $crate::proto::beta_theta_terminal::$grpc(
-                                &lease,
-                                request,
-                            )
-                            .await
-                            .map_err(|e| -> Error { e.into() })?;
-                            self.collect_stream(stream).await
-                        }
-                        .await;
-                        match $crate::mdds::macros::classify_attempt(
-                            self.session(),
-                            &snap,
-                            &mut refreshed_already,
-                            stringify!($name),
-                            attempt_result,
-                        ).await {
-                            $crate::mdds::macros::AttemptStep::Ok(t) => break 'retry t,
-                            $crate::mdds::macros::AttemptStep::Terminal(err) => return Err::<Vec<String>, Error>(err),
-                            $crate::mdds::macros::AttemptStep::Retry(err) => {
-                                if attempt == budget {
-                                    last_err = Some(err);
-                                    break;
-                                }
-                                $crate::mdds::macros::sleep_for_retry(&policy, attempt, stringify!($name), &err).await;
-                                last_err = Some(err);
+                // Auth recovery (session refresh) is a documented
+                // contract distinct from transient-retry policy: even
+                // with `RetryPolicy::disabled()` (budget=1), a caller
+                // expects refresh + one re-attempt on `Unauthenticated`.
+                // `refresh_retry_used` tracks the one-shot
+                // post-refresh re-attempt independently of the
+                // transient-retry budget.
+                let mut refresh_retry_used = false;
+                let mut attempt: u32 = 1;
+                let table: proto::DataTable = loop {
+                    let snap = self.session().snapshot().await;
+                    let qi = self.build_query_info(snap.uuid.clone());
+                    let request = proto::$req {
+                        query_info: Some(qi),
+                        params: Some(proto::$query { $($field : $val),* }),
+                    };
+                    let attempt_result: Result<proto::DataTable, Error> = async {
+                        // Bind the lease to a local so it lives
+                        // across the await — the pre-dispatch
+                        // reservation must outlive `server_streaming`
+                        // for the picker fix (Finding 4) to count
+                        // pending opens correctly under burst
+                        // contention. Deref coercion from
+                        // `&ChannelLease` to `&Channel` satisfies
+                        // the generated stub signature.
+                        let lease = self.channel();
+                        let stream = $crate::proto::beta_theta_terminal::$grpc(
+                            &lease,
+                            request,
+                        )
+                        .await
+                        .map_err(|e| -> Error { e.into() })?;
+                        self.collect_stream(stream).await
+                    }
+                    .await;
+                    let refreshed_before = refreshed_already;
+                    match $crate::mdds::macros::classify_attempt(
+                        self.session(),
+                        &snap,
+                        &mut refreshed_already,
+                        stringify!($name),
+                        attempt_result,
+                    ).await {
+                        $crate::mdds::macros::AttemptStep::Ok(t) => break t,
+                        $crate::mdds::macros::AttemptStep::Terminal(err) => return Err::<Vec<String>, Error>(err),
+                        $crate::mdds::macros::AttemptStep::Retry(err) => {
+                            // Refresh just flipped this iteration?
+                            // Grant one post-refresh attempt outside
+                            // the transient-retry budget.
+                            let refresh_just_now = !refreshed_before && refreshed_already;
+                            let can_post_refresh = refresh_just_now && !refresh_retry_used;
+                            if attempt >= budget && !can_post_refresh {
+                                return Err::<Vec<String>, Error>(err);
                             }
+                            if can_post_refresh {
+                                refresh_retry_used = true;
+                            } else {
+                                $crate::mdds::macros::sleep_for_retry(&policy, attempt, stringify!($name), &err).await;
+                            }
+                            attempt += 1;
                         }
                     }
-                    return Err(last_err.unwrap_or_else(|| Error::config_internal("retry loop exited without result")));
                 };
                 metrics::histogram!("thetadatadx.grpc.latency_ms", "endpoint" => stringify!($name))
                     .record(_metrics_start.elapsed().as_secs_f64() * 1_000.0);
@@ -472,8 +486,14 @@ macro_rules! parsed_endpoint {
                     let policy = client.config().retry;
                     let budget = policy.max_attempts.max(1);
                     let mut refreshed_already = false;
-                    let mut last_err: Option<Error> = None;
-                    for attempt in 1..=budget {
+                    // Auth recovery is independent of transient-retry
+                    // budget: `RetryPolicy::disabled()` (budget=1) on
+                    // a streaming call still gets refresh + restart
+                    // on `Unauthenticated`. `refresh_retry_used`
+                    // gates the one-shot post-refresh re-attempt.
+                    let mut refresh_retry_used = false;
+                    let mut attempt: u32 = 1;
+                    loop {
                         let snap = client.session().snapshot().await;
                         let qi = client.build_query_info(snap.uuid.clone());
                         let request = proto::$req {
@@ -529,20 +549,31 @@ macro_rules! parsed_endpoint {
                                 return Err::<(), Error>(err);
                             }
                             $crate::mdds::macros::StreamingAttemptOutcome::Refresh(err) => {
+                                // Refresh succeeded — restart from
+                                // chunk zero. Grant the post-refresh
+                                // attempt even if `attempt >= budget`
+                                // (auth-recovery contract).
+                                if refresh_retry_used {
+                                    // Should never reach here: the
+                                    // classifier only emits Refresh
+                                    // once per call (refresh budget
+                                    // = 1). Defensive — surface the
+                                    // error rather than spin.
+                                    return Err::<(), Error>(err);
+                                }
+                                refresh_retry_used = true;
                                 tracing::warn!(endpoint = stringify!($name), attempt, error = %err, "session refresh during stream — restarting from chunk zero");
-                                last_err = Some(err);
+                                attempt += 1;
                             }
                             $crate::mdds::macros::StreamingAttemptOutcome::Backoff(err) => {
-                                if attempt == budget {
-                                    last_err = Some(err);
-                                    break;
+                                if attempt >= budget {
+                                    return Err::<(), Error>(err);
                                 }
                                 $crate::mdds::macros::sleep_for_retry(&policy, attempt, stringify!($name), &err).await;
-                                last_err = Some(err);
+                                attempt += 1;
                             }
                         }
                     }
-                    Err::<(), Error>(last_err.unwrap_or_else(|| Error::config_internal("streaming retry loop exited without result")))
                 }).await
             }
 
@@ -571,53 +602,63 @@ macro_rules! parsed_endpoint {
                         let policy = client.config().retry;
                         let budget = policy.max_attempts.max(1);
                         let mut refreshed_already = false;
-                        let mut last_err: Option<Error> = None;
-                        let table: proto::DataTable = 'retry: loop {
-                            for attempt in 1..=budget {
-                                let snap = client.session().snapshot().await;
-                                let qi = client.build_query_info(snap.uuid.clone());
-                                let request = proto::$req {
-                                    query_info: Some(qi),
-                                    params: Some(proto::$query { $($field : $val),* }),
-                                };
-                                let attempt_result: Result<proto::DataTable, Error> = async {
-                                    // Bind the lease to a local so it
-                                    // lives across the await — see the
-                                    // sibling macro arm above for the
-                                    // full rationale. Deref coercion
-                                    // from `&ChannelLease` to `&Channel`
-                                    // satisfies the generated stub
-                                    // signature.
-                                    let lease = client.channel();
-                                    let stream = $crate::proto::beta_theta_terminal::$grpc(
-                                        &lease,
-                                        request,
-                                    )
-                                    .await
-                                    .map_err(|e| -> Error { e.into() })?;
-                                    client.collect_stream(stream).await
-                                }
-                                .await;
-                                match $crate::mdds::macros::classify_attempt(
-                                    client.session(),
-                                    &snap,
-                                    &mut refreshed_already,
-                                    stringify!($name),
-                                    attempt_result,
-                                ).await {
-                                    $crate::mdds::macros::AttemptStep::Ok(t) => break 'retry t,
-                                    $crate::mdds::macros::AttemptStep::Terminal(err) => return Err::<$ret, Error>(err),
-                                    $crate::mdds::macros::AttemptStep::Retry(err) => {
-                                        if attempt == budget {
-                                            last_err = Some(err);
-                                            break;
-                                        }
-                                        $crate::mdds::macros::sleep_for_retry(&policy, attempt, stringify!($name), &err).await;
-                                        last_err = Some(err);
+                        // See list_endpoint macro arm: refresh budget
+                        // is auth-recovery contract, distinct from
+                        // transient-retry policy. With
+                        // `RetryPolicy::disabled()` (budget=1) a
+                        // `NeedsRefresh` still gets refresh + one
+                        // retry.
+                        let mut refresh_retry_used = false;
+                        let mut attempt: u32 = 1;
+                        let table: proto::DataTable = loop {
+                            let snap = client.session().snapshot().await;
+                            let qi = client.build_query_info(snap.uuid.clone());
+                            let request = proto::$req {
+                                query_info: Some(qi),
+                                params: Some(proto::$query { $($field : $val),* }),
+                            };
+                            let attempt_result: Result<proto::DataTable, Error> = async {
+                                // Bind the lease to a local so it
+                                // lives across the await — see the
+                                // sibling macro arm above for the
+                                // full rationale. Deref coercion
+                                // from `&ChannelLease` to `&Channel`
+                                // satisfies the generated stub
+                                // signature.
+                                let lease = client.channel();
+                                let stream = $crate::proto::beta_theta_terminal::$grpc(
+                                    &lease,
+                                    request,
+                                )
+                                .await
+                                .map_err(|e| -> Error { e.into() })?;
+                                client.collect_stream(stream).await
+                            }
+                            .await;
+                            let refreshed_before = refreshed_already;
+                            match $crate::mdds::macros::classify_attempt(
+                                client.session(),
+                                &snap,
+                                &mut refreshed_already,
+                                stringify!($name),
+                                attempt_result,
+                            ).await {
+                                $crate::mdds::macros::AttemptStep::Ok(t) => break t,
+                                $crate::mdds::macros::AttemptStep::Terminal(err) => return Err::<$ret, Error>(err),
+                                $crate::mdds::macros::AttemptStep::Retry(err) => {
+                                    let refresh_just_now = !refreshed_before && refreshed_already;
+                                    let can_post_refresh = refresh_just_now && !refresh_retry_used;
+                                    if attempt >= budget && !can_post_refresh {
+                                        return Err::<$ret, Error>(err);
                                     }
+                                    if can_post_refresh {
+                                        refresh_retry_used = true;
+                                    } else {
+                                        $crate::mdds::macros::sleep_for_retry(&policy, attempt, stringify!($name), &err).await;
+                                    }
+                                    attempt += 1;
                                 }
                             }
-                            return Err(last_err.unwrap_or_else(|| Error::config_internal("retry loop exited without result")));
                         };
                         metrics::histogram!("thetadatadx.grpc.latency_ms", "endpoint" => stringify!($name))
                             .record(_metrics_start.elapsed().as_secs_f64() * 1_000.0);
@@ -957,5 +998,322 @@ mod streaming_attempt_tests {
         .await;
         assert!(matches!(out, StreamingAttemptOutcome::Terminal(_)));
         assert!(!refreshed, "decode terminal must not touch refresh budget");
+    }
+}
+
+#[cfg(test)]
+mod refresh_retry_disabled_tests {
+    //! Regression tests for the auth-recovery contract: when
+    //! `RetryPolicy::disabled()` is set (`max_attempts = 1`), a
+    //! `NeedsRefresh` outcome must still trigger session refresh +
+    //! one post-refresh re-attempt. Auth recovery is a separate
+    //! contract from transient-retry policy.
+    //!
+    //! These tests replay the exact control-flow algorithm embedded
+    //! in the `list_endpoint!` / `parsed_endpoint!` macro arms with
+    //! a queue of canned attempt outcomes. The replay is faithful to
+    //! the macro logic: same `refreshed_already` / `refresh_retry_used`
+    //! / `attempt` state machine, same `classify_attempt` invocation,
+    //! same break / retry decisions.
+    //!
+    //! A `SessionToken` is constructed pointing at an unreachable
+    //! Nexus URL; the test pre-bumps the token version via
+    //! `bump_for_test` so `session.refresh(&stale)` short-circuits on
+    //! the dedup fast-path and returns Ok without HTTP.
+    use super::{
+        classify_attempt, classify_streaming_attempt, AttemptStep, StreamingAttemptOutcome,
+    };
+    use crate::auth::session::{SessionSnapshot, SessionToken};
+    use crate::auth::Credentials;
+    use crate::config::RetryPolicy;
+    use crate::error::{Error, GrpcStatusKind};
+
+    fn fake_token(uuid: &str) -> SessionToken {
+        SessionToken::new(
+            uuid.to_string(),
+            "https://nexus.example.invalid/auth".to_string(),
+            Credentials::new("user@example.com", "hunter2"),
+        )
+    }
+
+    fn grpc(kind: GrpcStatusKind) -> Error {
+        Error::Grpc {
+            kind,
+            message: String::new(),
+        }
+    }
+
+    /// Replay the unary macro arm's retry-loop algorithm against a
+    /// queue of canned per-attempt outcomes. Returns the final result
+    /// plus the number of attempts the loop made — the regression
+    /// asserts that a `NeedsRefresh` outcome triggers a second
+    /// attempt even when `RetryPolicy::disabled()` would normally
+    /// permit only one.
+    async fn replay_unary_macro_loop(
+        session: &SessionToken,
+        snap: &SessionSnapshot,
+        policy: &RetryPolicy,
+        mut outcomes: Vec<Result<&'static str, Error>>,
+    ) -> (Result<&'static str, Error>, u32) {
+        outcomes.reverse(); // pop from end = FIFO
+        let budget = policy.max_attempts.max(1);
+        let mut refreshed_already = false;
+        let mut refresh_retry_used = false;
+        let mut attempt: u32 = 1;
+        let mut attempts_made: u32 = 0;
+        let result = loop {
+            attempts_made += 1;
+            let attempt_result = outcomes
+                .pop()
+                .expect("test fed fewer outcomes than the loop drove");
+            let refreshed_before = refreshed_already;
+            match classify_attempt(
+                session,
+                snap,
+                &mut refreshed_already,
+                "test_endpoint",
+                attempt_result,
+            )
+            .await
+            {
+                AttemptStep::Ok(t) => break Ok(t),
+                AttemptStep::Terminal(err) => break Err(err),
+                AttemptStep::Retry(err) => {
+                    let refresh_just_now = !refreshed_before && refreshed_already;
+                    let can_post_refresh = refresh_just_now && !refresh_retry_used;
+                    if attempt >= budget && !can_post_refresh {
+                        break Err(err);
+                    }
+                    if can_post_refresh {
+                        refresh_retry_used = true;
+                    }
+                    // Skip the backoff sleep in tests — the contract
+                    // we care about is loop-control, not wall-clock
+                    // delay.
+                    attempt += 1;
+                }
+            }
+        };
+        (result, attempts_made)
+    }
+
+    /// Replay the streaming macro arm's retry-loop algorithm.
+    async fn replay_streaming_macro_loop(
+        session: &SessionToken,
+        snap: &SessionSnapshot,
+        policy: &RetryPolicy,
+        mut outcomes: Vec<Result<(), Error>>,
+    ) -> (Result<(), Error>, u32) {
+        outcomes.reverse();
+        let budget = policy.max_attempts.max(1);
+        let mut refreshed_already = false;
+        let mut refresh_retry_used = false;
+        let mut attempt: u32 = 1;
+        let mut attempts_made: u32 = 0;
+        let result = loop {
+            attempts_made += 1;
+            let attempt_result = outcomes
+                .pop()
+                .expect("test fed fewer outcomes than the loop drove");
+            match classify_streaming_attempt(
+                session,
+                snap,
+                &mut refreshed_already,
+                "test_stream_endpoint",
+                attempt_result,
+            )
+            .await
+            {
+                StreamingAttemptOutcome::Done => break Ok(()),
+                StreamingAttemptOutcome::Terminal(err) => break Err(err),
+                StreamingAttemptOutcome::Refresh(err) => {
+                    if refresh_retry_used {
+                        break Err(err);
+                    }
+                    refresh_retry_used = true;
+                    attempt += 1;
+                }
+                StreamingAttemptOutcome::Backoff(err) => {
+                    if attempt >= budget {
+                        break Err(err);
+                    }
+                    attempt += 1;
+                }
+            }
+        };
+        (result, attempts_made)
+    }
+
+    #[tokio::test]
+    async fn disabled_policy_unary_refresh_then_retry_succeeds() {
+        // Setup: token at v0, pre-bump to v1 so refresh fast-paths
+        // without HTTP. First attempt returns NeedsRefresh; classify
+        // calls refresh (fast-path Ok, refreshed_already flips); the
+        // S2 fix grants ONE post-refresh attempt even though
+        // budget = 1. Second attempt returns Ok("payload").
+        let session = fake_token("v0");
+        let snap = session.snapshot().await;
+        session.bump_for_test("v1").await;
+        let policy = RetryPolicy::disabled();
+        assert_eq!(policy.max_attempts, 1, "preconditions: budget=1");
+
+        let outcomes: Vec<Result<&'static str, Error>> =
+            vec![Err(grpc(GrpcStatusKind::Unauthenticated)), Ok("payload")];
+        let (result, attempts) = replay_unary_macro_loop(&session, &snap, &policy, outcomes).await;
+
+        assert_eq!(result.expect("post-refresh retry must succeed"), "payload");
+        assert_eq!(
+            attempts, 2,
+            "loop must fire a second attempt after refresh even under RetryPolicy::disabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_policy_unary_refresh_then_terminal_surfaces_second_err() {
+        // After a successful refresh + retry, if the second attempt
+        // also fails terminally, surface that terminal error
+        // (NotFound here) — not a fabricated "retry exhausted"
+        // shape.
+        let session = fake_token("v0");
+        let snap = session.snapshot().await;
+        session.bump_for_test("v1").await;
+        let policy = RetryPolicy::disabled();
+
+        let outcomes: Vec<Result<&'static str, Error>> = vec![
+            Err(grpc(GrpcStatusKind::Unauthenticated)),
+            Err(grpc(GrpcStatusKind::NotFound)),
+        ];
+        let (result, attempts) = replay_unary_macro_loop(&session, &snap, &policy, outcomes).await;
+
+        let err = result.expect_err("second attempt failed terminally");
+        match err {
+            Error::Grpc {
+                kind: GrpcStatusKind::NotFound,
+                ..
+            } => {}
+            other => panic!("expected NotFound on second attempt, got {other:?}"),
+        }
+        assert_eq!(attempts, 2);
+    }
+
+    #[tokio::test]
+    async fn disabled_policy_unary_transient_does_not_get_extra_attempt() {
+        // Control case: a transient (Unavailable) under
+        // RetryPolicy::disabled() still surfaces after one attempt.
+        // The S2 fix targets refresh recovery specifically — it must
+        // NOT grant a free retry to bare transients.
+        let session = fake_token("v0");
+        let snap = session.snapshot().await;
+        let policy = RetryPolicy::disabled();
+
+        let outcomes: Vec<Result<&'static str, Error>> =
+            vec![Err(grpc(GrpcStatusKind::Unavailable))];
+        let (result, attempts) = replay_unary_macro_loop(&session, &snap, &policy, outcomes).await;
+
+        assert!(matches!(
+            result,
+            Err(Error::Grpc {
+                kind: GrpcStatusKind::Unavailable,
+                ..
+            })
+        ));
+        assert_eq!(
+            attempts, 1,
+            "disabled policy must NOT grant a free transient retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_policy_unary_only_one_post_refresh_attempt() {
+        // The refresh-recovery budget is one post-refresh attempt.
+        // If the post-refresh attempt also returns NeedsRefresh,
+        // classify_attempt surfaces it as Terminal (refreshed_already
+        // is true), and the loop ends without a third attempt.
+        let session = fake_token("v0");
+        let snap = session.snapshot().await;
+        session.bump_for_test("v1").await;
+        let policy = RetryPolicy::disabled();
+
+        let outcomes: Vec<Result<&'static str, Error>> = vec![
+            Err(grpc(GrpcStatusKind::Unauthenticated)),
+            Err(grpc(GrpcStatusKind::Unauthenticated)),
+        ];
+        let (result, attempts) = replay_unary_macro_loop(&session, &snap, &policy, outcomes).await;
+
+        assert!(matches!(
+            result,
+            Err(Error::Grpc {
+                kind: GrpcStatusKind::Unauthenticated,
+                ..
+            })
+        ));
+        assert_eq!(
+            attempts, 2,
+            "exactly one post-refresh attempt, then surface as terminal"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_policy_streaming_refresh_then_done_succeeds() {
+        // Streaming arm: same contract as unary. Disabled policy +
+        // mid-stream Unauthenticated must refresh + restart from
+        // chunk zero, and the restart must succeed (Done).
+        let session = fake_token("v0");
+        let snap = session.snapshot().await;
+        session.bump_for_test("v1").await;
+        let policy = RetryPolicy::disabled();
+
+        let outcomes: Vec<Result<(), Error>> =
+            vec![Err(grpc(GrpcStatusKind::Unauthenticated)), Ok(())];
+        let (result, attempts) =
+            replay_streaming_macro_loop(&session, &snap, &policy, outcomes).await;
+
+        result.expect("post-refresh stream must complete");
+        assert_eq!(attempts, 2);
+    }
+
+    #[tokio::test]
+    async fn disabled_policy_streaming_transient_no_extra_attempt() {
+        // Streaming arm: disabled policy + transient (Unavailable)
+        // must surface after the first attempt, no free retry.
+        let session = fake_token("v0");
+        let snap = session.snapshot().await;
+        let policy = RetryPolicy::disabled();
+
+        let outcomes: Vec<Result<(), Error>> = vec![Err(grpc(GrpcStatusKind::Unavailable))];
+        let (result, attempts) =
+            replay_streaming_macro_loop(&session, &snap, &policy, outcomes).await;
+
+        assert!(matches!(
+            result,
+            Err(Error::Grpc {
+                kind: GrpcStatusKind::Unavailable,
+                ..
+            })
+        ));
+        assert_eq!(attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn default_policy_unary_refresh_does_not_consume_transient_budget() {
+        // With max_attempts = 3, a NeedsRefresh on attempt 1 must
+        // grant the refresh-retry attempt without burning a transient
+        // budget slot. The post-refresh attempt succeeds → final
+        // attempts = 2, not 3.
+        let session = fake_token("v0");
+        let snap = session.snapshot().await;
+        session.bump_for_test("v1").await;
+        let policy = RetryPolicy {
+            initial_delay: std::time::Duration::ZERO,
+            max_delay: std::time::Duration::ZERO,
+            max_attempts: 3,
+            jitter: false,
+        };
+
+        let outcomes: Vec<Result<&'static str, Error>> =
+            vec![Err(grpc(GrpcStatusKind::Unauthenticated)), Ok("payload")];
+        let (result, attempts) = replay_unary_macro_loop(&session, &snap, &policy, outcomes).await;
+        assert_eq!(result.expect("must succeed"), "payload");
+        assert_eq!(attempts, 2);
     }
 }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -92,10 +92,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `streaming_async_batches(max_queue_depth=, backpressure=)`.
 - `ThetaDataDxClient.streaming_async_batches()` /
   `FpssClient.streaming_async_batches()` (#564). Arrow IPC zero-copy
-  surface: each `async for batch in session` yields a `pyarrow.Table`
-  whose column buffers alias the Disruptor consumer's pre-grouped
-  Arrow `RecordBatch` — no per-event Python object construction on
-  the reader path. Same self-pipe wake-FD signalling as
+  surface: each `async for batch in session` yields a
+  `pyarrow.RecordBatch` whose column buffers alias the Disruptor
+  consumer's pre-grouped Arrow `RecordBatch` — no per-event Python
+  object construction on the reader path. Same self-pipe wake-FD
+  signalling as
   `streaming_async()`; the column-shape SSOT (`tick_schema.toml`)
   guarantees schema parity with the per-event variant.
 - `queue_depth()` and `dropped_event_count()` getters on

--- a/sdks/python/src/streaming_async_batches.rs
+++ b/sdks/python/src/streaming_async_batches.rs
@@ -385,42 +385,84 @@ impl StreamingAsyncBatchesSession {
         }
     }
 
+    /// `__aenter__` body for the batched surface — mirrors the
+    /// row-based `StreamingAsyncSession::aenter_inner` FD-safety
+    /// pattern (see `streaming_async_session.rs` lines 547-557).
+    ///
+    /// Both pipe ends are wrapped in scope-local `OwnedFd` guards
+    /// immediately after `alloc_wake_pipe` so every fallible step
+    /// (`handle.start`, `asyncio.import`, `get_running_loop`,
+    /// `Event()`, `getattr("set")`, `add_reader`) drops the guard
+    /// on `?`-early-return and closes the FD via `OwnedFd::Drop`.
+    /// The write-end is released via `into_raw_fd()` only at the
+    /// instant `handle.start` is invoked (the Rust core's `WakeFd`
+    /// takes ownership inside `start`); the read-end is released
+    /// only on the committed path right before `self.read_fd = ...`.
     #[cfg(unix)]
     fn aenter_inner(&mut self, py: Python<'_>) -> PyResult<()> {
+        use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+
         if self.iterator.is_some() {
             return Err(PyRuntimeError::new_err(
                 "StreamingAsyncBatchesSession is already entered -- one session enters at most once",
             ));
         }
 
-        let (read_fd, write_fd) = crate::streaming_async_session::alloc_wake_pipe()?;
+        let (read_fd_raw, write_fd_raw) =
+            crate::streaming_async_session::alloc_wake_pipe()?;
 
+        // SAFETY: both FDs were just allocated by `alloc_wake_pipe`,
+        // are open, and have not been handed to any other owner.
+        // `OwnedFd` takes exclusive ownership; its `Drop` closes the
+        // FD if we return early via `?` before committing.
+        let read_guard = unsafe { OwnedFd::from_raw_fd(read_fd_raw) };
+        let write_guard = unsafe { OwnedFd::from_raw_fd(write_fd_raw) };
+
+        // Hand the write-end to the Rust core. The `Arc<WakeFd>`
+        // returned takes ownership of the write-end. We
+        // `into_raw_fd()` only at the call site so a panic / failure
+        // inside `start` does not double-close (the `OwnedFd` is
+        // dropped by `?` before `into_raw_fd` runs).
+        let write_fd_for_start = write_guard.into_raw_fd();
         let (rust_iter, wake) = match self.handle.start(
             py,
-            write_fd,
+            write_fd_for_start,
             self.max_queue_depth,
             self.backpressure.to_core(),
         ) {
             Ok(pair) => pair,
             Err(err) => {
-                // SAFETY: both FDs are open, owned by this scope,
-                // and not yet shared.
+                // `start` failed — the write FD was never observed
+                // by WakeFd, but we already released the guard.
+                // Close it manually so we do not leak.
+                // SAFETY: `write_fd_for_start` is open, owned by
+                // this scope, and not yet shared (start failed
+                // before building the WakeFd).
                 unsafe {
-                    libc::close(read_fd);
-                    libc::close(write_fd);
+                    libc::close(write_fd_for_start);
                 }
+                // `read_guard` is still alive and will Drop here,
+                // closing the read-end.
                 return Err(err);
             }
         };
 
+        // Every fallible step from here through `add_reader` keeps
+        // `read_guard` alive on the stack — a `?`-early-return drops
+        // the guard and closes the FD.
         let asyncio = py.import("asyncio")?;
         let event_loop = asyncio.call_method0("get_running_loop")?;
         let asyncio_event = asyncio.call_method0("Event")?;
 
         let set_event = asyncio_event.getattr("set")?;
-        event_loop.call_method1("add_reader", (read_fd, set_event))?;
+        // Borrow the FD via `as_raw_fd` so a failure leaves the
+        // `OwnedFd` guard intact — Drop closes it on the way out.
+        event_loop.call_method1("add_reader", (read_guard.as_raw_fd(), set_event))?;
 
-        self.read_fd = read_fd;
+        // Commit state. `into_raw_fd()` releases the guard's Drop
+        // and transfers FD ownership to `self.read_fd`; `__aexit__`
+        // is responsible for closing it from here on.
+        self.read_fd = read_guard.into_raw_fd();
         self.wake = Some(wake);
         self.iterator = Some(Arc::new(rust_iter));
         self.event_loop = Some(event_loop.unbind());
@@ -1108,5 +1150,171 @@ impl crate::fpss_client::FpssClient {
             py,
             StreamingAsyncBatchesSession::from_fpss(slf, max_queue_depth, backpressure),
         )
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod fd_safety_tests {
+    //! Regression tests for the `aenter_inner` FD-leak fix.
+    //!
+    //! The full asyncio path requires a live `FpssClient` with an
+    //! actual TLS connection, so these tests cannot drive
+    //! `__aenter__` end-to-end. Instead they pin the underlying
+    //! `OwnedFd::Drop` contract that the fix relies on:
+    //!
+    //! 1. `alloc_wake_pipe` returns a pair of open FDs.
+    //! 2. Wrapping in `OwnedFd` immediately transfers ownership.
+    //! 3. Dropping the `OwnedFd` closes the FD (verified by probing
+    //!    the specific FD numbers with `fcntl(F_GETFD)`).
+    //! 4. The "release on commit" pattern (`into_raw_fd`) cancels
+    //!    the Drop so the bare integer survives the scope exit.
+    //!
+    //! Probing specific FD numbers via `fcntl(F_GETFD)` rather than
+    //! counting `/proc/self/fd` entries avoids the test-harness
+    //! noise from stderr-capture FDs and the `read_dir` handle
+    //! itself.
+    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
+
+    use crate::streaming_async_session::alloc_wake_pipe;
+
+    /// Probe whether an FD is open by calling `fcntl(F_GETFD)`.
+    /// Returns `true` iff the kernel still recognises the FD.
+    /// `F_GETFD` is read-only and returns `EBADF` for a closed FD,
+    /// the documented portable probe.
+    fn fd_is_open(fd: i32) -> bool {
+        // SAFETY: F_GETFD is a read-only fcntl that returns the
+        // close-on-exec flag without modifying kernel state.
+        unsafe { libc::fcntl(fd, libc::F_GETFD) != -1 }
+    }
+
+    #[test]
+    fn alloc_wake_pipe_yields_two_open_fds() {
+        let (r, w) = alloc_wake_pipe().expect("pipe allocation must succeed");
+        assert!(fd_is_open(r), "read FD must be open after alloc");
+        assert!(fd_is_open(w), "write FD must be open after alloc");
+        assert_ne!(r, w, "read and write FDs must differ");
+        // Manual cleanup — no OwnedFd guard in this branch.
+        // SAFETY: the FDs are open and owned by this test.
+        unsafe {
+            libc::close(r);
+            libc::close(w);
+        }
+    }
+
+    #[test]
+    fn owned_fd_drop_closes_pipe_ends_on_early_return() {
+        // Simulates the S1 audit scenario: every fallible step
+        // between `alloc_wake_pipe` and the final `self.read_fd = ...`
+        // assignment must drop both `OwnedFd` guards on early-return,
+        // closing the FDs via the std `Drop` impl.
+        //
+        // Test discipline: probe each FD IMMEDIATELY after the
+        // expected close (no other syscalls in between) since the
+        // kernel recycles closed FDs to the next `open()` call.
+        let (read_raw, write_raw) = alloc_wake_pipe().expect("alloc must succeed");
+        // SAFETY: alloc_wake_pipe just allocated these FDs; we own
+        // them exclusively. OwnedFd takes ownership.
+        let read_guard = unsafe { OwnedFd::from_raw_fd(read_raw) };
+        let write_guard = unsafe { OwnedFd::from_raw_fd(write_raw) };
+        // Drop both — this simulates the `?`-early-return path
+        // through aenter_inner. `OwnedFd::Drop` must close both
+        // FDs via `libc::close`.
+        drop(write_guard);
+        assert!(
+            !fd_is_open(write_raw),
+            "OwnedFd::Drop must have closed the write end (fd {write_raw})"
+        );
+        drop(read_guard);
+        assert!(
+            !fd_is_open(read_raw),
+            "OwnedFd::Drop must have closed the read end (fd {read_raw})"
+        );
+    }
+
+    #[test]
+    fn into_raw_fd_cancels_drop_on_committed_path() {
+        // The committed branch: `into_raw_fd()` releases the
+        // `OwnedFd`'s Drop and transfers FD ownership to the
+        // session's `i32` field. After the `OwnedFd` is gone the
+        // bare integer must still refer to an open FD because the
+        // caller is now responsible for closing it.
+        let (read_raw, write_raw) = alloc_wake_pipe().expect("alloc must succeed");
+        // SAFETY: just-allocated, exclusively owned.
+        let read_guard = unsafe { OwnedFd::from_raw_fd(read_raw) };
+        let write_guard = unsafe { OwnedFd::from_raw_fd(write_raw) };
+        // Borrow path: as_raw_fd must NOT consume the guard.
+        assert_eq!(read_guard.as_raw_fd(), read_raw);
+        // Commit path: into_raw_fd releases Drop.
+        let read_committed = read_guard.into_raw_fd();
+        let write_committed = write_guard.into_raw_fd();
+        assert_eq!(read_committed, read_raw);
+        assert_eq!(write_committed, write_raw);
+        assert!(
+            fd_is_open(read_committed),
+            "committed read FD must remain open after into_raw_fd"
+        );
+        assert!(
+            fd_is_open(write_committed),
+            "committed write FD must remain open after into_raw_fd"
+        );
+        // Caller-side cleanup (mirrors `__aexit__`).
+        // SAFETY: caller owns both FDs after into_raw_fd.
+        unsafe {
+            libc::close(read_committed);
+            libc::close(write_committed);
+        }
+        assert!(!fd_is_open(read_committed));
+        assert!(!fd_is_open(write_committed));
+    }
+
+    #[test]
+    fn write_end_handoff_pattern_does_not_double_close() {
+        // The write-end is handed off via `into_raw_fd()` to the
+        // Rust core's `WakeFd` at the moment `handle.start` is
+        // invoked. If `start` itself fails, the integer was already
+        // released from the OwnedFd guard, so the failure branch
+        // must `libc::close` it manually — and the read-end (still
+        // wrapped) must Drop separately. Pin the contract: both FDs
+        // closed exactly once, no double-close, no leak.
+        //
+        // Test discipline: the kernel recycles closed FDs at the
+        // next `open()`-family call, so we cannot probe "is FD N
+        // closed?" after the test has done any other I/O. Instead
+        // we probe immediately after each close, with no other
+        // syscalls in between.
+        let (read_raw, write_raw) = alloc_wake_pipe().expect("alloc must succeed");
+        // SAFETY: just-allocated, exclusively owned.
+        let read_guard = unsafe { OwnedFd::from_raw_fd(read_raw) };
+        let write_guard = unsafe { OwnedFd::from_raw_fd(write_raw) };
+        // Both FDs must be open right after wrapping.
+        assert!(fd_is_open(read_raw));
+        assert!(fd_is_open(write_raw));
+        // Release write-end to a bare i32 (simulating "about to
+        // call handle.start(write_fd, ...)").
+        let write_released = write_guard.into_raw_fd();
+        assert_eq!(write_released, write_raw);
+        // Write end still open (into_raw_fd cancels Drop but doesn't close).
+        assert!(fd_is_open(write_released));
+        // Simulated handle.start failure → manual close of the
+        // released write-end. The read-end (still wrapped) Drops
+        // when we explicitly drop it below.
+        // SAFETY: write_released is open, owned, not yet shared.
+        unsafe {
+            libc::close(write_released);
+        }
+        // Immediately after close, the FD is gone — probe before
+        // any other syscall recycles it.
+        assert!(
+            !fd_is_open(write_released),
+            "write end must be closed by manual libc::close (fd {write_released})"
+        );
+        // Drop the read guard → close(read_raw) via Drop impl.
+        drop(read_guard);
+        // Probe immediately — no other syscalls in between.
+        assert!(
+            !fd_is_open(read_raw),
+            "read end must be closed by OwnedFd::Drop (fd {read_raw})"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes the 1M-token final audit on `ae39358b` (post-v10.0.0): 2 SERIOUS findings and 3 MINOR findings, one focused PR. No version bump — `[Unreleased]` carries the entries.

## Findings closed

### S1 — FD leak in `StreamingAsyncBatchesSession::aenter_inner`
The batched async session held the wake-pipe FDs as bare `i32` between `alloc_wake_pipe` and the final field assignment; six fallible Python operations in between each leaked the read-end on `?`-early-return. Apply the same `OwnedFd` guard pattern the row-based `StreamingAsyncSession::aenter_inner` already carries (R2 audit fix from 2026-05-20): wrap both pipe ends in scope-local `OwnedFd` immediately after allocation, release via `into_raw_fd()` only on the committed path. Four regression tests pin the `OwnedFd::Drop` contract directly via `fcntl(F_GETFD)` probes.

### S2 — `RetryPolicy::disabled()` blocks refresh-then-retry
The macro retry loop tied refresh-recovery to the same `attempt == budget` break-out as transient retries, so `RetryPolicy::disabled()` (`max_attempts = 1`) silently swallowed the post-refresh attempt: `classify_attempt` ran refresh, set `refreshed_already`, returned `Retry(err)`, the loop exited. Auth recovery is a documented contract separate from transient-retry policy. Restructure the unary + streaming loops to track a `refresh_retry_used` flag independently of the transient budget — one post-refresh attempt is always granted, even with disabled policy. Seven new regression tests replay the macro algorithm against canned outcomes (uses `SessionToken::bump_for_test` to take refresh's dedup fast-path without HTTP).

### M1 — `map_channel_error` discards typed taxonomy
The helper flattened every `ChannelError` variant into `Error::config_internal("...")` with a stringified message, defeating retry classifiers that match on `Error::Grpc { kind, .. }`. Replace the body with `Error::from(err)` so the canonical `From<ChannelError> for Error` impl (which produces typed `Grpc { kind: GrpcStatusKind::* }` / `Transport { kind: TransportErrorKind::* }` / `Timeout`) preserves the structured discrimination downstream.

### M2 — `build_rustls_config()` rebuilt N times in `open_channel_pool`
The webpki root store + ALPN list were rebuilt on every iteration of the per-channel connect loop. `rustls::ClientConfig` is designed for `Arc` sharing — hoist the build once before the loop and clone the `Arc` into each `Channel::connect_tls_with_max_message_size` call.

### M3 — CHANGELOG says `pyarrow.Table`, actual is `pyarrow.RecordBatch`
One-word correction to the `streaming_async_batches()` description in the `[Unreleased]` section. Applied to both `CHANGELOG.md` and `docs-site/docs/changelog.md` (Extended Surfaces gate enforces sync).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy --manifest-path sdks/python/Cargo.toml --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude thetadatadx-py` — full suite passes (S2 regression tests included)
- [x] `cargo test --manifest-path sdks/python/Cargo.toml --lib` — 51 tests pass (S1 fd_safety_tests included)
- [x] `maturin develop --release && pytest tests/ -v` — 293 passed, 29 skipped (live-gated)
- [x] `python3 scripts/check_banned_vocab.py` — clean
- [x] `python3 scripts/check_docs_consistency.py` — ok
- [ ] CI 12-gate matrix green