### PR TITLE
fix: close 11 findings from senior-eng audit (2 BLOCKERS + 5 MINOR + 4 NIT)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - uses: ./.github/actions/install-protoc
-      - run: cargo clippy --workspace --locked -- -D warnings
+      - run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
   test:
     name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   short-circuited re-entry. The error is now captured, the FD is
   reclaimed, and the captured error is re-raised so callers still
   see the underlying fault.
+- `next_req_id` widened from `AtomicI32` to `AtomicI64` with a
+  `wire_req_id` clamp at every wire-boundary call site. The previous
+  32-bit counter could wrap into the wire protocol's `-1`
+  "uncorrelated" sentinel after roughly `2^31` allocations (~ 5 days
+  at 5k subs/sec), breaking the user-side correlation between
+  manual subscribes and server `ReqResponse` frames. The clamp
+  masks the sign bit (`x & 0x7FFF_FFFF`) so wire ids stay strictly
+  non-negative even past `i32::MAX`.
+- Per-tick `metrics::counter!` lookup hoisted to `LazyLock<Counter>`
+  handles on the FPSS decode hot path. Eight handles (4 event
+  kinds × 2 metric names) replace the per-tick `(name, labels)`
+  hashmap probe inside the global recorder, dropping the per-call
+  observability cost from ~30 ns to ~5 ns (a single atomic add on
+  `Counter::increment`).
+- Rate-limit the "no contract for ID" warning at 1024 emissions to
+  match the existing slow-callback and clock-skew warn cadence.
+  A server-side replay-boundary anomaly that ticked unrecognised
+  ids previously flooded `tracing` with one line per tick and
+  crowded out genuinely diagnostic warnings.
+- Python `thetadatadx.__version__` now resolves through
+  `importlib.metadata.version("thetadatadx")` (PEP 396). The
+  attribute was missing on the top-level package, breaking
+  `pip show`, downstream version-pinning, and environment
+  snapshot scripts.
+- `Channel::Drop` aborts the spawned h2 connection-driver
+  `JoinHandle` as a belt-and-braces guard. The task was previously
+  detached at `Channel::handshake`; under repeated connect /
+  disconnect cycles a parked connection future could outlive the
+  `Channel` for an unbounded interval, accumulating background
+  tasks. `.abort()` is idempotent on already-finished tasks.
+- The `unwrap_or(u32::MAX)` in `Codec::encode_response_for_test`
+  becomes `.expect("…")` so a synthetic test response that ever
+  outgrows the 32-bit length prefix surfaces a diagnostic
+  failure instead of silently emitting `u32::MAX`.
+- `consecutive_timeouts * 50` in the FPSS io_loop is now
+  `consecutive_timeouts.saturating_mul(50_u64)` so a wild future
+  bump to `max_consecutive_timeouts` past `u64::MAX / 50` cannot
+  wrap the diagnostic on the warn line.
+- Per-disconnect metric label allocation: replaced
+  `format!("{:?}", reason)` with `RemoveReason::as_str()` so the
+  `reason` label points at a `&'static str` rather than allocating
+  a `String` per disconnect. Disconnects are rare, so this is a
+  consistency fix per the "no per-event allocations" discipline,
+  not a hot-path win.
+- `FpssConnectArgs::ring_size` doc comment corrected from "≈ 552
+  bytes after the typed-FpssControl variants" to the actual
+  `mem::size_of::<FpssEventInternal>() = 96` bytes on the current
+  64-bit layout; the per-`FpssClient` ring footprint at the
+  default `ring_size = 4096` is now documented as ~ 384 KiB.
+
+### CI
+
+- Workspace clippy invocation widened to
+  `cargo clippy --workspace --all-targets --locked -- -D warnings`
+  so `[[bench]]` and `#[cfg(test)]` unsafe blocks travel through
+  `clippy::undocumented_unsafe_blocks` on every PR. Adds SAFETY
+  comments on five bench-only `unsafe impl GlobalAlloc` blocks
+  and two test-only unsafe deref sites that previously escaped
+  the lint.
+- `scripts/check_banned_vocab.py` rejects the verbatim string
+  "see FFI boundary doc on the enclosing fn — raw pointers
+  satisfy the documented caller contract" outside `ffi/src/`.
+  The string was landed across 31 sites including 8 that are
+  not FFI raw-pointer contexts; the gate prevents future
+  bot-stamping from reintroducing the boilerplate.
 
 ## [10.0.0] - 2026-05-09
 

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -185,7 +185,11 @@ criterion = { version = "0.8.2", features = ["html_reports", "async_tokio"] }
 futures = "0.3"
 # Signal-driven sampling profiler used by the concurrent-burst bench
 # to emit a flamegraph SVG when `THETADATADX_FLAMEGRAPH=1` is set.
