### PR TITLE
fix: close 6 MINOR + 3 NIT + 1 INFO from post-#572 audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: python3 scripts/check_banned_vocab.py
+      - name: Structural SAFETY-comment boilerplate detector
+        run: |
+          python3 scripts/check_safety_comment_boilerplate.py --selftest
+          python3 scripts/check_safety_comment_boilerplate.py
 
   cargo-deny:
     name: Cargo deny

--- a/crates/tdbe/src/types/price.rs
+++ b/crates/tdbe/src/types/price.rs
@@ -76,8 +76,15 @@ pub struct Price {
     pub value: i32,
     /// Decimal type: 0 means zero, otherwise `10 - type` = fractional digits.
     ///
-    /// MUST stay within `0..=18` — the `POW10_I64` / `POW10_F64` tables
-    /// have 20 entries and every indexing path debug-asserts the bound.
+    /// MUST stay within `0..=19` — the `POW10_I64` / `POW10_F64` tables
+    /// have 20 entries (indices `0..=19`) and every indexing path
+    /// debug-asserts the bound. Index 19 is a reserved upper boundary:
+    /// the arithmetic only ever uses indices `0..=18` (since
+    /// `10^19` overflows `i64`, the index-19 slot stores `i64::MAX` as
+    /// an unreachable placeholder), but accepting `price_type = 19`
+    /// without rejecting it lets us widen the wire decode boundary
+    /// in one constant if a future server-side schema extends the
+    /// range.
     /// Public for backwards compatibility; new code should construct via
     /// [`Price::new`] (clamps) or [`Price::with_value_and_type`] (errors
     /// out of range) so the invariant is enforced at the boundary.
@@ -170,9 +177,11 @@ impl Price {
     }
 
     /// Convert to f64. This is lossy but useful for display/calculations.
-    // Reason: price_type is bounded to 0..=18 by new/with_value_and_type,
-    // and a debug_assert below pins the invariant for hand-constructed
-    // values that bypass those constructors.
+    // Reason: price_type is bounded to 0..=19 by new/with_value_and_type
+    // (index 19 is a reserved unreachable placeholder; see the constant
+    // doc on MAX_PRICE_TYPE), and a debug_assert below pins the
+    // invariant for hand-constructed values that bypass those
+    // constructors.
     #[allow(clippy::cast_sign_loss)]
     #[inline]
     #[must_use]
@@ -203,10 +212,12 @@ impl Price {
     }
 
     /// Normalize both prices to the same type for comparison.
-    // Reason: price_type is bounded to 0..=18, so differences are in
-    // 0..=18 (safe cast). `&self` required by PartialOrd/Ord trait
+    // Reason: price_type is bounded to 0..=19, so differences are in
+    // 0..=19 (safe cast). `&self` required by PartialOrd/Ord trait
     // implementations. Every index into POW10_I64 is guarded by a
-    // debug_assert in addition to the explicit `exp > 18` early-out.
+    // debug_assert in addition to the explicit `exp > 18` early-out
+    // (index 19 stores `i64::MAX` as an unreachable placeholder, so the
+    // early-out is what keeps the arithmetic correct).
     #[allow(clippy::cast_sign_loss, clippy::trivially_copy_pass_by_ref)]
     #[inline]
     fn compare(&self, other: &Self) -> Ordering {
@@ -270,9 +281,11 @@ impl fmt::Debug for Price {
 }
 
 impl fmt::Display for Price {
-    // Reason: price_type is bounded to 0..=18; debug_asserts pin the
+    // Reason: price_type is bounded to 0..=19; debug_asserts pin the
     // invariant for the formatter paths that arithmetic-cast it to
-    // unsigned.
+    // unsigned. The formatter never actually reaches an `exp` of 9
+    // (price_type 19) because `10^19` overflows i64 — the index-19 slot
+    // is an unreachable placeholder, see MAX_PRICE_TYPE.
     #[allow(clippy::cast_sign_loss)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.price_type == 0 {
@@ -345,9 +358,10 @@ mod tests {
         assert_eq!(a, c);
     }
 
-    /// Every valid `price_type` (0..=18) round-trips through Display
-    /// and to_f64 without panicking. Pins the invariant that the
-    /// POW10 tables are correctly sized for the supported range.
+    /// Every valid `price_type` (`0..=MAX_PRICE_TYPE`, i.e. `0..=19`)
+    /// round-trips through Display and to_f64 without panicking. Pins
+    /// the invariant that the POW10 tables are correctly sized for the
+    /// supported range, including the index-19 placeholder slot.
     #[test]
     fn every_valid_price_type_round_trips() {
         for pt in 0..=MAX_PRICE_TYPE {

--- a/crates/thetadatadx/benches/bench_delta_decode.rs
+++ b/crates/thetadatadx/benches/bench_delta_decode.rs
@@ -48,8 +48,11 @@ static ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
 // library.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        // SAFETY: forwarding to the system allocator under the same
-        // contract the caller is upholding.
+        // SAFETY: GlobalAlloc::alloc precondition is `layout.size() > 0`
+        // and `layout.align()` is a non-zero power of two — the alloc
+        // shim Rust generates for any `#[global_allocator]` enforces
+        // both before this call. `System.alloc` is the System impl
+        // upstream; forwarding satisfies it verbatim.
         let ptr = unsafe { System.alloc(layout) };
         if !ptr.is_null() {
             BYTES_ALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
@@ -59,8 +62,11 @@ unsafe impl GlobalAlloc for CountingAllocator {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        // SAFETY: forwarding to the system allocator under the same
-        // contract the caller is upholding.
+        // SAFETY: GlobalAlloc::dealloc precondition — `ptr` was
+        // returned by a prior `alloc` on this allocator with the same
+        // `layout`, and has not been deallocated. The shim Rust
+        // generates from `Vec`, `Box`, etc. upholds that pairing;
+        // forwarding to `System.dealloc` satisfies the System impl.
         unsafe { System.dealloc(ptr, layout) }
     }
 }

--- a/crates/thetadatadx/benches/grpc_channel.rs
+++ b/crates/thetadatadx/benches/grpc_channel.rs
@@ -54,8 +54,11 @@ static BYTES_DEALLOCATED: AtomicU64 = AtomicU64::new(0);
 // library.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        // SAFETY: forwarding to the system allocator under the same
-        // contract the caller is upholding.
+        // SAFETY: GlobalAlloc::alloc precondition is `layout.size() > 0`
+        // and `layout.align()` is a non-zero power of two — the alloc
+        // shim Rust generates for any `#[global_allocator]` enforces
+        // both before this call. `System.alloc` is the System impl
+        // upstream; forwarding satisfies it verbatim.
         let ptr = unsafe { System.alloc(layout) };
         if !ptr.is_null() {
             BYTES_ALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
@@ -65,8 +68,11 @@ unsafe impl GlobalAlloc for CountingAllocator {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         BYTES_DEALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
-        // SAFETY: forwarding to the system allocator under the same
-        // contract the caller is upholding.
+        // SAFETY: GlobalAlloc::dealloc precondition — `ptr` was
+        // returned by a prior `alloc` on this allocator with the same
+        // `layout`, and has not been deallocated. The shim Rust
+        // generates from `Vec`, `Box`, etc. upholds that pairing;
+        // forwarding to `System.dealloc` satisfies the System impl.
         unsafe { System.dealloc(ptr, layout) }
     }
 }

--- a/crates/thetadatadx/benches/grpc_concurrent_burst.rs
+++ b/crates/thetadatadx/benches/grpc_concurrent_burst.rs
@@ -45,8 +45,11 @@ static BYTES_DEALLOCATED: AtomicU64 = AtomicU64::new(0);
 // library.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        // SAFETY: forwarding to the system allocator under the same
-        // contract the caller is upholding.
+        // SAFETY: GlobalAlloc::alloc precondition is `layout.size() > 0`
+        // and `layout.align()` is a non-zero power of two — the alloc
+        // shim Rust generates for any `#[global_allocator]` enforces
+        // both before this call. `System.alloc` is the System impl
+        // upstream; forwarding satisfies it verbatim.
         let ptr = unsafe { System.alloc(layout) };
         if !ptr.is_null() {
             BYTES_ALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
@@ -56,8 +59,11 @@ unsafe impl GlobalAlloc for CountingAllocator {
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         BYTES_DEALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
-        // SAFETY: forwarding to the system allocator under the same
-        // contract the caller is upholding.
+        // SAFETY: GlobalAlloc::dealloc precondition — `ptr` was
+        // returned by a prior `alloc` on this allocator with the same
+        // `layout`, and has not been deallocated. The shim Rust
+        // generates from `Vec`, `Box`, etc. upholds that pairing;
+        // forwarding to `System.dealloc` satisfies the System impl.
         unsafe { System.dealloc(ptr, layout) }
     }
 }

--- a/crates/thetadatadx/benches/historical_streaming_memory.rs
+++ b/crates/thetadatadx/benches/historical_streaming_memory.rs
@@ -51,8 +51,11 @@ static MAX_LIVE_BYTES: AtomicU64 = AtomicU64::new(0);
 // shipped library.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        // SAFETY: forwarding to the system allocator under the same
-        // contract the caller is upholding.
+        // SAFETY: GlobalAlloc::alloc precondition is `layout.size() > 0`
+        // and `layout.align()` is a non-zero power of two — the alloc
+        // shim Rust generates for any `#[global_allocator]` enforces
+        // both before this call. `System.alloc` is the System impl
+        // upstream; forwarding satisfies it verbatim.
         let ptr = unsafe { System.alloc(layout) };
         if !ptr.is_null() {
             let allocated = BYTES_ALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed)
@@ -79,8 +82,11 @@ unsafe impl GlobalAlloc for CountingAllocator {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        // SAFETY: forwarding to the system allocator under the same
-        // contract the caller is upholding.
+        // SAFETY: GlobalAlloc::dealloc precondition — `ptr` was
+        // returned by a prior `alloc` on this allocator with the same
+        // `layout`, and has not been deallocated. The shim Rust
+        // generates from `Vec`, `Box`, etc. upholds that pairing;
+        // forwarding to `System.dealloc` satisfies the System impl.
         unsafe { System.dealloc(ptr, layout) };
         BYTES_DEALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
     }

--- a/crates/thetadatadx/src/fpss/decode.rs
+++ b/crates/thetadatadx/src/fpss/decode.rs
@@ -172,6 +172,14 @@ pub fn decode_frame(
     // unknown id would flood `tracing` with a per-tick line on every
     // affected contract — at FPSS arrival rates the log channel
     // becomes the bottleneck.
+    //
+    // `MISS_COUNT` is process-global (static AtomicU64), so the
+    // cadence is shared across every `FpssClient` running inside the
+    // same process. Operators reading the warning should treat the
+    // "1 of every 1024" rate as a process-wide aggregate, not a
+    // per-client signal — two clients each missing 512 unique
+    // contracts together hit the warn boundary exactly once between
+    // them.
     let warn_unknown_contract =
         |contract_id: i32,
          kind: &str,
@@ -185,7 +193,7 @@ pub fn decode_frame(
                         contract_id,
                         kind,
                         miss_count = prev + 1,
-                        "no contract for ID (1 of every 1024 emitted)"
+                        "no contract for ID (1 of every 1024 emitted across all FpssClients in this process)"
                     );
                 }
             }

--- a/crates/thetadatadx/src/fpss/events.rs
+++ b/crates/thetadatadx/src/fpss/events.rs
@@ -297,6 +297,23 @@ impl Default for FpssEventInternal {
     }
 }
 
+// Compile-time layout-compatibility guards for the `FpssEventInternal ->
+// FpssEvent` reborrow performed by [`FpssEventInternal::as_public`]. Both
+// enums are `#[repr(C, u8)]` with identical payload types at the
+// `Data` / `Control` discriminants, so size + alignment must match
+// exactly. A divergence here trips the build before any callback can
+// observe a corrupted reborrow. Discriminant-byte equality is verified
+// separately by the runtime `assert_layout_compat` unit test (it
+// requires `Arc`-bearing constructed values and is not const-evaluable).
+const _: () = assert!(
+    core::mem::size_of::<FpssEvent>() == core::mem::size_of::<FpssEventInternal>(),
+    "FpssEvent and FpssEventInternal must have identical size for the as_public reborrow",
+);
+const _: () = assert!(
+    core::mem::align_of::<FpssEvent>() == core::mem::align_of::<FpssEventInternal>(),
+    "FpssEvent and FpssEventInternal must have identical alignment for the as_public reborrow",
+);
+
 impl FpssEventInternal {
     /// Borrow this internal event as a public [`FpssEvent`] reference,
     /// or return `None` for the internal-only variants.
@@ -323,11 +340,17 @@ impl FpssEventInternal {
     /// [`FPSS_EVENT_TAG_UNPARSEABLE`], [`FPSS_EVENT_TAG_EMPTY`]) can
     /// never escape into the public type — they map to `None`.
     ///
-    /// The static assertions in [`assert_layout_compat`] (run in the
-    /// crate's unit tests) verify size + alignment + discriminant
-    /// equality at compile time so a future divergence — e.g. someone
-    /// adding a private field to `FpssData` only on the internal side
-    /// — fails the build before it can corrupt a user callback.
+    /// Two layers pin this invariant against future drift:
+    ///
+    /// * Compile-time `const _: () = assert!(...)` items at the bottom
+    ///   of this module check `size_of` and `align_of` equality between
+    ///   `FpssEvent` and `FpssEventInternal`. Any divergence — e.g.
+    ///   someone adding a private field to `FpssData` only on the
+    ///   internal side — fails the build before it can corrupt a user
+    ///   callback.
+    /// * The runtime unit test [`assert_layout_compat`] additionally
+    ///   pins discriminant-byte equality (which requires constructing
+    ///   `Arc`-bearing payloads and is therefore not const-evaluable).
     #[inline]
     pub fn as_public(&self) -> Option<&FpssEvent> {
         // Gate the layout-compatibility cast on a real `match`. The
@@ -351,10 +374,12 @@ impl FpssEventInternal {
                 // identical `Data(FpssData)` payloads at that
                 // discriminant, so the in-memory layout is shared
                 // (Rust reference, "Primitive representation of enums
-                // with fields"). `assert_layout_compat` (run as a unit
-                // test) pins size, alignment, and discriminant equality
-                // at compile time, so a future divergence trips the
-                // build before it can corrupt a callback. The reborrow
+                // with fields"). The compile-time `const _` items at
+                // the bottom of this module pin `size_of` and
+                // `align_of` equality; the runtime `assert_layout_compat`
+                // test pins discriminant-byte equality. Together they
+                // trip the build (or first test run) before a future
+                // layout divergence can corrupt a callback. The reborrow
                 // inherits the `&self` lifetime; aliasing rules treat
                 // it like the original borrow.
                 Some(unsafe { &*(self as *const Self as *const FpssEvent) })
@@ -582,8 +607,13 @@ mod tests {
     /// `FpssEvent` and the public-facing variants of
     /// `FpssEventInternal` must trip this test before it can corrupt a
     /// reborrow.
+    ///
+    /// Size + alignment are also pinned at compile time by `const _`
+    /// items at module scope; this test additionally pins
+    /// discriminant-byte equality (which requires constructing
+    /// `Arc`-bearing payloads and is not const-evaluable).
     #[test]
-    fn fpss_event_internal_layout_matches_public() {
+    fn assert_layout_compat() {
         // Same `#[repr(C, u8)]` declaration on both enums plus
         // identical payload types ⇒ identical size + alignment.
         assert_eq!(
@@ -638,7 +668,12 @@ mod tests {
         let public_control = FpssEvent::Control(FpssControl::LoginSuccess {
             permissions: String::new(),
         });
-        // SAFETY: pointer was returned by the matching constructor and not yet freed; ownership / lifetime is the caller's contract.
+        // SAFETY: `p` points at a local stack value (one of the four
+        // `FpssEvent` / `FpssEventInternal` bindings constructed above)
+        // whose first byte holds the `#[repr(C, u8)]` discriminant tag.
+        // Reading exactly 1 byte through `*const u8` is sound for the
+        // duration of the enclosing test scope — the bindings outlive
+        // every closure call below.
         let tag = |p: *const u8| unsafe { *p };
         assert_eq!(
             tag(&internal_data as *const _ as *const u8),

--- a/crates/thetadatadx/src/fpss/io_loop/mod.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/mod.rs
@@ -27,7 +27,7 @@ use std::io::Write;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::mpsc as std_mpsc;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 
 // parking_lot's Mutex is ~5ns uncontended (vs ~20-40ns for
 // std::sync::Mutex), inlines aggressively, and ships no poisoning
@@ -43,6 +43,26 @@ use std::thread::{self, ThreadId};
 use std::time::{Duration, Instant};
 
 use disruptor::{build_single_producer, Producer, Sequence};
+use metrics::Counter;
+
+// ─── Hoisted I/O-loop counter handles ───────────────────────────────
+//
+// Mirrors the `decode.rs` hoisting pattern: `metrics::counter!(name)`
+// resolves the metric handle through the global recorder on every
+// call (~30 ns per hit observed in the decode bench). The two
+// io_loop counters fire on hot-but-not-per-tick paths
+// (`drain_yields` on every mid-frame yield, `reconnects` on every
+// reconnect attempt), but the lookup pattern is the same and there
+// is no reason to leave them un-hoisted now that the surrounding
+// counters are.
+//
+// One handle per metric name. `Counter::increment` is `&self` so a
+// single `LazyLock<Counter>` serves every call site that fires the
+// same metric.
+static FPSS_DRAIN_YIELDS: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.drain_yields"));
+static FPSS_RECONNECTS: LazyLock<Counter> =
+    LazyLock::new(|| metrics::counter!("thetadatadx.fpss.reconnects"));
 
 use tdbe::types::enums::{RemoveReason, StreamMsgType};
 
@@ -607,7 +627,7 @@ pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
                     // drain-yield is expected behaviour on a trickling
                     // sender, not a sign of a dead connection. Fall
                     // through to the Phase 2 drain.
-                    metrics::counter!("thetadatadx.fpss.drain_yields").increment(1);
+                    FPSS_DRAIN_YIELDS.increment(1);
                     tracing::trace!(
                         "mid-frame drain-yield -- draining outbound commands \
                          before re-entering read"
@@ -752,7 +772,7 @@ pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
             delay_ms,
             "auto-reconnecting FPSS"
         );
-        metrics::counter!("thetadatadx.fpss.reconnects").increment(1);
+        FPSS_RECONNECTS.increment(1);
         if producer
             .try_publish(|slot| {
                 slot.event = FpssEventInternal::Control(FpssControl::Reconnecting {

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -219,8 +219,8 @@ pub struct FpssConnectArgs<'a> {
     /// Disruptor ring buffer size (events). Must be a power of two.
     ///
     /// Each ring slot stores one `FpssEventInternal` (96 bytes on the
-    /// current 64-bit layout, validated by the
-    /// `fpss_event_internal_layout_matches_public` test). The default
+    /// current 64-bit layout, validated by the `assert_layout_compat`
+    /// test). The default
     /// `ring_size = 4096` allocates roughly `4096 × 96 ≈ 384 KiB` per
     /// `FpssClient` for the ring, plus per-event refcounted
     /// `Arc<Contract>` storage on top. Tune downward (e.g., 1024) if

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -181,6 +181,16 @@ use self::protocol::{
 /// production streaming consumer). This helper masks off the sign bit
 /// and casts down, producing the positive `i32` the wire encoder
 /// expects.
+///
+/// Same-value id collisions remain possible after `2^31` allocations —
+/// this is a wire-protocol limitation (31-bit positive id space, since
+/// `-1` is reserved as the uncorrelated sentinel and negative ids are
+/// defensively excluded). The widening only eliminates the `-1`
+/// sentinel collision; an honest cycle of the positive id space still
+/// reuses earlier ids. Consumers correlating responses across a span
+/// longer than `2^31` allocations must add their own disambiguation
+/// (e.g. per-subscription state on the caller side, or a session-id
+/// salt prepended to the caller-visible request handle).
 #[inline]
 pub(in crate::fpss) fn wire_req_id(counter_value: i64) -> i32 {
     (counter_value & 0x7FFF_FFFF) as i32

--- a/crates/thetadatadx/src/grpc/channel.rs
+++ b/crates/thetadatadx/src/grpc/channel.rs
@@ -145,8 +145,12 @@ pub enum ChannelError {
 
 /// One HTTP/2 connection to a gRPC server.
 ///
-/// Clone-cheap — the inner `SendRequest<Bytes>` is itself an h2 channel
-/// handle that serializes through the connection's stream multiplexer.
+/// Owns the spawned h2 connection driver task via `connection_task`
+/// (`Option<JoinHandle<()>>`), which is `!Clone`. `Channel` is never
+/// cloned anywhere in the codebase — each pool entry holds one
+/// `Channel` and recycles it on `ConnectionClosed`. New streams open
+/// through the inner `SendRequest<Bytes>` clone, not through a
+/// `Channel` clone.
 pub struct Channel {
     /// Outbound stream factory. Cloning this gives a second handle to
     /// the same h2 connection; new streams it opens share the connection.

--- a/ffi/src/flatfiles.rs
+++ b/ffi/src/flatfiles.rs
@@ -175,7 +175,16 @@ pub unsafe extern "C" fn tdx_flatfile_rows_count(rowlist: *const TdxFlatFileRowL
         if rowlist.is_null() {
             return 0;
         }
-        // SAFETY: pointer was returned by the matching constructor and not yet freed; ownership / lifetime is the caller's contract.
+        // SAFETY: caller's contract on this FFI function requires
+        // `rowlist` to be either null (rejected above) or the value
+        // returned by `tdx_flatfile_request_decoded`, which built it
+        // via `Box::into_raw(Box::new(TdxFlatFileRowList { .. }))`.
+        // No mutating call (only `tdx_flatfile_rowlist_free`, which
+        // consumes the pointer) runs concurrently — single-threaded
+        // FFI ownership — so the box is live, `#[repr(Rust)]`
+        // well-aligned, and a shared `&TdxFlatFileRowList` reborrow
+        // (`(*rowlist).rows.len()` reads only the `len` field of the
+        // inner `Vec`, no field of `rowlist` is mutated) is sound.
         unsafe { (*rowlist).rows.len() }
     })
 }
@@ -202,7 +211,17 @@ pub unsafe extern "C" fn tdx_flatfile_rows_to_arrow_ipc(
                     len: 0,
                 };
             }
-            // SAFETY: pointer was returned by the matching constructor and not yet freed; ownership / lifetime is the caller's contract.
+            // SAFETY: caller's contract on this FFI function requires
+            // `rowlist` to be either null (rejected above) or the value
+            // returned by `tdx_flatfile_request_decoded`, which built
+            // it via `Box::into_raw(Box::new(TdxFlatFileRowList { .. }))`.
+            // The reborrowed `&Vec<FlatFileRow>` lives only for the
+            // duration of this expression (it is consumed by
+            // `rows_to_arrow` synchronously below); since the only
+            // function that invalidates the box —
+            // `tdx_flatfile_rowlist_free` — takes `*mut` and cannot run
+            // concurrently across a single FFI call, the borrow is
+            // valid for that span.
             let rows = unsafe { &(*rowlist).rows };
             let batch = match flatfiles::arrow::rows_to_arrow(rows) {
                 Ok(b) => b,

--- a/scripts/check_safety_comment_boilerplate.py
+++ b/scripts/check_safety_comment_boilerplate.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Structural detector for stamped SAFETY-comment boilerplate.
+
+The original `check_banned_vocab.py` regression guard only catches the
+literal string that landed in #572. A future bot can defeat that gate by
+re-emitting a fresh boilerplate string at three or more sites — the
+text changes, but the lint pathology is identical: a copy-pasted
+SAFETY annotation that names neither the invariant nor any per-site
+detail, masquerading as a real safety review.
+
+This detector closes that gap structurally:
+
+* Collect every ``// SAFETY: <text>`` block across the Rust tree.
+* Bucket by the exact normalised text.
+* Flag any bucket whose population is >= ``DEFAULT_MIN_OCCURRENCES``,
+  spans at least one non-FFI site, and whose text mentions no
+  per-site invariant token (an identifier in backticks, a lifetime
+  annotation, an atomic ordering, a layout property, etc.).
+
+The text-token heuristic is deliberately permissive — a genuine
+SAFETY annotation almost always names the type, the lifetime, or the
+ordering that makes the unsafe block sound. Boilerplate that says
+"caller upholds the contract" mentions none of those.
+
+Run::
+
+    python3 scripts/check_safety_comment_boilerplate.py
+
+Exit codes:
+
+* ``0`` — clean.
+* ``1`` — at least one offending bucket detected.
+
+Selftest::
+
+    python3 scripts/check_safety_comment_boilerplate.py --selftest
+
+The selftest simulates a regression and verifies the detector flags it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from collections import defaultdict
+from typing import Iterable
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+# Minimum number of verbatim-identical SAFETY comments at non-FFI sites
+# that triggers the gate. Three is the same floor cited in the audit
+# finding M3 — two copies are plausibly coincidence, three is a pattern.
+DEFAULT_MIN_OCCURRENCES = 3
+
+
+# Files / directories the detector skips. FFI surface comments are
+# exempt: every site there is an `extern "C" fn` whose caller contract
+# lives on the function signature, and the comment frequently is a
+# pointer back to that doc. The detector itself is also exempt — it
+# embeds the regression sample below as a string literal.
+SCAN_GLOBS = ("crates/**/*.rs", "ffi/**/*.rs", "tools/**/*.rs", "sdks/**/*.rs")
+
+FFI_EXEMPT_PREFIXES = ("ffi/src/",)
+
+EXEMPT_PATH_FRAGMENTS = (
+    "/target/",
+    "/.git/",
+)
+
+
+# Regex matching a `// SAFETY:` line and capturing the trailing text.
+# We collect continuation lines (subsequent `//` comments) into the same
+# block until the comment terminates. Doc-style `/// SAFETY:` is
+# included — same review pathology applies.
+SAFETY_LINE_RE = re.compile(r"^\s*///?\s*SAFETY:\s*(?P<body>.*)$")
+COMMENT_CONT_RE = re.compile(r"^\s*///?\s?(?P<body>.*)$")
+
+
+# Per-site invariant signals. If any of these appears in the comment
+# text the gate treats it as a "real" SAFETY annotation and skips it
+# regardless of duplicate count. Tokens come from the audit finding's
+# heuristic list: identifiers in backticks, lifetime annotations,
+# atomic orderings, layout properties, validity language, etc.
+INVARIANT_SIGNAL_PATTERNS = (
+    re.compile(r"`[^`]+`"),                       # backtick-quoted identifier
+    re.compile(r"\B'[a-z_][a-z_0-9]*\b"),         # lifetime annotation, e.g. 'a
+    re.compile(r"\bOrdering::"),                  # atomic ordering
+    re.compile(r"\brepr\("),                      # layout repr
+    re.compile(r"\bsize_of\b"),
+    re.compile(r"\balign_of\b"),
+    re.compile(r"\boffset(?:_of)?\b"),
+    re.compile(r"\bnon[- ]null\b", re.IGNORECASE),
+    re.compile(r"\bvalid for\b", re.IGNORECASE),
+    re.compile(r"\bdiscriminant\b"),
+    re.compile(r"\baligned\b"),
+    re.compile(r"\bUTF-?8\b", re.IGNORECASE),
+    re.compile(r"\bNULL\b"),
+    re.compile(r"\bunique\b", re.IGNORECASE),     # uniqueness / aliasing
+    re.compile(r"\bborrow\b", re.IGNORECASE),
+    re.compile(r"\bMutex|RwLock|Arc|Box|Rc\b"),
+    re.compile(r"\binitialise|initialize\b", re.IGNORECASE),
+)
+
+
+def _is_exempt(rel_path: pathlib.Path) -> bool:
+    parts = "/" + rel_path.as_posix() + "/"
+    for fragment in EXEMPT_PATH_FRAGMENTS:
+        if fragment in parts:
+            return True
+    return False
+
+
+def _is_ffi_exempt(rel_path: pathlib.Path) -> bool:
+    rel_str = rel_path.as_posix()
+    return any(rel_str.startswith(prefix) for prefix in FFI_EXEMPT_PREFIXES)
+
+
+def _iter_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
+    seen: set[pathlib.Path] = set()
+    for pattern in SCAN_GLOBS:
+        for candidate in root.glob(pattern):
+            if not candidate.is_file():
+                continue
+            rel = candidate.relative_to(root)
+            if _is_exempt(rel):
+                continue
+            if rel in seen:
+                continue
+            seen.add(rel)
+            yield candidate
+
+
+def _normalise(text: str) -> str:
+    """Collapse whitespace so trivial reflow does not defeat the gate."""
+    return " ".join(text.split())
+
+
+def _mentions_invariant(text: str) -> bool:
+    for pattern in INVARIANT_SIGNAL_PATTERNS:
+        if pattern.search(text):
+            return True
+    return False
+
+
+def _extract_safety_blocks(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Return (line_number, normalised_text) for every SAFETY block in `path`.
+
+    A block starts on a line matching ``// SAFETY: <body>`` and absorbs
+    subsequent contiguous ``// <body>`` lines (allowing multi-line
+    annotations).
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    blocks: list[tuple[int, str]] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        m = SAFETY_LINE_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        start = i + 1  # 1-based line number
+        chunks = [m.group("body").strip()]
+        j = i + 1
+        while j < len(lines):
+            cont = COMMENT_CONT_RE.match(lines[j])
+            if not cont:
+                break
+            body = cont.group("body").strip()
+            if not body:
+                # blank `//` line ends a multi-line comment block
+                break
+            if SAFETY_LINE_RE.match(lines[j]):
+                # another SAFETY: header — start a new block
+                break
+            chunks.append(body)
+            j += 1
+        normalised = _normalise(" ".join(chunks))
+        blocks.append((start, normalised))
+        i = j
+    return blocks
+
+
+def _scan(
+    root: pathlib.Path,
+    min_occurrences: int = DEFAULT_MIN_OCCURRENCES,
+) -> list[tuple[str, list[tuple[pathlib.Path, int]]]]:
+    """Return a list of (boilerplate_text, occurrences) buckets that trip the gate."""
+    buckets: dict[str, list[tuple[pathlib.Path, int]]] = defaultdict(list)
+    for path in _iter_files(root):
+        rel = path.relative_to(root)
+        ffi_exempt = _is_ffi_exempt(rel)
+        for lineno, body in _extract_safety_blocks(path):
+            buckets[body].append((rel, lineno))
+            # FFI exemption is per-site, applied at evaluation time below.
+            if ffi_exempt:
+                # Tag the entry as exempt so the evaluator can drop it
+                # from the population count.
+                buckets[body][-1] = (rel, -lineno if lineno > 0 else lineno)
+    flagged: list[tuple[str, list[tuple[pathlib.Path, int]]]] = []
+    for body, sites in buckets.items():
+        non_ffi_sites = [(p, ln) for (p, ln) in sites if ln > 0]
+        if len(non_ffi_sites) < min_occurrences:
+            continue
+        if _mentions_invariant(body):
+            continue
+        flagged.append((body, non_ffi_sites))
+    return flagged
+
+
+def _selftest() -> int:
+    """Build a temporary tree with 3 stamped sites + 1 genuine site, then scan."""
+    import tempfile
+
+    sample_boilerplate = (
+        "the caller upholds the FFI contract on this pointer; "
+        "ownership / lifetime is managed entirely outside Rust"
+    )
+    genuine = (
+        "the pointer was returned by `tdx_session_new` and refers to a "
+        "`Box<Session>` whose lifetime is bounded by `tdx_session_free`; "
+        "no aliasing mutator runs concurrently"
+    )
+
+    sample_files = {
+        pathlib.Path("crates/a/src/lib.rs"): f"""
+fn a() {{
+    // SAFETY: {sample_boilerplate}
+    unsafe {{ }}
+}}
+""",
+        pathlib.Path("crates/b/src/lib.rs"): f"""
+fn b() {{
+    // SAFETY: {sample_boilerplate}
+    unsafe {{ }}
+}}
+""",
+        pathlib.Path("crates/c/src/lib.rs"): f"""
+fn c() {{
+    // SAFETY: {sample_boilerplate}
+    unsafe {{ }}
+}}
+""",
+        # Genuine annotation — must NOT be flagged.
+        pathlib.Path("crates/d/src/lib.rs"): f"""
+fn d() {{
+    // SAFETY: {genuine}
+    unsafe {{ }}
+}}
+""",
+        # FFI site repeating the boilerplate — must be exempted from the
+        # population count so the synthetic bucket on its own is still
+        # only 3, not 4.
+        pathlib.Path("ffi/src/lib.rs"): f"""
+fn e() {{
+    // SAFETY: {sample_boilerplate}
+    unsafe {{ }}
+}}
+""",
+    }
+
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        for rel, content in sample_files.items():
+            target = root / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        flagged = _scan(root)
+        if not flagged:
+            print("selftest FAILED: stamped boilerplate not detected")
+            return 1
+        if len(flagged) != 1:
+            print(
+                f"selftest FAILED: expected exactly 1 flagged bucket, got {len(flagged)}"
+            )
+            return 1
+        body, sites = flagged[0]
+        non_ffi = [s for s in sites if not s[0].as_posix().startswith("ffi/")]
+        if len(non_ffi) != 3:
+            print(
+                f"selftest FAILED: expected 3 non-FFI sites, got {len(non_ffi)} "
+                f"({non_ffi!r})"
+            )
+            return 1
+        if "the caller upholds" not in body:
+            print(f"selftest FAILED: flagged the wrong bucket ({body!r})")
+            return 1
+        # Sanity: the genuine annotation must have been silenced by the
+        # backtick-identifier signal.
+        if any("tdx_session_new" in b for (b, _) in flagged):
+            print("selftest FAILED: genuine annotation was flagged")
+            return 1
+    print("selftest: ok")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="Run the embedded self-test and exit.",
+    )
+    parser.add_argument(
+        "--min-occurrences",
+        type=int,
+        default=DEFAULT_MIN_OCCURRENCES,
+        help=(
+            f"Minimum identical-text occurrences at non-FFI sites that "
+            f"trip the gate (default {DEFAULT_MIN_OCCURRENCES})."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return _selftest()
+
+    flagged = _scan(REPO_ROOT, min_occurrences=args.min_occurrences)
+    if not flagged:
+        print("safety-boilerplate: clean")
+        return 0
+    print(
+        f"safety-boilerplate: {len(flagged)} stamped-comment bucket(s) "
+        f"with >= {args.min_occurrences} non-FFI sites"
+    )
+    for body, sites in flagged:
+        truncated = body if len(body) <= 200 else body[:200] + "..."
+        print(f"  text: {truncated}")
+        for rel, lineno in sites:
+            print(f"    {rel}:{lineno}")
+    print(
+        "  -> Rewrite each comment to name the actual invariant "
+        "(identifier, lifetime, ordering, layout property). "
+        "Stamped boilerplate is not a SAFETY annotation."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -24,6 +24,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 CANONICAL_CARGO = ROOT / "crates" / "thetadatadx" / "Cargo.toml"
 CMAKE_LISTS = ROOT / "sdks" / "cpp" / "CMakeLists.txt"
+PY_INIT = ROOT / "sdks" / "python" / "python" / "thetadatadx" / "__init__.py"
+
+# Accepted values for the `__version__` fallback in the Python SDK
+# `__init__.py`. `"unknown"` is the canonical sentinel — anything that
+# happens to look like a semver literal (e.g. `"10.0.0"`) drifts
+# silently whenever `Cargo.toml` advances, so the gate warns the
+# operator immediately.
+PY_FALLBACK_OK = ("unknown",)
+PY_FALLBACK_RE = re.compile(r'__version__\s*=\s*"([^"]+)"')
 
 
 def cargo_version(path: Path) -> str:
@@ -80,6 +89,45 @@ DOC_PIN_PATHS = (
 DOC_PIN_RE = re.compile(
     r'thetadatadx\s*=\s*(?:"(\d+)(?:[.,)\'" ]|$)|\{\s*version\s*=\s*"(\d+)(?:[.,)\'" ]|$))'
 )
+
+
+def python_init_fallback_mismatches(canonical: str) -> list[str]:
+    """Warn if the Python SDK `__version__` fallback drifted away from
+    the `"unknown"` sentinel into a stale numeric literal.
+
+    A literal fallback like `"10.0.0"` silently lies whenever the
+    canonical `Cargo.toml` version advances — operators inspecting
+    `thetadatadx.__version__` on a source-tree import see a stale
+    number instead of an obvious "I cannot determine the version"
+    signal. The accepted value is the sentinel; anything else either
+    matches `canonical` (acceptable but fragile) or is stale.
+    """
+    if not PY_INIT.is_file():
+        return []
+    issues: list[str] = []
+    for lineno, line in enumerate(PY_INIT.read_text().splitlines(), start=1):
+        match = PY_FALLBACK_RE.search(line)
+        if not match:
+            continue
+        literal = match.group(1)
+        if literal in PY_FALLBACK_OK:
+            continue
+        if literal == canonical:
+            # Matches today, but will drift on the next bump — warn.
+            issues.append(
+                f"{PY_INIT.relative_to(ROOT)}:{lineno} `__version__` "
+                f'fallback is the numeric literal "{literal}" (matches '
+                "canonical today but will drift on next version bump — "
+                'prefer the "unknown" sentinel)'
+            )
+            continue
+        issues.append(
+            f"{PY_INIT.relative_to(ROOT)}:{lineno} `__version__` "
+            f'fallback is "{literal}", expected the "unknown" sentinel '
+            f"(canonical is {canonical} — a numeric literal here drifts "
+            "silently)"
+        )
+    return issues
 
 
 def doc_pin_mismatches(canonical_major: str) -> list[str]:
@@ -144,6 +192,11 @@ def main() -> int:
 
     # U5 closure: documentation pins must match the canonical major.
     failures.extend(doc_pin_mismatches(canonical_major))
+
+    # M4 closure (post-#572 audit): Python SDK `__version__` fallback
+    # must be the `"unknown"` sentinel, not a numeric literal that
+    # drifts silently.
+    failures.extend(python_init_fallback_mismatches(canonical))
 
     if failures:
         print("version-sync errors:")

--- a/sdks/python/python/thetadatadx/__init__.py
+++ b/sdks/python/python/thetadatadx/__init__.py
@@ -10,12 +10,13 @@ if hasattr(_ext, "__all__"):
 # Resolve the package version through `importlib.metadata` so the
 # string the user reads from `thetadatadx.__version__` is the same one
 # the installed wheel's `METADATA` declares — driven by `Cargo.toml`
-# via the maturin build. Falling back to the in-source default keeps
-# `thetadatadx.__version__` readable in editable / source-tree imports
-# where the wheel metadata is absent. Wrapping the import in a
-# try/except guards against the (theoretical) edge case where
-# `importlib.metadata` cannot resolve the distribution (unusual stale
-# install), so an import-time exception cannot break the wheel.
+# via the maturin build. The "unknown" fallback applies only when
+# `importlib.metadata` cannot resolve the distribution (editable /
+# source-tree imports where the wheel metadata is absent, unusual
+# stale installs). Using a literal sentinel here — rather than a
+# hardcoded version string — keeps the staleness immediately visible
+# to operators inspecting `__version__`, instead of silently lying
+# with a stale number that drifted away from `Cargo.toml`.
 try:
     from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
     from importlib.metadata import version as _pkg_version
@@ -23,6 +24,6 @@ try:
     try:
         __version__ = _pkg_version("thetadatadx")
     except _PackageNotFoundError:
-        __version__ = "10.0.0"
+        __version__ = "unknown"
 except ImportError:  # pragma: no cover - importlib.metadata is in stdlib >=3.8
-    __version__ = "10.0.0"
+    __version__ = "unknown"

--- a/sdks/python/python/thetadatadx/__init__.py
+++ b/sdks/python/python/thetadatadx/__init__.py
@@ -17,13 +17,10 @@ if hasattr(_ext, "__all__"):
 # hardcoded version string — keeps the staleness immediately visible
 # to operators inspecting `__version__`, instead of silently lying
 # with a stale number that drifted away from `Cargo.toml`.
-try:
-    from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
-    from importlib.metadata import version as _pkg_version
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
-    try:
-        __version__ = _pkg_version("thetadatadx")
-    except _PackageNotFoundError:
-        __version__ = "unknown"
-except ImportError:  # pragma: no cover - importlib.metadata is in stdlib >=3.8
+try:
+    __version__ = _pkg_version("thetadatadx")
+except _PackageNotFoundError:
     __version__ = "unknown"

--- a/sdks/python/src/streaming_async_batches.rs
+++ b/sdks/python/src/streaming_async_batches.rs
@@ -1306,7 +1306,13 @@ mod fd_safety_tests {
             );
         });
         // Manual cleanup of the write end — its peer was closed above.
-        // SAFETY: write_raw was alloc_wake_pipe-allocated and is the only owner.
+        // SAFETY: `write_raw` is the raw FD returned by
+        // `alloc_wake_pipe()` above, never duplicated and never
+        // handed to another scope; the production path under test
+        // closed `read_raw` (its peer) but left `write_raw`
+        // untouched, so it is still open and uniquely owned here.
+        // The `libc::close` precondition (valid open FD, single
+        // owner, no concurrent close) holds for this scope.
         unsafe {
             libc::close(write_raw);
         }
@@ -1344,7 +1350,12 @@ mod fd_safety_tests {
         );
         assert_eq!(fd_slot, -1, "read_fd slot must be sentinel-reclaimed");
         assert!(result.is_ok(), "happy-path close must return Ok");
-        // SAFETY: write_raw was alloc_wake_pipe-allocated and is the only owner.
+        // SAFETY: `write_raw` is the raw FD returned by
+        // `alloc_wake_pipe()` at the top of this test, never
+        // duplicated; the read end was closed by the happy-path
+        // close (verified above by `!fd_is_open(read_raw)`) and
+        // `write_raw` remains the sole open FD in this scope.
+        // The `libc::close` precondition holds.
         unsafe {
             libc::close(write_raw);
         }

--- a/sdks/python/src/streaming_async_session.rs
+++ b/sdks/python/src/streaming_async_session.rs
@@ -1272,7 +1272,13 @@ mod fd_safety_tests {
                 "re-raised error must be the captured RuntimeError"
             );
         });
-        // SAFETY: write_raw was alloc_wake_pipe-allocated and is the only owner.
+        // SAFETY: `write_raw` is the raw FD returned by
+        // `alloc_wake_pipe()` above, never duplicated and never
+        // handed to another scope; the read end was closed by the
+        // production path under test (see the `fd_is_open(read_raw)`
+        // assertion above) and `write_raw` is still open here. The
+        // `libc::close` precondition (valid open FD, single owner,
+        // no concurrent close) holds for this test scope.
         unsafe {
             libc::close(write_raw);
         }
@@ -1309,7 +1315,12 @@ mod fd_safety_tests {
         );
         assert_eq!(fd_slot, -1, "read_fd slot must be sentinel-reclaimed");
         assert!(result.is_ok(), "happy-path close must return Ok");
-        // SAFETY: write_raw was alloc_wake_pipe-allocated and is the only owner.
+        // SAFETY: `write_raw` is the raw FD returned by
+        // `alloc_wake_pipe()` at the top of this test, never
+        // duplicated; the read end was closed by the happy-path
+        // close (verified above by `!fd_is_open(read_raw)`) and
+        // `write_raw` remains the sole open FD owned by this
+        // scope. The `libc::close` precondition holds.
         unsafe {
             libc::close(write_raw);
         }


### PR DESCRIPTION
## Summary

Closes all 10 findings from the post-#572 audit. Doc-truth fixes,
structural CI gate, and small `LazyLock` / sentinel-fallback cleanups.
No version bump, no public API change. Logical commit grouping —
one commit per finding (or one commit per cluster for the three NITs
that touch unrelated files).

## Changes

### MINOR

- **M1** `docs(fpss): fix lying compile-time claim + rename test to assert_layout_compat` — the doc comments on `FpssEventInternal::as_public` named `assert_layout_compat` as a compile-time guard, but the actual code was a runtime test under a different name. Hoist size + alignment to genuine `const _: () = assert!(...)` items at module scope, rename the runtime test to `assert_layout_compat`, scope its remaining responsibility to discriminant-byte equality (which requires `Arc`-bearing constructed values).
- **M2** `fix: replace stamped SAFETY comments with per-site invariants` — three sites shared the same `pointer was returned by the matching constructor and not yet freed` filler. Rewrote each (`events.rs:641`, `ffi/src/flatfiles.rs:178/205`) to name the actual invariant: 1-byte discriminant tag read in the test scope; `tdx_flatfile_request_decoded` as the constructor for the FFI sites, with the aliasing rule under single-threaded FFI ownership.
- **M3** `chore(ci): structural detector for stamped SAFETY-comment boilerplate` — the regression guard added in #572 only catches the verbatim string. New `scripts/check_safety_comment_boilerplate.py` collects every `// SAFETY:` block, buckets by exact text, flags any bucket with >=3 non-FFI sites whose text mentions no per-site invariant token (backtick-quoted identifier, lifetime, atomic ordering, layout property). Ships with an embedded `--selftest` that synthesises a regression and verifies detection. Wired into the existing banned-vocab CI gate. The new detector surfaced 12 pre-existing boilerplate sites across 4 bench files and 2 streaming-async test cleanups — those were rewritten to name the actual `GlobalAlloc::{alloc,dealloc}` / `libc::close` precondition.
- **M4** `fix(python): fallback __version__ to "unknown" sentinel + extend version-sync gate` — `__init__.py` previously fell back to the literal `"10.0.0"`, which silently drifted on every `Cargo.toml` bump. Replaced with the `"unknown"` sentinel; extended `scripts/check_version_sync.py` to flag any numeric literal in the `__version__` fallback line (even one that happens to match the canonical today, since it will drift on the next bump).
- **M5** `docs(fpss): clarify wire_req_id same-value-collision contract` — the `wire_req_id` docstring implied the `AtomicI64` widening eliminated id reuse outright. It only eliminates the `-1` sentinel collision. Added a paragraph naming the 2^31-allocation limit and the disambiguation strategies for consumers that need to correlate beyond it.
- **M6** `docs(tdbe): fix MAX_PRICE_TYPE doc range to 0..=19 + placeholder note` — 5+ doc comments said `0..=18` while the constant + clamp accept 19. Reconciled the docs to the constant per the audit's preferred path (option b), with a one-line note on the index-19 unreachable placeholder slot at every affected site.

### NIT

- **N1** `chore: nit cleanup -- channel doc, miss-count message, io-loop counter hoist` — dropped the "Clone-cheap" sentence on `Channel` (it owns a `JoinHandle<()>` after #572 and is never cloned anywhere).
- **N2** (same commit) — `MISS_COUNT` is process-global; the warn-line and surrounding doc now name the aggregate semantics ("1 of every 1024 emitted across all `FpssClient`s in this process").
- **N3** (same commit) — hoisted the remaining two `metrics::counter!("thetadatadx.fpss.*")` sites in `io_loop/mod.rs` (`drain_yields`, `reconnects`) into `LazyLock<Counter>` handles, mirroring the eight decode.rs handles from #572.

### INFO

- **I1** `chore(python): drop dead ImportError guard on requires-python >=3.9` — `pyproject.toml` declares `requires-python = ">=3.9"`; `importlib.metadata` has been stdlib-mandatory since 3.8. The outer `try / except ImportError` can never fire. Dropped it; inner `PackageNotFoundError` guard stays.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo doc --no-deps --workspace` passes
- [x] `python3 scripts/check_banned_vocab.py` clean
- [x] `python3 scripts/check_safety_comment_boilerplate.py --selftest && python3 scripts/check_safety_comment_boilerplate.py` clean
- [x] `python3 scripts/check_version_sync.py` clean
- [x] `cd sdks/python && maturin develop && pytest -v` — 294 passed, 29 skipped
- [x] No CHANGELOG entry — all changes are doc / test / script-level, not user-visible
- [x] No version bump, no tag

## Testing

- The compile-time `const _` items in `events.rs` would fail the build on any future size or alignment divergence between `FpssEvent` and `FpssEventInternal`.
- The renamed `assert_layout_compat` runtime test continues to pin discriminant-byte equality (`cargo test -p thetadatadx --lib fpss::events::tests::assert_layout_compat`).
- The new SAFETY-boilerplate detector ships with a `--selftest` mode that synthesises 3 non-FFI boilerplate sites + 1 FFI site + 1 genuine-annotation site and verifies the detector flags only the 3 non-FFI sites.
- `scripts/check_version_sync.py` now fails CI if `__init__.py`'s `__version__` fallback becomes a numeric literal.

## Related Issues

Audit findings — no upstream issue numbers; tracked inline in commits.