### PR TITLE
feat(mdds): warn on large buffered response + rustdoc guidance (closes #576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `MddsConfig::warn_on_buffered_threshold_bytes` (#576). Buffered
+  `.await` historical responses whose estimated size exceeds the
+  threshold (default 100 MiB) now emit a single `tracing::warn!`
+  event with `endpoint`, `row_count`, `bytes_est`, and
+  `threshold_bytes` fields suggesting `.stream(handler)` for the
+  workload. Fires once per request after the `Vec<Tick>` materializes
+  — no per-chunk torrent. Set to `0` to disable the warn entirely.
+  Helper lives in `crate::mdds::macros::warn_buffered_response_size`
+  with pure-decision `should_warn_buffered_size` for cheap testing.
+  Five unit tests pin the threshold semantics (zero / equal /
+  off-by-one / overflow / end-to-end event capture).
+
 - `FallbackPolicy` + `_with_fallback` shims now reach every binding —
   FFI (C ABI), TypeScript (napi-rs), and C++ (`thetadx.hpp`) — closing
   the cross-binding parity gap that PR #579 left as a Python-only
@@ -131,6 +143,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `swap_classes_in_jar` (S3).
 
 ### Changed
+
+- Every `parsed_endpoint!` historical builder now ships a "When to
+  use `.await` vs `.stream(handler)`" decision matrix in rustdoc
+  (#576). Single source of truth lives in
+  `build_support/endpoints/render/mdds.rs::AWAIT_VS_STREAM_DOC` and
+  the codegen attaches it after the per-endpoint description, so
+  every `option_history_*` / `stock_history_*` / `index_history_*` /
+  `interest_rate_history_*` builder advertises the same guidance in
+  `cargo doc` without per-endpoint drift. The matrix calls out
+  tick-interval / Greeks / multi-day workloads as `.stream(handler)`
+  cases and points at `docs-site/docs/legacy-quote-handling.md` for
+  the full migration recipe.
 
 - `RestError::CsvDecode` / `RestError::MissingColumn` now lift into
   `Error::Transport { kind: Codec, .. }` instead of
@@ -418,6 +442,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the next major release.
 
 ### Fixed
+
+- Documentation did not flag which historical builder terminal to
+  use for which workload, so users reached for the buffered `.await`
+  even on bulk pulls and only discovered the wrong-API mode after
+  RSS climbed into double-digit GB (#576). Fixed by attaching a
+  `.await` vs `.stream(handler)` decision matrix to every parsed
+  historical builder in rustdoc, adding the same matrix to the root
+  + Python READMEs, expanding
+  `docs-site/docs/legacy-quote-handling.md` with a "Buffered vs
+  streaming" section, and emitting a single `tracing::warn!` event
+  when the buffered path returns a response above
+  `MddsConfig::warn_on_buffered_threshold_bytes` (default 100 MiB,
+  set to `0` to disable). Closes #576.
 
 - Post-Feb-2020 daily-expiry quote backfill no longer h2-cascades
   on the streaming path (#577). PR #573's lenient decoder + REST

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,6 +3590,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "webpki-roots",
  "x509-parser",

--- a/README.md
+++ b/README.md
@@ -163,8 +163,32 @@ tdx.subscribe_many(vec![stock.quote(), option.quote()])?;
 
 All prices (`bid`, `ask`, `price`, `open`, `high`, `low`, `close`) are `f64`, decoded during parsing.
 
+### Choosing buffered vs streaming for historical pulls
 
-All prices (`bid`, `ask`, `price`, `open`, `high`, `low`, `close`) are `f64`, decoded during parsing.
+Every historical builder (`option_history_*`, `stock_history_*`,
+`index_history_*`, `interest_rate_history_*`) supports two terminals:
+
+| Workload | Use |
+|---|---|
+| Single day / one-shot ad-hoc query | `.await` |
+| Single day, deterministic small response | `.await` |
+| Bulk / multi-day backfill | `.stream(handler)` |
+| Tick-interval responses | `.stream(handler)` |
+| Greeks responses across a long horizon | `.stream(handler)` |
+
+Buffered `.await` collects the full response into `Vec<Tick>` before
+returning. On a 2.4 M-tick day this consumes ~5 GiB of RSS before any
+caller code runs. `.stream(handler)` yields chunks via
+`handler(&[Tick])` and drops each chunk before the next is fetched —
+peak RSS stays at ~150 MiB regardless of response size.
+
+When the buffered path returns a response whose estimated size exceeds
+`MddsConfig::warn_on_buffered_threshold_bytes` (default 100 MiB), the
+SDK emits a single `tracing::warn!` event suggesting `.stream(handler)`
+for the workload (`endpoint`, `row_count`, `bytes_est` fields). Set the
+threshold to `0` to disable. See
+[`docs-site/docs/legacy-quote-handling.md`](docs-site/docs/legacy-quote-handling.md)
+for the full migration recipe.
 
 ## API coverage
 

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -181,6 +181,13 @@ mimalloc = { version = "0.1", default-features = false, optional = true }
 prost-build = { version = "=0.14.3", optional = true }
 
 [dev-dependencies]
+# `tracing_subscriber::Layer` lets the warn-on-buffered-response unit
+# tests (`mdds::macros::warn_buffered_tests`) capture emitted events
+# without a global `init()` race against parallel tests. `registry`
+# feature only — the bridge is a `Layer` impl that buffers into a
+# `Mutex<Vec<...>>`, not a stderr `fmt` subscriber. Same version pin
+# as `sdks/python` so the workspace lockfile stays clean.
+tracing-subscriber = { version = "0.3.20", default-features = false, features = ["registry"] }
 criterion = { version = "0.8.2", features = ["html_reports", "async_tokio"] }
 # `futures::future::join_all` for the concurrent-burst bench. Pulls in
 # the umbrella `futures` crate (we already depend on `futures-core`

--- a/crates/thetadatadx/build_support/endpoints/render/mdds.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/mdds.rs
@@ -79,6 +79,35 @@ pub(super) fn generate_mdds_list_endpoint(out: &mut String, endpoint: &Generated
     out.push_str("}\n\n");
 }
 
+/// Single source of truth for the `.await` vs `.stream(handler)`
+/// guidance attached to every parsed historical builder. Composed here
+/// so every `option_history_*` / `stock_history_*` / `index_history_*`
+/// / `interest_rate_history_*` builder advertises the same matrix in
+/// rustdoc; closes issue #576.
+const AWAIT_VS_STREAM_DOC: &str = "\n\
+# When to use `.await` vs `.stream(handler)`\n\
+\n\
+| Workload | Use |\n\
+|---|---|\n\
+| Single day / one-shot ad-hoc query | `.await` |\n\
+| Single day, deterministic small response | `.await` |\n\
+| Bulk / multi-day backfill | `.stream(handler)` |\n\
+| Tick-interval responses | `.stream(handler)` |\n\
+| Greeks responses across a long horizon | `.stream(handler)` |\n\
+\n\
+Buffered (`.await`) collects the full response into `Vec<Tick>`. On a\n\
+2.4 M-tick day this consumes ~5 GiB before any caller code runs.\n\
+Streaming yields chunks via `handler(&[Tick])`, capping per-request\n\
+RSS at ~150 MiB regardless of response size.\n\
+\n\
+When the buffered path returns a response whose estimated size\n\
+exceeds [`crate::config::MddsConfig::warn_on_buffered_threshold_bytes`]\n\
+(default 100 MiB), a single `tracing::warn!` event fires with\n\
+`endpoint`, `row_count`, and `bytes_est` fields.\n\
+\n\
+See [`docs-site/docs/legacy-quote-handling.md`](https://github.com/userFRM/ThetaDataDx/blob/main/docs-site/docs/legacy-quote-handling.md)\n\
+for the full migration rationale.\n";
+
 pub(super) fn generate_mdds_parsed_endpoint(out: &mut String, endpoint: &GeneratedEndpoint) {
     writeln!(out, "parsed_endpoint! {{").unwrap();
     writeln!(out, "    #[doc = {:?}]", compose_endpoint_doc(endpoint)).unwrap();
@@ -88,6 +117,12 @@ pub(super) fn generate_mdds_parsed_endpoint(out: &mut String, endpoint: &Generat
         format!("gRPC stub: `{}`", endpoint.grpc_name)
     )
     .unwrap();
+    // Issue #576: surface the `.await` vs `.stream(handler)` decision
+    // matrix in rustdoc on every historical builder. Same copy on
+    // every endpoint so `cargo doc` readers do not have to hunt for
+    // it — placed AFTER the per-endpoint description so the
+    // endpoint's own prose stays at the top of the rustdoc panel.
+    writeln!(out, "    #[doc = {:?}]", AWAIT_VS_STREAM_DOC).unwrap();
     writeln!(
         out,
         "    builder {}Builder;",

--- a/crates/thetadatadx/src/config/mdds.rs
+++ b/crates/thetadatadx/src/config/mdds.rs
@@ -75,6 +75,30 @@ pub struct MddsConfig {
     /// burst across 4 channels to land on the same decoder thread
     /// without queue-full back-pressure.
     pub decoder_ring_size: usize,
+
+    /// Estimated-bytes threshold above which the buffered `.await`
+    /// path on a `parsed_endpoint!` builder emits a single
+    /// `tracing::warn!` event suggesting `.stream(handler)` for the
+    /// workload.
+    ///
+    /// The buffered path materializes the full response as
+    /// `Vec<Tick>` before returning; the streaming path drops each
+    /// chunk after the user callback consumes it (see issue #565 +
+    /// #576). When `row_count * size_of::<Tick>() > threshold`, the
+    /// SDK logs an `endpoint = ..., row_count = ..., bytes_est = ...`
+    /// warn once at the end of the buffered collect — enough signal
+    /// for an operator running `RUST_LOG=warn` to notice that this
+    /// workload is on the wrong API, with zero impact on the value
+    /// returned to the caller.
+    ///
+    /// Default `100 * 1024 * 1024` (100 MiB) — catches bulk pulls
+    /// (multi-million-row option chains, multi-day backfills) while
+    /// staying silent on ad-hoc single-day queries.
+    ///
+    /// Set to `0` to disable the warn entirely. `usize::MAX`
+    /// effectively disables it too (no realistic response reaches
+    /// that size).
+    pub warn_on_buffered_threshold_bytes: usize,
 }
 
 impl MddsConfig {
@@ -94,6 +118,13 @@ impl MddsConfig {
             connect_timeout_secs: 10,
             decoder_threads: 0,
             decoder_ring_size: 256,
+            // 100 MiB — empirically catches bulk pulls (multi-million
+            // row option-chain or multi-day backfill responses) while
+            // staying silent on ad-hoc single-day quote / OHLC pulls
+            // that fit in a single h2 frame. Issue #576 sets the
+            // operator-visible "you are on the wrong API for this
+            // workload" signal at this boundary.
+            warn_on_buffered_threshold_bytes: 100 * 1024 * 1024,
         }
     }
 }

--- a/crates/thetadatadx/src/mdds/macros.rs
+++ b/crates/thetadatadx/src/mdds/macros.rs
@@ -349,6 +349,77 @@ where
     }
 }
 
+/// Decide whether the buffered `.await` path on a parsed builder
+/// crossed the operator-visible warning threshold for response size.
+///
+/// Pure function — no side effects, no allocation, no I/O. Lets the
+/// `parsed_endpoint!` macro keep the size check at the seam where
+/// `row_count` and `size_of::<Item>` are both already in scope and
+/// keeps the decision testable without a `tracing-subscriber` dep.
+///
+/// `row_size` is `size_of::<Tick>` at the call site — a lower bound
+/// on the resident-memory cost since each tick may carry inline
+/// `String`s + `Vec`s that allocate separately. The estimate is
+/// intentionally conservative (under-counts heap-side allocations)
+/// so the warn fires on the row-count axis we actually control;
+/// callers tuning the threshold should think in "row count × wire
+/// row size" terms rather than RSS.
+///
+/// Returns `Some(bytes_est)` when `bytes_est > threshold_bytes` and
+/// `threshold_bytes > 0`. Returns `None` when the warn is disabled
+/// (`threshold_bytes == 0`) or the response stayed under the
+/// configured ceiling. The threshold check is strict `>` so the
+/// caller can pin "exactly N bytes" silent in tests.
+pub(crate) fn should_warn_buffered_size(
+    row_count: usize,
+    row_size: usize,
+    threshold_bytes: usize,
+) -> Option<usize> {
+    // `0` is the documented "warn disabled" sentinel. Returning early
+    // also keeps `saturating_mul` out of the hot path on the common
+    // configuration.
+    if threshold_bytes == 0 {
+        return None;
+    }
+    // `saturating_mul` guards the (theoretical) overflow on a 32-bit
+    // target — at 64-bit no realistic `row_count * row_size` reaches
+    // `usize::MAX`, but the saturating path matches the rest of the
+    // crate's arithmetic and costs one extra cmov.
+    let bytes_est = row_count.saturating_mul(row_size);
+    if bytes_est > threshold_bytes {
+        Some(bytes_est)
+    } else {
+        None
+    }
+}
+
+/// Emit a single `tracing::warn!` event when the buffered `.await`
+/// path on a `parsed_endpoint!` builder crosses
+/// `mdds.warn_on_buffered_threshold_bytes` (issue #576).
+///
+/// Fires AT MOST ONCE per call — the macro invokes this helper
+/// immediately after the `Vec<Tick>` materializes, before returning
+/// to the caller, so a long-running operator workload sees exactly
+/// one log line per offending request rather than a per-chunk
+/// torrent. Threshold of `0` disables the warn entirely (see
+/// [`crate::config::MddsConfig::warn_on_buffered_threshold_bytes`]).
+pub(crate) fn warn_buffered_response_size(
+    endpoint: &'static str,
+    row_count: usize,
+    row_size: usize,
+    threshold_bytes: usize,
+) {
+    if let Some(bytes_est) = should_warn_buffered_size(row_count, row_size, threshold_bytes) {
+        tracing::warn!(
+            endpoint,
+            row_count,
+            bytes_est,
+            threshold_bytes,
+            "buffered .await returned a large response — consider .stream(handler) for this workload (see docs-site/docs/legacy-quote-handling.md)"
+        );
+    }
+}
+
 /// Classify an [`Error`] for retry / refresh routing.
 ///
 /// `From<tonic::Status>` folds the tonic enum into
@@ -727,7 +798,28 @@ macro_rules! parsed_endpoint {
                             .record(_metrics_start.elapsed().as_secs_f64() * 1_000.0);
                         // Strict decode: type mismatch in any cell propagates
                         // as Error::Decode via `From<DecodeError>`.
-                        $parser(&table).map_err(Error::from)
+                        let parsed = $parser(&table).map_err(Error::from)?;
+                        // Issue #576: surface the wrong-API-for-this-workload
+                        // signal exactly once per request, after the buffered
+                        // `Vec` materialized — before this point we don't yet
+                        // know the row count, after this point the caller has
+                        // already paid the buffered cost. `row_count` is the
+                        // length the caller is about to receive; `row_size`
+                        // is the wire-shape lower bound (`size_of::<Item>`).
+                        // Configurable via
+                        // `DirectConfig::mdds.warn_on_buffered_threshold_bytes`;
+                        // set to 0 to disable.
+                        let threshold = client
+                            .config()
+                            .mdds
+                            .warn_on_buffered_threshold_bytes;
+                        $crate::mdds::macros::warn_buffered_response_size(
+                            stringify!($name),
+                            parsed.len(),
+                            std::mem::size_of::<$item>(),
+                            threshold,
+                        );
+                        Ok(parsed)
                     };
                     $crate::mdds::macros::run_with_optional_deadline(deadline, inner).await
                 })
@@ -1418,5 +1510,218 @@ mod refresh_retry_disabled_tests {
         .await;
         assert_eq!(result.expect("must succeed"), "payload");
         assert_eq!(attempts, 2);
+    }
+}
+
+#[cfg(test)]
+mod warn_buffered_tests {
+    //! Coverage for the issue #576 large-buffered-response warn helper.
+    //!
+    //! Two layers of tests:
+    //!
+    //! 1. `should_warn_buffered_size`: pure decision function, hit with
+    //!    the boundary cases (zero threshold, exact-equal, off-by-one
+    //!    above + below, overflow). No tracing wiring needed.
+    //! 2. `warn_buffered_response_size`: end-to-end check that the
+    //!    helper actually emits a `tracing::warn!` event when the
+    //!    decision returns `Some` and stays silent when it returns
+    //!    `None`. Uses a custom `tracing_subscriber::Layer` that
+    //!    captures events into a `Mutex<Vec<_>>` so the test stays
+    //!    self-contained (no global `init()`, no race against parallel
+    //!    tests). Scoped via `tracing::subscriber::with_default`.
+    use super::{should_warn_buffered_size, warn_buffered_response_size};
+    use std::sync::{Arc, Mutex};
+    use tracing::{
+        field::{Field, Visit},
+        subscriber::with_default,
+        Event, Level, Subscriber,
+    };
+    use tracing_subscriber::{layer::Context, prelude::*, registry::Registry, Layer};
+
+    /// Captured snapshot of a single emitted event. Only the fields
+    /// we assert on are extracted — message + the three structured
+    /// fields the warn helper sets.
+    #[derive(Default, Debug)]
+    struct CapturedEvent {
+        level: Option<Level>,
+        message: Option<String>,
+        endpoint: Option<String>,
+        row_count: Option<u64>,
+        bytes_est: Option<u64>,
+        threshold_bytes: Option<u64>,
+    }
+
+    /// `Visit` impl that pulls our four structured fields + the
+    /// `message` literal off the event.
+    impl Visit for CapturedEvent {
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            match field.name() {
+                "row_count" => self.row_count = Some(value),
+                "bytes_est" => self.bytes_est = Some(value),
+                "threshold_bytes" => self.threshold_bytes = Some(value),
+                _ => {}
+            }
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            // `tracing` may surface usize literals as i64 on some
+            // builds — accept that path too so the test isn't
+            // fragile across versions.
+            if value >= 0 {
+                self.record_u64(field, value as u64);
+            }
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            if field.name() == "endpoint" {
+                self.endpoint = Some(value.to_string());
+            }
+            if field.name() == "message" {
+                self.message = Some(value.to_string());
+            }
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            // `tracing::warn!(..., "literal")` records the literal
+            // message via the implicit `message` field with the
+            // `Debug` recorder. Strip the surrounding quotes so the
+            // captured string matches the source literal.
+            if field.name() == "message" {
+                self.message = Some(format!("{value:?}").trim_matches('"').to_string());
+            } else if field.name() == "endpoint" && self.endpoint.is_none() {
+                self.endpoint = Some(format!("{value:?}").trim_matches('"').to_string());
+            }
+        }
+    }
+
+    /// Custom `Layer` that appends every event it sees to a shared
+    /// `Mutex<Vec<CapturedEvent>>`. The collector is cloned into the
+    /// layer; the test holds the original `Arc` so it can read the
+    /// captured events after `with_default` returns.
+    struct CaptureLayer {
+        sink: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl<S: Subscriber> Layer<S> for CaptureLayer {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut captured = CapturedEvent {
+                level: Some(*event.metadata().level()),
+                ..Default::default()
+            };
+            event.record(&mut captured);
+            if let Ok(mut sink) = self.sink.lock() {
+                sink.push(captured);
+            }
+        }
+    }
+
+    /// Run `body` with a fresh capturing subscriber active for the
+    /// duration of the closure. Returns whatever events `body`
+    /// emitted via `tracing`.
+    fn capture_warns(body: impl FnOnce()) -> Vec<CapturedEvent> {
+        let sink: Arc<Mutex<Vec<CapturedEvent>>> = Arc::default();
+        let layer = CaptureLayer {
+            sink: Arc::clone(&sink),
+        };
+        let subscriber = Registry::default().with(layer);
+        with_default(subscriber, body);
+        Arc::try_unwrap(sink)
+            .expect("sink should be uniquely owned after with_default returns")
+            .into_inner()
+            .expect("captured-events mutex must not be poisoned")
+    }
+
+    #[test]
+    fn should_warn_returns_none_when_threshold_is_zero() {
+        // Threshold = 0 is the documented "warn disabled" sentinel.
+        // Even a humongous response must NOT trigger a warn under
+        // this configuration — the operator opted out explicitly.
+        assert_eq!(should_warn_buffered_size(10_000_000, 256, 0), None);
+    }
+
+    #[test]
+    fn should_warn_returns_none_when_size_at_or_below_threshold() {
+        // Strict `>` keeps the documented "no warn at exactly N
+        // bytes" behaviour — callers can pin a threshold equal to
+        // the expected payload size and stay silent.
+        assert_eq!(should_warn_buffered_size(100, 256, 25_600), None);
+        // Off-by-one under: still silent.
+        assert_eq!(should_warn_buffered_size(100, 256, 25_601), None);
+    }
+
+    #[test]
+    fn should_warn_returns_some_above_threshold() {
+        // 101 * 256 = 25_856 bytes > 25_600 → warn fires.
+        let bytes = should_warn_buffered_size(101, 256, 25_600)
+            .expect("response over threshold must trigger warn");
+        assert_eq!(bytes, 25_856);
+    }
+
+    #[test]
+    fn should_warn_saturates_on_arithmetic_overflow() {
+        // On a 32-bit target `usize::MAX * 2` would overflow; the
+        // helper saturates instead so the warn still fires (the
+        // overflowed product is, by definition, above any
+        // realistic threshold).
+        let bytes =
+            should_warn_buffered_size(usize::MAX, 2, 1).expect("saturated product must warn");
+        assert_eq!(bytes, usize::MAX);
+    }
+
+    #[test]
+    fn warn_helper_emits_tracing_event_above_threshold() {
+        // End-to-end seam: 200 rows * 1 KiB = 200 KiB > 100 KiB
+        // threshold. The helper must emit exactly one `WARN` event
+        // carrying the three structured fields the operator reads
+        // from `RUST_LOG=warn`.
+        let events = capture_warns(|| {
+            warn_buffered_response_size("option_history_quote", 200, 1024, 100 * 1024);
+        });
+        assert_eq!(
+            events.len(),
+            1,
+            "exactly one warn event must fire per offending request"
+        );
+        let evt = &events[0];
+        assert_eq!(evt.level, Some(Level::WARN));
+        assert_eq!(evt.endpoint.as_deref(), Some("option_history_quote"));
+        assert_eq!(evt.row_count, Some(200));
+        assert_eq!(evt.bytes_est, Some(200 * 1024));
+        assert_eq!(evt.threshold_bytes, Some(100 * 1024));
+        // Spot-check the prose hint so a future refactor cannot
+        // silently strip the `.stream(handler)` recommendation
+        // that the issue brief explicitly asks for.
+        let msg = evt.message.as_deref().unwrap_or_default();
+        assert!(
+            msg.contains(".stream(handler)"),
+            "warn message must point operators at .stream(handler); got {msg:?}"
+        );
+    }
+
+    #[test]
+    fn warn_helper_stays_silent_below_threshold() {
+        // 200 rows * 1 KiB = 200 KiB, threshold 1 MiB → no warn.
+        let events = capture_warns(|| {
+            warn_buffered_response_size("option_history_quote", 200, 1024, 1024 * 1024);
+        });
+        assert!(
+            events.is_empty(),
+            "below-threshold response must not emit a warn; got {events:?}"
+        );
+    }
+
+    #[test]
+    fn warn_helper_stays_silent_when_threshold_is_zero() {
+        // Threshold = 0 is the documented "warn disabled" sentinel
+        // (see `MddsConfig::warn_on_buffered_threshold_bytes`). Even
+        // a deliberately huge response must NOT emit a warn — the
+        // operator explicitly opted out.
+        let events = capture_warns(|| {
+            warn_buffered_response_size("option_history_quote", 10_000_000, 1024, 0);
+        });
+        assert!(
+            events.is_empty(),
+            "threshold=0 must disable the warn entirely; got {events:?}"
+        );
     }
 }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `MddsConfig::warn_on_buffered_threshold_bytes` (#576). Buffered
+  `.await` historical responses whose estimated size exceeds the
+  threshold (default 100 MiB) now emit a single `tracing::warn!`
+  event with `endpoint`, `row_count`, `bytes_est`, and
+  `threshold_bytes` fields suggesting `.stream(handler)` for the
+  workload. Fires once per request after the `Vec<Tick>` materializes
+  — no per-chunk torrent. Set to `0` to disable the warn entirely.
+  Helper lives in `crate::mdds::macros::warn_buffered_response_size`
+  with pure-decision `should_warn_buffered_size` for cheap testing.
+  Five unit tests pin the threshold semantics (zero / equal /
+  off-by-one / overflow / end-to-end event capture).
+
 - `FallbackPolicy` + `_with_fallback` shims now reach every binding —
   FFI (C ABI), TypeScript (napi-rs), and C++ (`thetadx.hpp`) — closing
   the cross-binding parity gap that PR #579 left as a Python-only
@@ -131,6 +143,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `swap_classes_in_jar` (S3).
 
 ### Changed
+
+- Every `parsed_endpoint!` historical builder now ships a "When to
+  use `.await` vs `.stream(handler)`" decision matrix in rustdoc
+  (#576). Single source of truth lives in
+  `build_support/endpoints/render/mdds.rs::AWAIT_VS_STREAM_DOC` and
+  the codegen attaches it after the per-endpoint description, so
+  every `option_history_*` / `stock_history_*` / `index_history_*` /
+  `interest_rate_history_*` builder advertises the same guidance in
+  `cargo doc` without per-endpoint drift. The matrix calls out
+  tick-interval / Greeks / multi-day workloads as `.stream(handler)`
+  cases and points at `docs-site/docs/legacy-quote-handling.md` for
+  the full migration recipe.
 
 - `RestError::CsvDecode` / `RestError::MissingColumn` now lift into
   `Error::Transport { kind: Codec, .. }` instead of
@@ -418,6 +442,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the next major release.
 
 ### Fixed
+
+- Documentation did not flag which historical builder terminal to
+  use for which workload, so users reached for the buffered `.await`
+  even on bulk pulls and only discovered the wrong-API mode after
+  RSS climbed into double-digit GB (#576). Fixed by attaching a
+  `.await` vs `.stream(handler)` decision matrix to every parsed
+  historical builder in rustdoc, adding the same matrix to the root
+  + Python READMEs, expanding
+  `docs-site/docs/legacy-quote-handling.md` with a "Buffered vs
+  streaming" section, and emitting a single `tracing::warn!` event
+  when the buffered path returns a response above
+  `MddsConfig::warn_on_buffered_threshold_bytes` (default 100 MiB,
+  set to `0` to disable). Closes #576.
 
 - Post-Feb-2020 daily-expiry quote backfill no longer h2-cascades
   on the streaming path (#577). PR #573's lenient decoder + REST

--- a/docs-site/docs/legacy-quote-handling.md
+++ b/docs-site/docs/legacy-quote-handling.md
@@ -380,4 +380,90 @@ through a 2022 reproducer and asserts a non-empty response.
 * GitHub issue: [#571](https://github.com/userFRM/ThetaDataDx/issues/571)
 * Patch sources: `tools/local-terminal-patcher/patches/`
 * SDK module: [`crate::rest`](https://docs.rs/thetadatadx/latest/thetadatadx/rest/index.html)
+
+# Buffered `.await` vs streaming `.stream(handler)` (issue #576)
+
+The two terminals on every historical builder serve the same data
+over the same wire — pick by workload, not by capability.
+
+| Workload | Use |
+|---|---|
+| Single day / one-shot ad-hoc query | `.await` |
+| Single day, deterministic small response | `.await` |
+| Aggregates over full response (mean, std, count) | `.await` |
+| Notebook / script prototyping | `.await` |
+| Bulk / multi-day backfill | `.stream(handler)` |
+| Tick-interval responses | `.stream(handler)` |
+| Greeks responses across a long horizon | `.stream(handler)` |
+| Response > ~100k rows | `.stream(handler)` |
+| Bounded-RSS or low-memory environment | `.stream(handler)` |
+
+Buffered `.await` materializes the full response into `Vec<Tick>`
+before returning. Per the reproducer in issue #565, a 2.4 M-tick day
+on `option_history_quote(QQQ, 1DTE, interval=tick, strike_range=25)`
+at 4-permit concurrency consumes ~5 GiB of RSS before any caller code
+runs. The streaming variant decodes one chunk at a time, hands the
+slice to `handler`, drops the chunk before the next is fetched — peak
+RSS stays at ~150 MiB regardless of response size (35× lower on the
+same workload).
+
+## Runtime warning on large buffered responses
+
+When the buffered `.await` path returns a response whose estimated
+size (`row_count * size_of::<Tick>`) exceeds
+[`MddsConfig::warn_on_buffered_threshold_bytes`] (default 100 MiB), the
+SDK emits a single `tracing::warn!` event:
+
+```text
+buffered .await returned a large response — consider .stream(handler)
+for this workload (see docs-site/docs/legacy-quote-handling.md)
+endpoint=option_history_quote
+row_count=2_412_383
+bytes_est=2_315_887_680
+threshold_bytes=104_857_600
+```
+
+* **Threshold is configurable.** Set
+  `config.mdds.warn_on_buffered_threshold_bytes = X` to tune. `0`
+  disables the warn entirely; `usize::MAX` effectively disables it
+  too.
+* **One warn per request.** The warn fires once at the end of the
+  buffered collect — no per-chunk torrent. Long-running workloads
+  see exactly one log line per offending request.
+* **Logging only.** No panic, no API change, no policy enforcement.
+  The buffered call still returns the full `Vec<Tick>` to the
+  caller; the warn is the operator-visible "wrong API for this
+  workload" signal.
+
+## Side-by-side
+
+```rust
+use thetadatadx::ThetaDataDxClient;
+
+// Buffered — fine for ad-hoc one-shots.
+let ticks = tdx
+    .option_history_quote("QQQ", "20260516")
+    .strike(550.0)
+    .right("call")
+    .await?;
+println!("{} rows", ticks.len());
+
+// Streaming — required for bulk pulls.
+tdx.option_history_quote("QQQ", "20260516")
+    .strike_range(25)
+    .interval("tick")
+    .stream(|chunk| {
+        // write to parquet / accumulate stats / push to a bus
+        for tick in chunk {
+            // ...
+        }
+    })
+    .await?;
+```
+
+Both APIs serve identical wire payloads; the only difference is whether
+the SDK materializes the full `Vec` for the caller or hands chunks to a
+handler. See the Python SDK README for the `.stream(handler)` /
+`.stream_async(handler)` Python shapes (same memory profile, same
+warn-on-buffered behaviour).
 * Fallback policy: [`crate::FallbackPolicy`](https://docs.rs/thetadatadx/latest/thetadatadx/enum.FallbackPolicy.html)

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -480,6 +480,15 @@ decode_factor: 3.0 buffered  /  1.0 streamed
 
 For tick-interval requests across multi-day ranges or wide strike ranges, **always use `.stream()`** — the buffered path's `decode_factor=3.0` reflects the simultaneous residency of h2 frames + decompressed proto + decoded `Vec<T>` plus the `Vec::push` doubling transient.
 
+**Buffered-size warning (issue #576).** When the buffered `.list()` /
+`.await` path returns a response whose estimated size exceeds the
+configured threshold (default 100 MiB), the SDK emits a single
+`tracing::warn!` event with `endpoint`, `row_count`, and `bytes_est`
+fields suggesting `.stream(handler)` for the workload. Tune via
+`MddsConfig::warn_on_buffered_threshold_bytes` (set to `0` to disable).
+See [`docs-site/docs/legacy-quote-handling.md`](../../docs-site/docs/legacy-quote-handling.md)
+for the streaming-vs-buffered recipe.
+
 ### Chained DataFrame terminals
 
 Every historical endpoint returns a typed list wrapper (`EodTickList`,


### PR DESCRIPTION
## Summary

Closes issue #576 — documentation never told historical-builder
callers when to reach for `.await` vs `.stream(handler)`, and the
buffered path had no operator-visible signal when it amplified RSS
by 35× over the streaming variant on the same payload.

Three landings on the same scope:

* **Rustdoc on every parsed historical builder** — codegen seam at
  `build_support/endpoints/render/mdds.rs` attaches the same
  `.await` vs `.stream(handler)` matrix to every `parsed_endpoint!`
  emission. 53 builders (`option_history_*`, `stock_history_*`,
  `index_history_*`, `interest_rate_history_*`, snapshots, greeks,
  market-value, at-time) advertise the same workload-to-API
  guidance. Single source of truth; no per-endpoint drift.
* **Runtime warn on large buffered responses** — `parsed_endpoint!`
  emits a single `tracing::warn!` event after the `Vec<Tick>`
  materializes if estimated size exceeds the configurable
  `MddsConfig::warn_on_buffered_threshold_bytes` (default 100 MiB).
  Structured fields `endpoint`, `row_count`, `bytes_est`,
  `threshold_bytes` so an operator on `RUST_LOG=warn` gets one log
  line per offending request. Set the threshold to `0` to disable.
* **READMEs + docs-site** — root + Python READMEs gain a
  "buffered vs streaming" subsection;
  `docs-site/docs/legacy-quote-handling.md` gains a top-level
  section expanding the matrix with the workload axes called out in
  the issue and a side-by-side `.await` / `.stream()` worked
  example.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo doc --no-deps --workspace` with `RUSTDOCFLAGS="-D warnings"` clean
- [x] `cargo test --workspace` — all green; `mdds::macros::warn_buffered_tests` adds 5 new tests pinning the threshold semantics (zero / equal / off-by-one / overflow / end-to-end tracing-event capture via a `tracing-subscriber::Layer`)
- [x] `cargo build` on `sdks/python` clean; `cargo test` on `sdks/python` passes (57 tests)
- [x] `cargo run --bin generate_sdk_surfaces` does not modify any checked-in generated file (the Rust core builder rustdoc change is macro-driven, not Python/TS surface churn)
- [x] Manual rustdoc spot-check: the matrix landed on `OptionHistoryQuoteBuilder`, `StockHistoryEodBuilder`, `IndexHistoryOhlcBuilder`, `InterestRateHistoryEodBuilder`, etc.

## Out of scope

No version bump, no release tag, no Python/TypeScript binding
churn — Python operators see the same warn via the existing
`tracing` → `logging` bridge; the Python README documents the
threshold knob.