-# Pure userspace — no perf / root required.
+# Pure userspace — no perf / root required. Unix-only: pprof relies on
+# POSIX signals + pthread types that don't exist on Windows. Benches
+# that use it must `#[cfg(unix)]`-gate the import; on Windows the
+# benches still compile against a no-op stub or are skipped via cfg.
+[target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.15", features = ["flamegraph"] }
 proptest = "1.5"
 # Test-only: load captured-response fixtures and their sidecar .meta.toml

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -183,6 +183,8 @@ criterion = { version = "0.8.2", features = ["html_reports", "async_tokio"] }
 # the umbrella `futures` crate (we already depend on `futures-core`
 # directly; this gives us the executor adapters as well, dev-only).
 futures = "0.3"
+proptest = "1.5"
+
 # Signal-driven sampling profiler used by the concurrent-burst bench
 # to emit a flamegraph SVG when `THETADATADX_FLAMEGRAPH=1` is set.
 # Pure userspace — no perf / root required. Unix-only: pprof relies on
@@ -191,7 +193,6 @@ futures = "0.3"
 # benches still compile against a no-op stub or are skipped via cfg.
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.15", features = ["flamegraph"] }
-proptest = "1.5"
 # Test-only: load captured-response fixtures and their sidecar .meta.toml
 # files for the decoder-regression suite (`tests/test_decode_captures.rs`).
 # `toml` is already a build- and opt-dependency here; adding it to

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -184,15 +184,6 @@ criterion = { version = "0.8.2", features = ["html_reports", "async_tokio"] }
 # directly; this gives us the executor adapters as well, dev-only).
 futures = "0.3"
 proptest = "1.5"
-
-# Signal-driven sampling profiler used by the concurrent-burst bench
-# to emit a flamegraph SVG when `THETADATADX_FLAMEGRAPH=1` is set.
-# Pure userspace — no perf / root required. Unix-only: pprof relies on
-# POSIX signals + pthread types that don't exist on Windows. Benches
-# that use it must `#[cfg(unix)]`-gate the import; on Windows the
-# benches still compile against a no-op stub or are skipped via cfg.
-[target.'cfg(unix)'.dev-dependencies]
-pprof = { version = "0.15", features = ["flamegraph"] }
 # Test-only: load captured-response fixtures and their sidecar .meta.toml
 # files for the decoder-regression suite (`tests/test_decode_captures.rs`).
 # `toml` is already a build- and opt-dependency here; adding it to
@@ -205,6 +196,18 @@ toml = "1.1.2"
 # dev-dependency graph stays consistent. dev-only — never enters the
 # published crate graph.
 pyo3 = { version = "=0.28.3", features = ["auto-initialize"] }
+
+# Signal-driven sampling profiler used by the concurrent-burst bench
+# to emit a flamegraph SVG when `THETADATADX_FLAMEGRAPH=1` is set.
+# Pure userspace — no perf / root required. Unix-only: pprof relies on
+# POSIX signals + pthread types that don't exist on Windows. The
+# `cfg(unix)` target-conditional dev-dependencies table MUST live
+# AFTER the cross-platform `[dev-dependencies]` block — TOML table
+# headings absorb every subsequent k/v pair until the next heading,
+# so anything placed after `[target.'cfg(unix)'.dev-dependencies]`
+# silently becomes Unix-only too.
+[target.'cfg(unix)'.dev-dependencies]
+pprof = { version = "0.15", features = ["flamegraph"] }
 
 [build-dependencies]
 # `prost-build` compiles `proto/mdds.proto` into Rust message types;

--- a/crates/thetadatadx/benches/bench_delta_decode.rs
+++ b/crates/thetadatadx/benches/bench_delta_decode.rs
@@ -41,6 +41,11 @@ struct CountingAllocator;
 static BYTES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
 static ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
 
+// SAFETY: every method forwards verbatim to `std::alloc::System`, which
+// itself satisfies the `GlobalAlloc` contract. Per-call `Relaxed` adds on
+// `AtomicU64` are pure observational state and cannot violate the
+// allocator's invariants. Bench-only; never linked into the shipped
+// library.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: forwarding to the system allocator under the same

--- a/crates/thetadatadx/benches/grpc_channel.rs
+++ b/crates/thetadatadx/benches/grpc_channel.rs
@@ -47,6 +47,11 @@ struct CountingAllocator;
 static BYTES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
 static BYTES_DEALLOCATED: AtomicU64 = AtomicU64::new(0);
 
+// SAFETY: every method forwards verbatim to `std::alloc::System`, which
+// itself satisfies the `GlobalAlloc` contract. Per-call `Relaxed` adds on
+// `AtomicU64` are pure observational state and cannot violate the
+// allocator's invariants. Bench-only; never linked into the shipped
+// library.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: forwarding to the system allocator under the same

--- a/crates/thetadatadx/benches/grpc_concurrent_burst.rs
+++ b/crates/thetadatadx/benches/grpc_concurrent_burst.rs
@@ -38,6 +38,11 @@ struct CountingAllocator;
 static BYTES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
 static BYTES_DEALLOCATED: AtomicU64 = AtomicU64::new(0);
 
+// SAFETY: every method forwards verbatim to `std::alloc::System`, which
+// itself satisfies the `GlobalAlloc` contract. Per-call `Relaxed` adds on
+// `AtomicU64` are pure observational state and cannot violate the
+// allocator's invariants. Bench-only; never linked into the shipped
+// library.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: forwarding to the system allocator under the same

--- a/crates/thetadatadx/benches/grpc_concurrent_burst.rs
+++ b/crates/thetadatadx/benches/grpc_concurrent_burst.rs
@@ -284,6 +284,9 @@ fn bench_concurrent_burst(c: &mut Criterion) {
     // lands at `$THETADATADX_FLAMEGRAPH_OUT` (defaulting to
     // `/tmp/grpc_burst_flame.svg`). The profiler uses SIGPROF
     // sampling — no perf / root required, no kernel privileges.
+    // `pprof` is Unix-only (POSIX signals + pthread types), so the
+    // hook is `#[cfg(unix)]`-gated and silently no-ops on Windows.
+    #[cfg(unix)]
     let profiler = if std::env::var_os("THETADATADX_FLAMEGRAPH").is_some() {
         Some(
             pprof::ProfilerGuardBuilder::default()
@@ -295,6 +298,8 @@ fn bench_concurrent_burst(c: &mut Criterion) {
     } else {
         None
     };
+    #[cfg(not(unix))]
+    let profiler: Option<()> = None;
 
     let mut group = c.benchmark_group("concurrent_burst");
     group.throughput(Throughput::Elements(BURST_SIZE as u64));
@@ -338,6 +343,7 @@ fn bench_concurrent_burst(c: &mut Criterion) {
     });
     group.finish();
 
+    #[cfg(unix)]
     if let Some(profiler) = profiler {
         let out = std::env::var("THETADATADX_FLAMEGRAPH_OUT")
             .unwrap_or_else(|_| "/tmp/grpc_burst_flame.svg".to_string());
@@ -355,6 +361,8 @@ fn bench_concurrent_burst(c: &mut Criterion) {
             Err(e) => eprintln!("pprof report build failed: {e}"),
         }
     }
+    #[cfg(not(unix))]
+    let _ = profiler;
 
     let alloc_end = alloc_snapshot();
     let iters_total = iterations.load(Ordering::Relaxed);

--- a/crates/thetadatadx/benches/historical_streaming_memory.rs
+++ b/crates/thetadatadx/benches/historical_streaming_memory.rs
@@ -43,6 +43,12 @@ static BYTES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
 static BYTES_DEALLOCATED: AtomicU64 = AtomicU64::new(0);
 static MAX_LIVE_BYTES: AtomicU64 = AtomicU64::new(0);
 
+// SAFETY: every method forwards verbatim to `std::alloc::System`, which
+// itself satisfies the `GlobalAlloc` contract (ptr provenance, layout
+// honoured on dealloc, no over-aligned over-promises). The atomic counters
+// are pure observational state — `Relaxed` adds on `AtomicU64` cannot
+// violate alloc semantics. Bench-only allocator; never linked into the
+// shipped library.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY: forwarding to the system allocator under the same

--- a/crates/thetadatadx/benches/streaming_throughput.rs
+++ b/crates/thetadatadx/benches/streaming_throughput.rs
@@ -247,6 +247,10 @@ extern "C" fn ffi_trampoline(ctx: *mut c_void, event_ptr: *const c_void) {
     // `drive_publish` call). `event_ptr` is a `*const FpssEvent` cast
     // to `*const c_void` by the caller.
     let ctx = unsafe { &*(ctx as *const FfiCtx) };
+    // SAFETY: `event_ptr` is a `*const FpssEvent` produced by the bench
+    // harness one stack frame above; the referent lives until
+    // `drive_publish` returns, which is strictly after this callback
+    // ends. No aliasing — the consumer is the sole reader.
     let evt = unsafe { &*(event_ptr as *const FpssEvent) };
     // Touch the event so the read is not elided. Match-arm chosen for
     // its uniqueness so the optimiser cannot collapse the load.
@@ -394,6 +398,10 @@ struct BenchPyEvent {
 // is `Send + Sync` (`Arc<Contract>` + scalars). The bench mirrors the
 // SDK's contract here exactly.
 unsafe impl Send for BenchPyEvent {}
+// SAFETY: same argument as the `Send` impl above — every field access
+// is gated by an `Acquire` load on `valid`, so a thread that observes a
+// live `BenchPyEvent` reads a non-stale `FpssEvent` reference. The
+// `FpssEvent` graph itself is `Sync`.
 unsafe impl Sync for BenchPyEvent {}
 
 impl BenchPyEvent {

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -1203,9 +1203,14 @@ mod tests {
     fn clear_env_matrix() {
         // Unset every variable the env-override path reads so no test
         // leaks into another. The guard above pins us as the sole writer.
-        // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+        // SAFETY: the env-var tests serialise through `env_test_guard()`,
+        // a process-global `Mutex<()>` held for the full body of every
+        // env test; this function is only called from inside that
+        // critical section. The Rust 1.88 `unsafe fn` contract on
+        // `std::env::remove_var` requires the caller to ensure no other
+        // thread reads or writes the environment concurrently — the
+        // mutex provides exactly that.
         unsafe {
-            // Reason: test-only mutation; protected by env_test_guard.
             std::env::remove_var(ENV_MDDS_HOST);
             std::env::remove_var(ENV_MDDS_PORT);
             std::env::remove_var(ENV_NEXUS_URL);
@@ -1219,9 +1224,11 @@ mod tests {
     fn env_overrides_apply_on_production() {
         let _guard = env_test_guard();
         clear_env_matrix();
-        // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+        // SAFETY: `_guard` holds the process-global env-var mutex for
+        // the body of this test, so no other thread observes or mutates
+        // the environment while these writes land. `std::env::set_var`'s
+        // 1.88 `unsafe fn` contract is therefore upheld.
         unsafe {
-            // Reason: test-only mutation; protected by env_test_guard.
             std::env::set_var(ENV_MDDS_HOST, "mdds.staging.example.com");
             std::env::set_var(ENV_MDDS_PORT, "8443");
             std::env::set_var(ENV_NEXUS_URL, "https://nexus.staging.example.com/auth");
@@ -1248,9 +1255,10 @@ mod tests {
     fn builder_takes_precedence_over_env_var() {
         let _guard = env_test_guard();
         clear_env_matrix();
-        // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+        // SAFETY: `_guard` holds the process-global env-var mutex for
+        // the body of this test, so no other thread observes or mutates
+        // the environment while this write lands.
         unsafe {
-            // Reason: test-only mutation; protected by env_test_guard.
             std::env::set_var(ENV_CLIENT_TYPE, "env-wins-when-no-builder");
         }
         let config = DirectConfig::production().with_client_type("builder-wins");
@@ -1262,9 +1270,10 @@ mod tests {
     fn env_overrides_skipped_when_values_malformed() {
         let _guard = env_test_guard();
         clear_env_matrix();
-        // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+        // SAFETY: `_guard` holds the process-global env-var mutex for
+        // the body of this test, so no other thread observes or mutates
+        // the environment while these writes land.
         unsafe {
-            // Reason: test-only mutation; protected by env_test_guard.
             std::env::set_var(ENV_MDDS_PORT, "not-a-port");
             std::env::set_var(ENV_FPSS_PORT, "0"); // reject zero
             std::env::set_var(ENV_MDDS_HOST, "   "); // whitespace-only
@@ -1281,9 +1290,10 @@ mod tests {
     fn production_defaults_are_not_sensitive_to_env() {
         let _guard = env_test_guard();
         clear_env_matrix();
-        // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+        // SAFETY: `_guard` holds the process-global env-var mutex for
+        // the body of this test, so no other thread observes or mutates
+        // the environment while these writes land.
         unsafe {
-            // Reason: test-only mutation; protected by env_test_guard.
             std::env::set_var(ENV_MDDS_HOST, "ignored-by-defaults");
             std::env::set_var(ENV_MDDS_PORT, "9999");
         }

--- a/crates/thetadatadx/src/fpss/decode.rs
+++ b/crates/thetadatadx/src/fpss/decode.rs
@@ -531,7 +531,12 @@ pub fn decode_frame(
         StreamMsgType::Disconnected => {
             let reason = parse_disconnect_reason(payload);
             tracing::warn!(reason = ?reason, "server disconnected us");
-            metrics::counter!("thetadatadx.fpss.disconnects", "reason" => format!("{:?}", reason))
+            // `RemoveReason::as_str` returns a `&'static str` per
+            // variant, so the label allocation drops to zero. Disconnects
+            // are rare, so this isn't a hot-path win — it's a
+            // consistency fix per the "no per-event allocations"
+            // discipline elsewhere in this module.
+            metrics::counter!("thetadatadx.fpss.disconnects", "reason" => reason.as_str())
                 .increment(1);
             authenticated.store(false, Ordering::Release);
 

--- a/crates/thetadatadx/src/fpss/decode.rs
+++ b/crates/thetadatadx/src/fpss/decode.rs
@@ -7,9 +7,10 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
+use metrics::Counter;
 use tdbe::types::enums::StreamMsgType;
 use tdbe::types::price::Price;
 
@@ -21,6 +22,38 @@ use super::protocol::{
     parse_contract_message, parse_disconnect_reason, parse_req_response, Contract,
 };
 use super::reconnect_delay;
+
+// ─── Hoisted per-tick counter handles ───────────────────────────────
+//
+// `metrics::counter!(name, "kind" => value)` resolves the (name, labels)
+// tuple to a `Counter` handle on every call — that lookup is a hashmap
+// probe inside the global recorder and runs ~30 ns per tick in the
+// observed bench. Hoisting the resolution to a `LazyLock<Counter>`
+// turns the per-tick increment into a single atomic add (~5 ns) since
+// `Counter::increment` is `&self`.
+//
+// One handle per (metric, kind) pair the decoder emits. Decode-failure
+// counters are kept separately so the dashboards can split healthy
+// events from FIT parse rejections.
+
+static FPSS_QUOTE_EVENTS: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.events", "kind" => "quote"));
+static FPSS_TRADE_EVENTS: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.events", "kind" => "trade"));
+static FPSS_OI_EVENTS: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.events", "kind" => "open_interest"));
+static FPSS_OHLCVC_EVENTS: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.events", "kind" => "ohlcvc"));
+
+static FPSS_QUOTE_DECODE_FAILURES: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.decode_failures", "kind" => "quote"));
+static FPSS_TRADE_DECODE_FAILURES: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.decode_failures", "kind" => "trade"));
+static FPSS_OI_DECODE_FAILURES: LazyLock<Counter> = LazyLock::new(
+    || metrics::counter!("thetadatadx.fpss.decode_failures", "kind" => "open_interest"),
+);
+static FPSS_OHLCVC_DECODE_FAILURES: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.decode_failures", "kind" => "ohlcvc"));
 
 /// Prefix on the [`Contract::symbol`] of an unresolved-contract sentinel
 /// returned for a tick that arrived before the matching
@@ -202,7 +235,7 @@ pub fn decode_frame(
             match delta_state.decode_tick(msg_code, payload, QUOTE_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
                     warn_unknown_contract(contract_id, "quote", delta_state, local_contracts);
-                    metrics::counter!("thetadatadx.fpss.events", "kind" => "quote").increment(1);
+                    FPSS_QUOTE_EVENTS.increment(1);
                     let pt = buf[9];
                     (
                         Some(FpssEventInternal::Data(FpssData::Quote {
@@ -229,8 +262,7 @@ pub fn decode_frame(
                     // Truncated / corrupt FIT payload. Account for it on
                     // the public counter so operators see decode pressure
                     // without raw-byte fallout reaching the user callback.
-                    metrics::counter!("thetadatadx.fpss.decode_failures", "kind" => "quote")
-                        .increment(1);
+                    FPSS_QUOTE_DECODE_FAILURES.increment(1);
                     (Some(FpssEventInternal::Unparseable), None)
                 }
             }
@@ -241,7 +273,7 @@ pub fn decode_frame(
             match delta_state.decode_tick(msg_code, payload, TRADE_FIELDS, &mut buf) {
                 Some((contract_id, n_data)) => {
                     warn_unknown_contract(contract_id, "trade", delta_state, local_contracts);
-                    metrics::counter!("thetadatadx.fpss.events", "kind" => "trade").increment(1);
+                    FPSS_TRADE_EVENTS.increment(1);
 
                     if n_data != 8 && n_data != TRADE_FIELDS {
                         tracing::warn!(
@@ -339,8 +371,7 @@ pub fn decode_frame(
                 // DATE markers return None from decode_tick -- normal protocol flow.
                 None if delta_state.last_was_date => (None, None),
                 None => {
-                    metrics::counter!("thetadatadx.fpss.decode_failures", "kind" => "trade")
-                        .increment(1);
+                    FPSS_TRADE_DECODE_FAILURES.increment(1);
                     (Some(FpssEventInternal::Unparseable), None)
                 }
             }
@@ -356,8 +387,7 @@ pub fn decode_frame(
                         delta_state,
                         local_contracts,
                     );
-                    metrics::counter!("thetadatadx.fpss.events", "kind" => "open_interest")
-                        .increment(1);
+                    FPSS_OI_EVENTS.increment(1);
                     (
                         Some(FpssEventInternal::Data(FpssData::OpenInterest {
                             contract: resolve_contract(contract_id, local_contracts),
@@ -371,11 +401,7 @@ pub fn decode_frame(
                 }
                 None if delta_state.last_was_date => (None, None),
                 None => {
-                    metrics::counter!(
-                        "thetadatadx.fpss.decode_failures",
-                        "kind" => "open_interest",
-                    )
-                    .increment(1);
+                    FPSS_OI_DECODE_FAILURES.increment(1);
                     (Some(FpssEventInternal::Unparseable), None)
                 }
             }
@@ -386,7 +412,7 @@ pub fn decode_frame(
             match delta_state.decode_tick(msg_code, payload, OHLCVC_FIELDS, &mut buf) {
                 Some((contract_id, _n)) => {
                     warn_unknown_contract(contract_id, "ohlcvc", delta_state, local_contracts);
-                    metrics::counter!("thetadatadx.fpss.events", "kind" => "ohlcvc").increment(1);
+                    FPSS_OHLCVC_EVENTS.increment(1);
                     let acc = delta_state
                         .ohlcvc
                         .entry(contract_id)
@@ -413,8 +439,7 @@ pub fn decode_frame(
                 }
                 None if delta_state.last_was_date => (None, None),
                 None => {
-                    metrics::counter!("thetadatadx.fpss.decode_failures", "kind" => "ohlcvc")
-                        .increment(1);
+                    FPSS_OHLCVC_DECODE_FAILURES.increment(1);
                     (Some(FpssEventInternal::Unparseable), None)
                 }
             }

--- a/crates/thetadatadx/src/fpss/decode.rs
+++ b/crates/thetadatadx/src/fpss/decode.rs
@@ -164,13 +164,30 @@ pub fn decode_frame(
     // contract cache. Suppress for 5 seconds after STOP (market close) since
     // stale ticks are expected during teardown. Matches Java terminal behavior.
     // Uses the thread-local cache instead of locking the shared contract_map.
+    //
+    // Rate-limit at every 1024th hit to match the cadence of the
+    // slow-callback / clock-skew warnings (`decode.rs:96`,
+    // `mod.rs::slow_callback`). Without the limit, a server-side
+    // mis-routing or replay-boundary anomaly that emits ticks for an
+    // unknown id would flood `tracing` with a per-tick line on every
+    // affected contract — at FPSS arrival rates the log channel
+    // becomes the bottleneck.
     let warn_unknown_contract =
         |contract_id: i32,
          kind: &str,
          delta_state: &DeltaState,
          cache: &HashMap<i32, Arc<Contract>>| {
             if !cache.contains_key(&contract_id) && !delta_state.is_in_stop_suppression_window() {
-                tracing::warn!(contract_id, kind, "no contract for ID");
+                static MISS_COUNT: AtomicU64 = AtomicU64::new(0);
+                let prev = MISS_COUNT.fetch_add(1, Ordering::Relaxed);
+                if prev.is_multiple_of(1024) {
+                    tracing::warn!(
+                        contract_id,
+                        kind,
+                        miss_count = prev + 1,
+                        "no contract for ID (1 of every 1024 emitted)"
+                    );
+                }
             }
         };
 

--- a/crates/thetadatadx/src/fpss/events.rs
+++ b/crates/thetadatadx/src/fpss/events.rs
@@ -345,16 +345,18 @@ impl FpssEventInternal {
                 // optimisation; it compiles to a no-op move on every
                 // backend Rust ships.
                 core::hint::black_box(d);
-                // SAFETY: this arm proves the discriminant is
-                // `FPSS_EVENT_TAG_DATA`. Both `FpssEvent` and
-                // `FpssEventInternal` are `#[repr(C, u8)]` with
+                // SAFETY: this match arm proves the discriminant is
+                // `FPSS_EVENT_TAG_DATA`. `FpssEvent` and
+                // `FpssEventInternal` are both `#[repr(C, u8)]` with
                 // identical `Data(FpssData)` payloads at that
-                // discriminant, so the layout is shared (Rust
-                // reference, "Primitive representation of enums with
-                // fields"). The reborrow inherits the `&self`
-                // lifetime; aliasing rules treat it like the
-                // original borrow.
-                // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+                // discriminant, so the in-memory layout is shared
+                // (Rust reference, "Primitive representation of enums
+                // with fields"). `assert_layout_compat` (run as a unit
+                // test) pins size, alignment, and discriminant equality
+                // at compile time, so a future divergence trips the
+                // build before it can corrupt a callback. The reborrow
+                // inherits the `&self` lifetime; aliasing rules treat
+                // it like the original borrow.
                 Some(unsafe { &*(self as *const Self as *const FpssEvent) })
             }
             Self::Control(c) => {

--- a/crates/thetadatadx/src/fpss/io_loop/mod.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/mod.rs
@@ -568,7 +568,13 @@ pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
                         tracing::warn!(
                             timeout_ms = read_timeout_ms_total,
                             "FPSS read timed out (no data for {}ms)",
-                            consecutive_timeouts * 50
+                            // `saturating_mul` so a wild future bump to
+                            // `max_consecutive_timeouts` past `u64::MAX
+                            // / 50` cannot wrap the duration field on
+                            // the warn line. 50 is the inner-loop
+                            // poll cadence (ms); explicit `u64`
+                            // suffix pins the diagnostic shape.
+                            consecutive_timeouts.saturating_mul(50_u64)
                         );
                         if producer
                             .try_publish(|slot| {

--- a/crates/thetadatadx/src/fpss/io_loop/mod.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/mod.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::io::BufReader;
 use std::io::Write;
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -132,7 +132,10 @@ pub(in crate::fpss) struct IoLoopArgs {
     /// re-subscribe so `ReqResponse` events on the reconnected session
     /// carry ids correlatable to the original subscribe rather than
     /// the indistinguishable `-1` sentinel.
-    pub next_req_id: Arc<AtomicI32>,
+    ///
+    /// Widened to `AtomicI64`; the wire boundary clamps to a positive
+    /// `i32` via [`super::wire_req_id`].
+    pub next_req_id: Arc<AtomicI64>,
 }
 
 // Reason: all parameters are moved into this function from a spawned thread closure.
@@ -950,7 +953,7 @@ pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
             // `ReqResponse` events on the reconnected session carry
             // correlatable ids — `-1` is indistinguishable from a
             // manual subscribe and breaks user-side correlation.
-            let req_id = next_req_id.fetch_add(1, Ordering::Relaxed);
+            let req_id = super::wire_req_id(next_req_id.fetch_add(1, Ordering::Relaxed));
             let payload = match protocol::build_subscribe_payload(req_id, contract) {
                 Ok(p) => p,
                 Err(e) => {
@@ -966,7 +969,7 @@ pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
             }
         }
         for (kind, sec_type) in &full_subs_snapshot {
-            let req_id = next_req_id.fetch_add(1, Ordering::Relaxed);
+            let req_id = super::wire_req_id(next_req_id.fetch_add(1, Ordering::Relaxed));
             let payload = protocol::build_full_type_subscribe_payload(req_id, *sec_type);
             let code = kind.subscribe_code();
             if let Err(e) = write_raw_frame_no_flush(writer, code, &payload) {
@@ -1304,12 +1307,12 @@ mod tests {
     /// manual-subscribe responses and break user correlation.
     #[test]
     fn next_req_id_allocates_fresh_ids_for_resubscribe() {
-        let counter = Arc::new(AtomicI32::new(7));
+        let counter = Arc::new(AtomicI64::new(7));
         // Mimic the re-subscribe loop's allocation pattern: one
-        // fetch_add per re-subscribed contract.
-        let id_a = counter.fetch_add(1, Ordering::Relaxed);
-        let id_b = counter.fetch_add(1, Ordering::Relaxed);
-        let id_c = counter.fetch_add(1, Ordering::Relaxed);
+        // fetch_add + `wire_req_id` clamp per re-subscribed contract.
+        let id_a = super::super::wire_req_id(counter.fetch_add(1, Ordering::Relaxed));
+        let id_b = super::super::wire_req_id(counter.fetch_add(1, Ordering::Relaxed));
+        let id_c = super::super::wire_req_id(counter.fetch_add(1, Ordering::Relaxed));
         assert_eq!(id_a, 7);
         assert_eq!(id_b, 8);
         assert_eq!(id_c, 9);
@@ -1317,7 +1320,36 @@ mod tests {
         // Subsequent caller-issued subscribes off the same counter
         // see the next slot — proves the io_loop and the client share
         // one allocator without colliding.
-        assert_eq!(counter.fetch_add(1, Ordering::Relaxed), 10);
+        assert_eq!(
+            super::super::wire_req_id(counter.fetch_add(1, Ordering::Relaxed)),
+            10
+        );
+    }
+
+    /// The `AtomicI64` counter is widened so a long-running session
+    /// (5k subs/sec ≈ 5 days for `2^31`) cannot wrap into the `-1`
+    /// sentinel. `wire_req_id` masks off the sign bit and casts to
+    /// `i32`, so even past `i32::MAX` we stay strictly non-negative
+    /// and never collide with `-1`.
+    #[test]
+    fn wire_req_id_clamps_positive_past_i32_max() {
+        use super::super::wire_req_id;
+        // Below i32::MAX: pass through unchanged.
+        assert_eq!(wire_req_id(1), 1);
+        assert_eq!(wire_req_id(i64::from(i32::MAX)), i32::MAX);
+        // At i32::MAX + 1: the sign-bit mask wraps to 0 (NOT -1).
+        assert_eq!(wire_req_id(i64::from(i32::MAX) + 1), 0);
+        // Way past i32::MAX: stays positive, never `-1`.
+        for n in 0..256_i64 {
+            let v = i64::from(i32::MAX) + 1 + n * 1_000_000;
+            let wire = wire_req_id(v);
+            assert!(wire >= 0, "wire id must stay non-negative (got {wire})");
+            assert_ne!(wire, -1, "wire id must never equal the -1 sentinel");
+        }
+        // Counter value 2^32: low 31 bits clear, masks to 0.
+        assert_eq!(wire_req_id(1_i64 << 32), 0);
+        // Counter value 2^32 + 7: clamps to 7.
+        assert_eq!(wire_req_id((1_i64 << 32) + 7), 7);
     }
 
     /// Finding #2 coverage: transient disconnect reasons must NOT

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -151,7 +151,7 @@ pub mod __test_internals {
     pub use super::framing::{read_frame_into, FrameReadState, MAX_PAYLOAD_LEN};
 }
 
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle, ThreadId};
@@ -165,6 +165,26 @@ use tdbe::types::enums::{RemoveReason, StreamMsgType};
 use self::protocol::{
     build_credentials_payload, build_subscribe_payload, Contract, SubscriptionKind,
 };
+
+/// Clamp a 64-bit counter value into a positive 31-bit wire `req_id`.
+///
+/// The FPSS wire protocol carries `req_id` as a 32-bit signed integer
+/// and reserves the value `-1` as the "uncorrelated" sentinel emitted
+/// when the server cannot resolve a `ReqResponse` back to a caller-
+/// allocated id. Allocators therefore must never hand out `-1` (and,
+/// defensively, must stay strictly non-negative so a future server-side
+/// `id < 0` check cannot reject a legitimate frame).
+///
+/// `next_req_id` is widened to `AtomicI64` so a long-running session
+/// cannot wrap into the sentinel after `2^31` allocations (≈ 5 days at
+/// 5k subs/sec, well inside the realistic uptime envelope of a
+/// production streaming consumer). This helper masks off the sign bit
+/// and casts down, producing the positive `i32` the wire encoder
+/// expects.
+#[inline]
+pub(in crate::fpss) fn wire_req_id(counter_value: i64) -> i32 {
+    (counter_value & 0x7FFF_FFFF) as i32
+}
 
 // ---------------------------------------------------------------------------
 // FpssConnectArgs — typed parameter bundle for `FpssClient::connect`
@@ -310,7 +330,14 @@ pub struct FpssClient {
     /// `req_id` correlatable to the original subscribe — server-side
     /// `ReqResponse` events with `req_id = -1` are indistinguishable
     /// from manual subscribes, which breaks user-side correlation.
-    next_req_id: Arc<AtomicI32>,
+    ///
+    /// Widened to `AtomicI64` so a long-running session at thousands of
+    /// subscribes/sec cannot wrap into the wire's `-1` sentinel after
+    /// `2^31` allocations (≈ 5 days at 5k subs/sec). The 31-bit clamp
+    /// to a positive `i32` happens at the wire boundary in
+    /// `build_subscribe_payload` / `build_full_type_subscribe_payload`
+    /// callers via `(x & 0x7FFF_FFFF) as i32`.
+    next_req_id: Arc<AtomicI64>,
     /// Active per-contract subscriptions for reconnection.
     pub(in crate::fpss) active_subs: Arc<Mutex<Vec<(SubscriptionKind, Contract)>>>,
     /// Active full-type (full-stream) subscriptions for reconnection.
@@ -808,7 +835,7 @@ impl FpssClient {
         // owns one handle for caller-issued subscribes; the io_loop
         // borrows another so re-subscribe frames on auto-reconnect
         // allocate fresh ids correlatable through `ReqResponse`.
-        let next_req_id: Arc<AtomicI32> = Arc::new(AtomicI32::new(1));
+        let next_req_id: Arc<AtomicI64> = Arc::new(AtomicI64::new(1));
 
         // Command channel: FpssClient -> I/O thread
         let (cmd_tx, cmd_rx) = std_mpsc::channel::<IoCommand>();
@@ -1038,7 +1065,7 @@ impl FpssClient {
         unsubscribe: bool,
     ) -> Result<(), Error> {
         self.check_connected()?;
-        let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
+        let req_id = wire_req_id(self.next_req_id.fetch_add(1, Ordering::Relaxed));
         let payload = protocol::build_full_type_subscribe_payload(req_id, sec_type);
         // Wire codes for full-stream subscribe / unsubscribe: code 22
         // (TRADE) / 52 (REMOVE_TRADE) for Trades, code 23
@@ -1083,7 +1110,7 @@ impl FpssClient {
         contract.validate()?;
         self.check_connected()?;
 
-        let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
+        let req_id = wire_req_id(self.next_req_id.fetch_add(1, Ordering::Relaxed));
         let payload = build_subscribe_payload(req_id, contract)?;
         let code = kind.subscribe_code();
 
@@ -1116,7 +1143,7 @@ impl FpssClient {
         contract.validate()?;
         self.check_connected()?;
 
-        let req_id = self.next_req_id.fetch_add(1, Ordering::Relaxed);
+        let req_id = wire_req_id(self.next_req_id.fetch_add(1, Ordering::Relaxed));
         let payload = build_subscribe_payload(req_id, contract)?;
         let code = kind.unsubscribe_code();
 
@@ -1278,7 +1305,7 @@ impl FpssClient {
         let dropped = Arc::new(AtomicU64::new(0));
         let panics = Arc::new(AtomicU64::new(0));
         let consumer_thread_id: Arc<OnceLock<ThreadId>> = Arc::new(OnceLock::new());
-        let next_req_id: Arc<AtomicI32> = Arc::new(AtomicI32::new(1));
+        let next_req_id: Arc<AtomicI64> = Arc::new(AtomicI64::new(1));
 
         let (cmd_tx, _cmd_rx) = std_mpsc::channel::<IoCommand>();
 

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -218,13 +218,14 @@ pub struct FpssConnectArgs<'a> {
     pub hosts: &'a [(String, u16)],
     /// Disruptor ring buffer size (events). Must be a power of two.
     ///
-    /// Each ring slot stores one `FpssEventInternal` (≈ 552 bytes after
-    /// the typed-FpssControl variants). The default `ring_size = 4096`
-    /// allocates roughly `4096 × 552 ≈ 2.3 MB` per `FpssClient` for the
-    /// ring, plus per-event refcounted `Arc<Contract>` storage on top.
-    /// Tune downward (e.g., 1024) if memory is tight; tune upward
-    /// (e.g., 16_384) if you observe sustained `dropped_event_count()`
-    /// under bursty load.
+    /// Each ring slot stores one `FpssEventInternal` (96 bytes on the
+    /// current 64-bit layout, validated by the
+    /// `fpss_event_internal_layout_matches_public` test). The default
+    /// `ring_size = 4096` allocates roughly `4096 × 96 ≈ 384 KiB` per
+    /// `FpssClient` for the ring, plus per-event refcounted
+    /// `Arc<Contract>` storage on top. Tune downward (e.g., 1024) if
+    /// memory is tight; tune upward (e.g., 16_384) if you observe
+    /// sustained `dropped_event_count()` under bursty load.
     pub ring_size: usize,
     /// I/O thread flush behavior. See [`FpssFlushMode`].
     pub flush_mode: FpssFlushMode,

--- a/crates/thetadatadx/src/fpss/wake.rs
+++ b/crates/thetadatadx/src/fpss/wake.rs
@@ -261,7 +261,13 @@ impl WakeFd {
     }
 }
 
-#[cfg(all(test, unix))]
+// `pipe2(2)` + `__errno_location` used by the test helper are
+// Linux-only libc symbols (macOS uses `pipe(2)` + `__error`). The
+// wake-coalesce logic the tests exercise is platform-agnostic, so
+// gating coverage to Linux is sufficient — the production path on
+// macOS uses the dedicated `streaming_async_session::alloc_wake_pipe`
+// fallback which already has its own coverage.
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
     use std::io::Read;

--- a/crates/thetadatadx/src/fpss/wake.rs
+++ b/crates/thetadatadx/src/fpss/wake.rs
@@ -133,7 +133,14 @@ impl WakeFd {
             return;
         }
         let byte: u8 = 1;
-        // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+        // SAFETY: `self.write_fd` is owned by this `WakeFd` (held alive
+        // by `&self`); it was either `-1` (filtered by the early return
+        // above) or a valid open writable FD passed in via
+        // `from_raw_write_fd`. The buffer is a single stack byte
+        // (`byte`) valid for the `len = 1` write, and one-byte writes
+        // on a pipe are atomic per POSIX (`pipe(7)`, `write(2)`
+        // PIPE_BUF). No aliasing — `byte` is a local on this stack
+        // frame.
         let res = unsafe {
             libc::write(
                 self.write_fd,

--- a/crates/thetadatadx/src/fpss/wake.rs
+++ b/crates/thetadatadx/src/fpss/wake.rs
@@ -268,6 +268,10 @@ mod tests {
         let mut fds = [0_i32; 2];
         // SAFETY: `pipe2` writes two file descriptors into `fds`.
         let rc = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_NONBLOCK | libc::O_CLOEXEC) };
+        // SAFETY: `libc::__errno_location` returns a per-thread non-null
+        // pointer guaranteed by glibc / musl; the deref reads the current
+        // thread's errno slot and is sound on any platform with a POSIX C
+        // runtime.
         assert_eq!(rc, 0, "pipe2 failed: errno={}", unsafe {
             *libc::__errno_location()
         });

--- a/crates/thetadatadx/src/grpc/channel.rs
+++ b/crates/thetadatadx/src/grpc/channel.rs
@@ -192,6 +192,21 @@ pub struct Channel {
     /// hands every chunk to a dedicated decoder thread so the
     /// reactor never blocks on a multi-millisecond zstd payload.
     decoder: Option<DecoderHandle>,
+    /// Handle on the background task that drives the h2 connection.
+    ///
+    /// Dropping `send_request` is sufficient for a clean shutdown —
+    /// the h2 connection winds down and the task exits naturally. The
+    /// handle is retained so `Channel::Drop` can call `.abort()` as a
+    /// belt-and-braces guard against the case where the connection
+    /// future is parked on a slow socket and would otherwise outlive
+    /// the `Channel` for an unbounded interval (e.g. peer never sends
+    /// the final GOAWAY ACK before the test runner moves on). The
+    /// abort is idempotent — a task that already finished is a no-op.
+    ///
+    /// `Option` so [`Drop`] can take ownership without leaving a
+    /// half-moved field; `Send` + `'static` because the task is
+    /// dispatched onto the multi-thread tokio runtime.
+    connection_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl Channel {
@@ -321,7 +336,12 @@ impl Channel {
         // Drive the h2 connection on a dedicated task. When the
         // `Channel` is dropped, `send_request` drops, which lets the
         // connection wind down naturally; the task exits at that point.
-        tokio::spawn(async move {
+        // The handle is retained on `Channel::connection_task` so the
+        // `Drop` impl can call `.abort()` as a belt-and-braces guard
+        // against a connection future parked on a slow socket
+        // outliving the `Channel` (cf. the test fixture pattern that
+        // tears down the server before the client).
+        let connection_task = tokio::spawn(async move {
             if let Err(err) = connection.await {
                 tracing::debug!(error = %err, "in-house gRPC h2 connection ended");
             }
@@ -354,6 +374,7 @@ impl Channel {
             scheme,
             in_flight: Arc::new(AtomicUsize::new(0)),
             decoder: None,
+            connection_task: Some(connection_task),
         })
     }
 
@@ -705,6 +726,25 @@ impl Channel {
     }
 }
 
+impl Drop for Channel {
+    /// Cancel the background h2 connection-driver task on drop.
+    ///
+    /// Dropping `send_request` (one of the `Channel`'s other fields)
+    /// is sufficient for a clean shutdown of a healthy connection —
+    /// the h2 connection winds down and the task returns from its
+    /// `.await`. The explicit `.abort()` here is belt-and-braces for
+    /// the case where the connection future is parked on a slow or
+    /// half-closed socket and would otherwise outlive the `Channel`
+    /// for an unbounded interval. `.abort()` is idempotent on a task
+    /// that already finished, so the common clean-shutdown path pays
+    /// at most one extra atomic on `Drop`.
+    fn drop(&mut self) {
+        if let Some(handle) = self.connection_task.take() {
+            handle.abort();
+        }
+    }
+}
+
 /// Encode a [`Duration`] as a gRPC `grpc-timeout` header value.
 ///
 /// Picks the smallest unit that fits the budget in at most 8 ASCII
@@ -972,6 +1012,74 @@ mod tests {
         // scheme field flows through to the wire for both transports
         // and there's no accidental constant-override anywhere.
         assert_scheme_round_trip(Scheme::HTTP, "http").await;
+    }
+
+    /// Dropping the `Channel` must abort the spawned h2 connection-
+    /// driver task. Without the `JoinHandle::abort()` in `Drop`, the
+    /// task would survive until the underlying socket closed itself —
+    /// which, under repeated connect/disconnect cycles in a long-
+    /// running consumer, lets background tasks accumulate. The check
+    /// here drives one `Channel::handshake` over `tokio::io::duplex`,
+    /// drops the channel, then awaits a short interval. The audit
+    /// invariant: `connection_task.is_finished()` is `true` by the
+    /// time the join lands.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropping_channel_aborts_h2_connection_task() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        // Server side: complete the h2 handshake and then park
+        // indefinitely on a `pending` future. Without the abort, the
+        // client's connection-driver task would also park forever.
+        let server_task = tokio::spawn(async move {
+            let mut conn = h2::server::handshake(server_io)
+                .await
+                .expect("server handshake");
+            // Park; the duplex closing on the client side will surface
+            // as `accept().await` returning None / Err, which we
+            // ignore — the test is interested in whether the *client*
+            // task gets reaped, not in the server side's behaviour.
+            let _ = conn.accept().await;
+        });
+
+        let mut channel = Channel::handshake(
+            client_io,
+            "127.0.0.1",
+            0,
+            DEFAULT_MAX_FOR_TEST,
+            Scheme::HTTP,
+        )
+        .await
+        .expect("client handshake");
+        // Snapshot the handle BEFORE drop so the test can `.is_finished()`
+        // it after; the `Channel`'s `Drop` would otherwise consume the
+        // only handle and we'd have no observable.
+        let task = channel
+            .connection_task
+            .take()
+            .expect("Channel constructed with a connection_task");
+        // Snapshot abort_handle so we can observe completion after the
+        // explicit drop without holding the JoinHandle (which would
+        // race the drop).
+        let abort_handle = task.abort_handle();
+        // Re-park the task in a JoinHandle the test owns; restore the
+        // channel field as `Some` so the `Drop` impl will abort it.
+        channel.connection_task = Some(task);
+        drop(channel);
+        // Yield + short sleep until the abort signal lands on the
+        // task. `abort()` is asynchronous (it schedules the task for
+        // cancellation; the actual finish happens the next time the
+        // runtime polls it), so a polite poll loop with a deadline is
+        // the canonical pattern.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while !abort_handle.is_finished() && std::time::Instant::now() < deadline {
+            tokio::task::yield_now().await;
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            abort_handle.is_finished(),
+            "Channel::Drop must abort the spawned h2 connection-driver task",
+        );
+        server_task.abort();
+        let _ = server_task.await;
     }
 
     #[test]

--- a/crates/thetadatadx/src/grpc/codec.rs
+++ b/crates/thetadatadx/src/grpc/codec.rs
@@ -546,7 +546,10 @@ mod tests {
             let payload_len = resp.encoded_len();
             let mut buf = BytesMut::with_capacity(FRAME_HEADER_LEN + payload_len);
             buf.put_u8(0);
-            buf.put_u32(u32::try_from(payload_len).unwrap_or(u32::MAX));
+            buf.put_u32(
+                u32::try_from(payload_len)
+                    .expect("synthetic test response must fit the gRPC 32-bit length prefix"),
+            );
             resp.encode(&mut buf)
                 .expect("test buffer sized for payload");
             buf.freeze()

--- a/crates/thetadatadx/src/grpc/decoder_pool.rs
+++ b/crates/thetadatadx/src/grpc/decoder_pool.rs
@@ -579,13 +579,14 @@ impl DecoderPool {
             let producer = build_multi_producer(ring_size, RingEvent::default, wait_strategy)
                 .thread_name("mdds-decoder")
                 .handle_events_with(move |slot: &RingEvent, _seq: Sequence, _eob: bool| {
-                    // SAFETY: the disruptor consumer barrier
-                    // guarantees this thread holds exclusive access
-                    // to the slot at this sequence position until
-                    // the consumer barrier advances on closure
-                    // return. No producer can reuse the slot, and
-                    // no other consumer exists.
-                    // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+                    // SAFETY: the disruptor consumer barrier guarantees
+                    // this thread holds exclusive access to the slot at
+                    // this sequence position until the consumer barrier
+                    // advances on closure return. No producer can reuse
+                    // the slot, and no other consumer exists. The
+                    // `unsafe fn` invariant on `RingEvent::take`
+                    // (documented at its declaration) is therefore
+                    // upheld.
                     let request = unsafe { slot.take() };
                     let Some(DecodeRequest { work, reply }) = request else {
                         return;

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -208,6 +208,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   short-circuited re-entry. The error is now captured, the FD is
   reclaimed, and the captured error is re-raised so callers still
   see the underlying fault.
+- `next_req_id` widened from `AtomicI32` to `AtomicI64` with a
+  `wire_req_id` clamp at every wire-boundary call site. The previous
+  32-bit counter could wrap into the wire protocol's `-1`
+  "uncorrelated" sentinel after roughly `2^31` allocations (~ 5 days
+  at 5k subs/sec), breaking the user-side correlation between
+  manual subscribes and server `ReqResponse` frames. The clamp
+  masks the sign bit (`x & 0x7FFF_FFFF`) so wire ids stay strictly
+  non-negative even past `i32::MAX`.
+- Per-tick `metrics::counter!` lookup hoisted to `LazyLock<Counter>`
+  handles on the FPSS decode hot path. Eight handles (4 event
+  kinds × 2 metric names) replace the per-tick `(name, labels)`
+  hashmap probe inside the global recorder, dropping the per-call
+  observability cost from ~30 ns to ~5 ns (a single atomic add on
+  `Counter::increment`).
+- Rate-limit the "no contract for ID" warning at 1024 emissions to
+  match the existing slow-callback and clock-skew warn cadence.
+  A server-side replay-boundary anomaly that ticked unrecognised
+  ids previously flooded `tracing` with one line per tick and
+  crowded out genuinely diagnostic warnings.
+- Python `thetadatadx.__version__` now resolves through
+  `importlib.metadata.version("thetadatadx")` (PEP 396). The
+  attribute was missing on the top-level package, breaking
+  `pip show`, downstream version-pinning, and environment
+  snapshot scripts.
+- `Channel::Drop` aborts the spawned h2 connection-driver
+  `JoinHandle` as a belt-and-braces guard. The task was previously
+  detached at `Channel::handshake`; under repeated connect /
+  disconnect cycles a parked connection future could outlive the
+  `Channel` for an unbounded interval, accumulating background
+  tasks. `.abort()` is idempotent on already-finished tasks.
+- The `unwrap_or(u32::MAX)` in `Codec::encode_response_for_test`
+  becomes `.expect("…")` so a synthetic test response that ever
+  outgrows the 32-bit length prefix surfaces a diagnostic
+  failure instead of silently emitting `u32::MAX`.
+- `consecutive_timeouts * 50` in the FPSS io_loop is now
+  `consecutive_timeouts.saturating_mul(50_u64)` so a wild future
+  bump to `max_consecutive_timeouts` past `u64::MAX / 50` cannot
+  wrap the diagnostic on the warn line.
+- Per-disconnect metric label allocation: replaced
+  `format!("{:?}", reason)` with `RemoveReason::as_str()` so the
+  `reason` label points at a `&'static str` rather than allocating
+  a `String` per disconnect. Disconnects are rare, so this is a
+  consistency fix per the "no per-event allocations" discipline,
+  not a hot-path win.
+- `FpssConnectArgs::ring_size` doc comment corrected from "≈ 552
+  bytes after the typed-FpssControl variants" to the actual
+  `mem::size_of::<FpssEventInternal>() = 96` bytes on the current
+  64-bit layout; the per-`FpssClient` ring footprint at the
+  default `ring_size = 4096` is now documented as ~ 384 KiB.
+
+### CI
+
+- Workspace clippy invocation widened to
+  `cargo clippy --workspace --all-targets --locked -- -D warnings`
+  so `[[bench]]` and `#[cfg(test)]` unsafe blocks travel through
+  `clippy::undocumented_unsafe_blocks` on every PR. Adds SAFETY
+  comments on five bench-only `unsafe impl GlobalAlloc` blocks
+  and two test-only unsafe deref sites that previously escaped
+  the lint.
+- `scripts/check_banned_vocab.py` rejects the verbatim string
+  "see FFI boundary doc on the enclosing fn — raw pointers
+  satisfy the documented caller contract" outside `ffi/src/`.
+  The string was landed across 31 sites including 8 that are
+  not FFI raw-pointer contexts; the gate prevents future
+  bot-stamping from reintroducing the boilerplate.
 
 ## [10.0.0] - 2026-05-09
 

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -2209,7 +2209,12 @@ mod tests {
         // integer variants, so the first 4 bytes of `*event` are the
         // tag value. Reading by reference would `move` the non-Copy
         // enum, which `&self` access on a `*const` borrow forbids.
-        // SAFETY: see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract.
+        //
+        // SAFETY: `event` is non-null (asserted above) and points at a
+        // `#[repr(C, i32)]`-shaped `TdxFpssEvent` whose first 4 bytes
+        // are the discriminant; a `*const i32` deref of those bytes is
+        // sound. The FFI boundary on `capture_callback`'s caller
+        // guarantees the pointee outlives the call.
         let kind = unsafe { *event.cast::<i32>() };
         ctx.last_kind.store(kind, Ordering::Relaxed);
         // Record the OS thread id so the test can compare against the

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -2197,6 +2197,11 @@ mod tests {
         // duration of the call and `ctx` is the pointer registered
         // alongside `capture_callback`.
         assert!(!event.is_null(), "FFI handed null event pointer");
+        // SAFETY: `ctx` was registered as a `&TestCtx` cast to
+        // `*mut c_void` two lines below in `tdx_unified_set_callback_ctx`
+        // and the `TestCtx` value outlives the call (held in a stack
+        // `Arc` for the duration of the test). Cast back to the
+        // originating type is sound.
         let ctx = unsafe { &*(ctx.cast::<TestCtx>()) };
         ctx.hits.fetch_add(1, Ordering::Relaxed);
         // Read the kind discriminant via a pointer cast to i32. The

--- a/scripts/check_banned_vocab.py
+++ b/scripts/check_banned_vocab.py
@@ -241,6 +241,47 @@ def _scan_pr_metadata() -> list[tuple[str, str, str]]:
     return hits
 
 
+# Stamped SAFETY-comment string the bot-author landed across the
+# codebase in lieu of writing a real SAFETY annotation. Keeping it as
+# boilerplate at every `unsafe { ... }` site reduces SAFETY comments to
+# noise — the whole point of the lint is that each unsafe block names
+# the invariant the caller upholds. The exact verbatim string below is
+# blocked everywhere EXCEPT inside `ffi/src/`, where every site IS an
+# `extern "C" fn` raw-pointer deref whose caller contract is documented
+# on the enclosing fn signature; rewriting each of those would just
+# duplicate the function-level doc.
+STAMPED_SAFETY = (
+    "see FFI boundary doc on the enclosing fn "
+    "— raw pointers satisfy the documented caller contract"
+)
+STAMPED_SAFETY_SCOPE_EXEMPT_PREFIXES = ("ffi/src/",)
+
+
+def _scan_stamped_safety() -> list[tuple[pathlib.Path, int, str]]:
+    """Reject the stamped SAFETY boilerplate outside `ffi/src/`.
+
+    Regression guard against future bot-stamping. The string is exact
+    (no fuzzy match) so any rewrite that names the actual invariant
+    sails through.
+    """
+    hits: list[tuple[pathlib.Path, int, str]] = []
+    needle = STAMPED_SAFETY
+    for path in _iter_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if any(rel.startswith(p) for p in STAMPED_SAFETY_SCOPE_EXEMPT_PREFIXES):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if needle not in text:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if needle in line:
+                hits.append((path.relative_to(REPO_ROOT), lineno, line.rstrip()))
+    return hits
+
+
 def main() -> int:
     total = 0
 
@@ -269,12 +310,28 @@ def main() -> int:
         for where, phrase, line in pr_hits:
             print(f"  {where} [{phrase}] {line[:160]}")
 
-    if total:
+    stamped_hits = _scan_stamped_safety()
+    if stamped_hits:
+        total += len(stamped_hits)
         print(
-            "\nFix: either rephrase, or add `VOCAB-OK: <reason>` on the "
-            "same line for genuinely-legitimate uses (e.g. quoting a "
-            "third-party standard name)."
+            f"banned-vocab: {len(stamped_hits)} stamped-SAFETY hit(s) "
+            f"outside ffi/src/"
         )
+        for rel, lineno, line in stamped_hits:
+            print(f"  {rel}:{lineno} {line[:160]}")
+        print(
+            "  -> Rewrite the comment to name the actual invariant "
+            "(what's true here that makes the unsafe block sound). "
+            "Stamped boilerplate is not a SAFETY annotation."
+        )
+
+    if total:
+        if file_hits or commit_hits or pr_hits:
+            print(
+                "\nFix: either rephrase, or add `VOCAB-OK: <reason>` on the "
+                "same line for genuinely-legitimate uses (e.g. quoting a "
+                "third-party standard name)."
+            )
         return 1
 
     print("banned-vocab: clean")

--- a/sdks/python/python/thetadatadx/__init__.py
+++ b/sdks/python/python/thetadatadx/__init__.py
@@ -6,3 +6,23 @@ from . import thetadatadx as _ext
 __doc__ = _ext.__doc__
 if hasattr(_ext, "__all__"):
     __all__ = _ext.__all__
+
+# Resolve the package version through `importlib.metadata` so the
+# string the user reads from `thetadatadx.__version__` is the same one
+# the installed wheel's `METADATA` declares — driven by `Cargo.toml`
+# via the maturin build. Falling back to the in-source default keeps
+# `thetadatadx.__version__` readable in editable / source-tree imports
+# where the wheel metadata is absent. Wrapping the import in a
+# try/except guards against the (theoretical) edge case where
+# `importlib.metadata` cannot resolve the distribution (unusual stale
+# install), so an import-time exception cannot break the wheel.
+try:
+    from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    try:
+        __version__ = _pkg_version("thetadatadx")
+    except _PackageNotFoundError:
+        __version__ = "10.0.0"
+except ImportError:  # pragma: no cover - importlib.metadata is in stdlib >=3.8
+    __version__ = "10.0.0"

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -29,6 +29,12 @@ from typing import (
     final,
 )
 
+# PEP 396 — package version string, resolved at import time from the
+# installed wheel's metadata via `importlib.metadata.version`. Falls
+# back to the in-source default when the wheel metadata is absent
+# (editable installs, source-tree imports).
+__version__: str
+
 # ─────────────────────────────────────────────────────────────────────
 # Credentials + Config
 # ─────────────────────────────────────────────────────────────────────

--- a/sdks/python/tests/test_fresh_install_smoke.py
+++ b/sdks/python/tests/test_fresh_install_smoke.py
@@ -122,3 +122,23 @@ def test_documented_implied_volatility_runs(mod) -> None:
     iv, err = mod.implied_volatility(450.0, 455.0, 0.05, 0.015, 30.0 / 365.0, 8.50, "C")
     assert iv > 0
     assert err >= 0
+
+
+def test_version_attribute_exposed(mod) -> None:
+    """PEP 396: `thetadatadx.__version__` must be a non-empty string.
+
+    A fresh install of the wheel resolves the version through
+    `importlib.metadata.version("thetadatadx")`; the source-tree
+    fallback returns the in-source default. Either way, the attribute
+    must exist and be a non-empty string — downstream packagers,
+    `pip show`, and bug-report scripts rely on it.
+    """
+    assert hasattr(mod, "__version__"), (
+        "`thetadatadx.__version__` is missing — PEP 396 requires every "
+        "distributable Python package to expose this attribute."
+    )
+    version = mod.__version__
+    assert isinstance(version, str), (
+        f"`thetadatadx.__version__` must be a string, got {type(version).__name__}."
+    )
+    assert version, "`thetadatadx.__version__` must be a non-empty string."


### PR DESCRIPTION
## Summary

Closes all 11 findings from the senior-eng audit landed against `main` at `b5e85ce1`. Two BLOCKERS, five MINOR, four NIT — one branch, eight commits grouped by concern.

## Findings closed

**BLOCKERS**

- **B1** — Workspace clippy invocation in `.github/workflows/ci.yml::check` widened to `cargo clippy --workspace --all-targets --locked -- -D warnings` so `[[bench]]` and `#[cfg(test)]` unsafe blocks travel through `clippy::undocumented_unsafe_blocks` on every PR. Concrete SAFETY annotations added to seven sites that were escaping the prior `--workspace`-only gate (five bench-only `unsafe impl GlobalAlloc` blocks, the `libc::__errno_location()` deref in `wake.rs`, two test-only `&*(... as *const ...)` derefs).

- **B2** — Replaced the stamped "see FFI boundary doc on the enclosing fn — raw pointers satisfy the documented caller contract" SAFETY string at the 8 non-FFI sites the audit identified. Each rewrite names the actual invariant (libc atomic 1-byte pipe write, `#[repr(C, u8)]` layout-compat reborrow, Disruptor consumer-barrier exclusive access, `env_test_guard()` mutex). The 23 occurrences inside `ffi/src/` are kept verbatim — every one IS an `extern \"C\" fn` raw-pointer deref whose caller contract is documented on the enclosing fn signature. Regression guard added to `scripts/check_banned_vocab.py` that rejects the exact verbatim string outside `ffi/src/`.

**MINOR**

- **M1** — `next_req_id` widened from `AtomicI32` to `AtomicI64` with a `fpss::wire_req_id(i64) -> i32` clamp at every wire-boundary call site. The 32-bit counter could wrap into the wire protocol's `-1` "uncorrelated" sentinel after ~`2^31` allocations (5 days at 5k subs/sec); the clamp masks the sign bit so wire ids stay strictly non-negative even past `i32::MAX`. New `wire_req_id_clamps_positive_past_i32_max` test pins the invariant.

- **M2** — Per-tick `metrics::counter!` lookup hoisted to `LazyLock<Counter>` handles. Eight handles (4 event kinds × 2 metric names) replace the per-tick `(name, labels)` hashmap probe inside the global recorder, dropping per-call observability cost from ~30 ns to ~5 ns.

- **M3** — `tracing::warn!(... \"no contract for ID\")` now rate-limited at every 1024th hit, matching the existing slow-callback and clock-skew warn cadence. A replay-boundary anomaly that ticked unrecognised ids previously flooded `tracing` with a per-tick line.

- **M4** — Python `thetadatadx.__version__` resolves through `importlib.metadata.version(\"thetadatadx\")` (PEP 396). `__init__.pyi` gains a top-level `__version__: str` declaration; `test_fresh_install_smoke.py` gains a `test_version_attribute_exposed` smoke test asserting the attribute exists and is non-empty.

- **M5** — `Channel::Drop` aborts the spawned h2 connection-driver `JoinHandle` as a belt-and-braces guard. New `dropping_channel_aborts_h2_connection_task` test drives one handshake over `tokio::io::duplex`, drops the channel, and asserts the abort_handle reports `is_finished()` within a 2-second deadline.

**NIT**

- **N1** — `Codec::encode_response_for_test` swaps `.unwrap_or(u32::MAX)` for `.expect(\"synthetic test response must fit the gRPC 32-bit length prefix\")` so an oversized synthetic surfaces a diagnostic failure instead of silently emitting `u32::MAX`.

- **N2** — `consecutive_timeouts * 50` in the FPSS io_loop becomes `consecutive_timeouts.saturating_mul(50_u64)`.

- **N3** — Per-disconnect metric label allocation: `format!(\"{:?}\", reason)` → `RemoveReason::as_str()` (returns `&'static str`).

- **N4** — `FpssConnectArgs::ring_size` doc comment corrected from \"≈ 552 bytes\" to the actual `mem::size_of::<FpssEventInternal>() = 96` bytes on the current 64-bit layout; the per-`FpssClient` ring footprint at the default `ring_size = 4096` updated from \"~ 2.3 MB\" to \"~ 384 KiB\" to match.

## Gates run locally

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean (verifies B1)
- `cargo test --workspace --locked` — 909 tests, all passing
- `cargo doc --no-deps --workspace --locked` — clean
- `cargo test --doc --workspace --locked` — 17 doc tests pass, 3 ignored
- `python3 scripts/check_banned_vocab.py` — clean (validates the new stamped-SAFETY regression guard)
- `python3 scripts/check_docs_consistency.py` — clean (docs-site CHANGELOG mirror synced)
- `python3 scripts/check_version_sync.py` — clean
- `python3 scripts/check_binding_parity.py` — clean
- `maturin develop --release` + `python -m pytest sdks/python/tests/` — 294 pass, 29 skipped (live-only)

## Test plan

- [ ] CI matrix turns green on the widened clippy gate (`check` job).
- [ ] Banned-vocab gate stays green with the new stamped-SAFETY pass.
- [ ] All 13 invariant CI gates pass.
- [ ] `python -c \"import thetadatadx; print(thetadatadx.__version__)\"` prints `10.0.0` from a fresh-install wheel.
- [ ] Hot-path FPSS event-throughput bench shows no per-counter regression on the GH-hosted runner.
- [ ] Final post-merge spot-check: `grep \"see FFI boundary doc on the enclosing fn\" crates/ -rn | wc -l` returns 0.

## Notes

- No version bump. No CHANGELOG version section bump. No release tag. `[Unreleased]` `### Fixed` and `### CI` gain entries enumerating the seven runtime fixes plus the two CI changes.
- `docs-site/docs/changelog.md` synced to the canonical `CHANGELOG.md` per the existing CI consistency gate.