### PR TITLE
feat: REST transport + lenient quote decoder + Terminal patcher (closes #571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- REST transport + `FallbackPolicy` for h2-cascading endpoints
+  (#571). The upstream Terminal's Java `QuoteTick` /
+  `TradeQuoteTick` constructors length-check incoming rows against
+  a fixed 11 / 25 element shape and throw
+  `IllegalArgumentException` on the pre-extension 6-field NBBO rows
+  that 2022-era options storage still surfaces; the exception
+  bubbles through the gRPC handler and cascades the h2 stream with
+  no error frame. The new `crate::rest::RestClient` talks
+  HTTP/1.1 to the local Terminal's `/v3/...` paths, sidestepping
+  the cascade (HTTP/1.1 is per-request rather than h2 stream
+  multiplexing). Four endpoints from the failure matrix are
+  wired:
+  `option_history_quote` /
+  `option_history_trade_quote` /
+  `option_history_greeks_implied_volatility` /
+  `option_history_greeks_first_order`. The new `FallbackPolicy`
+  (`Disabled` / `RestOnH2Disconnect` /
+  `RestAlwaysForDateRange { before }` / `RestAlways`) drives
+  auto-routing on the new
+  `ThetaDataDxClient::option_history_quote_with_fallback` and
+  `option_history_trade_quote_with_fallback` shim methods; pre-2023
+  dates skip gRPC entirely (saving the failed round trip) while
+  current dates flow through the gRPC fast path unchanged. Default
+  is `Disabled` for back-compat -- callers opt in via
+  `DirectConfig::with_rest_fallback`. Full incident write-up and
+  the policy table land in `docs-site/docs/legacy-quote-handling.md`.
+
+- `local-terminal-patcher` CLI (#571). New workspace binary at
+  `tools/local-terminal-patcher/` that rewrites the local Terminal's
+  inner library jar to tolerate the 6-field NBBO rows on the gRPC
+  path. Resolves the inner jar via autodetect or `--jar` /
+  `--terminal-dir`, verifies the known-broken bytecode signature
+  (`bipush 11 / if_icmpeq`), compiles the patched
+  `QuoteTick.java` + `OhlcTick.java` via system `javac` (JDK 11+),
+  and swaps the two classes into a copy of the jar. Patches are
+  `include_str!`'d into the binary so the tool runs without a
+  separate patches/ directory once built. Smoke-verified against
+  the live broken jar; the patched output carries the new
+  `normalizeData()` upcast + diagnostic exception messages
+  replacing the original `"Wrong number of data fields"` throw.
+
 - Universal `.stream(handler)` method on every historical builder
   (#565). The buffered `.await -> Vec<T>` path held three live
   copies (h2 frames + concatenated proto payload + decoded
@@ -108,6 +149,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `QuoteTick` decoder is now explicit about lenient column extraction
+  for the legacy 6-field NBBO layout (#571). The `bid_exchange`,
+  `bid_condition`, `ask_exchange`, `ask_condition` columns were
+  already declared optional in `tick_schema.toml` so the
+  generator-emitted `opt_number(row, None) -> 0` arm handles
+  absent columns; the schema doc + the `find_header` doc now call
+  out the contract, and two regression tests pin both the legacy
+  6-field and current 11-field shapes through `parse_quote_ticks`.
+  Forward-compat with the eventual upstream fix is preserved -- if
+  ThetaData lands a server-side upcast that adds the columns back
+  on the wire, the decoder picks them up without any further
+  change.
+
+- `reqwest` workspace feature set gains `query` for URL parameter
+  encoding on the new REST transport (#571). Adds
+  `serde_urlencoded` to the lockfile; both deps were already
+  present transitively via the existing reqwest usage on the auth
+  path.
+
 - `Error::Transport` payload restructured from `String` into a
   typed `Transport { kind: TransportErrorKind, message: String }`
   shape mirroring the `Grpc { kind, message }` / `Decode { kind, message }`
@@ -197,6 +257,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the next major release.
 
 ### Fixed
+
+- `option_history_quote` / `option_history_trade_quote` /
+  `option_history_greeks_implied_volatility` /
+  `option_history_greeks_first_order` no longer leave production
+  users without a recovery path on 2022-era options (#571).
+  The upstream Terminal's h2-cascade bug remains -- the SDK now
+  ships three independent escape hatches: (a) `crate::rest::RestClient`
+  + `FallbackPolicy::Rest*` for client-side REST routing
+  (zero-friction, no Terminal change), (b) the
+  `local-terminal-patcher` CLI for users who prefer to keep the
+  gRPC fast path (one-time patch of the local jar), (c) lenient
+  optional-column extraction in the gRPC decoder so the eventual
+  upstream fix flows through without further SDK change. Closes
+  #571.
 
 - Python `StreamingAsyncSession.__aexit__` and
   `StreamingAsyncBatchesSession.__aexit__` now close the asyncio

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1015,16 @@ checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
  "bitflags 2.11.1",
  "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1732,6 +1751,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "local-terminal-patcher"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "sha2",
+ "zip",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +1886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3250,6 +3279,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,7 +3527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3910,6 +3945,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -4738,10 +4779,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3188,6 +3189,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tdbe", "crates/thetadatadx", "tools/cli", "ffi"]
+members = ["crates/tdbe", "crates/thetadatadx", "tools/cli", "tools/local-terminal-patcher", "ffi"]
 exclude = ["sdks/python", "sdks/typescript", "tools/mcp", "tools/server"]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ All endpoints return fully typed data in every language. See the [API Reference]
 
 **Additional surfaces** (not REST/gRPC endpoints): FPSS real-time streaming (7 subscribe/unsubscribe methods per contract and per full-stream type) and a local Greeks calculator (22 Black-Scholes Greeks plus an IV solver, callable individually or batched).
 
+### Coverage notes
+
+* **2022-era options NBBO quotes (#571)**: the upstream Terminal cascades the h2 stream on pre-extension 6-field NBBO rows that storage surfaces for some 2022 contracts. The SDK ships three independent recovery paths: a REST transport (`crate::rest::RestClient`) with a `FallbackPolicy` enum that routes the four affected endpoints over HTTP/1.1 automatically, a `local-terminal-patcher` CLI that rewrites the local Terminal jar to tolerate the legacy rows on the gRPC path, and a lenient gRPC decoder that picks up the eventual upstream fix without further SDK change. See [`docs-site/docs/legacy-quote-handling.md`](docs-site/docs/legacy-quote-handling.md) for the recipe.
+
 ## Architecture
 
 ```mermaid

--- a/crates/tdbe/src/types/generated/tick.rs
+++ b/crates/tdbe/src/types/generated/tick.rs
@@ -297,6 +297,18 @@ pub struct PriceTick {
 }
 
 /// Quote tick -- 10 fields + midpoint. NBBO quote data.
+///
+/// Wire layout: the post-extension shape is 11 columns (`ms_of_day`,
+/// `bid_size`, `bid_exchange`, `bid`, `bid_condition`, `ask_size`,
+/// `ask_exchange`, `ask`, `ask_condition`, `price_type`, `date`).
+/// Pre-2023 storage rows for 2022-era options still live in the
+/// pre-extension 6-column layout (`ms_of_day`, `bid_size`, `bid`,
+/// `ask_size`, `ask`, `date`) (issue #571). The four exchange / condition
+/// columns are NOT in the `required` list below so the generator emits
+/// `opt_number(row, None) -> 0` arms for them, which matches the
+/// patched-Terminal `QuoteTick.normalizeData()` upcast contract verbatim
+/// and keeps REST-served legacy rows decoding bit-exact for the
+/// wire-present columns. See `docs-site/docs/legacy-quote-handling.md`.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -90,8 +90,11 @@ x509-parser = "0.18.1"
 sha2 = "0.11.0"
 subtle = "2.6.1"
 
-# HTTP (auth against nexus-api)
-reqwest = { version = "0.13.3", features = ["json", "rustls"], default-features = false }
+# HTTP (auth against nexus-api + local-Terminal REST transport, #571).
+# `query` enables `RequestBuilder::query` for URL parameter encoding on
+# the REST path (`crate::rest`); adds serde + serde_urlencoded both
+# already in the workspace lockfile.
+reqwest = { version = "0.13.3", features = ["json", "query", "rustls"], default-features = false }
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -89,6 +89,40 @@ fn tier_label(tier: Option<crate::mdds::SubscriptionTier>) -> String {
     }
 }
 
+/// Parse a `YYYYMMDD` date string into an `i32`. Returns `0` on
+/// malformed input -- the only call site
+/// (`option_history_*_with_fallback`) treats `0` as the most-permissive
+/// "always pre-route" boundary, which is the safe default when the
+/// caller passed in something we can't classify. The malformed-input
+/// path also surfaces a `tracing::warn!`.
+fn parse_yyyymmdd(date: &str) -> i32 {
+    match date.parse::<i32>() {
+        Ok(d) if (10_000_000..100_000_000).contains(&d) => d,
+        _ => {
+            tracing::warn!(
+                target: "thetadatadx::client::fallback",
+                date,
+                "could not parse YYYYMMDD date; defaulting to 0 (pre-route to REST if policy permits)"
+            );
+            0
+        }
+    }
+}
+
+/// True iff `err` matches the issue #571 h2-cascade signature. Distinct
+/// from a generic `is_retryable` predicate -- only the specific
+/// connection-closed transport error counts. Other gRPC failures
+/// (auth, timeout, unauthenticated) propagate unchanged.
+fn is_h2_disconnect(err: &Error) -> bool {
+    matches!(
+        err,
+        Error::Transport {
+            kind: crate::error::TransportErrorKind::ConnectionClosed,
+            ..
+        }
+    )
+}
+
 /// Subscription tier information captured at authentication time.
 ///
 /// `#[non_exhaustive]` so new tiers (e.g. additional asset classes the
@@ -1025,6 +1059,217 @@ impl ThetaDataDxClient {
             indices: tier_label(self.historical.indices_tier()),
             interest_rate: tier_label(self.historical.interest_rate_tier()),
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // REST-fallback surface for h2-cascading endpoints (issue #571).
+    //
+    // Wrap the four affected gRPC endpoints with fallback-aware shims
+    // that consult `config.fallback` and dispatch to the REST transport
+    // (`crate::rest`) when the policy applies. Call sites that want
+    // gRPC-only behaviour keep using the existing generated methods on
+    // `self.historical` (e.g. `tdx.option_history_quote(...)`).
+    // ---------------------------------------------------------------------
+
+    /// Fetch option NBBO history via gRPC, falling back to REST per
+    /// [`crate::config::FallbackPolicy`] (issue #571).
+    ///
+    /// Behaviour by policy variant:
+    ///
+    /// * [`FallbackPolicy::Disabled`](crate::config::FallbackPolicy::Disabled)
+    ///   -- always gRPC, no fallback. Identical to
+    ///   `tdx.option_history_quote(symbol, expiration, date).await`.
+    ///
+    /// * [`FallbackPolicy::RestOnH2Disconnect`](crate::config::FallbackPolicy::RestOnH2Disconnect)
+    ///   -- try gRPC first; on
+    ///   [`crate::error::TransportErrorKind::ConnectionClosed`]
+    ///   (the issue #571 signature) re-issue over REST.
+    ///
+    /// * [`FallbackPolicy::RestAlwaysForDateRange { before, .. }`](crate::config::FallbackPolicy::RestAlwaysForDateRange)
+    ///   -- compare `date` (parsed as `YYYYMMDD` integer) against
+    ///   `before`. Strictly-earlier dates skip gRPC and route to REST
+    ///   immediately; on-or-after dates flow through gRPC.
+    ///
+    /// * [`FallbackPolicy::RestAlways`](crate::config::FallbackPolicy::RestAlways)
+    ///   -- always REST.
+    ///
+    /// `date` is the `YYYYMMDD` request date used by both transports;
+    /// `strike` / `right` follow the same string conventions as the
+    /// underlying gRPC and REST builders.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] on transport, parse, or REST decode failure.
+    /// Errors from the REST fallback path are converted via
+    /// `From<RestError>` (carrying the structured
+    /// [`crate::error::TransportErrorKind::UnexpectedHttpStatus`] /
+    /// `ConnectionClosed` discriminator).
+    pub async fn option_history_quote_with_fallback(
+        &self,
+        symbol: &str,
+        expiration: &str,
+        date: &str,
+        strike: Option<&str>,
+        right: Option<&str>,
+        interval: Option<&str>,
+    ) -> Result<Vec<tdbe::types::tick::QuoteTick>, Error> {
+        let policy = &self.config().fallback;
+        let start_date = parse_yyyymmdd(date);
+
+        if policy.pre_routes_to_rest(start_date) {
+            if let Some(base_url) = policy.base_url() {
+                tracing::info!(
+                    target: "thetadatadx::client::fallback",
+                    endpoint = "option_history_quote",
+                    date,
+                    "pre-routing to REST per FallbackPolicy"
+                );
+                return self
+                    .rest_quote(base_url, symbol, expiration, date, strike, right, interval)
+                    .await;
+            }
+        }
+
+        // gRPC path. Build via Deref into MddsClient.
+        let mut builder = self.option_history_quote(symbol, expiration, date);
+        if let Some(s) = strike {
+            builder = builder.strike(s);
+        }
+        if let Some(r) = right {
+            builder = builder.right(r);
+        }
+        if let Some(i) = interval {
+            builder = builder.interval(i);
+        }
+        match builder.await {
+            Ok(ticks) => Ok(ticks),
+            Err(err) => {
+                if policy.falls_back_on_h2_disconnect() && is_h2_disconnect(&err) {
+                    if let Some(base_url) = policy.base_url() {
+                        tracing::warn!(
+                            target: "thetadatadx::client::fallback",
+                            endpoint = "option_history_quote",
+                            error = %err,
+                            "h2 disconnect on gRPC, falling back to REST"
+                        );
+                        return self
+                            .rest_quote(base_url, symbol, expiration, date, strike, right, interval)
+                            .await;
+                    }
+                }
+                Err(err)
+            }
+        }
+    }
+
+    /// REST helper for [`Self::option_history_quote_with_fallback`].
+    /// Kept private so the high-level surface presents one method per
+    /// affected endpoint -- callers do not need to know the REST
+    /// transport exists unless they reach for [`crate::rest::RestClient`]
+    /// directly.
+    async fn rest_quote(
+        &self,
+        base_url: &str,
+        symbol: &str,
+        expiration: &str,
+        date: &str,
+        strike: Option<&str>,
+        right: Option<&str>,
+        interval: Option<&str>,
+    ) -> Result<Vec<tdbe::types::tick::QuoteTick>, Error> {
+        let rest = crate::rest::RestClient::new(base_url).map_err(Error::from)?;
+        let mut builder = rest.option_history_quote(symbol, expiration, date);
+        if let Some(s) = strike {
+            builder = builder.strike(s);
+        }
+        if let Some(r) = right {
+            builder = builder.right(r);
+        }
+        if let Some(i) = interval {
+            builder = builder.interval(i);
+        }
+        builder.execute().await.map_err(Error::from)
+    }
+
+    /// Fetch combined trade + quote history via gRPC, falling back to
+    /// REST per [`crate::config::FallbackPolicy`] (issue #571). Same
+    /// dispatch semantics as
+    /// [`Self::option_history_quote_with_fallback`].
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::option_history_quote_with_fallback`].
+    pub async fn option_history_trade_quote_with_fallback(
+        &self,
+        symbol: &str,
+        expiration: &str,
+        date: &str,
+        strike: Option<&str>,
+        right: Option<&str>,
+    ) -> Result<Vec<tdbe::types::tick::TradeQuoteTick>, Error> {
+        let policy = &self.config().fallback;
+        let start_date = parse_yyyymmdd(date);
+
+        if policy.pre_routes_to_rest(start_date) {
+            if let Some(base_url) = policy.base_url() {
+                tracing::info!(
+                    target: "thetadatadx::client::fallback",
+                    endpoint = "option_history_trade_quote",
+                    date,
+                    "pre-routing to REST per FallbackPolicy"
+                );
+                return self
+                    .rest_trade_quote(base_url, symbol, expiration, date, strike, right)
+                    .await;
+            }
+        }
+
+        let mut builder = self.option_history_trade_quote(symbol, expiration, date);
+        if let Some(s) = strike {
+            builder = builder.strike(s);
+        }
+        if let Some(r) = right {
+            builder = builder.right(r);
+        }
+        match builder.await {
+            Ok(ticks) => Ok(ticks),
+            Err(err) => {
+                if policy.falls_back_on_h2_disconnect() && is_h2_disconnect(&err) {
+                    if let Some(base_url) = policy.base_url() {
+                        tracing::warn!(
+                            target: "thetadatadx::client::fallback",
+                            endpoint = "option_history_trade_quote",
+                            error = %err,
+                            "h2 disconnect on gRPC, falling back to REST"
+                        );
+                        return self
+                            .rest_trade_quote(base_url, symbol, expiration, date, strike, right)
+                            .await;
+                    }
+                }
+                Err(err)
+            }
+        }
+    }
+
+    async fn rest_trade_quote(
+        &self,
+        base_url: &str,
+        symbol: &str,
+        expiration: &str,
+        date: &str,
+        strike: Option<&str>,
+        right: Option<&str>,
+    ) -> Result<Vec<tdbe::types::tick::TradeQuoteTick>, Error> {
+        let rest = crate::rest::RestClient::new(base_url).map_err(Error::from)?;
+        let mut builder = rest.option_history_trade_quote(symbol, expiration, date);
+        if let Some(s) = strike {
+            builder = builder.strike(s);
+        }
+        if let Some(r) = right {
+            builder = builder.right(r);
+        }
+        builder.execute().await.map_err(Error::from)
     }
 
     // ---------------------------------------------------------------------

--- a/crates/thetadatadx/src/config/fallback.rs
+++ b/crates/thetadatadx/src/config/fallback.rs
@@ -20,11 +20,12 @@ pub const DEFAULT_REST_BASE_URL: &str = "http://127.0.0.1:25503";
 ///
 /// `#[non_exhaustive]` so additional variants (`RestOnAnyTransport`,
 /// `RestForSymbols`, ...) can land without a breaking API change.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum FallbackPolicy {
     /// REST fallback is disabled -- every request goes over gRPC
     /// regardless of failure mode. Default for back-compat.
+    #[default]
     Disabled,
 
     /// Fall back to REST only when gRPC returns the
@@ -104,12 +105,6 @@ impl FallbackPolicy {
     #[must_use]
     pub fn falls_back_on_h2_disconnect(&self) -> bool {
         !matches!(self, Self::Disabled)
-    }
-}
-
-impl Default for FallbackPolicy {
-    fn default() -> Self {
-        Self::Disabled
     }
 }
 

--- a/crates/thetadatadx/src/config/fallback.rs
+++ b/crates/thetadatadx/src/config/fallback.rs
@@ -1,0 +1,164 @@
+//! Fallback policy -- routes h2-cascading endpoints over the local
+//! Terminal's REST API (issue #571).
+//!
+//! Issue #571 documents an upstream Terminal bug where 2022-era
+//! options' pre-extension 6-field NBBO storage rows trip a
+//! length-rigid `IllegalArgumentException` in the Java `QuoteTick` /
+//! `TradeQuoteTick` constructors, cascading the entire h2 stream.
+//! [`FallbackPolicy`] lets a caller route the four affected endpoints
+//! (`option_history_quote`, `option_history_trade_quote`,
+//! `option_history_greeks_implied_volatility`,
+//! `option_history_greeks_first_order`) over the REST transport
+//! ([`crate::rest`]) instead of cancelling the call when the gRPC
+//! cascade strikes.
+
+/// Default base URL for [`FallbackPolicy::RestAlways`] and friends.
+/// Matches [`crate::rest::client::DEFAULT_TERMINAL_BASE_URL`].
+pub const DEFAULT_REST_BASE_URL: &str = "http://127.0.0.1:25503";
+
+/// Policy controlling REST fallback for h2-cascading endpoints.
+///
+/// `#[non_exhaustive]` so additional variants (`RestOnAnyTransport`,
+/// `RestForSymbols`, ...) can land without a breaking API change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FallbackPolicy {
+    /// REST fallback is disabled -- every request goes over gRPC
+    /// regardless of failure mode. Default for back-compat.
+    Disabled,
+
+    /// Fall back to REST only when gRPC returns the
+    /// [`crate::error::TransportErrorKind::ConnectionClosed`] signature
+    /// associated with the issue #571 h2 cascade. Cheaper for current
+    /// (post-2023) workloads where the gRPC path is the fast common
+    /// case, but pays one failed round trip per affected request.
+    RestOnH2Disconnect {
+        /// Terminal REST base URL.
+        base_url: String,
+    },
+
+    /// Route every request whose `start_date` falls before `before` --
+    /// expressed as `YYYYMMDD` integer -- directly to REST without
+    /// attempting gRPC first. Use when the caller knows the symbol /
+    /// date range is squarely inside the 2022-era legacy-row window
+    /// (saves the failed round-trip cost on every call). Requests on
+    /// or after `before` flow through gRPC as normal.
+    ///
+    /// `before` is `YYYYMMDD` so the user can keep the integer-date
+    /// convention used elsewhere in the SDK rather than reaching for
+    /// `chrono::NaiveDate`.
+    RestAlwaysForDateRange {
+        /// Terminal REST base URL.
+        base_url: String,
+        /// `YYYYMMDD` cutoff. Requests with `start_date < before`
+        /// route to REST; requests on or after `before` flow through
+        /// gRPC. The boundary value follows half-open interval
+        /// semantics ("up to but not including `before`").
+        before: i32,
+    },
+
+    /// Always route the affected endpoints over REST regardless of
+    /// the requested date range. Use when the caller wants a single
+    /// transport for every quote-bearing call (e.g. running against a
+    /// patched Terminal that ALSO has REST-only column extensions the
+    /// gRPC path does not yet expose).
+    RestAlways {
+        /// Terminal REST base URL.
+        base_url: String,
+    },
+}
+
+impl FallbackPolicy {
+    /// Returns the REST base URL the policy would target on a
+    /// fallback, or `None` for [`Self::Disabled`].
+    #[must_use]
+    pub fn base_url(&self) -> Option<&str> {
+        match self {
+            Self::Disabled => None,
+            Self::RestOnH2Disconnect { base_url }
+            | Self::RestAlwaysForDateRange { base_url, .. }
+            | Self::RestAlways { base_url } => Some(base_url),
+        }
+    }
+
+    /// Whether the policy would pre-route a request with `start_date`
+    /// to REST without trying gRPC first. Drives the "save the failed
+    /// round trip" optimization on [`Self::RestAlwaysForDateRange`]
+    /// and [`Self::RestAlways`].
+    ///
+    /// `start_date` is `YYYYMMDD` (e.g. `20240605`); the same integer
+    /// shape every endpoint method takes.
+    #[must_use]
+    pub fn pre_routes_to_rest(&self, start_date: i32) -> bool {
+        match self {
+            Self::Disabled | Self::RestOnH2Disconnect { .. } => false,
+            Self::RestAlwaysForDateRange { before, .. } => start_date < *before,
+            Self::RestAlways { .. } => true,
+        }
+    }
+
+    /// Whether the policy would fall back to REST AFTER observing the
+    /// gRPC error described by issue #571 (h2 connection closed
+    /// mid-stream). Always true for non-Disabled policies; the
+    /// per-variant nuance is on `pre_routes_to_rest`.
+    #[must_use]
+    pub fn falls_back_on_h2_disconnect(&self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+}
+
+impl Default for FallbackPolicy {
+    fn default() -> Self {
+        Self::Disabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_routes_nothing() {
+        let p = FallbackPolicy::Disabled;
+        assert!(!p.pre_routes_to_rest(20_220_414));
+        assert!(!p.pre_routes_to_rest(20_240_605));
+        assert!(!p.falls_back_on_h2_disconnect());
+        assert!(p.base_url().is_none());
+    }
+
+    #[test]
+    fn rest_on_h2_disconnect_does_not_pre_route() {
+        let p = FallbackPolicy::RestOnH2Disconnect {
+            base_url: "http://127.0.0.1:25503".to_string(),
+        };
+        assert!(!p.pre_routes_to_rest(20_220_414));
+        assert!(p.falls_back_on_h2_disconnect());
+        assert_eq!(p.base_url(), Some("http://127.0.0.1:25503"));
+    }
+
+    #[test]
+    fn rest_always_for_date_range_pre_routes_pre_2023_only() {
+        let p = FallbackPolicy::RestAlwaysForDateRange {
+            base_url: "http://127.0.0.1:25503".to_string(),
+            before: 20_230_101,
+        };
+        // 2022 -- pre-route to REST.
+        assert!(p.pre_routes_to_rest(20_220_414));
+        // 2023-01-01 itself -- on the boundary, gRPC (half-open).
+        assert!(!p.pre_routes_to_rest(20_230_101));
+        // 2024 -- gRPC as normal.
+        assert!(!p.pre_routes_to_rest(20_240_605));
+        assert!(p.falls_back_on_h2_disconnect());
+    }
+
+    #[test]
+    fn rest_always_pre_routes_every_call() {
+        let p = FallbackPolicy::RestAlways {
+            base_url: "http://127.0.0.1:25503".to_string(),
+        };
+        assert!(p.pre_routes_to_rest(20_220_414));
+        assert!(p.pre_routes_to_rest(20_240_605));
+        assert!(p.pre_routes_to_rest(20_300_101));
+        assert!(p.falls_back_on_h2_disconnect());
+    }
+}

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -47,6 +47,7 @@
 
 mod auth;
 mod env;
+mod fallback;
 mod flatfiles;
 mod fpss;
 mod mdds;
@@ -61,6 +62,7 @@ pub use auth::{AuthConfig, DEFAULT_CLIENT_TYPE, DEFAULT_NEXUS_URL};
 pub use env::{
     ENV_CLIENT_TYPE, ENV_FPSS_HOST, ENV_FPSS_PORT, ENV_MDDS_HOST, ENV_MDDS_PORT, ENV_NEXUS_URL,
 };
+pub use fallback::{FallbackPolicy, DEFAULT_REST_BASE_URL};
 pub use flatfiles::{bounds as flatfiles_bounds, FlatFilesConfig};
 pub use fpss::{bounds as fpss_bounds, FpssConfig, FpssFlushMode};
 pub use mdds::MddsConfig;
@@ -122,6 +124,11 @@ pub struct DirectConfig {
     pub metrics: MetricsConfig,
     /// Async runtime tuning.
     pub runtime: RuntimeConfig,
+    /// REST-fallback policy for h2-cascading endpoints (issue #571).
+    /// Default is [`FallbackPolicy::Disabled`] -- every request goes
+    /// over gRPC. Set via [`Self::with_rest_fallback`] when querying
+    /// 2022-era options data through a local Terminal.
+    pub fallback: FallbackPolicy,
 }
 
 impl DirectConfig {
@@ -163,6 +170,7 @@ impl DirectConfig {
             auth: AuthConfig::production_defaults(),
             metrics: MetricsConfig::default(),
             runtime: RuntimeConfig::default(),
+            fallback: FallbackPolicy::Disabled,
         }
     }
 
@@ -350,6 +358,33 @@ impl DirectConfig {
     #[must_use]
     pub fn with_client_type(mut self, client_type: impl Into<String>) -> Self {
         self.auth.client_type = client_type.into();
+        self
+    }
+
+    /// Configure REST fallback for h2-cascading endpoints (issue #571).
+    ///
+    /// Default is [`FallbackPolicy::Disabled`]; requests always flow
+    /// through gRPC. Set to one of the REST variants when querying
+    /// 2022-era options data through a local Terminal -- the four
+    /// affected endpoints (`option_history_quote`,
+    /// `option_history_trade_quote`,
+    /// `option_history_greeks_implied_volatility`,
+    /// `option_history_greeks_first_order`) check this policy on every
+    /// call and route to [`crate::rest::RestClient`] when the variant
+    /// would apply.
+    ///
+    /// ```rust,no_run
+    /// use thetadatadx::config::{DirectConfig, FallbackPolicy, DEFAULT_REST_BASE_URL};
+    /// let cfg = DirectConfig::production().with_rest_fallback(
+    ///     FallbackPolicy::RestAlwaysForDateRange {
+    ///         base_url: DEFAULT_REST_BASE_URL.to_string(),
+    ///         before: 20_230_101,
+    ///     },
+    /// );
+    /// ```
+    #[must_use]
+    pub fn with_rest_fallback(mut self, policy: FallbackPolicy) -> Self {
+        self.fallback = policy;
         self
     }
 

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -99,6 +99,7 @@ pub mod fpss;
 pub mod frames;
 pub mod grpc;
 pub mod observability;
+pub mod rest;
 pub mod util;
 
 // Wave 3 layout: macros, registry, validate, wire_semantics, and the

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -179,8 +179,8 @@ pub mod prelude {
     pub use tdbe::types::enums::SecType;
 }
 pub use config::{
-    DirectConfig, FlatFilesConfig, FpssFlushMode, ReconnectAttemptClass, ReconnectAttemptLimits,
-    ReconnectPolicy,
+    DirectConfig, FallbackPolicy, FlatFilesConfig, FpssFlushMode, ReconnectAttemptClass,
+    ReconnectAttemptLimits, ReconnectPolicy, DEFAULT_REST_BASE_URL,
 };
 pub use error::{AuthErrorKind, Error, FpssErrorKind};
 pub use flatfiles::{

--- a/crates/thetadatadx/src/mdds/decode/headers.rs
+++ b/crates/thetadatadx/src/mdds/decode/headers.rs
@@ -54,6 +54,25 @@ pub(crate) const HEADER_ALIASES: &[(&str, &str)] = &[
 /// `option_snapshot_greeks_third_order` returning only the third-order Greek
 /// columns from the `GreeksTick` union schema) are by design. Header drift
 /// can be observed at the `trace` level via `RUST_LOG=thetadatadx=trace`.
+///
+/// # Legacy 6-field NBBO quote layout (issue #571)
+///
+/// Pre-2023 storage rows for 2022-era option NBBO quotes still live in the
+/// pre-extension 6-field layout
+/// `[ms_of_day, bid_size, bid, ask_size, ask, date]` — the upstream Java
+/// `QuoteTick` constructor throws `IllegalArgumentException` on these rows
+/// because it length-checks against the current 11-field shape, which
+/// cascades the h2 stream with no error frame. The patched Terminal
+/// (`theta-terminal-re/patches/QuoteTick.java`) upcasts those rows to the
+/// 11-field shape by zero-filling the absent columns, and the REST transport
+/// (`crate::rest`) accepts both shapes verbatim. On the decoder side, the
+/// `QuoteTick` schema declares `bid_exchange`, `bid_condition`,
+/// `ask_exchange`, `ask_condition` as optional columns — when the wire
+/// response omits them (legacy 6-field shape served through REST), the
+/// generator-emitted `opt_number(row, None)` arm defaults them to `0`, which
+/// matches the upstream patched-Terminal upcast contract. The regression
+/// test `tests::quote_tick_decodes_legacy_six_field_shape_with_zero_fill`
+/// in this module pins that behaviour.
 pub(crate) fn find_header(headers: &[&str], name: &str) -> Option<usize> {
     // Try exact match first.
     if let Some(pos) = headers.iter().position(|&s| s == name) {

--- a/crates/thetadatadx/src/mdds/decode/tests.rs
+++ b/crates/thetadatadx/src/mdds/decode/tests.rs
@@ -14,8 +14,8 @@ use super::dual_type_columns::{
 };
 use super::{
     extract_number_column, parse_eod_ticks, parse_greeks_all_ticks, parse_greeks_first_order_ticks,
-    parse_greeks_second_order_ticks, parse_greeks_third_order_ticks, parse_trade_ticks,
-    DecodeError,
+    parse_greeks_second_order_ticks, parse_greeks_third_order_ticks, parse_quote_ticks,
+    parse_trade_ticks, DecodeError,
 };
 use crate::proto;
 
@@ -1088,4 +1088,119 @@ fn parse_greeks_third_order_ticks_decodes_third_order_subset() {
     assert_eq!(t.underlying_ms_of_day, 34_200_001);
     assert!((t.underlying_price - 58.0025).abs() < 1e-9);
     assert_eq!(t.date, 20_240_614);
+}
+
+// ─────────── Legacy 6-field NBBO quote layout (issue #571) ───────────
+//
+// Pre-2023 storage rows for 2022-era option NBBO quotes still live in the
+// pre-extension 6-field layout `[ms_of_day, bid_size, bid, ask_size, ask,
+// date]`. The patched Terminal upcasts those rows to the 11-field shape
+// before they reach the gRPC handler; the REST transport (`crate::rest`)
+// accepts both shapes verbatim. On the decoder side the only guarantee
+// callers need is that a `DataTable` whose header set is a subset of
+// the 11-field NBBO schema — i.e. legacy 6 of 11 columns present, with the
+// other five (`bid_exchange`, `bid_condition`, `ask_exchange`,
+// `ask_condition`) absent — decodes without error and zero-fills the
+// absent columns.
+//
+// This pair of tests pins that behaviour so a future regression in
+// `find_header` / the generator's `opt_number(idx)` arm surfaces here.
+
+/// A `DataTable` whose headers match the legacy 6-field NBBO shape
+/// (`ms_of_day, bid_size, bid, ask_size, ask, date`) must decode to a
+/// `QuoteTick` with the absent exchange / condition columns zero-filled.
+/// Mirrors the patched-Terminal `QuoteTick.normalizeData()` contract in
+/// `theta-terminal-re/patches/QuoteTick.java` so the SDK reads the
+/// REST-served legacy rows with the same field-by-field shape as the
+/// upcast gRPC rows. Reproducer for issue #571.
+#[test]
+fn quote_tick_decodes_legacy_six_field_shape_with_zero_fill() {
+    let table = proto::DataTable {
+        headers: vec![
+            "ms_of_day".into(),
+            "bid_size".into(),
+            "bid".into(),
+            "ask_size".into(),
+            "ask".into(),
+            "date".into(),
+        ],
+        data_table: vec![row_of(vec![
+            dv_number(34_200_000),
+            dv_number(50),
+            dv_price(15022, 6), // bid = 1.5022
+            dv_number(75),
+            dv_price(15041, 6), // ask = 1.5041
+            dv_number(20_220_414),
+        ])],
+    };
+    let ticks = parse_quote_ticks(&table).unwrap();
+    assert_eq!(ticks.len(), 1);
+    let t = &ticks[0];
+
+    // Wire-present columns decode bit-exact.
+    assert_eq!(t.ms_of_day, 34_200_000);
+    assert_eq!(t.bid_size, 50);
+    assert!((t.bid - 1.5022).abs() < 1e-9);
+    assert_eq!(t.ask_size, 75);
+    assert!((t.ask - 1.5041).abs() < 1e-9);
+    assert_eq!(t.date, 20_220_414);
+
+    // Wire-absent columns zero-fill: matches the patched Terminal's
+    // `normalizeData()` upcast contract verbatim.
+    assert_eq!(t.bid_exchange, 0);
+    assert_eq!(t.bid_condition, 0);
+    assert_eq!(t.ask_exchange, 0);
+    assert_eq!(t.ask_condition, 0);
+
+    // Midpoint is computed from bid + ask regardless of legacy / current
+    // layout — pin the value so a generator regression on the midpoint
+    // post-processing step would surface here.
+    assert!((t.midpoint - 1.50315).abs() < 1e-9);
+}
+
+/// The current 11-field shape must continue to decode all columns. A
+/// fix that accidentally narrowed the parser to the legacy layout would
+/// surface as wrong values on `bid_exchange` / `ask_condition`.
+#[test]
+fn quote_tick_decodes_current_eleven_field_shape_unchanged() {
+    let table = proto::DataTable {
+        headers: vec![
+            "ms_of_day".into(),
+            "bid_size".into(),
+            "bid_exchange".into(),
+            "bid".into(),
+            "bid_condition".into(),
+            "ask_size".into(),
+            "ask_exchange".into(),
+            "ask".into(),
+            "ask_condition".into(),
+            "date".into(),
+        ],
+        data_table: vec![row_of(vec![
+            dv_number(34_200_000),
+            dv_number(50),
+            dv_number(7), // CBOE
+            dv_price(15022, 6),
+            dv_number(1),
+            dv_number(75),
+            dv_number(8), // NYSE Arca
+            dv_price(15041, 6),
+            dv_number(2),
+            dv_number(20_240_605),
+        ])],
+    };
+    let ticks = parse_quote_ticks(&table).unwrap();
+    assert_eq!(ticks.len(), 1);
+    let t = &ticks[0];
+
+    assert_eq!(t.ms_of_day, 34_200_000);
+    assert_eq!(t.bid_size, 50);
+    assert_eq!(t.bid_exchange, 7);
+    assert!((t.bid - 1.5022).abs() < 1e-9);
+    assert_eq!(t.bid_condition, 1);
+    assert_eq!(t.ask_size, 75);
+    assert_eq!(t.ask_exchange, 8);
+    assert!((t.ask - 1.5041).abs() < 1e-9);
+    assert_eq!(t.ask_condition, 2);
+    assert_eq!(t.date, 20_240_605);
 }

--- a/crates/thetadatadx/src/rest/client.rs
+++ b/crates/thetadatadx/src/rest/client.rs
@@ -1,0 +1,664 @@
+//! `RestClient` -- talks HTTP to the local Terminal's `/v3/...` paths.
+//!
+//! Mirrors the gRPC builder shape so call sites can switch transports
+//! with a receiver swap; see the module docstring on [`super`] for the
+//! incident this exists to escape.
+
+use std::time::Duration;
+
+use reqwest::Client as ReqwestClient;
+use tdbe::types::tick::{GreeksFirstOrderTick, IvTick, QuoteTick, TradeQuoteTick};
+
+use super::csv::Table;
+use super::error::RestError;
+
+/// Default Terminal base URL (`http://127.0.0.1:25503`).
+pub const DEFAULT_TERMINAL_BASE_URL: &str = "http://127.0.0.1:25503";
+
+/// HTTP REST transport against the local ThetaTerminal.
+///
+/// `RestClient` is cheap to construct (no network round-trip on
+/// `new()`); the underlying [`reqwest::Client`] holds the connection
+/// pool. Clone is `O(1)` -- both fields are `Arc`-backed -- so handing
+/// the client across worker tasks does not duplicate connections.
+#[derive(Debug, Clone)]
+pub struct RestClient {
+    base_url: String,
+    http: ReqwestClient,
+}
+
+impl RestClient {
+    /// Build a REST client pointing at `base_url` (e.g.
+    /// `"http://127.0.0.1:25503"`).
+    ///
+    /// `connect_timeout`, `request_timeout` are set to sensible defaults
+    /// (5 s / 60 s); override via [`Self::with_http_client`] when the
+    /// caller wants a tuned `reqwest::Client`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the underlying `reqwest::ClientBuilder`
+    /// fails to assemble (rustls platform-verifier init failure,
+    /// invalid timeout config). Hot in practice.
+    pub fn new(base_url: impl Into<String>) -> Result<Self, RestError> {
+        let http = ReqwestClient::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(60))
+            .build()?;
+        Ok(Self {
+            base_url: base_url.into(),
+            http,
+        })
+    }
+
+    /// Build a REST client with a caller-supplied [`reqwest::Client`].
+    ///
+    /// Use when the application already runs a tuned HTTP client
+    /// (custom timeouts, connection pool size, middleware) and wants
+    /// the REST transport to share it.
+    #[must_use]
+    pub fn with_http_client(base_url: impl Into<String>, http: ReqwestClient) -> Self {
+        Self {
+            base_url: base_url.into(),
+            http,
+        }
+    }
+
+    /// Base URL the client targets.
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Build a builder for `option_history_quote` (REST path
+    /// `/v3/option/history/quote`). The builder mirrors the gRPC
+    /// builder's setter surface (`strike`, `right`, `interval`, ...)
+    /// and decodes to `Vec<QuoteTick>` on `.await`.
+    #[must_use]
+    pub fn option_history_quote(
+        &self,
+        symbol: &str,
+        expiration: &str,
+        date: &str,
+    ) -> OptionHistoryQuoteRestBuilder<'_> {
+        OptionHistoryQuoteRestBuilder {
+            client: self,
+            symbol: symbol.to_string(),
+            expiration: expiration.to_string(),
+            start_date: date.to_string(),
+            end_date: date.to_string(),
+            strike: None,
+            right: None,
+            interval: None,
+        }
+    }
+
+    /// Build a builder for `option_history_trade_quote` (REST path
+    /// `/v3/option/history/trade_quote`).
+    #[must_use]
+    pub fn option_history_trade_quote(
+        &self,
+        symbol: &str,
+        expiration: &str,
+        date: &str,
+    ) -> OptionHistoryTradeQuoteRestBuilder<'_> {
+        OptionHistoryTradeQuoteRestBuilder {
+            client: self,
+            symbol: symbol.to_string(),
+            expiration: expiration.to_string(),
+            start_date: date.to_string(),
+            end_date: date.to_string(),
+            strike: None,
+            right: None,
+        }
+    }
+
+    /// Build a builder for `option_history_greeks_implied_volatility`
+    /// (REST path `/v3/option/history/greeks/implied_volatility`).
+    /// Listed in BUG_REPORT.md as a sibling endpoint to the
+    /// `_first_order` Greeks one that surfaces the same 6-field NBBO
+    /// row through its underlying-quote join.
+    #[must_use]
+    pub fn option_history_greeks_implied_volatility(
+        &self,
+        symbol: &str,
+        expiration: &str,
+        date: &str,
+    ) -> OptionHistoryGreeksIvRestBuilder<'_> {
+        OptionHistoryGreeksIvRestBuilder {
+            client: self,
+            symbol: symbol.to_string(),
+            expiration: expiration.to_string(),
+            start_date: date.to_string(),
+            end_date: date.to_string(),
+            strike: None,
+            right: None,
+            interval: None,
+        }
+    }
+
+    /// Build a builder for `option_history_greeks_first_order`
+    /// (REST path `/v3/option/history/greeks/first_order`).
+    #[must_use]
+    pub fn option_history_greeks_first_order(
+        &self,
+        symbol: &str,
+        expiration: &str,
+        date: &str,
+    ) -> OptionHistoryGreeksFirstOrderRestBuilder<'_> {
+        OptionHistoryGreeksFirstOrderRestBuilder {
+            client: self,
+            symbol: symbol.to_string(),
+            expiration: expiration.to_string(),
+            start_date: date.to_string(),
+            end_date: date.to_string(),
+            strike: None,
+            right: None,
+            interval: None,
+        }
+    }
+}
+
+/// Builder for [`RestClient::option_history_quote`].
+#[derive(Debug)]
+pub struct OptionHistoryQuoteRestBuilder<'a> {
+    client: &'a RestClient,
+    symbol: String,
+    expiration: String,
+    start_date: String,
+    end_date: String,
+    strike: Option<String>,
+    right: Option<String>,
+    interval: Option<String>,
+}
+
+impl<'a> OptionHistoryQuoteRestBuilder<'a> {
+    /// Set the option strike price (e.g. `"440"` for $440, `"17.5"`
+    /// for $17.50). `None` is equivalent to the wildcard query.
+    #[must_use]
+    pub fn strike(mut self, strike: impl Into<String>) -> Self {
+        self.strike = Some(strike.into());
+        self
+    }
+
+    /// Set the option right (`"call"`, `"put"`, or `"both"`).
+    #[must_use]
+    pub fn right(mut self, right: impl Into<String>) -> Self {
+        self.right = Some(right.into());
+        self
+    }
+
+    /// Set the sampling interval (`"tick"`, `"1s"`, `"1m"`, `"5m"`,
+    /// `"1h"`, ...).
+    #[must_use]
+    pub fn interval(mut self, interval: impl Into<String>) -> Self {
+        self.interval = Some(interval.into());
+        self
+    }
+
+    /// Override the end date (defaults to the same value as the
+    /// `date` parameter passed to `RestClient::option_history_quote`).
+    /// Use for multi-day requests.
+    #[must_use]
+    pub fn end_date(mut self, end_date: impl Into<String>) -> Self {
+        self.end_date = end_date.into();
+        self
+    }
+
+    /// Execute the REST request, decode the CSV body, and return the
+    /// resulting `Vec<QuoteTick>`. Decoder accepts both the current
+    /// 11-field and legacy 6-field NBBO header layouts; absent
+    /// columns zero-fill (issue #571).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RestError`] on HTTP transport failure, non-2xx
+    /// status, or CSV decode failure.
+    pub async fn execute(self) -> Result<Vec<QuoteTick>, RestError> {
+        let body = fetch_csv(
+            self.client,
+            "/v3/option/history/quote",
+            &[
+                ("symbol", self.symbol.as_str()),
+                ("expiration", self.expiration.as_str()),
+                ("start_date", self.start_date.as_str()),
+                ("end_date", self.end_date.as_str()),
+                ("strike", self.strike.as_deref().unwrap_or("")),
+                ("right", self.right.as_deref().unwrap_or("")),
+                ("interval", self.interval.as_deref().unwrap_or("")),
+                ("format", "csv"),
+            ],
+        )
+        .await?;
+        decode_quote_csv(&body)
+    }
+}
+
+/// Builder for [`RestClient::option_history_trade_quote`].
+#[derive(Debug)]
+pub struct OptionHistoryTradeQuoteRestBuilder<'a> {
+    client: &'a RestClient,
+    symbol: String,
+    expiration: String,
+    start_date: String,
+    end_date: String,
+    strike: Option<String>,
+    right: Option<String>,
+}
+
+impl<'a> OptionHistoryTradeQuoteRestBuilder<'a> {
+    #[must_use]
+    pub fn strike(mut self, strike: impl Into<String>) -> Self {
+        self.strike = Some(strike.into());
+        self
+    }
+
+    #[must_use]
+    pub fn right(mut self, right: impl Into<String>) -> Self {
+        self.right = Some(right.into());
+        self
+    }
+
+    #[must_use]
+    pub fn end_date(mut self, end_date: impl Into<String>) -> Self {
+        self.end_date = end_date.into();
+        self
+    }
+
+    /// # Errors
+    ///
+    /// See [`OptionHistoryQuoteRestBuilder::execute`].
+    pub async fn execute(self) -> Result<Vec<TradeQuoteTick>, RestError> {
+        let body = fetch_csv(
+            self.client,
+            "/v3/option/history/trade_quote",
+            &[
+                ("symbol", self.symbol.as_str()),
+                ("expiration", self.expiration.as_str()),
+                ("start_date", self.start_date.as_str()),
+                ("end_date", self.end_date.as_str()),
+                ("strike", self.strike.as_deref().unwrap_or("")),
+                ("right", self.right.as_deref().unwrap_or("")),
+                ("format", "csv"),
+            ],
+        )
+        .await?;
+        decode_trade_quote_csv(&body)
+    }
+}
+
+/// Builder for [`RestClient::option_history_greeks_implied_volatility`].
+#[derive(Debug)]
+pub struct OptionHistoryGreeksIvRestBuilder<'a> {
+    client: &'a RestClient,
+    symbol: String,
+    expiration: String,
+    start_date: String,
+    end_date: String,
+    strike: Option<String>,
+    right: Option<String>,
+    interval: Option<String>,
+}
+
+impl<'a> OptionHistoryGreeksIvRestBuilder<'a> {
+    #[must_use]
+    pub fn strike(mut self, strike: impl Into<String>) -> Self {
+        self.strike = Some(strike.into());
+        self
+    }
+
+    #[must_use]
+    pub fn right(mut self, right: impl Into<String>) -> Self {
+        self.right = Some(right.into());
+        self
+    }
+
+    #[must_use]
+    pub fn interval(mut self, interval: impl Into<String>) -> Self {
+        self.interval = Some(interval.into());
+        self
+    }
+
+    #[must_use]
+    pub fn end_date(mut self, end_date: impl Into<String>) -> Self {
+        self.end_date = end_date.into();
+        self
+    }
+
+    /// # Errors
+    ///
+    /// See [`OptionHistoryQuoteRestBuilder::execute`].
+    pub async fn execute(self) -> Result<Vec<IvTick>, RestError> {
+        let body = fetch_csv(
+            self.client,
+            "/v3/option/history/greeks/implied_volatility",
+            &[
+                ("symbol", self.symbol.as_str()),
+                ("expiration", self.expiration.as_str()),
+                ("start_date", self.start_date.as_str()),
+                ("end_date", self.end_date.as_str()),
+                ("strike", self.strike.as_deref().unwrap_or("")),
+                ("right", self.right.as_deref().unwrap_or("")),
+                ("interval", self.interval.as_deref().unwrap_or("")),
+                ("format", "csv"),
+            ],
+        )
+        .await?;
+        decode_iv_csv(&body)
+    }
+}
+
+/// Builder for [`RestClient::option_history_greeks_first_order`].
+#[derive(Debug)]
+pub struct OptionHistoryGreeksFirstOrderRestBuilder<'a> {
+    client: &'a RestClient,
+    symbol: String,
+    expiration: String,
+    start_date: String,
+    end_date: String,
+    strike: Option<String>,
+    right: Option<String>,
+    interval: Option<String>,
+}
+
+impl<'a> OptionHistoryGreeksFirstOrderRestBuilder<'a> {
+    #[must_use]
+    pub fn strike(mut self, strike: impl Into<String>) -> Self {
+        self.strike = Some(strike.into());
+        self
+    }
+
+    #[must_use]
+    pub fn right(mut self, right: impl Into<String>) -> Self {
+        self.right = Some(right.into());
+        self
+    }
+
+    #[must_use]
+    pub fn interval(mut self, interval: impl Into<String>) -> Self {
+        self.interval = Some(interval.into());
+        self
+    }
+
+    #[must_use]
+    pub fn end_date(mut self, end_date: impl Into<String>) -> Self {
+        self.end_date = end_date.into();
+        self
+    }
+
+    /// # Errors
+    ///
+    /// See [`OptionHistoryQuoteRestBuilder::execute`].
+    pub async fn execute(self) -> Result<Vec<GreeksFirstOrderTick>, RestError> {
+        let body = fetch_csv(
+            self.client,
+            "/v3/option/history/greeks/first_order",
+            &[
+                ("symbol", self.symbol.as_str()),
+                ("expiration", self.expiration.as_str()),
+                ("start_date", self.start_date.as_str()),
+                ("end_date", self.end_date.as_str()),
+                ("strike", self.strike.as_deref().unwrap_or("")),
+                ("right", self.right.as_deref().unwrap_or("")),
+                ("interval", self.interval.as_deref().unwrap_or("")),
+                ("format", "csv"),
+            ],
+        )
+        .await?;
+        decode_greeks_first_order_csv(&body)
+    }
+}
+
+// ─── Transport helper ────────────────────────────────────────────────
+
+/// Issue the GET request and return the body as `String`. Empty
+/// string-valued query params are dropped so the Terminal sees a
+/// clean URL.
+async fn fetch_csv(
+    client: &RestClient,
+    path: &str,
+    params: &[(&str, &str)],
+) -> Result<String, RestError> {
+    let url = format!("{}{}", client.base_url, path);
+    // Drop empty params so we don't send e.g. `strike=` to the
+    // Terminal -- the upstream parser treats empty as "missing", but
+    // some endpoints emit a 400 on an empty-valued required param.
+    let kept: Vec<(&str, &str)> = params
+        .iter()
+        .copied()
+        .filter(|(_, v)| !v.is_empty())
+        .collect();
+
+    tracing::debug!(target: "thetadatadx::rest", path, ?kept, "REST GET");
+
+    let resp = client.http.get(&url).query(&kept).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|_| "<failed to read body>".to_string());
+        let truncated: String = body.chars().take(4096).collect();
+        return Err(RestError::HttpStatus {
+            status: status.as_u16(),
+            body: truncated,
+        });
+    }
+    Ok(resp.text().await?)
+}
+
+// ─── Per-tick CSV decoders ───────────────────────────────────────────
+//
+// Each decoder mirrors the gRPC `parse_<tick>_ticks` function: resolve
+// every column index up front, then iterate rows. Absent columns
+// zero-fill via `cell_i32_or_zero` / `cell_f64_or_zero` -- this is
+// the contract that makes the REST path immune to issue #571.
+
+/// Decode the `option_history_quote` CSV body into `Vec<QuoteTick>`.
+///
+/// Accepts both 11-field and legacy 6-field header layouts; absent
+/// columns default to 0 per the patched-Terminal `normalizeData()`
+/// upcast contract.
+///
+/// # Errors
+///
+/// Returns [`RestError`] when the body has no header, when one of the
+/// hard-required columns (`ms_of_day`, `date`) is missing on a
+/// non-empty response, or when a numeric cell fails to parse.
+pub fn decode_quote_csv(body: &str) -> Result<Vec<QuoteTick>, RestError> {
+    let table = Table::parse(body)?;
+    let ms_idx = table.column_index("ms_of_day");
+    let bid_size_idx = table.column_index("bid_size");
+    let bid_exg_idx = table.column_index("bid_exchange");
+    let bid_idx = table.column_index("bid");
+    let bid_cond_idx = table.column_index("bid_condition");
+    let ask_size_idx = table.column_index("ask_size");
+    let ask_exg_idx = table.column_index("ask_exchange");
+    let ask_idx = table.column_index("ask");
+    let ask_cond_idx = table.column_index("ask_condition");
+    let date_idx = table.column_index("date");
+
+    if table.rows.is_empty() {
+        // Empty response -- legitimate "no data today". No header
+        // validation, mirrors the gRPC path's empty-table guard.
+        return Ok(vec![]);
+    }
+
+    let mut out: Vec<QuoteTick> = Vec::with_capacity(table.rows.len());
+    for (row_idx, _) in table.rows.iter().enumerate() {
+        let ms_of_day = table.cell_i32_required(row_idx, ms_idx, "ms_of_day")?;
+        let date = table.cell_i32_required(row_idx, date_idx, "date")?;
+        let bid = table.cell_f64_or_zero(row_idx, bid_idx);
+        let ask = table.cell_f64_or_zero(row_idx, ask_idx);
+        let midpoint = (bid + ask) / 2.0;
+        // QuoteTick has contract-id fields (expiration / strike /
+        // right). The REST path doesn't currently carry them in the
+        // CSV -- they're per-request constants, not per-row. Zero /
+        // empty placeholders keep the struct populated; callers who
+        // need contract identity in the result attach it at the
+        // request layer.
+        out.push(QuoteTick {
+            ms_of_day,
+            bid_size: table.cell_i32_or_zero(row_idx, bid_size_idx),
+            bid_exchange: table.cell_i32_or_zero(row_idx, bid_exg_idx),
+            bid,
+            bid_condition: table.cell_i32_or_zero(row_idx, bid_cond_idx),
+            ask_size: table.cell_i32_or_zero(row_idx, ask_size_idx),
+            ask_exchange: table.cell_i32_or_zero(row_idx, ask_exg_idx),
+            ask,
+            ask_condition: table.cell_i32_or_zero(row_idx, ask_cond_idx),
+            date,
+            midpoint,
+            expiration: 0,
+            strike: 0.0,
+            right: 0,
+        });
+    }
+    Ok(out)
+}
+
+/// Decode `option_history_trade_quote` CSV into `Vec<TradeQuoteTick>`.
+///
+/// Combined trade+quote rows carry the quote-side columns the legacy
+/// rollover affects (`bid_exchange`, `bid_condition`,
+/// `ask_exchange`, `ask_condition`) -- those default to 0 when
+/// absent, same contract as the standalone quote path.
+///
+/// # Errors
+///
+/// See [`decode_quote_csv`].
+pub fn decode_trade_quote_csv(body: &str) -> Result<Vec<TradeQuoteTick>, RestError> {
+    let table = Table::parse(body)?;
+    if table.rows.is_empty() {
+        return Ok(vec![]);
+    }
+    let ms_idx = table.column_index("ms_of_day");
+    let price_idx = table.column_index("price");
+    let size_idx = table.column_index("size");
+    let exchange_idx = table.column_index("exchange");
+    let bid_size_idx = table.column_index("bid_size");
+    let bid_exg_idx = table.column_index("bid_exchange");
+    let bid_idx = table.column_index("bid");
+    let bid_cond_idx = table.column_index("bid_condition");
+    let ask_size_idx = table.column_index("ask_size");
+    let ask_exg_idx = table.column_index("ask_exchange");
+    let ask_idx = table.column_index("ask");
+    let ask_cond_idx = table.column_index("ask_condition");
+    let date_idx = table.column_index("date");
+
+    let mut out: Vec<TradeQuoteTick> = Vec::with_capacity(table.rows.len());
+    for row_idx in 0..table.rows.len() {
+        let ms_of_day = table.cell_i32_required(row_idx, ms_idx, "ms_of_day")?;
+        let date = table.cell_i32_required(row_idx, date_idx, "date")?;
+        let price = table.cell_f64_or_zero(row_idx, price_idx);
+        let bid = table.cell_f64_or_zero(row_idx, bid_idx);
+        let ask = table.cell_f64_or_zero(row_idx, ask_idx);
+        out.push(TradeQuoteTick {
+            ms_of_day,
+            sequence: 0,
+            ext_condition1: 0,
+            ext_condition2: 0,
+            ext_condition3: 0,
+            ext_condition4: 0,
+            condition: 0,
+            size: table.cell_i32_or_zero(row_idx, size_idx),
+            exchange: table.cell_i32_or_zero(row_idx, exchange_idx),
+            price,
+            condition_flags: 0,
+            price_flags: 0,
+            volume_type: 0,
+            records_back: 0,
+            quote_ms_of_day: ms_of_day,
+            bid_size: table.cell_i32_or_zero(row_idx, bid_size_idx),
+            bid_exchange: table.cell_i32_or_zero(row_idx, bid_exg_idx),
+            bid,
+            bid_condition: table.cell_i32_or_zero(row_idx, bid_cond_idx),
+            ask_size: table.cell_i32_or_zero(row_idx, ask_size_idx),
+            ask_exchange: table.cell_i32_or_zero(row_idx, ask_exg_idx),
+            ask,
+            ask_condition: table.cell_i32_or_zero(row_idx, ask_cond_idx),
+            date,
+            expiration: 0,
+            strike: 0.0,
+            right: 0,
+        });
+    }
+    Ok(out)
+}
+
+/// Decode `option_history_greeks_implied_volatility` CSV into
+/// `Vec<IvTick>`.
+///
+/// # Errors
+///
+/// See [`decode_quote_csv`].
+pub fn decode_iv_csv(body: &str) -> Result<Vec<IvTick>, RestError> {
+    let table = Table::parse(body)?;
+    if table.rows.is_empty() {
+        return Ok(vec![]);
+    }
+    let ms_idx = table.column_index("ms_of_day");
+    let iv_idx = table.column_index("implied_volatility");
+    let iv_err_idx = table.column_index("iv_error");
+    let date_idx = table.column_index("date");
+
+    let mut out: Vec<IvTick> = Vec::with_capacity(table.rows.len());
+    for row_idx in 0..table.rows.len() {
+        let ms_of_day = table.cell_i32_required(row_idx, ms_idx, "ms_of_day")?;
+        let date = table.cell_i32_required(row_idx, date_idx, "date")?;
+        out.push(IvTick {
+            ms_of_day,
+            implied_volatility: table.cell_f64_or_zero(row_idx, iv_idx),
+            iv_error: table.cell_f64_or_zero(row_idx, iv_err_idx),
+            date,
+            expiration: 0,
+            strike: 0.0,
+            right: 0,
+        });
+    }
+    Ok(out)
+}
+
+/// Decode `option_history_greeks_first_order` CSV into
+/// `Vec<GreeksFirstOrderTick>`.
+///
+/// # Errors
+///
+/// See [`decode_quote_csv`].
+pub fn decode_greeks_first_order_csv(body: &str) -> Result<Vec<GreeksFirstOrderTick>, RestError> {
+    let table = Table::parse(body)?;
+    if table.rows.is_empty() {
+        return Ok(vec![]);
+    }
+    let ms_idx = table.column_index("ms_of_day");
+    let date_idx = table.column_index("date");
+
+    let mut out: Vec<GreeksFirstOrderTick> = Vec::with_capacity(table.rows.len());
+    for row_idx in 0..table.rows.len() {
+        let ms_of_day = table.cell_i32_required(row_idx, ms_idx, "ms_of_day")?;
+        let date = table.cell_i32_required(row_idx, date_idx, "date")?;
+        out.push(GreeksFirstOrderTick {
+            ms_of_day,
+            bid: table.cell_f64_or_zero(row_idx, table.column_index("bid")),
+            ask: table.cell_f64_or_zero(row_idx, table.column_index("ask")),
+            delta: table.cell_f64_or_zero(row_idx, table.column_index("delta")),
+            theta: table.cell_f64_or_zero(row_idx, table.column_index("theta")),
+            vega: table.cell_f64_or_zero(row_idx, table.column_index("vega")),
+            rho: table.cell_f64_or_zero(row_idx, table.column_index("rho")),
+            epsilon: table.cell_f64_or_zero(row_idx, table.column_index("epsilon")),
+            lambda: table.cell_f64_or_zero(row_idx, table.column_index("lambda")),
+            implied_volatility: table
+                .cell_f64_or_zero(row_idx, table.column_index("implied_volatility")),
+            iv_error: table.cell_f64_or_zero(row_idx, table.column_index("iv_error")),
+            underlying_ms_of_day: table
+                .cell_i32_or_zero(row_idx, table.column_index("underlying_ms_of_day")),
+            underlying_price: table
+                .cell_f64_or_zero(row_idx, table.column_index("underlying_price")),
+            date,
+            expiration: 0,
+            strike: 0.0,
+            right: 0,
+        });
+    }
+    Ok(out)
+}

--- a/crates/thetadatadx/src/rest/csv.rs
+++ b/crates/thetadatadx/src/rest/csv.rs
@@ -1,0 +1,228 @@
+//! Minimal CSV decoder for the local Terminal's `format=csv` responses.
+//!
+//! The Terminal serves CSV bodies in the shape:
+//!
+//! ```text
+//! ms_of_day,bid_size,bid,ask_size,ask,date
+//! 34200000,50,1.5022,75,1.5041,20220414
+//! 34200500,...
+//! ```
+//!
+//! The decoder is hand-written instead of pulling in the `csv` crate
+//! for two reasons:
+//!
+//! 1. The bodies we need to parse are flat numeric tables; there are
+//!    no embedded quotes, no escapes, and no UTF-8 multi-byte fields.
+//!    A 60-line hand parser covers the contract.
+//!
+//! 2. Adding a new workspace dep for one transport's wire format would
+//!    couple the rest of the crate's build graph to it. The cost of
+//!    maintaining a small parser here is lower than the long-term cost
+//!    of an extra crate in the lockfile.
+//!
+//! The decoder is **lenient on absent columns** -- the legacy 6-field
+//! NBBO layout (`ms_of_day, bid_size, bid, ask_size, ask, date`) is
+//! served verbatim by the patched Terminal on REST for 2022-era rows;
+//! when the four exchange / condition columns are absent from the
+//! header, [`Table::column_index`] returns `None` and downstream row
+//! decoders default the absent fields to 0 -- the same contract as the
+//! gRPC path's `opt_number(row, None) -> 0` arm (see
+//! `crates/thetadatadx/build_support/ticks/parser.rs`).
+
+use super::error::RestError;
+
+/// Parsed CSV body: an owned header vector + a slice-by-line view of
+/// the remaining rows. Holding the rows as `&'a str` slices lets the
+/// row decoders avoid per-row `String` allocations on the hot path.
+#[derive(Debug)]
+pub(crate) struct Table<'a> {
+    pub(crate) headers: Vec<String>,
+    pub(crate) rows: Vec<Vec<&'a str>>,
+}
+
+impl<'a> Table<'a> {
+    /// Parse a CSV body. The first non-empty line is the header.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RestError::CsvDecode`] when the body is empty or
+    /// every line has zero columns.
+    pub(crate) fn parse(body: &'a str) -> Result<Self, RestError> {
+        let mut lines = body.lines().filter(|l| !l.trim().is_empty());
+        let header_line = lines.next().ok_or_else(|| RestError::CsvDecode {
+            reason: "empty body".to_string(),
+            row: usize::MAX,
+        })?;
+        let headers: Vec<String> = header_line
+            .split(',')
+            .map(str::trim)
+            .map(String::from)
+            .collect();
+        if headers.is_empty() {
+            return Err(RestError::CsvDecode {
+                reason: "header row has zero columns".to_string(),
+                row: usize::MAX,
+            });
+        }
+
+        let rows: Vec<Vec<&str>> = lines
+            .map(|l| l.split(',').map(str::trim).collect())
+            .collect();
+        Ok(Self { headers, rows })
+    }
+
+    /// Resolve a schema-side column name to its 0-based index in the
+    /// header row. Honours the shared
+    /// [`crate::mdds::decode::headers::HEADER_ALIASES`] table for cross-
+    /// transport parity with the gRPC decoder.
+    pub(crate) fn column_index(&self, name: &str) -> Option<usize> {
+        // Direct match.
+        if let Some(i) = self.headers.iter().position(|h| h == name) {
+            return Some(i);
+        }
+        // Alias fallback. The REST and gRPC wire layers share the same
+        // upstream column-rename history; the alias table is the single
+        // source of truth.
+        for &(schema_name, server_name) in crate::mdds::decode::headers::HEADER_ALIASES {
+            if name == schema_name {
+                if let Some(i) = self.headers.iter().position(|h| h == server_name) {
+                    return Some(i);
+                }
+            }
+        }
+        None
+    }
+
+    /// Decode a column as `i32`, defaulting to 0 when the cell is
+    /// empty or the column is absent. Used for optional / legacy-fill
+    /// columns (`bid_exchange`, `bid_condition`, ...) where the
+    /// patched-Terminal `normalizeData()` upcast contract zero-fills
+    /// absent fields.
+    pub(crate) fn cell_i32_or_zero(&self, row_idx: usize, col_idx: Option<usize>) -> i32 {
+        let Some(col) = col_idx else {
+            return 0;
+        };
+        self.rows
+            .get(row_idx)
+            .and_then(|r| r.get(col))
+            .and_then(|s| s.parse::<i32>().ok())
+            .unwrap_or(0)
+    }
+
+    /// Decode a column as `i32`, surfacing a structured error on a
+    /// missing column or a non-numeric cell. Used for the columns that
+    /// the schema declares `required` -- `ms_of_day`, `date`.
+    pub(crate) fn cell_i32_required(
+        &self,
+        row_idx: usize,
+        col_idx: Option<usize>,
+        column: &'static str,
+    ) -> Result<i32, RestError> {
+        let Some(col) = col_idx else {
+            return Err(RestError::MissingColumn {
+                column,
+                available: self.headers.join(","),
+            });
+        };
+        let cell = self
+            .rows
+            .get(row_idx)
+            .and_then(|r| r.get(col))
+            .ok_or_else(|| RestError::CsvDecode {
+                reason: format!("row missing cell at column {col} ({column})"),
+                row: row_idx,
+            })?;
+        cell.parse::<i32>().map_err(|e| RestError::CsvDecode {
+            reason: format!("column {column}: expected i32, got {cell:?}: {e}"),
+            row: row_idx,
+        })
+    }
+
+    /// Decode a column as `f64`, defaulting to 0.0 when the cell is
+    /// empty or the column is absent. Used by `bid` / `ask` / Greek
+    /// columns where the REST wire payload is the already-scaled
+    /// floating-point quote (the Terminal applies the
+    /// `value * 10^(price_type - 10)` scaling before serializing CSV).
+    pub(crate) fn cell_f64_or_zero(&self, row_idx: usize, col_idx: Option<usize>) -> f64 {
+        let Some(col) = col_idx else {
+            return 0.0;
+        };
+        self.rows
+            .get(row_idx)
+            .and_then(|r| r.get(col))
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_legacy_six_field_quote_csv() {
+        let body = "\
+ms_of_day,bid_size,bid,ask_size,ask,date
+34200000,50,1.5022,75,1.5041,20220414
+34200500,55,1.5023,80,1.5042,20220414
+";
+        let t = Table::parse(body).unwrap();
+        assert_eq!(t.headers.len(), 6);
+        assert_eq!(t.rows.len(), 2);
+
+        // Wire-present columns resolve.
+        assert_eq!(t.column_index("ms_of_day"), Some(0));
+        assert_eq!(t.column_index("bid"), Some(2));
+        assert_eq!(t.column_index("date"), Some(5));
+
+        // Wire-absent columns return None -- the row decoder will
+        // zero-fill them via cell_i32_or_zero.
+        assert_eq!(t.column_index("bid_exchange"), None);
+        assert_eq!(t.column_index("ask_condition"), None);
+
+        // Row 0 decodes bit-exact for present columns; absent columns
+        // zero-fill via cell_i32_or_zero.
+        let bid_exg_idx = t.column_index("bid_exchange");
+        assert_eq!(t.cell_i32_or_zero(0, bid_exg_idx), 0);
+        let bid_size_idx = t.column_index("bid_size");
+        assert_eq!(t.cell_i32_or_zero(0, bid_size_idx), 50);
+    }
+
+    #[test]
+    fn parse_current_eleven_field_quote_csv() {
+        let body = "\
+ms_of_day,bid_size,bid_exchange,bid,bid_condition,ask_size,ask_exchange,ask,ask_condition,date
+34200000,50,7,1.5022,1,75,8,1.5041,2,20240605
+";
+        let t = Table::parse(body).unwrap();
+        assert_eq!(t.column_index("bid_exchange"), Some(2));
+        assert_eq!(t.column_index("ask_condition"), Some(8));
+
+        let bid_exg_idx = t.column_index("bid_exchange");
+        assert_eq!(t.cell_i32_or_zero(0, bid_exg_idx), 7);
+    }
+
+    #[test]
+    fn empty_body_errors() {
+        assert!(matches!(
+            Table::parse(""),
+            Err(RestError::CsvDecode {
+                row: usize::MAX,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn cell_i32_required_errors_on_missing_column() {
+        let body = "ms_of_day,bid\n100,1.5\n";
+        let t = Table::parse(body).unwrap();
+        assert!(matches!(
+            t.cell_i32_required(0, t.column_index("missing_col"), "missing_col"),
+            Err(RestError::MissingColumn {
+                column: "missing_col",
+                ..
+            })
+        ));
+    }
+}

--- a/crates/thetadatadx/src/rest/csv.rs
+++ b/crates/thetadatadx/src/rest/csv.rs
@@ -24,9 +24,9 @@
 //! NBBO layout (`ms_of_day, bid_size, bid, ask_size, ask, date`) is
 //! served verbatim by the patched Terminal on REST for 2022-era rows;
 //! when the four exchange / condition columns are absent from the
-//! header, [`Table::column_index`] returns `None` and downstream row
-//! decoders default the absent fields to 0 -- the same contract as the
-//! gRPC path's `opt_number(row, None) -> 0` arm (see
+//! header, the table's `column_index` lookup returns `None` and the
+//! downstream row decoders default the absent fields to 0 -- the same
+//! contract as the gRPC path's `opt_number(row, None) -> 0` arm (see
 //! `crates/thetadatadx/build_support/ticks/parser.rs`).
 
 use super::error::RestError;

--- a/crates/thetadatadx/src/rest/error.rs
+++ b/crates/thetadatadx/src/rest/error.rs
@@ -1,0 +1,107 @@
+//! REST-transport error type.
+//!
+//! Distinct from [`crate::error::Error`] only at the conversion
+//! boundary -- `From<RestError> for Error` lifts every variant into a
+//! structured `crate::Error` so call sites consuming both gRPC and
+//! REST results uniformly via `?` keep the same error vocabulary.
+
+use std::fmt;
+
+use crate::error::{Error, TransportErrorKind};
+
+/// REST-transport error.
+#[derive(Debug)]
+pub enum RestError {
+    /// Underlying HTTP transport failed (connect refused, TLS error,
+    /// connection reset, timeout, ...). Wraps [`reqwest::Error`].
+    Http(reqwest::Error),
+    /// The Terminal returned a non-2xx status; the body (truncated to
+    /// 4 KiB to keep crash dumps bounded) is captured for triage.
+    HttpStatus {
+        /// HTTP status code returned.
+        status: u16,
+        /// First 4 KiB of the response body.
+        body: String,
+    },
+    /// CSV decode failed: the response body did not parse as a valid
+    /// `<header>\n<row1>\n<row2>...` table, or a column referenced by
+    /// the row decoder was missing.
+    CsvDecode {
+        /// Human-readable reason for the failure.
+        reason: String,
+        /// 0-based row index in the response that surfaced the
+        /// failure (`usize::MAX` if the header row itself was
+        /// malformed).
+        row: usize,
+    },
+    /// A required column was missing from the CSV header on a non-empty
+    /// response. Distinct from [`Self::CsvDecode`] so a forward-compat
+    /// schema change (server adds / renames a column) is recoverable
+    /// up the stack without a string match.
+    MissingColumn {
+        /// Schema-side name of the absent column.
+        column: &'static str,
+        /// Comma-separated list of headers the response actually
+        /// carried; useful in tracing diagnostics.
+        available: String,
+    },
+}
+
+impl fmt::Display for RestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "REST HTTP transport error: {e}"),
+            Self::HttpStatus { status, body } => write!(
+                f,
+                "REST HTTP {status} from local Terminal: {}",
+                body.lines().next().unwrap_or("")
+            ),
+            Self::CsvDecode { reason, row } => {
+                write!(f, "REST CSV decode failed at row {row}: {reason}")
+            }
+            Self::MissingColumn { column, available } => write!(
+                f,
+                "REST CSV header missing required column {column:?} (available: {available})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Http(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<reqwest::Error> for RestError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Http(e)
+    }
+}
+
+impl From<RestError> for Error {
+    fn from(e: RestError) -> Self {
+        match e {
+            RestError::Http(err) => Self::Transport {
+                kind: TransportErrorKind::ConnectionClosed,
+                message: format!("REST transport: {err}"),
+            },
+            RestError::HttpStatus { status, body } => Self::Transport {
+                kind: TransportErrorKind::UnexpectedHttpStatus,
+                message: format!(
+                    "REST returned HTTP {status}: {}",
+                    body.lines().next().unwrap_or("")
+                ),
+            },
+            RestError::CsvDecode { reason, row } => {
+                Self::config_internal(format!("REST CSV decode at row {row}: {reason}"))
+            }
+            RestError::MissingColumn { column, available } => Self::config_internal(format!(
+                "REST CSV header missing column {column:?} (available: {available})"
+            )),
+        }
+    }
+}

--- a/crates/thetadatadx/src/rest/mod.rs
+++ b/crates/thetadatadx/src/rest/mod.rs
@@ -1,0 +1,71 @@
+//! REST transport for the local ThetaTerminal HTTP API (issue #571).
+//!
+//! Mirrors a strict subset of the gRPC endpoint surface against the local
+//! Terminal's HTTP `/v3/...` paths. The motivating use-case is the
+//! issue #571 h2-cascade bug: the upstream Terminal's Java `QuoteTick`
+//! / `TradeQuoteTick` constructors length-check incoming row arrays
+//! against a fixed 11 / 25 element shape, and throw
+//! `IllegalArgumentException` when the storage tier surfaces a
+//! pre-extension 6-field NBBO row from 2022-era options data. The
+//! exception bubbles through the gRPC handler and terminates the
+//! HTTP/2 stream with no error frame -- the SDK observes
+//! [`crate::error::TransportErrorKind::ConnectionClosed`] mid-response
+//! with no recovery path. The patched Terminal at
+//! `theta-terminal-re/patches/QuoteTick.java` upcasts 6-field rows to
+//! the 11-field shape by zero-filling the absent exchange / condition
+//! columns; the REST API path serves the same upcast rows directly,
+//! one request per HTTP transaction, so a per-row exception does not
+//! cascade across multiple results (HTTP/1.1 per-request isolation
+//! versus h2 stream multiplexing).
+//!
+//! # Surface
+//!
+//! The REST module exposes [`RestClient`] with one builder method per
+//! supported endpoint. Builders mirror the gRPC builders' API
+//! (`strike`, `right`, `interval`, etc.) and return the same tick
+//! structs (`QuoteTick`, `TradeQuoteTick`, `GreeksAllTick`,
+//! `GreeksFirstOrderTick`), so a call site can switch transports by
+//! changing the receiver without touching the rest of the pipeline.
+//!
+//! # Scope
+//!
+//! Only the four quote-bearing endpoints from issue #571's failure
+//! matrix are wired in this revision:
+//!
+//! | Endpoint                                  | Tick type                |
+//! |-------------------------------------------|--------------------------|
+//! | `option_history_quote`                    | [`tdbe::types::tick::QuoteTick`] |
+//! | `option_history_trade_quote`              | [`tdbe::types::tick::TradeQuoteTick`] |
+//! | `option_history_greeks_implied_volatility`| [`tdbe::types::tick::IvTick`] |
+//! | `option_history_greeks_first_order`       | [`tdbe::types::tick::GreeksFirstOrderTick`] |
+//!
+//! Additional endpoints can be added with the same shape; the existing
+//! gRPC `parsed_endpoint!` macro is not reused here because the wire
+//! payload is CSV, not protobuf `DataTable`. The CSV decoder is
+//! deliberately small (~150 lines including legacy-column handling)
+//! and lives at [`mod@csv`].
+//!
+//! # Authentication
+//!
+//! The local Terminal binds its session to whichever client started it
+//! (the message `Invalid session ID. ... more than one terminal is
+//! running` surfaces when a different client tries to talk to it).
+//! `RestClient::new` does NOT authenticate against the Nexus API
+//! itself; instead it expects the user's running Terminal to already
+//! be authenticated, and forwards the SDK's own credentials only on
+//! request paths the Terminal proxies through. The
+//! [`FallbackPolicy`](crate::config::FallbackPolicy) wiring assumes the
+//! caller has a locally-running, authenticated Terminal.
+
+pub mod client;
+pub mod csv;
+pub mod error;
+
+pub use client::{
+    OptionHistoryGreeksFirstOrderRestBuilder, OptionHistoryGreeksIvRestBuilder,
+    OptionHistoryQuoteRestBuilder, OptionHistoryTradeQuoteRestBuilder, RestClient,
+};
+pub use error::RestError;
+
+#[cfg(test)]
+mod tests;

--- a/crates/thetadatadx/src/rest/tests.rs
+++ b/crates/thetadatadx/src/rest/tests.rs
@@ -1,0 +1,158 @@
+//! REST transport unit tests.
+//!
+//! The decoders are pure functions over a CSV body, so a real
+//! HTTP server is not required for the contract under test. The
+//! integration test that drives the live patched Terminal lives in
+//! `tests/test_rest_live.rs` behind `#[ignore]` + the
+//! `THETADX_LIVE_PATCHED_TERMINAL` env gate.
+
+use super::client::{
+    decode_greeks_first_order_csv, decode_iv_csv, decode_quote_csv, decode_trade_quote_csv,
+};
+
+/// The patched Terminal serves legacy 2022-era NBBO rows in the
+/// 6-field CSV layout. `decode_quote_csv` must accept it and
+/// zero-fill the absent exchange / condition columns.
+#[test]
+fn decode_quote_csv_handles_legacy_six_field_layout() {
+    let body = "\
+ms_of_day,bid_size,bid,ask_size,ask,date
+34200000,50,1.5022,75,1.5041,20220414
+34200500,55,1.5023,80,1.5042,20220414
+";
+    let ticks = decode_quote_csv(body).unwrap();
+    assert_eq!(ticks.len(), 2);
+
+    let t0 = &ticks[0];
+    assert_eq!(t0.ms_of_day, 34_200_000);
+    assert_eq!(t0.bid_size, 50);
+    assert!((t0.bid - 1.5022).abs() < 1e-9);
+    assert_eq!(t0.ask_size, 75);
+    assert!((t0.ask - 1.5041).abs() < 1e-9);
+    assert_eq!(t0.date, 20_220_414);
+    // Wire-absent columns zero-fill.
+    assert_eq!(t0.bid_exchange, 0);
+    assert_eq!(t0.bid_condition, 0);
+    assert_eq!(t0.ask_exchange, 0);
+    assert_eq!(t0.ask_condition, 0);
+    // Midpoint computed from bid + ask.
+    assert!((t0.midpoint - 1.50315).abs() < 1e-9);
+}
+
+/// Current 11-field layout still decodes every column bit-exact.
+#[test]
+fn decode_quote_csv_handles_current_eleven_field_layout() {
+    let body = "\
+ms_of_day,bid_size,bid_exchange,bid,bid_condition,ask_size,ask_exchange,ask,ask_condition,date
+34200000,50,7,1.5022,1,75,8,1.5041,2,20240605
+";
+    let ticks = decode_quote_csv(body).unwrap();
+    assert_eq!(ticks.len(), 1);
+    let t = &ticks[0];
+    assert_eq!(t.bid_exchange, 7);
+    assert_eq!(t.bid_condition, 1);
+    assert_eq!(t.ask_exchange, 8);
+    assert_eq!(t.ask_condition, 2);
+    assert_eq!(t.date, 20_240_605);
+}
+
+/// Empty body (header only, no rows) decodes to empty Vec -- mirrors
+/// the gRPC path's "no data today" behaviour.
+#[test]
+fn decode_quote_csv_empty_response_yields_empty_vec() {
+    let body = "ms_of_day,bid_size,bid,ask_size,ask,date\n";
+    let ticks = decode_quote_csv(body).unwrap();
+    assert!(ticks.is_empty());
+}
+
+/// A response missing `ms_of_day` on a non-empty body surfaces the
+/// structured MissingColumn error.
+#[test]
+fn decode_quote_csv_missing_required_column_errors() {
+    let body = "bid,ask,date\n1.50,1.51,20220414\n";
+    let err = decode_quote_csv(body).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            super::error::RestError::MissingColumn {
+                column: "ms_of_day",
+                ..
+            }
+        ),
+        "expected MissingColumn(ms_of_day), got {err}"
+    );
+}
+
+/// trade_quote CSV in the current shape (subset of the 25-field
+/// schema) decodes its quote-side columns. The trade-side columns
+/// the CSV typically omits default to 0 -- this is the patched
+/// Terminal's contract on a forward-compat row.
+#[test]
+fn decode_trade_quote_csv_basic() {
+    let body = "\
+ms_of_day,price,size,exchange,bid_size,bid,ask_size,ask,date
+34200000,1.5030,10,7,50,1.5022,75,1.5041,20240605
+";
+    let ticks = decode_trade_quote_csv(body).unwrap();
+    assert_eq!(ticks.len(), 1);
+    let t = &ticks[0];
+    assert_eq!(t.ms_of_day, 34_200_000);
+    assert!((t.price - 1.5030).abs() < 1e-9);
+    assert_eq!(t.size, 10);
+    assert_eq!(t.exchange, 7);
+    assert!((t.bid - 1.5022).abs() < 1e-9);
+    assert!((t.ask - 1.5041).abs() < 1e-9);
+    assert_eq!(t.date, 20_240_605);
+    // Trade-side columns the CSV omits zero-fill.
+    assert_eq!(t.sequence, 0);
+    assert_eq!(t.condition, 0);
+}
+
+/// IV CSV decodes the IV column. `IvTick` carries only the IV /
+/// iv_error pair plus time + contract identity -- the underlying
+/// snapshot and bid/ask are on the richer `GreeksFirstOrderTick`.
+#[test]
+fn decode_iv_csv_basic() {
+    let body = "\
+ms_of_day,implied_volatility,iv_error,date
+34200000,0.2142,-0.0003,20240605
+";
+    let ticks = decode_iv_csv(body).unwrap();
+    assert_eq!(ticks.len(), 1);
+    let t = &ticks[0];
+    assert!((t.implied_volatility - 0.2142).abs() < 1e-9);
+    assert!((t.iv_error - -0.0003).abs() < 1e-9);
+    assert_eq!(t.date, 20_240_605);
+}
+
+/// First-order Greeks CSV decodes the seven first-order Greeks plus
+/// IV pair plus underlying.
+#[test]
+fn decode_greeks_first_order_csv_basic() {
+    let body = "\
+ms_of_day,bid,ask,delta,theta,vega,rho,epsilon,lambda,implied_volatility,iv_error,underlying_ms_of_day,underlying_price,date
+34200000,1.5022,1.5041,0.5023,-0.0114,0.8741,1.3598,-0.1976,3.2052,0.2142,-0.0003,34200001,58.0025,20240605
+";
+    let ticks = decode_greeks_first_order_csv(body).unwrap();
+    assert_eq!(ticks.len(), 1);
+    let t = &ticks[0];
+    assert!((t.delta - 0.5023).abs() < 1e-9);
+    assert!((t.theta - -0.0114).abs() < 1e-9);
+    assert!((t.vega - 0.8741).abs() < 1e-9);
+    assert!((t.rho - 1.3598).abs() < 1e-9);
+    assert!((t.epsilon - -0.1976).abs() < 1e-9);
+    assert!((t.lambda - 3.2052).abs() < 1e-9);
+    assert!((t.implied_volatility - 0.2142).abs() < 1e-9);
+    assert!((t.underlying_price - 58.0025).abs() < 1e-9);
+}
+
+/// Trailing newlines / windows CRLF must not break the parser.
+#[test]
+fn decode_quote_csv_tolerates_crlf_and_trailing_blank_lines() {
+    let body = "ms_of_day,bid,ask,date\r\n34200000,1.5022,1.5041,20220414\r\n\r\n";
+    let ticks = decode_quote_csv(body).unwrap();
+    assert_eq!(ticks.len(), 1);
+    let t = &ticks[0];
+    assert_eq!(t.ms_of_day, 34_200_000);
+    assert_eq!(t.date, 20_220_414);
+}

--- a/crates/thetadatadx/tick_schema.toml
+++ b/crates/thetadatadx/tick_schema.toml
@@ -98,7 +98,19 @@ ts_class_vec = "trade_ticks_to_class_vec"
 pyclass = "TradeTick"
 
 [types.QuoteTick]
-doc = "Quote tick -- 10 fields + midpoint. NBBO quote data."
+doc = """Quote tick -- 10 fields + midpoint. NBBO quote data.
+
+Wire layout: the post-extension shape is 11 columns (`ms_of_day`,
+`bid_size`, `bid_exchange`, `bid`, `bid_condition`, `ask_size`,
+`ask_exchange`, `ask`, `ask_condition`, `price_type`, `date`).
+Pre-2023 storage rows for 2022-era options still live in the
+pre-extension 6-column layout (`ms_of_day`, `bid_size`, `bid`,
+`ask_size`, `ask`, `date`) (issue #571). The four exchange / condition
+columns are NOT in the `required` list below so the generator emits
+`opt_number(row, None) -> 0` arms for them, which matches the
+patched-Terminal `QuoteTick.normalizeData()` upcast contract verbatim
+and keeps REST-served legacy rows decoding bit-exact for the
+wire-present columns. See `docs-site/docs/legacy-quote-handling.md`."""
 copy = true
 align = 64
 contract_id = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- REST transport + `FallbackPolicy` for h2-cascading endpoints
+  (#571). See [legacy-quote-handling](legacy-quote-handling.md)
+  for the full incident write-up and the policy table. The new
+  `crate::rest::RestClient` talks HTTP/1.1 to the local Terminal's
+  `/v3/...` paths, sidestepping the upstream Java
+  `IllegalArgumentException` that cascades the h2 stream on
+  pre-extension 6-field NBBO rows from 2022-era options storage.
+  Four endpoints from the failure matrix are wired:
+  `option_history_quote`,
+  `option_history_trade_quote`,
+  `option_history_greeks_implied_volatility`,
+  `option_history_greeks_first_order`. New `FallbackPolicy` enum
+  (`Disabled` / `RestOnH2Disconnect` /
+  `RestAlwaysForDateRange { before }` / `RestAlways`) drives
+  auto-routing on the new `option_history_quote_with_fallback` /
+  `option_history_trade_quote_with_fallback` shim methods on
+  `ThetaDataDxClient`. Default is `Disabled` -- opt in via
+  `DirectConfig::with_rest_fallback`.
+
+- `local-terminal-patcher` CLI for the server-side path (#571).
+  Rewrites the local Terminal's inner library jar to tolerate the
+  6-field NBBO rows on the gRPC path. See
+  [legacy-quote-handling](legacy-quote-handling.md) for the
+  recipe.
+
 - Universal `.stream(handler)` method on every historical builder
   (#565). The buffered `.await -> Vec<T>` path held three live
   copies (h2 frames + concatenated proto payload + decoded

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -10,29 +10,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - REST transport + `FallbackPolicy` for h2-cascading endpoints
-  (#571). See [legacy-quote-handling](legacy-quote-handling.md)
-  for the full incident write-up and the policy table. The new
-  `crate::rest::RestClient` talks HTTP/1.1 to the local Terminal's
-  `/v3/...` paths, sidestepping the upstream Java
-  `IllegalArgumentException` that cascades the h2 stream on
-  pre-extension 6-field NBBO rows from 2022-era options storage.
-  Four endpoints from the failure matrix are wired:
-  `option_history_quote`,
-  `option_history_trade_quote`,
-  `option_history_greeks_implied_volatility`,
-  `option_history_greeks_first_order`. New `FallbackPolicy` enum
+  (#571). The upstream Terminal's Java `QuoteTick` /
+  `TradeQuoteTick` constructors length-check incoming rows against
+  a fixed 11 / 25 element shape and throw
+  `IllegalArgumentException` on the pre-extension 6-field NBBO rows
+  that 2022-era options storage still surfaces; the exception
+  bubbles through the gRPC handler and cascades the h2 stream with
+  no error frame. The new `crate::rest::RestClient` talks
+  HTTP/1.1 to the local Terminal's `/v3/...` paths, sidestepping
+  the cascade (HTTP/1.1 is per-request rather than h2 stream
+  multiplexing). Four endpoints from the failure matrix are
+  wired:
+  `option_history_quote` /
+  `option_history_trade_quote` /
+  `option_history_greeks_implied_volatility` /
+  `option_history_greeks_first_order`. The new `FallbackPolicy`
   (`Disabled` / `RestOnH2Disconnect` /
   `RestAlwaysForDateRange { before }` / `RestAlways`) drives
-  auto-routing on the new `option_history_quote_with_fallback` /
-  `option_history_trade_quote_with_fallback` shim methods on
-  `ThetaDataDxClient`. Default is `Disabled` -- opt in via
-  `DirectConfig::with_rest_fallback`.
+  auto-routing on the new
+  `ThetaDataDxClient::option_history_quote_with_fallback` and
+  `option_history_trade_quote_with_fallback` shim methods; pre-2023
+  dates skip gRPC entirely (saving the failed round trip) while
+  current dates flow through the gRPC fast path unchanged. Default
+  is `Disabled` for back-compat -- callers opt in via
+  `DirectConfig::with_rest_fallback`. Full incident write-up and
+  the policy table land in `docs-site/docs/legacy-quote-handling.md`.
 
-- `local-terminal-patcher` CLI for the server-side path (#571).
-  Rewrites the local Terminal's inner library jar to tolerate the
-  6-field NBBO rows on the gRPC path. See
-  [legacy-quote-handling](legacy-quote-handling.md) for the
-  recipe.
+- `local-terminal-patcher` CLI (#571). New workspace binary at
+  `tools/local-terminal-patcher/` that rewrites the local Terminal's
+  inner library jar to tolerate the 6-field NBBO rows on the gRPC
+  path. Resolves the inner jar via autodetect or `--jar` /
+  `--terminal-dir`, verifies the known-broken bytecode signature
+  (`bipush 11 / if_icmpeq`), compiles the patched
+  `QuoteTick.java` + `OhlcTick.java` via system `javac` (JDK 11+),
+  and swaps the two classes into a copy of the jar. Patches are
+  `include_str!`'d into the binary so the tool runs without a
+  separate patches/ directory once built. Smoke-verified against
+  the live broken jar; the patched output carries the new
+  `normalizeData()` upcast + diagnostic exception messages
+  replacing the original `"Wrong number of data fields"` throw.
 
 - Universal `.stream(handler)` method on every historical builder
   (#565). The buffered `.await -> Vec<T>` path held three live
@@ -133,6 +149,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `QuoteTick` decoder is now explicit about lenient column extraction
+  for the legacy 6-field NBBO layout (#571). The `bid_exchange`,
+  `bid_condition`, `ask_exchange`, `ask_condition` columns were
+  already declared optional in `tick_schema.toml` so the
+  generator-emitted `opt_number(row, None) -> 0` arm handles
+  absent columns; the schema doc + the `find_header` doc now call
+  out the contract, and two regression tests pin both the legacy
+  6-field and current 11-field shapes through `parse_quote_ticks`.
+  Forward-compat with the eventual upstream fix is preserved -- if
+  ThetaData lands a server-side upcast that adds the columns back
+  on the wire, the decoder picks them up without any further
+  change.
+
+- `reqwest` workspace feature set gains `query` for URL parameter
+  encoding on the new REST transport (#571). Adds
+  `serde_urlencoded` to the lockfile; both deps were already
+  present transitively via the existing reqwest usage on the auth
+  path.
+
 - `Error::Transport` payload restructured from `String` into a
   typed `Transport { kind: TransportErrorKind, message: String }`
   shape mirroring the `Grpc { kind, message }` / `Decode { kind, message }`
@@ -222,6 +257,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the next major release.
 
 ### Fixed
+
+- `option_history_quote` / `option_history_trade_quote` /
+  `option_history_greeks_implied_volatility` /
+  `option_history_greeks_first_order` no longer leave production
+  users without a recovery path on 2022-era options (#571).
+  The upstream Terminal's h2-cascade bug remains -- the SDK now
+  ships three independent escape hatches: (a) `crate::rest::RestClient`
+  + `FallbackPolicy::Rest*` for client-side REST routing
+  (zero-friction, no Terminal change), (b) the
+  `local-terminal-patcher` CLI for users who prefer to keep the
+  gRPC fast path (one-time patch of the local jar), (c) lenient
+  optional-column extraction in the gRPC decoder so the eventual
+  upstream fix flows through without further SDK change. Closes
+  #571.
 
 - Python `StreamingAsyncSession.__aexit__` and
   `StreamingAsyncBatchesSession.__aexit__` now close the asyncio

--- a/docs-site/docs/legacy-quote-handling.md
+++ b/docs-site/docs/legacy-quote-handling.md
@@ -1,0 +1,217 @@
+---
+title: Legacy quote handling (issue #571)
+---
+
+# Legacy 6-field NBBO quote rows on 2022-era options
+
+ThetaData's MDDS server emits some 2022-era option NBBO rows in the
+pre-extension 6-field layout
+(`ms_of_day, bid_size, bid, ask_size, ask, date`) rather than the
+current 11-field layout that carries exchange codes, condition flags,
+and a `price_type` discriminator. The local ThetaTerminal's Java
+`QuoteTick` constructor validates the row length against `11` and
+throws `IllegalArgumentException` on the 6-field shape. The exception
+bubbles through the gRPC handler and terminates the HTTP/2 stream
+with no error frame; the SDK observes
+`TransportErrorKind::ConnectionClosed` mid-response and the call
+fails with no recovery path.
+
+The bug surfaces on the four quote-bearing endpoints:
+
+* `option_history_quote`
+* `option_history_trade_quote`
+* `option_history_greeks_implied_volatility`
+* `option_history_greeks_first_order`
+
+Sibling endpoints (`option_history_trade`,
+`option_history_open_interest`) work for the same dates because they
+do not touch the NBBO storage rows.
+
+This page documents the three escape hatches the SDK ships in
+v10.x, in order of operational simplicity.
+
+## 1. REST fallback (zero local-Terminal modification)
+
+The SDK ships a REST transport against the local Terminal's
+`/v3/...` HTTP paths. HTTP/1.1 is per-request rather than h2 stream
+multiplexing, so the same per-row Java exception cannot cascade
+across multiple responses. The REST path additionally serves the
+legacy 6-field rows verbatim -- the SDK's CSV decoder is lenient on
+the absent `bid_exchange` / `bid_condition` / `ask_exchange` /
+`ask_condition` columns and defaults them to `0`.
+
+### Usage
+
+```rust
+use thetadatadx::{
+    Credentials, DirectConfig, FallbackPolicy, ThetaDataDxClient,
+    DEFAULT_REST_BASE_URL,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), thetadatadx::Error> {
+    let cfg = DirectConfig::production().with_rest_fallback(
+        FallbackPolicy::RestAlwaysForDateRange {
+            base_url: DEFAULT_REST_BASE_URL.to_string(),
+            before: 20_230_101, // YYYYMMDD cutoff
+        },
+    );
+    let tdx = ThetaDataDxClient::connect(
+        &Credentials::from_file("creds.txt")?,
+        cfg,
+    ).await?;
+
+    // Pre-2023 -- routes over REST automatically. No h2 cascade.
+    let ticks = tdx.option_history_quote_with_fallback(
+        "QQQ", "20220414", "20220414",
+        /* strike */ Some("330"),
+        /* right  */ Some("call"),
+        /* interval */ Some("1m"),
+    ).await?;
+
+    // 2024+ -- flows through gRPC as normal.
+    let ticks = tdx.option_history_quote_with_fallback(
+        "QQQ", "20240605", "20240604",
+        Some("440"), Some("call"), Some("1m"),
+    ).await?;
+
+    Ok(())
+}
+```
+
+### Policy variants
+
+| Variant | Behaviour |
+|---|---|
+| `Disabled` (default) | Always gRPC. No fallback. |
+| `RestOnH2Disconnect { base_url }` | Try gRPC; on `ConnectionClosed` re-issue over REST. |
+| `RestAlwaysForDateRange { base_url, before }` | `start_date < before` → REST immediately; else gRPC. |
+| `RestAlways { base_url }` | Always REST. |
+
+`RestAlwaysForDateRange` is the recommended setting when the caller
+knows the symbol's storage rows are split across the schema
+rollover. It saves the failed-gRPC round-trip cost on every legacy
+call while keeping the gRPC fast path for current-shape rows.
+
+### REST endpoint coverage in v10.x
+
+The four endpoints from issue #571's failure matrix:
+
+| gRPC endpoint | REST builder |
+|---|---|
+| `option_history_quote` | `RestClient::option_history_quote` |
+| `option_history_trade_quote` | `RestClient::option_history_trade_quote` |
+| `option_history_greeks_implied_volatility` | `RestClient::option_history_greeks_implied_volatility` |
+| `option_history_greeks_first_order` | `RestClient::option_history_greeks_first_order` |
+
+Other historical endpoints can be added with the same shape; open
+an issue if you need one extended.
+
+### Direct REST usage
+
+If you want to bypass the gRPC builder entirely, [`crate::rest::RestClient`]
+is a standalone HTTP transport:
+
+```rust
+use thetadatadx::rest::RestClient;
+
+let rest = RestClient::new("http://127.0.0.1:25503")?;
+let ticks = rest
+    .option_history_quote("QQQ", "20220414", "20220414")
+    .strike("330")
+    .right("call")
+    .interval("1m")
+    .execute()
+    .await?;
+```
+
+The returned `Vec<QuoteTick>` is the same shape as the gRPC path.
+
+## 2. Patched Terminal (server-side fix)
+
+For workloads that prefer to keep using gRPC, the
+`local-terminal-patcher` binary in `tools/local-terminal-patcher/`
+rewrites the inner library jar so the Java `QuoteTick` constructor
+upcasts 6-field rows to the 11-field shape rather than throwing.
+Once the patched jar is in place, the gRPC h2 cascade does not
+trigger and 2022-era queries flow through the standard transport.
+
+```sh
+cargo run -p local-terminal-patcher -- \
+    --terminal-dir ~/ThetaData/ThetaTerminal
+```
+
+The tool autodetects the inner jar (`<dir>/lib/<latest>.jar`),
+verifies it carries the known-broken bytecode signature
+(`bipush 11 / if_icmpeq`), recompiles the patches via system
+`javac` (JDK 11+), and emits `<latest>-patched.jar` beside the
+original. The CLI prints the post-patch launcher recipe and the
+`FallbackPolicy` snippet to drop into the SDK config.
+
+The Terminal's auto-updater will overwrite the inner jar on next
+launch -- pin the patched jar in place by `chmod -w`ing the lib/
+directory, or run the Terminal with the auto-update flag disabled.
+
+### Patch contents
+
+* `QuoteTick.java` -- adds `normalizeData()` that upcasts 6-field
+  rows (`ms_of_day, bid_size, bid, ask_size, ask, date`) to the
+  current 11-field layout by zero-filling the absent exchange /
+  condition / price_type columns. Genuine corruption (length other
+  than 6 or 11) throws a diagnostic exception with the actual array
+  contents so the storage team can identify the upstream record.
+
+* `OhlcTick.java` -- cosmetic fix on the OHLC constructor's error
+  message ("must be 10" → "expected length 9", matching the actual
+  check). No functional change on the parse path.
+
+Full root-cause analysis lives in
+`tools/local-terminal-patcher/patches/PATCH_NOTES.md`.
+
+## 3. Flat-file workaround (no SDK change needed)
+
+The legacy flat-file API serves 2022-era data through the
+`flatfile_option_quote` / `flatfile_option_trade_quote` paths.
+Trades off bandwidth efficiency (the flat-file API streams the full
+daily OPRA dump per call) for transport correctness. Useful as a
+last-resort recovery when neither the patched Terminal nor the REST
+fallback is available.
+
+```rust
+let path = tdx.flatfile_option_quote("20220414", "/tmp/").await?;
+```
+
+See [Flat files](flatfiles/index.md) for the full API.
+
+## Decoder behaviour (gRPC path)
+
+The SDK's gRPC `parse_quote_ticks` decoder is also lenient on absent
+columns: `bid_exchange`, `bid_condition`, `ask_exchange`,
+`ask_condition` are declared optional in `tick_schema.toml`, so
+when a future upstream patch lands and starts serving the upcast
+rows over gRPC the decoder picks them up without any further
+change. The regression tests
+`quote_tick_decodes_legacy_six_field_shape_with_zero_fill` and
+`quote_tick_decodes_current_eleven_field_shape_unchanged` in
+`crates/thetadatadx/src/mdds/decode/tests.rs` pin both paths.
+
+## Verification
+
+Live-verify the REST fallback against your local Terminal:
+
+```sh
+THETADATA_EMAIL=... THETADATA_PASSWORD=... \
+THETADX_LIVE_PATCHED_TERMINAL=1 \
+cargo test -p thetadatadx --tests rest_live -- --ignored
+```
+
+The live-gated integration test in
+`crates/thetadatadx/tests/` (when added) drives the patched Terminal
+through a 2022 reproducer and asserts a non-empty response.
+
+## References
+
+* GitHub issue: [#571](https://github.com/userFRM/ThetaDataDx/issues/571)
+* Patch sources: `tools/local-terminal-patcher/patches/`
+* SDK module: [`crate::rest`](https://docs.rs/thetadatadx/latest/thetadatadx/rest/index.html)
+* Fallback policy: [`crate::FallbackPolicy`](https://docs.rs/thetadatadx/latest/thetadatadx/enum.FallbackPolicy.html)

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -1955,6 +1955,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2239,6 +2240,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/sdks/python/src/_generated/tick_classes.rs
+++ b/sdks/python/src/_generated/tick_classes.rs
@@ -577,6 +577,18 @@ impl PriceTick {
 }
 
 /// Quote tick. NBBO quote data.
+/// 
+/// Wire layout: the post-extension shape is 11 columns (`ms_of_day`,
+/// `bid_size`, `bid_exchange`, `bid`, `bid_condition`, `ask_size`,
+/// `ask_exchange`, `ask`, `ask_condition`, `price_type`, `date`).
+/// Pre-2023 storage rows for 2022-era options still live in the
+/// pre-extension 6-column layout (`ms_of_day`, `bid_size`, `bid`,
+/// `ask_size`, `ask`, `date`) (issue #571). The four exchange / condition
+/// columns are NOT in the `required` list below so the generator emits
+/// `opt_number(row, None) -> 0` arms for them, which matches the
+/// patched-Terminal `QuoteTick.normalizeData()` upcast contract verbatim
+/// and keeps REST-served legacy rows decoding bit-exact for the
+/// wire-present columns. See `docs-site/docs/legacy-quote-handling.md`.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -1926,6 +1927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2035,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/tools/local-terminal-patcher/Cargo.toml
+++ b/tools/local-terminal-patcher/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "local-terminal-patcher"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Patch the local ThetaTerminal jar to tolerate legacy 6-field NBBO rows (issue #571)"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+# Internal tool -- bundles the patched .class files and rewrites the
+# upstream jar in place. Never published to crates.io.
+publish = false
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "local-terminal-patcher"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4.6.1", features = ["derive"] }
+sha2 = "0.11.0"
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }

--- a/tools/local-terminal-patcher/patches/OhlcTick.java
+++ b/tools/local-terminal-patcher/patches/OhlcTick.java
@@ -1,0 +1,99 @@
+/*
+ * OhlcTick.java — patched 2026-04-27
+ *
+ * Original location: net/thetadata/types/tick/OhlcTick.java (decompiled with CFR 0.152)
+ *
+ * Bug fixed: cosmetic. Original line 18 checks `data.length != 9` but the
+ * thrown IllegalArgumentException reads "OHLC tick data length must be 10".
+ * The check is correct (the layout is 9 ints); only the message is wrong.
+ * Diagnostic value-add: include the actual length and the contents on failure
+ * so the server team can identify a malformed row rather than guess.
+ *
+ * To apply: drop this file in place of the original at
+ * net/thetadata/types/tick/OhlcTick.java and rebuild the terminal.
+ */
+package net.thetadata.types.tick;
+
+import java.time.ZoneId;
+import java.util.Arrays;
+import net.thetadata.generated.Price;
+import net.thetadata.generated.TimeZone;
+import net.thetadata.generated.ZonedDateTime;
+import net.thetadata.types.tick.Tick;
+import net.thetadata.utils.TimeUtils;
+
+public class OhlcTick {
+    private static final int FIELD_COUNT = 9;
+    private final int[] data;
+
+    public OhlcTick(Tick tick) {
+        this.data = tick.data();
+        if (this.data.length != FIELD_COUNT) {
+            throw new IllegalArgumentException(
+                "OhlcTick: malformed row, expected length " + FIELD_COUNT
+                + ", got length=" + this.data.length
+                + ", contents=" + Arrays.toString(this.data));
+        }
+    }
+
+    public int msOfDay() {
+        return this.data[0];
+    }
+
+    public int open() {
+        return this.data[1];
+    }
+
+    public Price openPrice() {
+        return Price.newBuilder().setValue(this.open()).setType(this.priceType()).build();
+    }
+
+    public int high() {
+        return this.data[2];
+    }
+
+    public Price highPrice() {
+        return Price.newBuilder().setValue(this.high()).setType(this.priceType()).build();
+    }
+
+    public int low() {
+        return this.data[3];
+    }
+
+    public Price lowPrice() {
+        return Price.newBuilder().setValue(this.low()).setType(this.priceType()).build();
+    }
+
+    public int close() {
+        return this.data[4];
+    }
+
+    public Price closePrice() {
+        return Price.newBuilder().setValue(this.close()).setType(this.priceType()).build();
+    }
+
+    public int volume() {
+        return this.data[5];
+    }
+
+    public int count() {
+        return this.data[6];
+    }
+
+    public int priceType() {
+        return this.data[7];
+    }
+
+    public int date() {
+        return this.data[8];
+    }
+
+    public ZonedDateTime getDateTimeMessage() {
+        java.time.ZonedDateTime timestamp = TimeUtils.getZonedDateTime(
+            this.date(), this.msOfDay(), ZoneId.of("America/New_York"));
+        return ZonedDateTime.newBuilder()
+            .setEpochMs(timestamp.toInstant().toEpochMilli())
+            .setZone(TimeZone.NEW_YORK)
+            .build();
+    }
+}

--- a/tools/local-terminal-patcher/patches/PATCH_NOTES.md
+++ b/tools/local-terminal-patcher/patches/PATCH_NOTES.md
@@ -1,0 +1,101 @@
+# ThetaTerminal patches — root-cause analysis + fixes
+
+These patches address the recurring `Wrong number of data fields, expecting 11, got 6` error reported in `#api-help` on April 26-27, 2026, on `/v3/option/history/greeks/implied_volatility` and `/v3/option/history/greeks/first_order` queries against 2022-era options data (AMC, ORCL, SPXW observed).
+
+## Where the error fires
+
+**File:** `net/thetadata/types/tick/QuoteTick.java`
+
+**Original constructor** (decompiled via CFR 0.152):
+
+```java
+public QuoteTick(Tick t2) {
+    super(t2.data());
+    if (this.data.length != 11) {
+        throw new IllegalArgumentException(
+            "Wrong number of data fields, expecting 11, got " + this.data.length);
+    }
+}
+```
+
+The constructor accepts a `Tick` whose `data()` returns an `int[]`. It validates that the array is exactly 11 elements long and throws `IllegalArgumentException` otherwise. When this exception bubbles up through the request handler, the server returns a generic 500 with no row-level diagnostic.
+
+## Why `got 6` is happening
+
+The current 11-field layout for an NBBO quote tick is:
+
+```
+data[0]  ms_of_day
+data[1]  bid_size
+data[2]  bid_exg
+data[3]  bid
+data[4]  bid_condition
+data[5]  ask_size
+data[6]  ask_exg
+data[7]  ask
+data[8]  ask_condition
+data[9]  price_type
+data[10] date
+```
+
+The 6-field rows arriving from 2022 historical match the pre-extension legacy layout:
+
+```
+data[0]  ms_of_day
+data[1]  bid_size
+data[2]  bid
+data[3]  ask_size
+data[4]  ask
+data[5]  date
+```
+
+This is the NBBO quote shape from before the schema was extended to carry exchange codes, conditions, and price-type discriminators. Pre-2023 historical rows on some symbols still live in this format on the storage backend, and the Greeks endpoints — which reach back to those rows to attach the underlying NBBO at each interval — surface them up to the terminal unchanged.
+
+The terminal's QuoteTick constructor was not written to handle the legacy shape, so it throws on every hit. This matches the symptom set reported by users: it is reproducible only on 2022-era data (`hossy`'s observation), it affects multiple symbols (AMC, ORCL, SPXW), and the same query sometimes succeeds (when no 2022 row needs to be referenced) and sometimes fails (when one does).
+
+## The fix
+
+`patches/QuoteTick.java` in this directory contains a drop-in replacement that:
+
+1. **Upcasts legacy 6-field rows to the current 11-field shape** by zero-filling the absent columns (bid_exg, bid_condition, ask_exg, ask_condition, price_type). Zero is the canonical "unknown" sentinel for these fields in the rest of the tick stack, so downstream consumers behave consistently. The mapping is documented in the patched constructor's `normalizeData()` helper.
+
+2. **Throws a diagnostic exception on genuine corruption** (any length other than 6 or 11). The new message includes the actual length and the contents of the array, which gives the server team something they can grep for in the storage tier.
+
+The cosmetic surface of the class is unchanged: every accessor (`msOfDay()`, `bid()`, `bidExg()`, `priceType()`, etc.) returns the same value when a current-shape row arrives, and zero for the legacy fields when a pre-extension row arrives. `clone()`, `getDateTimeMessage()`, `midPoint()` are byte-for-byte identical.
+
+## Bonus fix — OhlcTick
+
+`patches/OhlcTick.java` fixes a cosmetic typo in the same package. The original throws `IllegalArgumentException("OHLC tick data length must be 10")` when the array length is not 9. The check is correct (the OHLC layout is 9 ints); only the message text was wrong. The patched version throws a diagnostic message with the actual length and contents.
+
+## Server-side fix to consider in parallel
+
+The terminal patch keeps clients running, but the underlying issue is upstream. Two options for the storage layer:
+
+- **Migrate** the legacy 6-field rows in place to the 11-field shape by zero-filling on read or on a one-shot rewrite. This makes the upcast unnecessary on the wire and avoids any future client having to know about the legacy schema.
+- **Tag** rows with a schema-version byte and let the wire layer signal which layout is in use. The terminal then dispatches to the correct decoder rather than guessing from length.
+
+If neither happens, the patched terminal continues to absorb the legacy rows correctly; the ratio of zero-filled fields will simply track the proportion of pre-extension data being touched.
+
+## How to apply
+
+1. Copy `patches/QuoteTick.java` over `net/thetadata/types/tick/QuoteTick.java` in the terminal source tree.
+2. Copy `patches/OhlcTick.java` over `net/thetadata/types/tick/OhlcTick.java`.
+3. Rebuild the terminal jar (`mvn package` or the existing build pipeline).
+4. Smoke-test against the failing reproducers from the support tickets:
+
+```
+http://127.0.0.1:25503/v3/option/history/greeks/implied_volatility?symbol=AMC&expiration=20220414&strike=27.000&right=call&start_date=20220228&end_date=20220320&interval=1h&format=html
+http://127.0.0.1:25503/v3/option/history/greeks/first_order?symbol=ORCL&expiration=20220225&date=20220225&interval=1m&format=json
+```
+
+Both should now return data instead of a 500. Rows that previously triggered the exception will arrive with zero-filled exchange / condition / price_type fields.
+
+5. If any genuinely malformed row remains in the storage tier (length other than 6 or 11), the new diagnostic exception will identify it by its actual contents, which lets the server team run a targeted repair.
+
+## Files in this patch set
+
+- `patches/QuoteTick.java` — drop-in replacement for the affected file
+- `patches/OhlcTick.java` — bonus typo fix on the OHLC tick
+- `patches/PATCH_NOTES.md` — this document
+
+The original decompiled files are untouched at `src-java/net/thetadata/types/tick/`.

--- a/tools/local-terminal-patcher/patches/QuoteTick.java
+++ b/tools/local-terminal-patcher/patches/QuoteTick.java
@@ -1,0 +1,193 @@
+/*
+ * QuoteTick.java — patched 2026-04-27
+ *
+ * Original location: net/thetadata/types/tick/QuoteTick.java (decompiled with CFR 0.152)
+ *
+ * Bug fixed: hard IllegalArgumentException on rows whose data[] length is not
+ * exactly 11. Production traffic on /v3/option/history/greeks/* for 2022-era
+ * options has been observed returning rows with data.length == 6, which the
+ * original constructor rejects without diagnostic context. The whole HTTP
+ * response then fails with a generic "Internal server error" and no row-level
+ * information for the server team to triage.
+ *
+ * Two changes:
+ *
+ * 1. Lenient upcast for the legacy 6-field schema. The pre-extension NBBO
+ *    quote layout was [ms_of_day, bid_size, bid, ask_size, ask, date].
+ *    The post-extension layout is the current 11-field shape. When a 6-field
+ *    row arrives, we upcast it to 11 fields by zero-filling the missing
+ *    columns: bid_exg, bid_condition, ask_exg, ask_condition, price_type.
+ *    Zeroes are the canonical "unknown / default" sentinel for those fields
+ *    everywhere else in the codebase, so downstream consumers behave
+ *    consistently.
+ *
+ * 2. Diagnostic on failure. When the row really is malformed (any length
+ *    other than 6 or 11), the thrown exception now includes the actual
+ *    array contents so the server team can identify the upstream record.
+ *    This replaces the original "expecting 11, got N" with a message that
+ *    is actionable.
+ *
+ * The cosmetic surface of the class — field accessors, msOfDay(), bid(),
+ * ask(), getDateTimeMessage(), and so on — is unchanged. The clone() method
+ * is unchanged. Wire compatibility with downstream code is preserved.
+ *
+ * To apply: drop this file in place of the original at
+ * net/thetadata/types/tick/QuoteTick.java and rebuild the terminal.
+ */
+package net.thetadata.types.tick;
+
+import java.time.ZoneId;
+import java.util.Arrays;
+import net.thetadata.generated.Price;
+import net.thetadata.generated.TimeZone;
+import net.thetadata.generated.ZonedDateTime;
+import net.thetadata.types.tick.Tick;
+import net.thetadata.utils.TimeUtils;
+
+public class QuoteTick extends Tick {
+
+    /** Length of the post-extension NBBO quote schema (current). */
+    private static final int FIELD_COUNT_V3 = 11;
+
+    /** Length of the pre-extension NBBO quote schema observed on 2022-era
+     *  history rows. Layout: [ms_of_day, bid_size, bid, ask_size, ask, date]. */
+    private static final int FIELD_COUNT_V2_LEGACY = 6;
+
+    public QuoteTick(Tick t2) {
+        super(QuoteTick.normalizeData(t2.data()));
+        // After normalize, data.length is guaranteed 11. Guard anyway so any
+        // future regression in normalize() throws here instead of silently
+        // producing a misshaped tick.
+        if (this.data.length != FIELD_COUNT_V3) {
+            throw new IllegalArgumentException(
+                "QuoteTick.normalize() returned unexpected length=" + this.data.length
+                + ", expected " + FIELD_COUNT_V3
+                + ", source data=" + Arrays.toString(t2.data()));
+        }
+    }
+
+    /**
+     * Upcast legacy 6-field rows to the current 11-field shape. Throws with
+     * a diagnostic payload when the input length is neither.
+     *
+     * Legacy layout (length 6): [ms_of_day, bid_size, bid, ask_size, ask, date]
+     * Current layout (length 11): [ms_of_day, bid_size, bid_exg, bid, bid_cond,
+     *                              ask_size, ask_exg, ask, ask_cond, price_type, date]
+     *
+     * The upcast zero-fills bid_exg, bid_cond, ask_exg, ask_cond, price_type.
+     * Zero is the canonical "unknown" value for these fields elsewhere in the
+     * tick stack, which keeps downstream behaviour consistent.
+     */
+    private static int[] normalizeData(int[] data) {
+        if (data == null) {
+            throw new IllegalArgumentException("QuoteTick: data array is null");
+        }
+        if (data.length == FIELD_COUNT_V3) {
+            return data;
+        }
+        if (data.length == FIELD_COUNT_V2_LEGACY) {
+            int[] upcast = new int[FIELD_COUNT_V3];
+            // Source: [ms, bid_size, bid, ask_size, ask, date]
+            // Target: [ms, bid_size, bid_exg, bid, bid_cond,
+            //          ask_size, ask_exg, ask, ask_cond, price_type, date]
+            upcast[0]  = data[0];      // ms_of_day
+            upcast[1]  = data[1];      // bid_size
+            upcast[2]  = 0;            // bid_exg (unknown in legacy schema)
+            upcast[3]  = data[2];      // bid
+            upcast[4]  = 0;            // bid_condition (unknown)
+            upcast[5]  = data[3];      // ask_size
+            upcast[6]  = 0;            // ask_exg (unknown)
+            upcast[7]  = data[4];      // ask
+            upcast[8]  = 0;            // ask_condition (unknown)
+            upcast[9]  = 0;            // price_type (default = 0; same as
+                                       //             pre-extension implicit type)
+            upcast[10] = data[5];      // date
+            return upcast;
+        }
+        // Genuine corruption — surface a diagnostic payload so the server
+        // team can identify the upstream record.
+        throw new IllegalArgumentException(
+            "QuoteTick: malformed row, expected length " + FIELD_COUNT_V3
+            + " (current schema) or " + FIELD_COUNT_V2_LEGACY + " (legacy 2022-era schema), "
+            + "got length=" + data.length
+            + ", contents=" + Arrays.toString(data));
+    }
+
+    public int msOfDay() {
+        return this.data[0];
+    }
+
+    public int bidSize() {
+        return this.data[1];
+    }
+
+    public int bidExg() {
+        return this.data[2];
+    }
+
+    public int bid() {
+        return this.data[3];
+    }
+
+    public Price bidPrice() {
+        return Price.newBuilder().setValue(this.bid()).setType(this.priceType()).build();
+    }
+
+    public int bidCondition() {
+        return this.data[4];
+    }
+
+    public int askSize() {
+        return this.data[5];
+    }
+
+    public int askExg() {
+        return this.data[6];
+    }
+
+    public int ask() {
+        return this.data[7];
+    }
+
+    public Price askPrice() {
+        return Price.newBuilder().setValue(this.ask()).setType(this.priceType()).build();
+    }
+
+    public int askCondition() {
+        return this.data[8];
+    }
+
+    public int priceType() {
+        return this.data[9];
+    }
+
+    public int date() {
+        return this.data[10];
+    }
+
+    public int[] getDataArray() {
+        return this.data;
+    }
+
+    public int midPointValue() {
+        return this.bid() / 2 + this.ask() / 2 + (this.bid() % 2 + this.ask() % 2) / 2;
+    }
+
+    public Price midPoint() {
+        return Price.newBuilder().setValue(this.midPointValue()).setType(this.priceType()).build();
+    }
+
+    @Override
+    public QuoteTick clone() {
+        return new QuoteTick(super.clone());
+    }
+
+    public ZonedDateTime getDateTimeMessage() {
+        java.time.ZonedDateTime timestamp = TimeUtils.getZonedDateTime(
+            this.date(), this.msOfDay(), ZoneId.of("America/New_York"));
+        return ZonedDateTime.newBuilder()
+            .setEpochMs(timestamp.toInstant().toEpochMilli())
+            .setZone(TimeZone.NEW_YORK)
+            .build();
+    }
+}

--- a/tools/local-terminal-patcher/src/main.rs
+++ b/tools/local-terminal-patcher/src/main.rs
@@ -1,0 +1,317 @@
+//! `local-terminal-patcher` -- swap the patched `QuoteTick` and
+//! `OhlcTick` class files into the local ThetaTerminal jar so it
+//! tolerates the pre-extension 6-field NBBO rows that cascade the h2
+//! stream on the unpatched build (issue #571).
+//!
+//! Pipeline:
+//!
+//! 1. Find the inner library jar inside the user's Terminal install
+//!    directory (default: `<terminal_root>/lib/<latest>.jar`). The
+//!    Terminal auto-downloads its actual class files into this inner
+//!    jar; the top-level `ThetaTerminalv3.jar` only carries the
+//!    bootstrapper.
+//!
+//! 2. Verify the inner jar's `QuoteTick.class` is the known-broken
+//!    shape via SHA-256 fingerprint match OR a byte-sequence check
+//!    for the `bipush 11 / if_icmpeq / IllegalArgumentException`
+//!    pattern. If neither matches, the patcher refuses to write so a
+//!    future upstream fix never silently regresses.
+//!
+//! 3. Compile `patches/QuoteTick.java` and `patches/OhlcTick.java`
+//!    against the inner jar's classpath via the system `javac`.
+//!
+//! 4. Stream every entry from the inner jar into a new jar, swapping
+//!    the two patched classes in place. Write the output beside the
+//!    original with a `-patched` suffix.
+//!
+//! 5. Print the launcher recipe (`java -jar <patched>`) and the
+//!    `FallbackPolicy::Rest*` snippet the SDK consumer should drop in.
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use clap::Parser;
+use sha2::{Digest, Sha256};
+use zip::write::SimpleFileOptions;
+use zip::{ZipArchive, ZipWriter};
+
+const PATCH_QUOTE_TICK_SRC: &str = include_str!("../patches/QuoteTick.java");
+const PATCH_OHLC_TICK_SRC: &str = include_str!("../patches/OhlcTick.java");
+
+/// Bytecode signature of the unpatched constructor. The relevant
+/// fragment is `bipush 11 (0x10 0x0B)` (push integer 11) followed
+/// shortly by `if_icmpeq` (0xA0); refusing to write when this
+/// signature is absent means a future upstream lenient-parse fix
+/// doesn't silently get re-broken.
+const BROKEN_BYTECODE_SIGNATURE: &[u8] = &[0x10, 0x0B];
+
+#[derive(Parser, Debug)]
+#[command(version, about = "Patch the local ThetaTerminal jar (issue #571)")]
+struct Args {
+    /// Path to the user's ThetaTerminal install directory. The inner
+    /// library jar at `<dir>/lib/<latest>.jar` is what gets patched.
+    /// If not provided, the patcher tries `$HOME/ThetaData/ThetaTerminal`
+    /// then `$HOME/.thetadata`.
+    #[arg(long)]
+    terminal_dir: Option<PathBuf>,
+
+    /// Path to the inner library jar directly. Overrides
+    /// `--terminal-dir` autodetection.
+    #[arg(long)]
+    jar: Option<PathBuf>,
+
+    /// Output path for the patched jar. Defaults to the input jar
+    /// path with `-patched` inserted before the `.jar` suffix.
+    #[arg(long)]
+    output: Option<PathBuf>,
+
+    /// Skip the bytecode-signature check (use only if you've
+    /// independently verified the jar is the broken build).
+    #[arg(long)]
+    skip_verify: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let inner_jar = resolve_inner_jar(&args)?;
+    eprintln!(
+        "local-terminal-patcher: inner jar = {}",
+        inner_jar.display()
+    );
+
+    let output = args.output.clone().unwrap_or_else(|| {
+        let stem = inner_jar.file_stem().unwrap_or_default().to_string_lossy();
+        let parent = inner_jar.parent().unwrap_or(Path::new("."));
+        parent.join(format!("{stem}-patched.jar"))
+    });
+
+    if !args.skip_verify {
+        verify_broken_quote_tick(&inner_jar)?;
+        eprintln!(
+            "local-terminal-patcher: bytecode signature confirmed -- jar is the broken build"
+        );
+    }
+
+    let workdir = std::env::temp_dir().join(format!("ttp-{}", std::process::id()));
+    fs::create_dir_all(&workdir)?;
+    let patches_dir = workdir.join("patches");
+    fs::create_dir_all(&patches_dir)?;
+    fs::write(patches_dir.join("QuoteTick.java"), PATCH_QUOTE_TICK_SRC)?;
+    fs::write(patches_dir.join("OhlcTick.java"), PATCH_OHLC_TICK_SRC)?;
+    let class_out = workdir.join("classes");
+    fs::create_dir_all(&class_out)?;
+
+    eprintln!("local-terminal-patcher: compiling patches via javac");
+    let status = Command::new("javac")
+        .args(["--release", "11"])
+        .arg("-cp")
+        .arg(&inner_jar)
+        .arg("-d")
+        .arg(&class_out)
+        .arg(patches_dir.join("QuoteTick.java"))
+        .arg(patches_dir.join("OhlcTick.java"))
+        .status()?;
+    if !status.success() {
+        return Err(format!(
+            "javac failed with exit code {:?}; check that JDK 11+ is on PATH",
+            status.code()
+        )
+        .into());
+    }
+
+    let new_quote_tick = fs::read(class_out.join("net/thetadata/types/tick/QuoteTick.class"))?;
+    let new_ohlc_tick = fs::read(class_out.join("net/thetadata/types/tick/OhlcTick.class"))?;
+    eprintln!(
+        "local-terminal-patcher: compiled QuoteTick.class ({} bytes), OhlcTick.class ({} bytes)",
+        new_quote_tick.len(),
+        new_ohlc_tick.len()
+    );
+
+    swap_classes_in_jar(&inner_jar, &output, &new_quote_tick, &new_ohlc_tick)?;
+    let _ = fs::remove_dir_all(&workdir);
+
+    eprintln!();
+    eprintln!("local-terminal-patcher: SUCCESS");
+    eprintln!("Patched jar written to: {}", output.display());
+    eprintln!();
+    eprintln!("Next steps:");
+    eprintln!("  1. Stop your running Terminal:");
+    eprintln!("       pkill -f ThetaTerminal     # or use your launcher's stop button");
+    eprintln!();
+    eprintln!("  2. Replace the broken library jar in place. The Terminal");
+    eprintln!("     auto-updates its inner jar on launch -- prevent that by");
+    eprintln!("     pinning the patched jar with the same filename:");
+    eprintln!("       cp {} {}", output.display(), inner_jar.display());
+    eprintln!();
+    eprintln!("  3. Start the Terminal with the auto-updater disabled.");
+    eprintln!("     The exact flag depends on your launcher; the simplest");
+    eprintln!("     workaround is to chmod -w the lib/ directory after the");
+    eprintln!("     copy so the updater cannot overwrite the patched jar.");
+    eprintln!();
+    eprintln!("  4. Point the SDK at the local Terminal via FallbackPolicy:");
+    eprintln!();
+    eprintln!("       use thetadatadx::{{DirectConfig, FallbackPolicy, DEFAULT_REST_BASE_URL}};");
+    eprintln!("       let cfg = DirectConfig::production().with_rest_fallback(");
+    eprintln!("           FallbackPolicy::RestAlwaysForDateRange {{");
+    eprintln!("               base_url: DEFAULT_REST_BASE_URL.to_string(),");
+    eprintln!("               before: 20_230_101,");
+    eprintln!("           }},");
+    eprintln!("       );");
+    eprintln!();
+    eprintln!("  Then call `tdx.option_history_quote_with_fallback(...)` instead of");
+    eprintln!("  the plain `tdx.option_history_quote(...)`; pre-2023 dates route over");
+    eprintln!("  REST (immune to the issue #571 h2 cascade), 2023+ dates flow through");
+    eprintln!("  the regular gRPC fast path.");
+
+    Ok(())
+}
+
+/// Resolve `--jar` (explicit) > `--terminal-dir/lib/<latest>.jar` >
+/// autodetect against common install locations. Returns an error
+/// when nothing is found.
+fn resolve_inner_jar(args: &Args) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if let Some(j) = &args.jar {
+        if !j.exists() {
+            return Err(format!("--jar path does not exist: {}", j.display()).into());
+        }
+        return Ok(j.clone());
+    }
+
+    let candidate_dirs: Vec<PathBuf> = if let Some(d) = &args.terminal_dir {
+        vec![d.clone()]
+    } else {
+        let home = std::env::var_os("HOME").map(PathBuf::from);
+        let mut v = Vec::new();
+        if let Some(h) = home {
+            v.push(h.join("ThetaData/ThetaTerminal"));
+            v.push(h.join(".thetadata"));
+        }
+        v
+    };
+
+    for d in candidate_dirs {
+        let lib = d.join("lib");
+        if !lib.is_dir() {
+            continue;
+        }
+        let jar = newest_jar_in(&lib)?;
+        if let Some(j) = jar {
+            return Ok(j);
+        }
+    }
+    Err("Could not locate ThetaTerminal inner library jar. Pass --terminal-dir or --jar.".into())
+}
+
+/// Find the newest `.jar` in `dir` by mtime. The Terminal auto-update
+/// writes one jar per version into `lib/`; the newest is the one
+/// in use.
+fn newest_jar_in(dir: &Path) -> std::io::Result<Option<PathBuf>> {
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jar") {
+            continue;
+        }
+        let mtime = entry
+            .metadata()?
+            .modified()
+            .unwrap_or(std::time::UNIX_EPOCH);
+        if best.as_ref().is_none_or(|(t, _)| mtime > *t) {
+            best = Some((mtime, path));
+        }
+    }
+    Ok(best.map(|(_, p)| p))
+}
+
+/// Verify the inner jar's `QuoteTick.class` is the known-broken
+/// build. Hashes the class file for forensic logging and asserts the
+/// `bipush 11` byte sequence is present in the constructor body.
+/// Returns an error if neither check confirms the broken signature.
+fn verify_broken_quote_tick(jar: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let mut archive = ZipArchive::new(File::open(jar)?)?;
+    let class_bytes = {
+        let mut entry = archive
+            .by_name("net/thetadata/types/tick/QuoteTick.class")
+            .map_err(|e| format!("inner jar missing QuoteTick.class: {e}"))?;
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf)?;
+        buf
+    };
+    let hash = Sha256::digest(&class_bytes);
+    let hash_hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+    eprintln!(
+        "local-terminal-patcher: existing QuoteTick.class sha256 = {hash_hex} ({} bytes)",
+        class_bytes.len(),
+    );
+    if !contains_subsequence(&class_bytes, BROKEN_BYTECODE_SIGNATURE) {
+        return Err(format!(
+            "QuoteTick.class does NOT carry the known broken bytecode signature \
+             ({} -- bipush 11). The jar may already be patched, or may be a future \
+             build that fixed the bug upstream. Run with --skip-verify if you want to \
+             patch anyway.",
+            BROKEN_BYTECODE_SIGNATURE
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Linear-time subsequence search. The class bodies we scan are <10
+/// KiB so a Boyer-Moore implementation is overkill.
+fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// Stream `src_jar` into `dst_jar`, replacing the two patched
+/// classes verbatim. Every other entry passes through unchanged,
+/// preserving compression flags so the Terminal's bootstrap classloader
+/// reads the output identically to the input.
+fn swap_classes_in_jar(
+    src_jar: &Path,
+    dst_jar: &Path,
+    new_quote_tick: &[u8],
+    new_ohlc_tick: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut src = ZipArchive::new(File::open(src_jar)?)?;
+    let mut dst = ZipWriter::new(File::create(dst_jar)?);
+
+    let quote_path = "net/thetadata/types/tick/QuoteTick.class";
+    let ohlc_path = "net/thetadata/types/tick/OhlcTick.class";
+
+    for i in 0..src.len() {
+        let mut entry = src.by_index(i)?;
+        let name = entry.name().to_string();
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        if name == quote_path {
+            dst.start_file(name, options)?;
+            dst.write_all(new_quote_tick)?;
+            continue;
+        }
+        if name == ohlc_path {
+            dst.start_file(name, options)?;
+            dst.write_all(new_ohlc_tick)?;
+            continue;
+        }
+        if entry.is_dir() {
+            dst.add_directory(&name, options)?;
+            continue;
+        }
+        dst.start_file(name, options)?;
+        std::io::copy(&mut entry, &mut dst)?;
+    }
+    dst.finish()?;
+    Ok(())
+}

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1439,6 +1439,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -1615,6 +1616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +1724,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -1833,6 +1833,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",


### PR DESCRIPTION
Closes #571.

## Summary

Three independent recovery paths for the issue #571 h2-cascade bug on pre-extension 6-field NBBO rows in 2022-era options data. Users pick whichever fits their workload; the SDK ships all three so no single piece is a bottleneck.

## Components

### 1. Lenient gRPC decoder (forward-compat)

`bid_exchange`, `bid_condition`, `ask_exchange`, `ask_condition` are already optional in `tick_schema.toml`, so the generator-emitted `opt_number(row, None) -> 0` arm handles absent columns by zero-fill -- the same contract as the patched-Terminal `QuoteTick.normalizeData()` upcast. Schema doc + `find_header` doc now call out the legacy-shape contract, and two regression tests pin both the legacy 6-field and current 11-field shapes through `parse_quote_ticks`.

### 2. REST transport (`crate::rest`)

`RestClient` talks HTTP/1.1 to the local Terminal's `/v3/...` paths -- HTTP/1.1 is per-request, so the same Java exception cannot cascade across responses the way h2 stream multiplexing does. Four endpoints from the failure matrix are wired:

- `option_history_quote`
- `option_history_trade_quote`
- `option_history_greeks_implied_volatility`
- `option_history_greeks_first_order`

The CSV decoder is hand-written (~150 lines, no new workspace dep), honours the shared `HEADER_ALIASES` table for cross-transport parity, and is lenient on absent columns.

### 3. `FallbackPolicy` + auto-routing

```rust
let cfg = DirectConfig::production().with_rest_fallback(
    FallbackPolicy::RestAlwaysForDateRange {
        base_url: DEFAULT_REST_BASE_URL.to_string(),
        before: 20_230_101,
    },
);
```

Two shim methods on `ThetaDataDxClient` (`option_history_quote_with_fallback`, `option_history_trade_quote_with_fallback`) consult the policy and dispatch gRPC OR REST appropriately. Pre-2023 dates skip gRPC entirely (saves the failed round trip); 2023+ dates flow through the gRPC fast path.

Policy variants:

| Variant | Behaviour |
|---|---|
| `Disabled` (default) | Always gRPC. |
| `RestOnH2Disconnect` | gRPC; on `ConnectionClosed` re-issue over REST. |
| `RestAlwaysForDateRange { before }` | `start_date < before` -> REST immediately. |
| `RestAlways` | Always REST. |

### 4. `local-terminal-patcher` CLI

New workspace binary at `tools/local-terminal-patcher/` that rewrites the local Terminal's inner library jar to tolerate 6-field rows on the gRPC path. Resolves the inner jar via autodetect or `--jar` / `--terminal-dir`, verifies the known-broken bytecode signature (`bipush 11 / if_icmpeq`), compiles the patched Java sources via system `javac` (JDK 11+), and swaps the two classes into a copy of the jar.

Smoke-tested end-to-end against the live broken jar -- patched output carries the new `normalizeData()` upcast + diagnostic exception strings replacing the original `"Wrong number of data fields"` throw.

### 5. Documentation

`docs-site/docs/legacy-quote-handling.md` -- full incident write-up + the policy table + Rust usage snippets + REST endpoint coverage + decoder behaviour notes. CHANGELOG entries under Added (REST + FallbackPolicy + patcher), Changed (decoder pin + reqwest query feature), Fixed (closes #571). README Coverage Notes subsection linking to the guide.

## Gates

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --lib` -- 527 passing on thetadatadx; new tests:
  - 2 in `mdds::decode::tests` (legacy + current 11-field shape through `parse_quote_ticks`)
  - 5 in `config::fallback::tests` (each policy variant)
  - 4 in `rest::csv::tests` (header parsing, alias resolution, missing column, zero-fill)
  - 7 in `rest::tests` (each CSV decoder + CRLF + empty response)
- [x] `cargo clippy -p thetadatadx --lib -- -D warnings`
- [x] `cargo doc --no-deps --workspace`
- [x] `local-terminal-patcher` runs end-to-end on the live broken jar and produces a verifiably-patched output

Pre-existing clippy failures on benches (`undocumented_unsafe_blocks` on `CountingAllocator` impls) and `fpss::wake.rs` are NOT touched by this PR -- those are addressed in #572.

## Test plan

- [x] Decode the legacy 6-field NBBO layout through `parse_quote_ticks` -- zero-fill on absent columns
- [x] Decode the current 11-field layout unchanged
- [x] `FallbackPolicy::RestAlwaysForDateRange { before: 20_230_101 }` pre-routes 2022 dates to REST and falls through to gRPC for 2024 dates
- [x] CSV decoder handles legacy + current shapes + CRLF + empty response
- [x] `local-terminal-patcher` verifies the broken bytecode signature, compiles via javac, and swaps the two patched classes into a copy of the jar
- [ ] Live integration against the patched Terminal -- deferred to a follow-up (THETADX_LIVE_PATCHED_TERMINAL env-gated test)