### PR TITLE
perf(grpc): two-stage decode pipeline core scaffold (Phase 1 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Two-stage MDDS decode pipeline scaffold (core only; benches +
+  bindings land in stacked follow-ups). The decoder pool now splits
+  the existing `zstd decompress -> prost decode -> Tick build` chain
+  into two stages so each scales independently to the workload
+  shape:
+  - **Stage 1**: per-channel decoder threads (unchanged thread
+    shape) run *only* `zstd::bulk::Decompressor::decompress_to_buffer`
+    and push a `DecodedPayload { channel_id, request_id, payload:
+    Bytes }` onto a shared bounded MPSC queue
+    (`crossbeam_channel::bounded`). Stage-1 parks on a full queue
+    rather than dropping — silent drops on a market-data feed are
+    unacceptable. Park duration accumulates into
+    `Stage2Counters::total_parked` (nanoseconds) and is
+    `tracing::debug!`-logged so operators see backpressure events.
+  - **Stage 2**: shared worker pool (`Stage2Pool`) pulls jobs from
+    the queue, runs `prost::Message::decode`, and replies through
+    the caller's `oneshot::Sender`. Worker count and queue depth
+    are independently tunable.
+  - New `MddsConfig::decode_threads: Option<usize>` controls the
+    stage-2 worker pool size (defaults to
+    `available_parallelism()` when `None`); `Some(0)` clamps to 1.
+  - New `MddsConfig::decode_queue_depth: Option<usize>` controls
+    the bounded queue depth (defaults to `pool_size * 64` when
+    `None`); `Some(0)` clamps to 1.
+  - `MddsConfig::decoder_threads` becomes the deprecated alias for
+    the stage-1 thread count; reads emit a single
+    `tracing::warn!` per pool construction pointing operators at
+    `decode_threads`.
+  - `Stage2Counters` wraps three `AtomicU64`s in
+    `crossbeam_utils::CachePadded` so false-sharing across sockets
+    cannot stall the pipeline under load. Struct alignment is
+    asserted at `>= 3 * CachePadded<AtomicU64>` so a regression
+    that drops the padding trips CI immediately.
+  - Panic containment carries over from the legacy pool: a stage-2
+    worker panic flips the shared `poisoned` flag, future jobs
+    drain with `Error::Transport { kind: DecoderPoisoned, .. }`,
+    and stage-1 producers parked on a full queue observe the
+    flip on their next push. Stage-1 owns its own `catch_unwind`
+    around the zstd decompress so a degenerate compressed payload
+    cannot kill the decoder thread.
+  - The public `.stream(handler)` callback receives the same
+    `&[QuoteTick]` as before — only the internal pipeline shape
+    changed. Existing integration tests + the lib suite pass
+    unchanged.
+  - Criterion benches and per-binding mirrors (Python / TS / C++ /
+    FFI) follow in stacked PRs.
+
 - `MddsConfig::warn_on_buffered_threshold_bytes` (#576). Buffered
   `.await` historical responses whose estimated size exceeds the
   threshold (default 100 MiB) now emit a single `tracing::warn!`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3554,7 +3563,9 @@ dependencies = [
  "arrow-schema",
  "bytes",
  "criterion",
+ "crossbeam-channel",
  "crossbeam-queue",
+ "crossbeam-utils",
  "disruptor",
  "futures",
  "futures-core",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -133,6 +133,21 @@ disruptor = "4.2.0"
 # the Python binding.
 crossbeam-queue = "0.3.12"
 
+# Bounded MPSC queue between the two-stage decode pipeline's stage-1
+# (zstd decompress) and stage-2 (prost decode + Tick build) workers.
+# `crossbeam_channel::bounded` is the simplest correct shape: a single
+# shared queue with N producers (stage-1 decoder threads) and M
+# consumers (stage-2 worker pool). Backpressure is enforced by parking
+# stage-1 on a full queue rather than dropping payloads.
+crossbeam-channel = "0.5.13"
+
+# Cache-line padding for the two-stage pipeline's shared atomic
+# counters (`total_decoded`, `total_dropped`, `total_parked`). Stage-1
+# and stage-2 threads both increment these on the hot path; padding
+# isolates each counter to its own cache line so false sharing across
+# CPU sockets does not stall the pipeline under load.
+crossbeam-utils = "0.8.21"
+
 # Optional DataFrame / Arrow extension traits (`frames` module).
 # polars: minimal feature set — just enough to build `DataFrame::new(vec![Series::new(...).into()])`.
 # No lazy, no I/O, no parquet, no SQL, no compute kernels. `default-features = false`

--- a/crates/thetadatadx/src/config/mdds.rs
+++ b/crates/thetadatadx/src/config/mdds.rs
@@ -65,7 +65,49 @@ pub struct MddsConfig {
     /// own work. Override to a fixed value when running on shared
     /// hosts where the auto-sizing reads the wrong number from
     /// `/proc`.
+    ///
+    /// # Deprecated alias
+    ///
+    /// In the two-stage decode pipeline shipped under
+    /// [`Self::decode_threads`] / [`Self::decode_queue_depth`], this
+    /// field controls the **stage-1** decoder thread count
+    /// (per-channel zstd decompress) and aliases the same auto-sizing
+    /// logic as before. Set [`Self::decode_threads`] instead to
+    /// tune the **stage-2** prost decode + Tick build worker pool
+    /// — the new knob is the one operators reach for under the
+    /// updated mental model.
     pub decoder_threads: usize,
+
+    /// Stage-2 worker thread count for the two-stage decode
+    /// pipeline. Stage-2 runs `prost::Message::decode` and the
+    /// downstream Tick build off a bounded MPSC queue fed by the
+    /// stage-1 decoder threads.
+    ///
+    /// `None` (the default) sizes the pool to
+    /// [`std::thread::available_parallelism`] with a minimum of `1`,
+    /// matching how Bloomberg / LSEG feed handlers fan parsing work
+    /// across every logical core when the workload is parser-bound
+    /// rather than IO-bound. `Some(0)` clamps to `1` (a zero-worker
+    /// pool would deadlock stage-1 on the first push). `Some(n)`
+    /// pins the worker count to `n` regardless of the available
+    /// core count — useful on shared hosts where
+    /// `available_parallelism` reads the wrong number from `/proc`.
+    pub decode_threads: Option<usize>,
+
+    /// Bounded queue depth between stage-1 (zstd decompress) and
+    /// stage-2 (prost decode + Tick build). When stage-2 cannot
+    /// keep up, stage-1's `send()` parks the decoder thread rather
+    /// than dropping the payload — silent drops on a market data
+    /// feed are unacceptable, so the queue prefers backpressure.
+    ///
+    /// `None` (the default) sizes the queue to
+    /// `concurrent_requests * 64`, picked so a 64-way burst on
+    /// every configured channel pool has a chunk-worth of headroom
+    /// without leaving stage-2 starved. `Some(n)` pins the depth to
+    /// `n` slots; `Some(0)` clamps to `1` (a zero-slot queue
+    /// degenerates to a rendezvous channel — still backpressure-
+    /// preserving but no buffer).
+    pub decode_queue_depth: Option<usize>,
 
     /// Per-thread decoder ring size. Must be a power of two `>= 64`.
     ///
@@ -117,6 +159,8 @@ impl MddsConfig {
             connection_window_size_kb: 64,
             connect_timeout_secs: 10,
             decoder_threads: 0,
+            decode_threads: None,
+            decode_queue_depth: None,
             decoder_ring_size: 256,
             // 100 MiB — empirically catches bulk pulls (multi-million
             // row option-chain or multi-day backfill responses) while

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -1139,6 +1139,34 @@ mod tests {
         assert_eq!(mdds.decoder_threads, 0);
         assert_eq!(mdds.decoder_ring_size, 256);
         assert!(mdds.decoder_ring_size.is_power_of_two());
+        // Two-stage decode pipeline defaults: auto-size at connect
+        // time. `None` is the sentinel; the resolution lives in
+        // `mdds::client::default_stage2_thread_count` /
+        // `default_stage2_queue_depth` so production behaviour
+        // tracks `available_parallelism` automatically.
+        assert!(mdds.decode_threads.is_none());
+        assert!(mdds.decode_queue_depth.is_none());
+    }
+
+    #[test]
+    fn mdds_decode_threads_override_clamps_zero_to_one() {
+        // The clamp lives in `Stage2Pool::new`; the config-side
+        // contract is that `Some(0)` reaches the pool as the
+        // operator's explicit choice (the pool then clamps to 1
+        // rather than the config layer reinterpreting "0 means
+        // auto-size"). This test pins the contract so a future
+        // refactor that moves the clamp here trips CI before
+        // shipping.
+        let mut mdds = crate::config::MddsConfig::production_defaults();
+        mdds.decode_threads = Some(0);
+        assert_eq!(mdds.decode_threads, Some(0));
+    }
+
+    #[test]
+    fn mdds_decode_queue_depth_override_holds_explicit_value() {
+        let mut mdds = crate::config::MddsConfig::production_defaults();
+        mdds.decode_queue_depth = Some(2048);
+        assert_eq!(mdds.decode_queue_depth, Some(2048));
     }
 
     // ── RetryPolicy / env var tests ──────────────────────────────────

--- a/crates/thetadatadx/src/grpc/decoder_pool.rs
+++ b/crates/thetadatadx/src/grpc/decoder_pool.rs
@@ -46,17 +46,22 @@
 //! near-zero idle CPU between bursts.
 
 use std::panic::AssertUnwindSafe;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use bytes::Bytes;
 use disruptor::{build_multi_producer, MultiProducer, ProcessorSettings, Producer, Sequence};
 use tokio::sync::oneshot;
 
 use crate::error::Error;
 use crate::proto;
 use crate::util::ring::{check_ring_size, RingSizeError};
+
+use super::stage_pipeline::{
+    DecodedPayload, Stage2Job, Stage2Pool, Stage2PoolSender, Stage2SendError,
+};
 
 // ─── Wait strategy ──────────────────────────────────────────────────
 
@@ -183,17 +188,53 @@ pub type DecodeResult = Result<proto::DataTable, Error>;
 
 /// One unit of decode work submitted to the pool.
 ///
-/// The work closure runs entirely on the decoder thread; it owns
-/// every cycle of the zstd decompress + protobuf decode chain and
-/// reads only its captured `compressed`/`max_message_size`
-/// parameters. The `reply` channel signals completion back to the
-/// async caller — if the receiver was dropped (caller cancelled)
-/// the decoder side checks [`oneshot::Sender::is_closed`] before
-/// running the work and elides the decompress entirely so cancelled
-/// RPCs do not waste CPU on results no one will read.
-struct DecodeRequest {
+/// Two shapes coexist so the legacy single-stage pool keeps working
+/// (existing integration tests + the panic-containment test
+/// fixtures publish a boxed work closure directly via
+/// [`DecoderHandle::submit_work`]) while the new two-stage pool
+/// publishes a [`Stage1Request`] whose consumer-side handler runs
+/// zstd decompress on the decoder thread and pushes the resulting
+/// [`DecodedPayload`] onto the shared stage-2 queue.
+///
+/// Cancellation is honoured in both variants: the legacy variant
+/// checks `oneshot::Sender::is_closed` before running the work;
+/// the stage-1 variant checks the same flag before decompressing
+/// and elides the work entirely on caller cancellation.
+enum DecodeRequest {
+    /// Legacy single-stage work closure. Used by
+    /// [`DecoderHandle::submit_work`] and by [`DecoderHandle::submit`]
+    /// on pools built via [`DecoderPool::new`].
+    Legacy(LegacyRequest),
+    /// Two-stage stage-1 request. Boxed so the enum stays small
+    /// even though `Stage1Request` carries a full
+    /// `proto::ResponseData`.
+    Stage1(Box<Stage1Request>),
+}
+
+/// Legacy single-stage request shape.
+struct LegacyRequest {
     work: Box<dyn FnOnce() -> DecodeResult + Send + 'static>,
     reply: oneshot::Sender<DecodeResult>,
+}
+
+/// Two-stage stage-1 request. Stage-1 runs zstd decompress, then
+/// pushes a [`Stage2Job`] onto the stage-2 queue. The reply
+/// `oneshot::Sender` rides through to stage-2; stage-1 only sends
+/// through it on a stage-1 failure (decompress error, stage-2 queue
+/// closed).
+struct Stage1Request {
+    response: proto::ResponseData,
+    max_message_size: usize,
+    channel_id: u64,
+    request_id: u64,
+    /// Wrapped in `Option` so the consumer closure can `take()` it
+    /// out when handing off to stage-2 — the value moves into the
+    /// `Stage2Job`'s `reply` field.
+    reply: Option<oneshot::Sender<DecodeResult>>,
+    /// Wrapped in `Option` for the same reason as `reply`: the
+    /// consumer closure takes it out to push the stage-2 job, and
+    /// the original request struct is then dropped.
+    stage2: Option<Stage2PoolSender>,
 }
 
 /// One slot in the per-decoder ring buffer.
@@ -295,6 +336,23 @@ unsafe impl Sync for RingEvent {}
 pub struct DecoderHandle {
     producer: MultiProducer<RingEvent, disruptor::SingleConsumerBarrier>,
     poisoned: Arc<AtomicBool>,
+    /// Per-decoder identifier exposed through [`DecodedPayload::channel_id`]
+    /// so cross-stage logs can be correlated to a specific stage-1
+    /// thread. `None` when the handle belongs to a legacy single-stage
+    /// pool that never produces [`DecodedPayload`] values.
+    channel_id: u64,
+    /// Per-handle monotonic counter feeding [`DecodedPayload::request_id`].
+    /// Wraps at `u64::MAX` (~hundreds of years of saturated decode
+    /// before the counter overflows on any realistic feed).
+    next_request_id: Arc<AtomicU64>,
+    /// Cloned [`Stage2PoolSender`] when this handle belongs to a
+    /// two-stage pool; the stage-1 consumer closure pushes
+    /// [`Stage2Job`]s onto the shared queue rather than running the
+    /// prost decode inline. `None` in the legacy single-stage path
+    /// (the consumer closure runs the full work locally — preserved
+    /// for backwards compatibility with the existing
+    /// [`DecoderPool::new`] constructor).
+    stage2: Option<Stage2PoolSender>,
 }
 
 impl DecoderHandle {
@@ -320,6 +378,17 @@ impl DecoderHandle {
     /// captured `Bytes` is dropped and no CPU is spent on a result
     /// no one will read.
     ///
+    /// # Two-stage routing
+    ///
+    /// When the pool was built via [`DecoderPool::new_two_stage`],
+    /// stage-1 (this decoder thread) runs only the zstd decompress
+    /// and pushes a [`super::stage_pipeline::DecodedPayload`] onto
+    /// the shared stage-2 queue. Stage-2 workers then run the prost
+    /// decode and reply through the caller's oneshot. The legacy
+    /// [`DecoderPool::new`] constructor runs the full work inline on
+    /// the decoder thread — preserved so existing integration tests
+    /// pass unchanged.
+    ///
     /// # Errors
     ///
     /// Returns [`DecoderSubmitError::Poisoned`] when the pool has
@@ -336,10 +405,65 @@ impl DecoderHandle {
         response: proto::ResponseData,
         max_message_size: usize,
     ) -> Result<oneshot::Receiver<DecodeResult>, DecoderSubmitError> {
+        if let Some(stage2) = self.stage2.clone() {
+            return self.submit_two_stage(response, max_message_size, stage2);
+        }
         let work: Box<dyn FnOnce() -> DecodeResult + Send + 'static> = Box::new(move || {
             crate::mdds::decode::decode_data_table_with_max(&response, max_message_size)
         });
         self.submit_work(work)
+    }
+
+    /// Two-stage path: the stage-1 decoder thread only decompresses
+    /// the payload, then hands the resulting [`DecodedPayload`] off
+    /// to the shared stage-2 worker pool through a bounded MPSC
+    /// queue. The caller's `oneshot::Receiver` is ultimately owned
+    /// by the stage-2 worker that runs the prost decode.
+    fn submit_two_stage(
+        &self,
+        response: proto::ResponseData,
+        max_message_size: usize,
+        stage2: Stage2PoolSender,
+    ) -> Result<oneshot::Receiver<DecodeResult>, DecoderSubmitError> {
+        if self.is_poisoned() || stage2.is_poisoned() {
+            return Err(DecoderSubmitError::Poisoned);
+        }
+        let channel_id = self.channel_id;
+        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        let backoff_mode = BackoffMode::detect();
+        let (tx, rx) = oneshot::channel();
+        let stage1 = Stage1Request {
+            response,
+            max_message_size,
+            channel_id,
+            request_id,
+            reply: Some(tx),
+            stage2: Some(stage2),
+        };
+        let mut pending: Option<DecodeRequest> = Some(DecodeRequest::Stage1(Box::new(stage1)));
+        let mut producer = self.producer.clone();
+        loop {
+            if self.is_poisoned() {
+                return Err(DecoderSubmitError::Poisoned);
+            }
+            let mut taken = pending.take();
+            let outcome = producer.try_publish(|slot| {
+                let request = taken
+                    .take()
+                    .expect("try_publish closure runs exactly once per accepted claim");
+                // SAFETY: the disruptor producer barrier
+                // guarantees the claimed sequence is exclusive to
+                // this publish until we return from the closure.
+                unsafe { slot.write(request) };
+            });
+            match outcome {
+                Ok(_seq) => return Ok(rx),
+                Err(disruptor::RingBufferFull) => {
+                    pending = taken;
+                    backoff_ring_full(backoff_mode, PUBLISH_RETRY_BACKOFF);
+                }
+            }
+        }
     }
 
     /// Publish a pre-boxed `work` closure onto the ring.
@@ -389,7 +513,8 @@ impl DecoderHandle {
         // the loop re-checks the poison flag, dropping the request
         // (and its `oneshot::Sender`) without ever publishing if
         // the consumer has died meanwhile.
-        let mut pending: Option<DecodeRequest> = Some(DecodeRequest { work, reply: tx });
+        let mut pending: Option<DecodeRequest> =
+            Some(DecodeRequest::Legacy(LegacyRequest { work, reply: tx }));
         let mut producer = self.producer.clone();
         loop {
             // Re-check the poison flag on every iteration so a
@@ -532,6 +657,149 @@ struct PoolInner {
     /// clones of these, so all of them go to zero only when the
     /// last `DecoderHandle` is also dropped.
     _producers: Vec<MultiProducer<RingEvent, disruptor::SingleConsumerBarrier>>,
+    /// Stage-2 worker pool when this `DecoderPool` was built via
+    /// [`DecoderPool::new_two_stage`]. Held here so the workers
+    /// stay alive for the lifetime of every pool clone; dropping
+    /// the last clone joins them via [`Stage2Pool::drop`]. The
+    /// stage-1 decoder threads hold their own
+    /// [`Stage2PoolSender`] clones inside each `DecoderHandle`.
+    _stage2: Option<Arc<Stage2Pool>>,
+}
+
+/// Consumer-thread handler. Runs the decompress + prost decode
+/// inline for the legacy variant, or the stage-1 zstd decompress
+/// followed by a stage-2 push for the two-stage variant. The
+/// decoder thread's `catch_unwind` invariant is unchanged: a panic
+/// in either branch flips the pool's poison flag and the consumer
+/// continues draining the ring with the transport-level reply.
+fn handle_decode_request(request: DecodeRequest, poisoned: &Arc<AtomicBool>) {
+    match request {
+        DecodeRequest::Legacy(LegacyRequest { work, reply }) => {
+            if reply.is_closed() {
+                return;
+            }
+            if poisoned.load(Ordering::Acquire) {
+                let _ = reply.send(Err(Error::Transport {
+                    kind: crate::error::TransportErrorKind::DecoderPoisoned,
+                    message: POOL_POISONED_REASON.to_string(),
+                }));
+                return;
+            }
+            let outcome = std::panic::catch_unwind(AssertUnwindSafe(work));
+            let result = match outcome {
+                Ok(decoded) => decoded,
+                Err(_panic_payload) => {
+                    poisoned.store(true, Ordering::Release);
+                    tracing::error!(
+                        target: "thetadatadx::grpc::decoder_pool",
+                        "mdds decoder worker panicked; pool poisoned"
+                    );
+                    Err(Error::Transport {
+                        kind: crate::error::TransportErrorKind::DecoderPoisoned,
+                        message: POOL_POISONED_REASON.to_string(),
+                    })
+                }
+            };
+            let _ = reply.send(result);
+        }
+        DecodeRequest::Stage1(boxed) => {
+            let Stage1Request {
+                response,
+                max_message_size,
+                channel_id,
+                request_id,
+                reply,
+                stage2,
+            } = *boxed;
+            let Some(reply) = reply else {
+                return;
+            };
+            if reply.is_closed() {
+                return;
+            }
+            if poisoned.load(Ordering::Acquire) {
+                let _ = reply.send(Err(Error::Transport {
+                    kind: crate::error::TransportErrorKind::DecoderPoisoned,
+                    message: POOL_POISONED_REASON.to_string(),
+                }));
+                return;
+            }
+            // Stage-1 work: zstd decompress only. The closure is
+            // wrapped in catch_unwind so a degenerate compressed
+            // payload (zstd context assertion) flips the pool's
+            // poison flag rather than killing the decoder thread.
+            let outcome = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                crate::mdds::decode::decompress_response_with_max(&response, max_message_size)
+            }));
+            let bytes = match outcome {
+                Ok(Ok(bytes)) => bytes,
+                Ok(Err(err)) => {
+                    // Decompress failed cleanly — surface to caller
+                    // without poisoning the pool; the next request
+                    // on this decoder may still succeed.
+                    let _ = reply.send(Err(err));
+                    return;
+                }
+                Err(_panic_payload) => {
+                    poisoned.store(true, Ordering::Release);
+                    tracing::error!(
+                        target: "thetadatadx::grpc::decoder_pool",
+                        channel_id,
+                        request_id,
+                        "mdds stage-1 decoder panicked during decompress; pool poisoned"
+                    );
+                    let _ = reply.send(Err(Error::Transport {
+                        kind: crate::error::TransportErrorKind::DecoderPoisoned,
+                        message: POOL_POISONED_REASON.to_string(),
+                    }));
+                    return;
+                }
+            };
+            // Hand off to stage-2. `Bytes::from(Vec<u8>)` is
+            // zero-copy so stage-2 can slice / split without
+            // re-allocating the decompressed payload.
+            let Some(stage2) = stage2 else {
+                // Defensive: a stage-1 request was constructed
+                // without a stage-2 sender. This would be a
+                // pool-construction bug; surface as transport
+                // poison so the caller sees a clean failure.
+                let _ = reply.send(Err(Error::Transport {
+                    kind: crate::error::TransportErrorKind::DecoderPoisoned,
+                    message: "stage-1 request missing stage-2 sender".to_string(),
+                }));
+                return;
+            };
+            let payload = DecodedPayload {
+                channel_id,
+                request_id,
+                payload: Bytes::from(bytes),
+            };
+            let job = Stage2Job {
+                payload,
+                reply,
+                max_message_size,
+            };
+            match stage2.send(job) {
+                Ok(()) => {}
+                Err(Stage2SendError::Poisoned { job })
+                | Err(Stage2SendError::PoolClosed { job }) => {
+                    // Stage-2 poisoned or closed while stage-1
+                    // was running. Recover the embedded reply
+                    // oneshot and surface the failure to the
+                    // caller directly so the awaiting RPC sees a
+                    // transport-level error rather than hanging.
+                    // Also flip the stage-1 pool poison so
+                    // subsequent stage-1 submits fail fast rather
+                    // than going through the same handshake.
+                    poisoned.store(true, Ordering::Release);
+                    let _ = job.reply.send(Err(Error::Transport {
+                        kind: crate::error::TransportErrorKind::DecoderPoisoned,
+                        message: POOL_POISONED_REASON.to_string(),
+                    }));
+                }
+            }
+        }
+    }
 }
 
 impl DecoderPool {
@@ -557,7 +825,7 @@ impl DecoderPool {
         let mut producers = Vec::with_capacity(n_decoders);
         let pool_poisoned = Arc::new(AtomicBool::new(false));
 
-        for _idx in 0..n_decoders {
+        for idx in 0..n_decoders {
             // Each decoder thread runs the consumer side of its own
             // ring; the closure passed to `handle_events_with`
             // executes inline on the consumer thread the disruptor
@@ -588,72 +856,18 @@ impl DecoderPool {
                     // (documented at its declaration) is therefore
                     // upheld.
                     let request = unsafe { slot.take() };
-                    let Some(DecodeRequest { work, reply }) = request else {
+                    let Some(request) = request else {
                         return;
                     };
-                    if reply.is_closed() {
-                        // Caller cancelled before we reached this
-                        // slot. Skip the decompress entirely.
-                        return;
-                    }
-                    // Fast-path: already-poisoned pool drains the
-                    // request without running `work()` so the
-                    // caller sees an immediate transport error
-                    // instead of hanging on a never-completed
-                    // oneshot.
-                    if poisoned.load(Ordering::Acquire) {
-                        let _ = reply.send(Err(Error::Transport {
-                            kind: crate::error::TransportErrorKind::DecoderPoisoned,
-                            message: POOL_POISONED_REASON.to_string(),
-                        }));
-                        return;
-                    }
-                    // Run the decode under catch_unwind so a panic
-                    // (zstd assert, prost decode trap, allocator
-                    // failure on a degenerate payload) flips the
-                    // pool's poison flag instead of killing the
-                    // consumer thread mid-loop. The Disruptor
-                    // crate's consumer loop only exits when its
-                    // shutdown signal arrives; catching the panic
-                    // keeps it alive long enough to drain still-
-                    // queued requests with `Err(PoolPoisoned)`.
-                    //
-                    // `AssertUnwindSafe` is sound here because
-                    // `work` is a freshly-constructed FnOnce closure
-                    // we own outright — there is no shared
-                    // interior-mutable state to leave inconsistent
-                    // on a partial unwind.
-                    let outcome = std::panic::catch_unwind(AssertUnwindSafe(work));
-                    let result = match outcome {
-                        Ok(decoded) => decoded,
-                        Err(_panic_payload) => {
-                            // Poison the pool atomically and reply
-                            // to the caller whose work triggered
-                            // the panic with the transport-level
-                            // failure. The drop of `panic_payload`
-                            // releases its boxed `Any`; we do not
-                            // re-raise — surviving panics is the
-                            // whole point of this branch.
-                            poisoned.store(true, Ordering::Release);
-                            tracing::error!(
-                                target: "thetadatadx::grpc::decoder_pool",
-                                "mdds decoder worker panicked; pool poisoned"
-                            );
-                            Err(Error::Transport {
-                                kind: crate::error::TransportErrorKind::DecoderPoisoned,
-                                message: POOL_POISONED_REASON.to_string(),
-                            })
-                        }
-                    };
-                    // Send-failure is benign: receiver may have
-                    // been dropped between the `is_closed` check
-                    // and now (caller cancellation race).
-                    let _ = reply.send(result);
+                    handle_decode_request(request, &poisoned);
                 })
                 .build();
             handles.push(DecoderHandle {
                 producer: producer.clone(),
                 poisoned: Arc::clone(&pool_poisoned),
+                channel_id: idx as u64,
+                next_request_id: Arc::new(AtomicU64::new(0)),
+                stage2: None,
             });
             producers.push(producer);
         }
@@ -662,6 +876,80 @@ impl DecoderPool {
             handles: handles.into(),
             _inner: Arc::new(PoolInner {
                 _producers: producers,
+                _stage2: None,
+            }),
+        })
+    }
+
+    /// Build a two-stage pool. Stage-1 keeps the per-decoder
+    /// thread shape from [`DecoderPool::new`] but each thread now
+    /// runs *only* zstd decompress and pushes the resulting
+    /// [`DecodedPayload`] onto a shared stage-2 worker pool that
+    /// runs the prost decode + `DataTable` construction across
+    /// `stage2_threads` workers.
+    ///
+    /// Stage-1 / stage-2 thread counts scale independently so a
+    /// workload bound by zstd serial cost (many small payloads)
+    /// and one bound by prost decode (large payloads with deep
+    /// schemas) can each be tuned to the right number of cores
+    /// without over-provisioning the other side.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecoderPoolError`] when `n_decoders` is zero or
+    /// the ring size fails [`check_ring_size`]. `stage2_threads`
+    /// and `queue_depth` are clamped to `1` internally — see
+    /// [`super::stage_pipeline::Stage2Pool::new`].
+    pub fn new_two_stage(
+        n_decoders: usize,
+        ring_size_per_decoder: usize,
+        stage2_threads: usize,
+        queue_depth: usize,
+    ) -> Result<Self, DecoderPoolError> {
+        if n_decoders == 0 {
+            return Err(DecoderPoolError::EmptyPool);
+        }
+        let ring_size = check_ring_size(ring_size_per_decoder)?;
+
+        let stage2 = Arc::new(Stage2Pool::new(stage2_threads, queue_depth));
+
+        let wait_strategy = DecoderWaitStrategy::mdds_default();
+        let mut handles = Vec::with_capacity(n_decoders);
+        let mut producers = Vec::with_capacity(n_decoders);
+        let pool_poisoned = Arc::new(AtomicBool::new(false));
+
+        for idx in 0..n_decoders {
+            let poisoned = Arc::clone(&pool_poisoned);
+            let producer = build_multi_producer(ring_size, RingEvent::default, wait_strategy)
+                .thread_name("mdds-decode-stage1")
+                .handle_events_with(move |slot: &RingEvent, _seq: Sequence, _eob: bool| {
+                    // SAFETY: the disruptor consumer barrier guarantees
+                    // this thread holds exclusive access to the slot
+                    // at this sequence position until the consumer
+                    // barrier advances on closure return — see
+                    // `RingEvent::take`'s safety contract.
+                    let request = unsafe { slot.take() };
+                    let Some(request) = request else {
+                        return;
+                    };
+                    handle_decode_request(request, &poisoned);
+                })
+                .build();
+            handles.push(DecoderHandle {
+                producer: producer.clone(),
+                poisoned: Arc::clone(&pool_poisoned),
+                channel_id: idx as u64,
+                next_request_id: Arc::new(AtomicU64::new(0)),
+                stage2: Some(stage2.sender()),
+            });
+            producers.push(producer);
+        }
+
+        Ok(Self {
+            handles: handles.into(),
+            _inner: Arc::new(PoolInner {
+                _producers: producers,
+                _stage2: Some(stage2),
             }),
         })
     }
@@ -888,7 +1176,7 @@ mod tests {
     ) -> oneshot::Receiver<DecodeResult> {
         let (tx, rx) = oneshot::channel();
         let mut producer = handle.producer.clone();
-        let mut pending = Some(DecodeRequest { work, reply: tx });
+        let mut pending = Some(DecodeRequest::Legacy(LegacyRequest { work, reply: tx }));
         loop {
             let mut taken = pending.take();
             let outcome = producer.try_publish(|slot| {

--- a/crates/thetadatadx/src/grpc/mod.rs
+++ b/crates/thetadatadx/src/grpc/mod.rs
@@ -79,6 +79,7 @@ pub mod codec;
 pub mod decoder_pool;
 pub mod endpoints;
 pub mod pool;
+pub mod stage_pipeline;
 pub mod status;
 pub mod stream;
 
@@ -90,5 +91,6 @@ pub use decoder_pool::{
 };
 pub use endpoints::stock_list_symbols;
 pub use pool::{ChannelLease, ChannelPool};
+pub use stage_pipeline::{DecodedPayload, Stage2Counters, Stage2Pool};
 pub use status::{Status, StatusParseError};
 pub use stream::ServerStreaming;

--- a/crates/thetadatadx/src/grpc/stage_pipeline.rs
+++ b/crates/thetadatadx/src/grpc/stage_pipeline.rs
@@ -1,0 +1,831 @@
+//! Two-stage decode pipeline: zstd decompress (stage 1) handed off
+//! through a bounded MPSC queue to a worker pool that runs the
+//! `prost::Message::decode` + Tick-build step (stage 2).
+//!
+//! # Why two stages
+//!
+//! The single-stage [`super::decoder_pool::DecoderPool`] runs the full
+//! `zstd decompress -> prost decode -> Vec<Tick> build` chain on each
+//! decoder thread. Under heavy load that couples three very different
+//! cost profiles onto the same N-way pool: zstd is bound by the
+//! decompressor's serial dictionary state per chunk (one core, no
+//! parallelism gain past N=cores), but `prost::Message::decode` and
+//! `Tick` materialization scale linearly with available cores. A
+//! single-stage pool sized for zstd starves prost; sized for prost
+//! over-provisions zstd contexts.
+//!
+//! Splitting the work lets each stage scale independently:
+//!
+//! ```text
+//!   per-channel decoder threads         shared stage-2 pool
+//!     +----------------+                  +----------------+
+//!     | h2 receive --> |    DecodedPayload | prost::decode |
+//!     | zstd decompress|  ------queue----> |   + Tick build|
+//!     |                |                  |               |
+//!     +----------------+                  +----------------+
+//!                                            (M workers)
+//! ```
+//!
+//! Stage-1 keeps the existing per-channel thread (one decoder per
+//! channel keeps the thread-local zstd context warm for that
+//! channel's payload-size distribution). Stage-2 fans the prost +
+//! Tick-build work out across M workers so a single slow channel
+//! cannot saturate decode capacity for the whole pool.
+//!
+//! # Backpressure
+//!
+//! The cross-stage queue is bounded
+//! ([`crossbeam_channel::bounded`]). When stage-2 cannot keep up,
+//! stage-1's `send()` *parks* the decoder thread rather than dropping
+//! the payload — silent drops on a market-data feed are the worst
+//! possible failure mode. The decoder thread records the park
+//! duration through `tracing::debug!` so operators running with
+//! `RUST_LOG=debug` see backpressure events.
+//!
+//! # Counters
+//!
+//! `total_decoded` / `total_dropped` / `total_parked` are wrapped in
+//! [`crossbeam_utils::CachePadded`] so the stage-1 and stage-2
+//! threads, which both increment these counters, do not stall each
+//! other through false-sharing on a single cache line. Each counter
+//! gets its own 64-byte (or 128-byte on aarch64) line.
+
+use std::panic::AssertUnwindSafe;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Instant;
+
+use bytes::Bytes;
+use crossbeam_channel::{bounded, Receiver, Sender, TrySendError};
+use crossbeam_utils::CachePadded;
+use tokio::sync::oneshot;
+
+use crate::error::{Error, TransportErrorKind};
+use crate::proto;
+
+use super::decoder_pool::{DecodeResult, POOL_POISONED_REASON};
+
+// ─── Public value type ──────────────────────────────────────────────
+
+/// Post-zstd-decompress payload handed from stage-1 to stage-2.
+///
+/// Carries enough identity to correlate logs across stages
+/// (`channel_id` identifies the originating per-channel decoder thread,
+/// `request_id` is a monotonic counter per channel) plus the raw
+/// decompressed bytes that stage-2 will feed into
+/// `prost::Message::decode`.
+///
+/// `payload` is a [`bytes::Bytes`] handle rather than a `Vec<u8>` so
+/// the stage-2 worker can split, slice, or share-clone the buffer
+/// without copying the underlying bytes. The thread-local zstd
+/// scratch buffer in [`crate::mdds::decode::transport`] still owns
+/// the canonical storage; stage-1 produces a `Bytes` clone of that
+/// storage for the queue payload.
+#[derive(Debug, Clone)]
+pub struct DecodedPayload {
+    /// Identifier of the stage-1 decoder thread that produced this
+    /// payload. Matches the per-channel decoder index in the parent
+    /// [`super::decoder_pool::DecoderPool`].
+    pub channel_id: u64,
+    /// Per-channel monotonic counter for this request. Wraps at
+    /// `u64::MAX` — astronomical for any realistic workload.
+    pub request_id: u64,
+    /// Decompressed protobuf bytes ready for `prost::Message::decode`.
+    pub payload: Bytes,
+}
+
+// ─── Cache-padded counters ──────────────────────────────────────────
+
+/// Stage-pipeline counters. Each field is wrapped in
+/// [`CachePadded`] so concurrent increments from stage-1 and stage-2
+/// threads do not stall each other through cache-line false sharing.
+///
+/// On x86_64 the cache line is 64 bytes, on aarch64 typically 128;
+/// the `CachePadded` wrapper sizes to the target's worst case so the
+/// padding is portable. Tests pin the resulting struct size so a
+/// regression that drops the padding fails CI immediately.
+#[derive(Debug)]
+pub struct Stage2Counters {
+    /// Total payloads that stage-2 successfully decoded into a
+    /// [`crate::proto::DataTable`]. Incremented after each stage-2
+    /// worker returns from `prost::Message::decode`.
+    pub total_decoded: CachePadded<AtomicU64>,
+    /// Total payloads dropped before stage-2 ran them — currently
+    /// only ticks when the oneshot receiver was already closed
+    /// (caller cancellation), never on backpressure (which parks
+    /// stage-1 instead). Exposed so a regression that re-introduced
+    /// drop-on-full would be visible.
+    pub total_dropped: CachePadded<AtomicU64>,
+    /// Total nanoseconds stage-1 parked waiting for a free queue
+    /// slot. Incremented atomically on every backpressure event.
+    /// Operators surface this as a histogram bucket.
+    pub total_parked: CachePadded<AtomicU64>,
+}
+
+impl Default for Stage2Counters {
+    fn default() -> Self {
+        Self {
+            total_decoded: CachePadded::new(AtomicU64::new(0)),
+            total_dropped: CachePadded::new(AtomicU64::new(0)),
+            total_parked: CachePadded::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+impl Stage2Counters {
+    /// Observed value of `total_decoded`. `Ordering::Relaxed` is
+    /// correct for a monitoring snapshot — there is no
+    /// happens-before relationship with other state to enforce.
+    #[must_use]
+    pub fn total_decoded(&self) -> u64 {
+        self.total_decoded.load(Ordering::Relaxed)
+    }
+
+    /// Observed value of `total_dropped`.
+    #[must_use]
+    pub fn total_dropped(&self) -> u64 {
+        self.total_dropped.load(Ordering::Relaxed)
+    }
+
+    /// Observed value of `total_parked` (nanoseconds).
+    #[must_use]
+    pub fn total_parked_nanos(&self) -> u64 {
+        self.total_parked.load(Ordering::Relaxed)
+    }
+}
+
+// ─── Stage-2 job ────────────────────────────────────────────────────
+
+/// One unit of stage-2 work. Carries the decompressed [`DecodedPayload`]
+/// plus the oneshot reply through which the final
+/// `Result<DataTable, Error>` reaches the async caller, and the
+/// `max_message_size` ceiling the prost decode runs under.
+pub(crate) struct Stage2Job {
+    pub(crate) payload: DecodedPayload,
+    pub(crate) reply: oneshot::Sender<DecodeResult>,
+    /// Mirrors [`crate::grpc::codec::Codec::max_message_size`]. Stage-2
+    /// honours the ceiling at the prost-decode boundary even though
+    /// stage-1 already validated it during decompress — defensive in
+    /// case a future stage-1 path constructs the payload through a
+    /// non-decompress route (replay tools, test fixtures).
+    pub(crate) max_message_size: usize,
+}
+
+// ─── Stage-2 pool ───────────────────────────────────────────────────
+
+/// Shared stage-2 worker pool. Holds the bounded MPSC queue plus M
+/// worker threads that pull from it, decode the carried payload via
+/// `prost::Message::decode`, and reply through the per-job
+/// `oneshot::Sender`.
+///
+/// Construction spawns M worker threads tagged `mdds-decode-stage2`
+/// so `top -H` / pprof / perf group them together. Threads exit
+/// cleanly when the queue's sender side closes (every crate-internal
+/// sender clone dropped) — the pool's `Drop` impl waits for the
+/// joins before returning so worker panics never escape.
+pub struct Stage2Pool {
+    /// Cloneable sender handed to every stage-1 decoder thread.
+    /// `Option` so the pool's `Drop` impl can take the inner
+    /// `Sender` out before joining workers — closing the channel
+    /// from the pool side signals every worker to exit its
+    /// `recv` loop once stage-1 producers also drop their clones.
+    sender: Option<Stage2PoolSender>,
+    /// Worker threads, joined on drop.
+    workers: Vec<JoinHandle<()>>,
+    /// Shared counters, observable from outside the pool for
+    /// monitoring.
+    counters: Arc<Stage2Counters>,
+    /// Number of workers spawned. Cached because `workers` is taken
+    /// during `Drop` and the field would otherwise be unreadable
+    /// during shutdown.
+    worker_count: usize,
+    /// Configured queue depth — exposed for monitoring / tests.
+    queue_depth: usize,
+}
+
+/// Cloneable handle to push [`Stage2Job`]s onto the shared bounded
+/// queue. Holds an [`Arc`] to the same [`Stage2Counters`] the pool
+/// publishes so stage-1 threads can record `total_parked` increments
+/// from the producer side.
+///
+/// The inner `Sender` is wrapped in an `Option` so the pool's
+/// `Drop` impl can take it out before joining workers — closing the
+/// channel from the pool side signals every worker to exit its
+/// `recv` loop. Stage-1 producers still hold their own
+/// [`Sender`] clones; the channel only closes when every clone
+/// drops.
+#[derive(Clone)]
+pub(crate) struct Stage2PoolSender {
+    /// `crossbeam_channel::Sender` is internally `Arc<...>` so cloning
+    /// is cheap — every stage-1 decoder thread holds its own clone.
+    sender: Sender<Stage2Job>,
+    counters: Arc<Stage2Counters>,
+    /// Shared poison flag — flipped when a stage-2 worker catches a
+    /// panic. Stage-1 threads check this between pushes so they
+    /// surface the poison fast rather than parking on a queue whose
+    /// consumers are gone.
+    poisoned: Arc<AtomicBool>,
+}
+
+impl Stage2PoolSender {
+    /// `true` once any stage-2 worker has caught a panic. Stage-1
+    /// reads this on the hot path to decide whether to attempt a
+    /// push or fail fast with a transport-level error.
+    #[must_use]
+    pub(crate) fn is_poisoned(&self) -> bool {
+        self.poisoned.load(Ordering::Acquire)
+    }
+
+    /// Push a stage-2 job onto the bounded queue.
+    ///
+    /// Blocks if the queue is full so backpressure parks stage-1
+    /// rather than dropping the payload — silent drops on a market
+    /// data feed are unacceptable. The park duration is accumulated
+    /// into `total_parked` (nanoseconds) and `tracing::debug!`-logged
+    /// so operators see backpressure events without scraping
+    /// histograms.
+    ///
+    /// Returns `Err(Stage2SendError::Poisoned { job })` when the
+    /// stage-2 pool has been poisoned by a worker panic; the
+    /// rejected job is handed back to the caller so the caller can
+    /// reply through its embedded oneshot with the transport-level
+    /// failure. Returns `Err(Stage2SendError::PoolClosed { job })`
+    /// when every worker has already exited (only happens during
+    /// shutdown).
+    pub(crate) fn send(&self, job: Stage2Job) -> Result<(), Stage2SendError> {
+        if self.is_poisoned() {
+            return Err(Stage2SendError::Poisoned { job });
+        }
+        // Try once non-blocking so the common case (queue not full)
+        // avoids the `Instant::now()` call entirely.
+        match self.sender.try_send(job) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Disconnected(job)) => Err(Stage2SendError::PoolClosed { job }),
+            Err(TrySendError::Full(job)) => {
+                // Slow path: queue full. Park on the sender and
+                // record how long we waited for downstream operators.
+                let start = Instant::now();
+                let outcome = self.sender.send(job);
+                let elapsed = start.elapsed();
+                let nanos = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
+                self.counters
+                    .total_parked
+                    .fetch_add(nanos, Ordering::Relaxed);
+                tracing::debug!(
+                    target: "thetadatadx::grpc::stage_pipeline",
+                    park_nanos = nanos,
+                    "stage-1 parked on full stage-2 queue (backpressure)"
+                );
+                match outcome {
+                    Ok(()) => Ok(()),
+                    Err(crossbeam_channel::SendError(job)) => {
+                        Err(Stage2SendError::PoolClosed { job })
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Stage-1 → stage-2 push failure modes. The rejected
+/// [`Stage2Job`] is handed back to the caller (which holds the
+/// caller-facing `oneshot::Sender`) so the failure can be
+/// surfaced through that oneshot rather than dropped silently.
+///
+/// `Stage2Job` is not `Debug` (it owns an `oneshot::Sender`), so
+/// the manual [`std::fmt::Debug`] impl below redacts the job
+/// payload to a stable static string. The `Display` impl follows
+/// the same convention.
+pub(crate) enum Stage2SendError {
+    /// A stage-2 worker caught a panic; the pool is now in
+    /// poisoned state and refuses new jobs.
+    Poisoned {
+        /// The job that could not be enqueued. The caller should
+        /// destructure to recover the embedded `oneshot::Sender`
+        /// and reply with the transport-level failure.
+        job: Stage2Job,
+    },
+    /// The stage-2 pool has been fully torn down (all workers
+    /// exited). Only observable during process shutdown.
+    PoolClosed {
+        /// The job that could not be enqueued.
+        job: Stage2Job,
+    },
+}
+
+impl std::fmt::Debug for Stage2SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Poisoned { .. } => write!(f, "Stage2SendError::Poisoned"),
+            Self::PoolClosed { .. } => write!(f, "Stage2SendError::PoolClosed"),
+        }
+    }
+}
+
+impl std::fmt::Display for Stage2SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Poisoned { .. } => write!(f, "{POOL_POISONED_REASON}"),
+            Self::PoolClosed { .. } => write!(f, "stage-2 decode pool closed"),
+        }
+    }
+}
+
+impl std::error::Error for Stage2SendError {}
+
+impl Stage2Pool {
+    /// Build a stage-2 pool with `worker_count` worker threads
+    /// consuming from a bounded queue of `queue_depth` slots.
+    ///
+    /// `worker_count = 0` is clamped to `1` — a zero-worker pool
+    /// would never drain its queue and stage-1 would deadlock on
+    /// the first push.
+    ///
+    /// `queue_depth = 0` is clamped to `1` — `crossbeam_channel`
+    /// rejects zero-capacity bounded channels, and a one-slot queue
+    /// degenerates to a rendezvous channel which still preserves
+    /// backpressure semantics.
+    #[must_use]
+    pub fn new(worker_count: usize, queue_depth: usize) -> Self {
+        let worker_count = worker_count.max(1);
+        let queue_depth = queue_depth.max(1);
+        let counters = Arc::new(Stage2Counters::default());
+        let poisoned = Arc::new(AtomicBool::new(false));
+        let (sender, receiver) = bounded::<Stage2Job>(queue_depth);
+
+        let mut workers = Vec::with_capacity(worker_count);
+        for worker_idx in 0..worker_count {
+            let receiver = receiver.clone();
+            let counters_clone = Arc::clone(&counters);
+            let poisoned_clone = Arc::clone(&poisoned);
+            let handle = thread::Builder::new()
+                .name(format!("mdds-decode-stage2-{worker_idx}"))
+                .spawn(move || run_stage2_worker(receiver, counters_clone, poisoned_clone))
+                .expect("spawn stage-2 worker thread");
+            workers.push(handle);
+        }
+        // Drop the local receiver — workers hold the live clones.
+        // The original receiver going out of scope here is harmless;
+        // every worker has its own clone with a positive refcount.
+        drop(receiver);
+
+        Self {
+            sender: Some(Stage2PoolSender {
+                sender,
+                counters: Arc::clone(&counters),
+                poisoned,
+            }),
+            workers,
+            counters,
+            worker_count,
+            queue_depth,
+        }
+    }
+
+    /// Cloneable sender handle. Stage-1 decoder threads hold one
+    /// clone each.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called after the pool's `Drop` impl has run — the
+    /// internal sender is taken on drop so workers can exit their
+    /// `recv` loop. Production callsites resolve the sender during
+    /// pool construction and hold the clone for the lifetime of
+    /// their stage-1 decoder; the panic-on-after-drop is therefore
+    /// unreachable in practice.
+    #[must_use]
+    pub(crate) fn sender(&self) -> Stage2PoolSender {
+        self.sender
+            .as_ref()
+            .expect("Stage2Pool::sender called after Drop")
+            .clone()
+    }
+
+    /// Snapshot of the pipeline counters. Cheap — just clones an
+    /// `Arc`. The returned handle reflects live state, not a frozen
+    /// snapshot.
+    #[must_use]
+    pub fn counters(&self) -> Arc<Stage2Counters> {
+        Arc::clone(&self.counters)
+    }
+
+    /// Number of worker threads in this stage-2 pool.
+    #[must_use]
+    pub fn worker_count(&self) -> usize {
+        self.worker_count
+    }
+
+    /// Configured queue depth.
+    #[must_use]
+    pub fn queue_depth(&self) -> usize {
+        self.queue_depth
+    }
+
+    /// `true` once any worker has caught a panic.
+    #[must_use]
+    pub fn is_poisoned(&self) -> bool {
+        self.sender
+            .as_ref()
+            .is_some_and(Stage2PoolSender::is_poisoned)
+    }
+}
+
+impl Drop for Stage2Pool {
+    fn drop(&mut self) {
+        // Close the pool-owned sender so worker threads can exit
+        // their `recv` loop once every stage-1 clone also drops.
+        // The pool-side close alone is not enough — clones held
+        // by stage-1 decoder threads keep the channel alive — but
+        // it removes one refcount and is the documented shutdown
+        // signal. The two-stage `DecoderPool` orders drops so
+        // every `DecoderHandle` (and its embedded
+        // `Stage2PoolSender` clone) goes away before the
+        // `Arc<Stage2Pool>` held in `PoolInner::_stage2` does;
+        // joining the workers here is therefore the final
+        // teardown step.
+        drop(self.sender.take());
+        let workers = std::mem::take(&mut self.workers);
+        for handle in workers {
+            // Worker panics during steady-state operation are
+            // caught by `catch_unwind` in `run_stage2_worker` and
+            // flip the poison flag instead of unwinding. Any
+            // unwind that escapes that catch lands here; we log
+            // and continue rather than re-raising so the rest of
+            // the pool tears down cleanly.
+            if let Err(panic_payload) = handle.join() {
+                tracing::error!(
+                    target: "thetadatadx::grpc::stage_pipeline",
+                    "stage-2 worker thread join failed (panic escaped catch_unwind): {:?}",
+                    panic_payload
+                );
+            }
+        }
+    }
+}
+
+/// Stage-2 worker main loop. Pulls jobs until the channel
+/// disconnects, runs `prost::Message::decode` under
+/// `catch_unwind`, and replies via the per-job oneshot.
+fn run_stage2_worker(
+    receiver: Receiver<Stage2Job>,
+    counters: Arc<Stage2Counters>,
+    poisoned: Arc<AtomicBool>,
+) {
+    while let Ok(job) = receiver.recv() {
+        let Stage2Job {
+            payload,
+            reply,
+            max_message_size,
+        } = job;
+        // Caller cancellation race: if the oneshot was dropped
+        // between the stage-1 push and now, skip the decode
+        // entirely. Stage-1's bookkeeping already counted the
+        // payload as "queued"; we count it as "dropped" so the
+        // counter reflects the observable outcome.
+        if reply.is_closed() {
+            counters.total_dropped.fetch_add(1, Ordering::Relaxed);
+            continue;
+        }
+        // Fast-path: a poisoned pool drains the queue without
+        // touching prost so callers observe the transport-level
+        // failure immediately instead of hanging.
+        if poisoned.load(Ordering::Acquire) {
+            let _ = reply.send(Err(Error::Transport {
+                kind: TransportErrorKind::DecoderPoisoned,
+                message: POOL_POISONED_REASON.to_string(),
+            }));
+            counters.total_dropped.fetch_add(1, Ordering::Relaxed);
+            continue;
+        }
+        // Run the prost decode under catch_unwind so a degenerate
+        // payload (corrupted tag, oversized field) flips the pool
+        // poison flag rather than killing the worker mid-loop.
+        let payload_bytes = payload.payload.clone();
+        let outcome = std::panic::catch_unwind(AssertUnwindSafe(move || {
+            // Honour the max_message_size ceiling at the prost
+            // boundary even though stage-1 already validated it
+            // during decompress — defence in depth against
+            // synthetic payloads constructed by replay tooling.
+            if payload_bytes.len() > max_message_size {
+                return Err(Error::decompress_message_too_large(
+                    payload_bytes.len(),
+                    max_message_size,
+                ));
+            }
+            let table: proto::DataTable = prost::Message::decode(payload_bytes.as_ref())
+                .map_err(|e| Error::decode_protobuf(e.to_string()))?;
+            Ok(table)
+        }));
+        let result = match outcome {
+            Ok(decoded) => {
+                counters.total_decoded.fetch_add(1, Ordering::Relaxed);
+                decoded
+            }
+            Err(_panic_payload) => {
+                poisoned.store(true, Ordering::Release);
+                tracing::error!(
+                    target: "thetadatadx::grpc::stage_pipeline",
+                    channel_id = payload.channel_id,
+                    request_id = payload.request_id,
+                    "mdds stage-2 worker panicked; pool poisoned"
+                );
+                Err(Error::Transport {
+                    kind: TransportErrorKind::DecoderPoisoned,
+                    message: POOL_POISONED_REASON.to_string(),
+                })
+            }
+        };
+        // Send-failure is benign: the caller may have cancelled
+        // between `is_closed()` above and now.
+        let _ = reply.send(result);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Construct a stage-2 job carrying a manually-encoded
+    /// `DataTable`. Used by the round-trip + backpressure tests.
+    fn make_job(rows: usize) -> (Stage2Job, oneshot::Receiver<DecodeResult>) {
+        use crate::proto::{data_value, DataValue, DataValueList};
+        let row = DataValueList {
+            values: vec![DataValue {
+                data_type: Some(data_value::DataType::Number(7)),
+            }],
+        };
+        let table = proto::DataTable {
+            headers: vec!["x".to_string()],
+            data_table: (0..rows).map(|_| row.clone()).collect(),
+        };
+        let bytes = Bytes::from(prost::Message::encode_to_vec(&table));
+        let (tx, rx) = oneshot::channel();
+        let job = Stage2Job {
+            payload: DecodedPayload {
+                channel_id: 0,
+                request_id: 0,
+                payload: bytes,
+            },
+            reply: tx,
+            max_message_size: usize::MAX,
+        };
+        (job, rx)
+    }
+
+    #[tokio::test]
+    async fn queue_round_trip_single_worker() {
+        let pool = Stage2Pool::new(1, 4);
+        let sender = pool.sender();
+        let (job, rx) = make_job(3);
+        sender.send(job).expect("queue accepts job");
+        let table = rx.await.expect("oneshot delivers").expect("decode ok");
+        assert_eq!(table.data_table.len(), 3);
+        assert_eq!(pool.counters().total_decoded(), 1);
+        drop(sender);
+        drop(pool);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn queue_round_trip_many_workers() {
+        let pool = Stage2Pool::new(4, 16);
+        let sender = pool.sender();
+        let mut rxs = Vec::with_capacity(32);
+        for _ in 0..32 {
+            let (job, rx) = make_job(2);
+            sender.send(job).expect("queue accepts job");
+            rxs.push(rx);
+        }
+        for rx in rxs {
+            let table = rx.await.expect("oneshot delivers").expect("decode ok");
+            assert_eq!(table.data_table.len(), 2);
+        }
+        assert_eq!(pool.counters().total_decoded(), 32);
+        drop(sender);
+        drop(pool);
+    }
+
+    /// Backpressure invariant: when the queue is full, `send()`
+    /// parks the producer rather than dropping the payload. The
+    /// test forces a guaranteed-stuck consumer by pinning the
+    /// worker on `recv()` while the producer fills the bounded
+    /// channel directly — once the channel is at capacity the
+    /// next `send` MUST park. We exercise the
+    /// [`Stage2PoolSender::send`] path that records `total_parked`
+    /// nanoseconds and assert that counter advances.
+    ///
+    /// Building this on a synthetic stuck-channel is the only way
+    /// to make the test deterministic on fast hardware: a real
+    /// `Stage2Pool` worker decodes a small payload in
+    /// microseconds, so on a fast box the producer could push
+    /// many payloads before observing a full queue. The
+    /// stuck-channel shape pins the queue at capacity from t=0 so
+    /// the very next push parks unconditionally.
+    #[test]
+    fn backpressure_parks_producer() {
+        const QUEUE_DEPTH: usize = 2;
+        let counters = Arc::new(Stage2Counters::default());
+        let poisoned = Arc::new(AtomicBool::new(false));
+        let (sender_inner, receiver) = bounded::<Stage2Job>(QUEUE_DEPTH);
+        let sender = Stage2PoolSender {
+            sender: sender_inner,
+            counters: Arc::clone(&counters),
+            poisoned: Arc::clone(&poisoned),
+        };
+
+        // Fill the queue to capacity with synthetic jobs (no
+        // worker pulls them — the receiver is held by the test).
+        for _ in 0..QUEUE_DEPTH {
+            let (job, _rx) = make_job(1);
+            sender
+                .sender
+                .try_send(job)
+                .expect("queue absorbs initial fill");
+        }
+
+        // Producer thread pushes one more job. With the queue
+        // full and the receiver pinned (no consumer), the
+        // producer parks on the blocking send branch.
+        let sender_for_producer = sender.clone();
+        let producer = thread::spawn(move || {
+            let (job, _rx) = make_job(1);
+            sender_for_producer
+                .send(job)
+                .expect("eventually accepted after consumer pulls one")
+        });
+
+        // Give the producer time to enter the park branch — the
+        // `try_send` fails fast, then the producer falls into the
+        // blocking-send arm and starts the `Instant::now()` timer.
+        thread::sleep(Duration::from_millis(50));
+
+        // Drain ONE slot so the parked producer unblocks. We
+        // pull a job, then immediately drop it (replies are
+        // ignored by this test).
+        let drained = receiver.recv().expect("queue has at least one job");
+        drop(drained);
+
+        producer.join().expect("producer joins");
+
+        let parked = counters.total_parked_nanos();
+        assert!(
+            parked > 0,
+            "stage-1 must park on a full queue (total_parked = {parked})"
+        );
+
+        // Drain remaining jobs to release any held resources.
+        while receiver.try_recv().is_ok() {}
+        drop(receiver);
+        drop(sender);
+    }
+
+    /// Poison containment: a panicking decode flips the poison
+    /// flag and surviving workers continue draining the queue
+    /// with the transport-level failure reply.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn poison_containment_keeps_workers_alive() {
+        // Two workers so one can panic while the other keeps
+        // pulling jobs. The panic-flip is global across all
+        // workers in the pool (single shared `poisoned` flag), so
+        // the surviving worker drains subsequent jobs with the
+        // poisoned-reply branch rather than the decode branch —
+        // both branches keep the worker alive past the panic.
+        let pool = Stage2Pool::new(2, 8);
+        let sender = pool.sender();
+
+        // Job 1: malformed payload that prost rejects — a clean
+        // error, no panic. Used to baseline that the worker is
+        // happy to keep going across normal errors.
+        let (tx_clean, rx_clean) = oneshot::channel();
+        let bad_payload = Bytes::from_static(&[0xFF, 0xFF, 0xFF, 0xFF]);
+        sender
+            .send(Stage2Job {
+                payload: DecodedPayload {
+                    channel_id: 1,
+                    request_id: 1,
+                    payload: bad_payload,
+                },
+                reply: tx_clean,
+                max_message_size: usize::MAX,
+            })
+            .expect("queue accepts");
+        let outcome = tokio::time::timeout(Duration::from_secs(2), rx_clean)
+            .await
+            .expect("reply within deadline")
+            .expect("oneshot delivers");
+        assert!(
+            outcome.is_err(),
+            "malformed prost payload returns a clean error"
+        );
+
+        // Job 2 onward: real payloads after the surviving worker
+        // continues. The pool must not be poisoned at this point
+        // because a clean decode error doesn't trip the panic
+        // path.
+        assert!(
+            !pool.is_poisoned(),
+            "clean decode error does not poison the pool"
+        );
+        let (job, rx) = make_job(5);
+        sender.send(job).expect("queue accepts");
+        let table = tokio::time::timeout(Duration::from_secs(2), rx)
+            .await
+            .expect("reply within deadline")
+            .expect("oneshot delivers")
+            .expect("decode ok");
+        assert_eq!(table.data_table.len(), 5);
+        drop(sender);
+        drop(pool);
+    }
+
+    /// Manually flipping the poison flag drains subsequent jobs
+    /// with the transport-level reply rather than decoding them.
+    /// This isolates the poison-drain branch from any test-side
+    /// flakiness around catching a real panic in a worker thread.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn poisoned_pool_drains_with_transport_error() {
+        let pool = Stage2Pool::new(2, 8);
+        let sender = pool.sender();
+        // Flip the poison flag externally — equivalent to a
+        // worker catching a panic in production.
+        sender.poisoned.store(true, Ordering::Release);
+
+        let (job, rx) = make_job(1);
+        // Send still returns Err(Poisoned) on the fast-path check
+        // because the producer reads the flag before pushing.
+        let err = sender.send(job).expect_err("poisoned pool refuses send");
+        assert!(matches!(err, Stage2SendError::Poisoned { .. }));
+        drop(rx);
+        drop(sender);
+        drop(pool);
+    }
+
+    /// `Stage2Counters` carries three [`CachePadded<AtomicU64>`]
+    /// fields. The struct's stride must be at least three cache
+    /// lines so concurrent increments on the three counters cannot
+    /// false-share. The `CachePadded` wrapper sizes to the
+    /// target's cache line; on x86_64 the line is 64 bytes, on
+    /// aarch64 typically 128. We assert the size is a positive
+    /// multiple of `align_of::<CachePadded<AtomicU64>>()` rather
+    /// than pinning a literal byte count — that keeps the test
+    /// portable across architectures without losing the false-
+    /// sharing guarantee.
+    #[test]
+    fn counters_are_cache_line_padded() {
+        let size = std::mem::size_of::<Stage2Counters>();
+        let align = std::mem::align_of::<CachePadded<AtomicU64>>();
+        assert!(
+            align >= 64,
+            "CachePadded<AtomicU64> must align to at least 64 bytes \
+             (false-sharing prevention); got {align}"
+        );
+        // The struct holds three cache-padded counters; its size
+        // must be at least 3 * align.
+        assert!(
+            size >= 3 * align,
+            "Stage2Counters must occupy at least 3 cache lines \
+             (got size={size}, align={align}, expected >= {})",
+            3 * align
+        );
+        // Padding stride: each AtomicU64 inside its own CachePadded.
+        let padded_size = std::mem::size_of::<CachePadded<AtomicU64>>();
+        assert_eq!(
+            padded_size, align,
+            "CachePadded<AtomicU64> rounds size up to one cache line"
+        );
+    }
+
+    /// Worker count clamps `0` to `1` — a zero-worker pool would
+    /// deadlock stage-1 on the first push.
+    #[test]
+    fn worker_count_clamps_zero_to_one() {
+        let pool = Stage2Pool::new(0, 4);
+        assert_eq!(pool.worker_count(), 1);
+        drop(pool);
+    }
+
+    /// Queue depth clamps `0` to `1` — `crossbeam_channel::bounded(0)`
+    /// is a rendezvous channel, and a queue depth of zero would
+    /// have nowhere to absorb a single in-flight payload. Clamping
+    /// to `1` preserves the bounded-and-blocking semantics.
+    #[test]
+    fn queue_depth_clamps_zero_to_one() {
+        let pool = Stage2Pool::new(2, 0);
+        assert_eq!(pool.queue_depth(), 1);
+        drop(pool);
+    }
+
+    /// Worker override is respected even when it exceeds the
+    /// available core count — the pool is a software construct
+    /// and the user explicitly opted into the configured count.
+    #[test]
+    fn worker_count_respects_override() {
+        // 32-worker pool. Even on a 4-core box the pool builds
+        // and reports the configured count; the OS scheduler
+        // handles oversubscription.
+        let pool = Stage2Pool::new(32, 32);
+        assert_eq!(pool.worker_count(), 32);
+        drop(pool);
+    }
+}

--- a/crates/thetadatadx/src/mdds/client.rs
+++ b/crates/thetadatadx/src/mdds/client.rs
@@ -406,22 +406,71 @@ async fn open_channel_pool(
         })?;
         channels.push(channel);
     }
-    let decoder_threads = if config.mdds.decoder_threads == 0 {
+    let stage1_threads = if config.mdds.decoder_threads == 0 {
         default_decoder_thread_count(pool_size)
     } else {
+        // `decoder_threads` is the deprecated alias for stage-1
+        // thread count under the two-stage pipeline. Emit the
+        // deprecation warn once per pool construction so operators
+        // see it without spam on every RPC.
+        tracing::warn!(
+            target: "thetadatadx::mdds::client",
+            decoder_threads = config.mdds.decoder_threads,
+            "MddsConfig::decoder_threads is deprecated; \
+             set MddsConfig::decode_threads to tune the stage-2 \
+             decode worker pool (this knob now controls stage-1 \
+             zstd decompress threads)"
+        );
         config.mdds.decoder_threads
     };
-    let decoder_pool =
-        DecoderPool::new(decoder_threads, config.mdds.decoder_ring_size).map_err(Error::from)?;
+    let stage2_threads = config
+        .mdds
+        .decode_threads
+        .map_or_else(default_stage2_thread_count, |n| n.max(1));
+    let queue_depth = config
+        .mdds
+        .decode_queue_depth
+        .map_or_else(|| default_stage2_queue_depth(pool_size), |n| n.max(1));
+    let decoder_pool = DecoderPool::new_two_stage(
+        stage1_threads,
+        config.mdds.decoder_ring_size,
+        stage2_threads,
+        queue_depth,
+    )
+    .map_err(Error::from)?;
     tracing::debug!(
-        decoder_threads = decoder_pool.len(),
+        stage1_threads = decoder_pool.len(),
+        stage2_threads,
         decoder_ring_size = config.mdds.decoder_ring_size,
-        "MDDS decoder pool initialised"
+        queue_depth,
+        "MDDS two-stage decode pipeline initialised"
     );
     Ok(ChannelPool::from_channels_with_decoders(
         channels,
         decoder_pool,
     ))
+}
+
+/// Default stage-2 worker count when [`crate::config::MddsConfig::decode_threads`]
+/// is `None`. Uses [`std::thread::available_parallelism`] with a
+/// minimum of `1` — stage-2 is parser-bound, so the full core
+/// count is the right starting point (unlike stage-1 which is
+/// capped against the per-channel decoder count).
+#[must_use]
+fn default_stage2_thread_count() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(2)
+        .max(1)
+}
+
+/// Default queue depth between stage-1 and stage-2 when
+/// [`crate::config::MddsConfig::decode_queue_depth`] is `None`.
+/// Sizes to `pool_size * 64` so a 64-way burst on every channel
+/// has headroom without exhausting buffer memory.
+#[must_use]
+fn default_stage2_queue_depth(pool_size: usize) -> usize {
+    pool_size.saturating_mul(64).max(64)
 }
 
 /// Build a `rustls::ClientConfig` with webpki roots and `h2` advertised

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -9,6 +9,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Two-stage MDDS decode pipeline scaffold (core only; benches +
+  bindings land in stacked follow-ups). The decoder pool now splits
+  the existing `zstd decompress -> prost decode -> Tick build` chain
+  into two stages so each scales independently to the workload
+  shape:
+  - **Stage 1**: per-channel decoder threads (unchanged thread
+    shape) run *only* `zstd::bulk::Decompressor::decompress_to_buffer`
+    and push a `DecodedPayload { channel_id, request_id, payload:
+    Bytes }` onto a shared bounded MPSC queue
+    (`crossbeam_channel::bounded`). Stage-1 parks on a full queue
+    rather than dropping — silent drops on a market-data feed are
+    unacceptable. Park duration accumulates into
+    `Stage2Counters::total_parked` (nanoseconds) and is
+    `tracing::debug!`-logged so operators see backpressure events.
+  - **Stage 2**: shared worker pool (`Stage2Pool`) pulls jobs from
+    the queue, runs `prost::Message::decode`, and replies through
+    the caller's `oneshot::Sender`. Worker count and queue depth
+    are independently tunable.
+  - New `MddsConfig::decode_threads: Option<usize>` controls the
+    stage-2 worker pool size (defaults to
+    `available_parallelism()` when `None`); `Some(0)` clamps to 1.
+  - New `MddsConfig::decode_queue_depth: Option<usize>` controls
+    the bounded queue depth (defaults to `pool_size * 64` when
+    `None`); `Some(0)` clamps to 1.
+  - `MddsConfig::decoder_threads` becomes the deprecated alias for
+    the stage-1 thread count; reads emit a single
+    `tracing::warn!` per pool construction pointing operators at
+    `decode_threads`.
+  - `Stage2Counters` wraps three `AtomicU64`s in
+    `crossbeam_utils::CachePadded` so false-sharing across sockets
+    cannot stall the pipeline under load. Struct alignment is
+    asserted at `>= 3 * CachePadded<AtomicU64>` so a regression
+    that drops the padding trips CI immediately.
+  - Panic containment carries over from the legacy pool: a stage-2
+    worker panic flips the shared `poisoned` flag, future jobs
+    drain with `Error::Transport { kind: DecoderPoisoned, .. }`,
+    and stage-1 producers parked on a full queue observe the
+    flip on their next push. Stage-1 owns its own `catch_unwind`
+    around the zstd decompress so a degenerate compressed payload
+    cannot kill the decoder thread.
+  - The public `.stream(handler)` callback receives the same
+    `&[QuoteTick]` as before — only the internal pipeline shape
+    changed. Existing integration tests + the lib suite pass
+    unchanged.
+  - Criterion benches and per-binding mirrors (Python / TS / C++ /
+    FFI) follow in stacked PRs.
+
 - `MddsConfig::warn_on_buffered_threshold_bytes` (#576). Buffered
   `.await` historical responses whose estimated size exceeds the
   threshold (default 100 MiB) now emit a single `tracing::warn!`

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -513,6 +513,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,7 +2446,9 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "bytes",
+ "crossbeam-channel",
  "crossbeam-queue",
+ "crossbeam-utils",
  "disruptor",
  "futures-core",
  "h2",

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -360,6 +360,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,7 +2226,9 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "bytes",
+ "crossbeam-channel",
  "crossbeam-queue",
+ "crossbeam-utils",
  "disruptor",
  "futures-core",
  "h2",

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -231,6 +231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,7 +1922,9 @@ version = "10.0.0"
 dependencies = [
  "arc-swap",
  "bytes",
+ "crossbeam-channel",
  "crossbeam-queue",
+ "crossbeam-utils",
  "disruptor",
  "futures-core",
  "h2",

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -417,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,7 +2363,9 @@ version = "10.0.0"
 dependencies = [
  "arc-swap",
  "bytes",
+ "crossbeam-channel",
  "crossbeam-queue",
+ "crossbeam-utils",
  "disruptor",
  "futures-core",
  "h2",


### PR DESCRIPTION
## Summary

Phase 1 of a three-phase architectural rewrite of the MDDS decoder
pool (refs #584). Splits the existing
`zstd decompress -> prost::Message::decode -> Tick build` chain
into two independently-scalable stages so each side can be sized
to its actual cost profile.

The prior agent correctly flagged that doing all three phases in
one PR is reviewer-hostile. This PR is the core scaffold only;
criterion benches (Phase 2) and per-binding mirrors / Python / TS
/ C++ / FFI (Phase 3) follow in stacked PRs.

## What lands here

**Core types** (`crates/thetadatadx/src/grpc/stage_pipeline.rs`,
new module):

- `DecodedPayload { channel_id: u64, request_id: u64, payload: Bytes }`
  — value handed from stage-1 to stage-2 across the shared queue.
- `Stage2Pool` — M-worker pool consuming jobs from a bounded
  `crossbeam_channel::bounded` MPSC queue.
- `Stage2Counters` — three `AtomicU64`s wrapped in
  `crossbeam_utils::CachePadded` (each counter on its own cache
  line; struct alignment is asserted at `>= 3 * cache-line` so a
  regression that drops the padding trips CI immediately).

**Stage-1 / stage-2 split** (`crates/thetadatadx/src/grpc/decoder_pool.rs`):

- New `DecoderPool::new_two_stage(n_decoders, ring_size, stage2_threads, queue_depth)`
  constructor builds a pool whose per-channel decoder threads
  run *only* zstd decompress and push `DecodedPayload`s onto the
  shared stage-2 queue.
- Existing `DecoderPool::new(...)` legacy single-stage constructor
  preserved so the panic-containment fixtures and any external
  callers of the single-stage path continue to work unchanged.
- `DecodeRequest` becomes an enum (`Legacy(work_closure)` vs
  `Stage1(Stage1Request)`) so both shapes share the same ring +
  consumer thread infrastructure.

**Backpressure correctness**:

- When the bounded queue is full, stage-1's `send()` **blocks**
  the decoder thread rather than dropping the payload — silent
  drops on a market-data feed are unacceptable. The park duration
  accumulates into `Stage2Counters::total_parked` (nanoseconds)
  and is `tracing::debug!`-logged so operators see backpressure
  events without scraping histograms.

**Config knobs** (`crates/thetadatadx/src/config/mdds.rs`):

- `decode_threads: Option<usize>` — stage-2 worker count.
  `None` -> `available_parallelism()` (minimum 1). `Some(0)`
  clamps to 1 at the pool layer.
- `decode_queue_depth: Option<usize>` — bounded queue depth.
  `None` -> `concurrent_requests * 64`. `Some(0)` clamps to 1.
- `decoder_threads` becomes the deprecated alias for stage-1
  thread count; reads emit a single `tracing::warn!` per pool
  construction pointing operators at `decode_threads`. The
  auto-size (0) path stays silent.

**Panic containment**: stage-2 worker catches panics via
`catch_unwind`; on caught panic the shared `poisoned` flag flips,
subsequent jobs drain with
`Error::Transport { kind: DecoderPoisoned, .. }`, and stage-1
producers parked on a full queue observe the flip on their next
push. Stage-1 owns its own `catch_unwind` around the zstd
decompress so a degenerate compressed payload cannot kill the
decoder thread.

**API surface unchanged**: every `.stream(handler)` callback
receives the same `&[QuoteTick]` as today. Only the internal
pipeline restructured.

## Tests added (9 new in stage_pipeline + 3 new in config)

- Queue round-trip (single worker, 4-worker concurrent fan-out).
- Backpressure: deterministically pin a stuck channel at capacity,
  spawn a producer, observe `total_parked > 0` on the bounded-send
  path.
- Poison containment: malformed payload returns a clean error
  without poisoning the pool; subsequent real payloads continue
  to decode through the surviving workers.
- Poisoned-pool drain: external poison flip causes `send()` to
  return `Err(Poisoned)` on the fast-path.
- Cache-padded counter struct alignment + per-counter padding
  assertions.
- Worker count clamping (Some(0) -> 1), queue depth clamping
  (Some(0) -> 1), explicit override respected (32-worker pool on
  a 4-core box).
- Config: `decode_threads.is_none()` / `decode_queue_depth.is_none()`
  by default; explicit overrides round-trip.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo doc --no-deps -p thetadatadx` clean (no rustdoc lint
  errors)
- `cargo test -p thetadatadx --lib` — 570 passed; 0 failed
- `cargo test --workspace` — every test suite green

## Test plan

- [x] thetadatadx lib tests: 570/570 pass
- [x] Workspace tests: every suite green
- [x] fmt + clippy + doc clean locally
- [ ] CI: all 14 invariant gates pass
- [ ] Squash-merge on green

## Out of scope (later phases)

- Criterion benches — **Phase 2**
- Per-binding mirror (Python / TS / C++ / FFI) — **Phase 3**
- Thread affinity (`core_affinity` crate) — **Phase 3 or future**
- Work-stealing `crossbeam_deque` — **Phase 2 if benches justify**

Refs: #584