### PR TITLE
feat(bindings): expose MDDS two-stage decode pipeline knobs (Phase 3 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cross-binding parity for the two-stage MDDS decode pipeline knobs
+  (Phase 3 of 3). The `MddsConfig::decode_threads` and
+  `decode_queue_depth` fields landed in #587 (core scaffold) and #588
+  (criterion benches); PR #586 mirrored the legacy single-stage knobs
+  to every binding. This entry closes the parity gap so Python /
+  TypeScript / C++ / FFI callers can size the stage-2 prost-decode +
+  Tick-build worker pool and the bounded MPSC queue independently of
+  channel count, matching the Rust surface bit-for-bit.
+  - **Python**: `cfg.decode_threads = N` and
+    `cfg.decode_queue_depth = N` (with `None` for the auto-size
+    sentinel) and full `.pyi` stubs. Negatives raise `ValueError`
+    at the setter; explicit `0` is a legal value that the pool
+    clamps to `1` at construction.
+  - **TypeScript**: `cfg.setDecodeThreads(N)` /
+    `cfg.setDecodeQueueDepth(N)` accepting `number | null | undefined`,
+    with regenerated `index.d.ts`. The mirror property getters return
+    `number | null` for the current value.
+  - **C++**: `cfg.set_decode_threads(std::optional<size_t>)` /
+    `cfg.set_decode_queue_depth(std::optional<size_t>)` on
+    `tdx::Config`. `std::nullopt` encodes the auto-size sentinel.
+    The wrappers throw `std::runtime_error` on null-handle FFI
+    failure (unreachable through the RAII contract).
+  - **FFI**: `tdx_config_set_decode_threads(*TdxConfig, size_t) -> int32_t`
+    and `tdx_config_set_decode_queue_depth(*TdxConfig, size_t) -> int32_t`,
+    both C-ABI clean. `n = 0` encodes the auto-size sentinel; any
+    `n > 0` is the explicit `Some(n)` override. Returns `0` on
+    success, `-1` on null-handle (diagnostic via `tdx_last_error()`).
+  - 13 new Python tests, 13 new TypeScript tests, 7 new C++ Catch2
+    tests, 7 new FFI Rust tests.
+
 - MDDS pool-sizing surface on every binding (closes #584). Three
   knobs on `MddsConfig` are now exposed through the Python, TypeScript,
   C++, and FFI surfaces — they previously existed in the Rust core

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -75,6 +75,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cross-binding parity for the two-stage MDDS decode pipeline knobs
+  (Phase 3 of 3). The `MddsConfig::decode_threads` and
+  `decode_queue_depth` fields landed in #587 (core scaffold) and #588
+  (criterion benches); PR #586 mirrored the legacy single-stage knobs
+  to every binding. This entry closes the parity gap so Python /
+  TypeScript / C++ / FFI callers can size the stage-2 prost-decode +
+  Tick-build worker pool and the bounded MPSC queue independently of
+  channel count, matching the Rust surface bit-for-bit.
+  - **Python**: `cfg.decode_threads = N` and
+    `cfg.decode_queue_depth = N` (with `None` for the auto-size
+    sentinel) and full `.pyi` stubs. Negatives raise `ValueError`
+    at the setter; explicit `0` is a legal value that the pool
+    clamps to `1` at construction.
+  - **TypeScript**: `cfg.setDecodeThreads(N)` /
+    `cfg.setDecodeQueueDepth(N)` accepting `number | null | undefined`,
+    with regenerated `index.d.ts`. The mirror property getters return
+    `number | null` for the current value.
+  - **C++**: `cfg.set_decode_threads(std::optional<size_t>)` /
+    `cfg.set_decode_queue_depth(std::optional<size_t>)` on
+    `tdx::Config`. `std::nullopt` encodes the auto-size sentinel.
+    The wrappers throw `std::runtime_error` on null-handle FFI
+    failure (unreachable through the RAII contract).
+  - **FFI**: `tdx_config_set_decode_threads(*TdxConfig, size_t) -> int32_t`
+    and `tdx_config_set_decode_queue_depth(*TdxConfig, size_t) -> int32_t`,
+    both C-ABI clean. `n = 0` encodes the auto-size sentinel; any
+    `n > 0` is the explicit `Some(n)` override. Returns `0` on
+    success, `-1` on null-handle (diagnostic via `tdx_last_error()`).
+  - 13 new Python tests, 13 new TypeScript tests, 7 new C++ Catch2
+    tests, 7 new FFI Rust tests.
+
 - MDDS pool-sizing surface on every binding (closes #584). Three
   knobs on `MddsConfig` are now exposed through the Python, TypeScript,
   C++, and FFI surfaces — they previously existed in the Rust core

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -318,6 +318,92 @@ pub unsafe extern "C" fn tdx_config_set_decoder_ring_size(config: *mut TdxConfig
     })
 }
 
+// ── MDDS two-stage decode pipeline (Phase 3 / PR #587 #588) ────────
+//
+// Mirror of `MddsConfig::decode_threads` and `decode_queue_depth`
+// (both `Option<usize>`) onto the C ABI. C callers encode the
+// `None` (auto-size) sentinel with `n = 0`; any `n > 0` is the
+// explicit `Some(n)` override. The Rust core's pool-construction
+// path clamps `Some(0)` to `1` internally, so encoding "explicit 1"
+// with `n = 1` and "auto-size" with `n = 0` gives clean semantics
+// on the C side without leaking the `Option<usize>` shape into the
+// header.
+//
+// Each setter returns `0` on success, `-1` on null-handle (the
+// diagnostic is also written to TLS via `set_error`). This follows
+// the cross-binding contract spelled out in the task brief for
+// Phase 3 -- the existing pool-sizing FFI family (`u32`-arg, `void`
+// return, null-handle no-op) keeps its shape unchanged for ABI
+// stability; the new setters carry an explicit return code so C
+// callers can branch on validation failure without polling
+// `tdx_last_error()` every call.
+
+/// Set the stage-2 worker thread count for the two-stage MDDS
+/// decode pipeline.
+///
+/// Stage-2 runs prost decode + Tick build off a bounded MPSC queue
+/// fed by the stage-1 (per-channel zstd decompress) threads.
+///
+/// * `n = 0` (default) auto-sizes to
+///   `std::thread::available_parallelism()` at connect time.
+///   Mirrors `MddsConfig::decode_threads = None` on the Rust side.
+/// * `n > 0` pins the stage-2 worker count to `n`. The pool clamps
+///   internally to a minimum of `1`, so `n = 1` and the auto-size
+///   default produce identical runtime pool shapes only when the
+///   detected `available_parallelism` happens to be `1`; on any
+///   multi-core host they diverge.
+///
+/// Returns `0` on success, `-1` if `config` is null (also writes the
+/// diagnostic to thread-local storage retrievable via
+/// `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_set_decode_threads(config: *mut TdxConfig, n: usize) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            set_error("config handle is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null pointer returned by
+        // tdx_config_production / tdx_config_dev / tdx_config_stage
+        // and not yet freed.
+        let config = unsafe { &mut *config };
+        config.inner.mdds.decode_threads = if n == 0 { None } else { Some(n) };
+        0
+    })
+}
+
+/// Set the bounded queue depth between stage-1 and stage-2 of the
+/// two-stage MDDS decode pipeline.
+///
+/// When stage-2 cannot keep up, stage-1 parks rather than drops -
+/// silent drops on a market-data feed are unacceptable.
+///
+/// * `n = 0` (default) auto-sizes to `concurrent_requests * 64`
+///   (floor of `64`) at connect time. Mirrors
+///   `MddsConfig::decode_queue_depth = None` on the Rust side.
+/// * `n > 0` pins the queue depth to `n`. The queue clamps
+///   internally to a minimum of `1`.
+///
+/// Returns `0` on success, `-1` if `config` is null.
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_set_decode_queue_depth(
+    config: *mut TdxConfig,
+    n: usize,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            set_error("config handle is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null pointer returned by
+        // tdx_config_production / tdx_config_dev / tdx_config_stage
+        // and not yet freed.
+        let config = unsafe { &mut *config };
+        config.inner.mdds.decode_queue_depth = if n == 0 { None } else { Some(n) };
+        0
+    })
+}
+
 // ── Client ──
 
 /// Connect to `ThetaData` servers (authenticates via Nexus API).
@@ -489,6 +575,147 @@ mod pool_sizing_tests {
             super::tdx_config_set_concurrent_requests(std::ptr::null_mut(), 4);
             super::tdx_config_set_decoder_threads(std::ptr::null_mut(), 4);
             super::tdx_config_set_decoder_ring_size(std::ptr::null_mut(), 256);
+        }
+    }
+}
+
+#[cfg(test)]
+mod decode_pipeline_tests {
+    //! Offline tests for the two-stage decode pipeline setters
+    //! (Phase 3, follow-up to PR #587 / #588).
+    //!
+    //! Each test allocates a fresh `TdxConfig` via `tdx_config_production`,
+    //! calls the setter under test, then reads the underlying Rust
+    //! `MddsConfig::decode_threads` / `decode_queue_depth` field
+    //! (both `Option<usize>`) to confirm the value round-tripped:
+    //!
+    //!   * `n = 0` on the C side encodes the `None` (auto-size)
+    //!     sentinel on the Rust side.
+    //!   * `n > 0` encodes `Some(n)` verbatim.
+    //!   * Null-handle calls return `-1` and surface the diagnostic
+    //!     via `tdx_last_error()`.
+
+    use crate::error::tdx_last_error;
+    use std::ffi::CStr;
+
+    /// Snapshot the current TLS error string for assertions below.
+    fn last_error_text() -> String {
+        // SAFETY: `tdx_last_error` always returns a valid C string
+        // pointer (potentially the empty-string sentinel).
+        unsafe {
+            let p = tdx_last_error();
+            if p.is_null() {
+                return String::new();
+            }
+            CStr::from_ptr(p).to_string_lossy().into_owned()
+        }
+    }
+
+    #[test]
+    fn decode_threads_zero_maps_to_none_sentinel() {
+        let cfg = super::tdx_config_production();
+        assert!(!cfg.is_null());
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            // Production default is already `None`; pin the explicit
+            // round-trip from `Some(x) -> None` to confirm the setter
+            // can return the config to the auto-size sentinel after
+            // an explicit override.
+            (*cfg).inner.mdds.decode_threads = Some(8);
+            let rc = super::tdx_config_set_decode_threads(cfg, 0);
+            assert_eq!(rc, 0);
+            assert_eq!((*cfg).inner.mdds.decode_threads, None);
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn decode_threads_explicit_round_trips_as_some() {
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            for n in [1usize, 2, 4, 8, 16, 32, 64, 4096] {
+                let rc = super::tdx_config_set_decode_threads(cfg, n);
+                assert_eq!(rc, 0);
+                assert_eq!((*cfg).inner.mdds.decode_threads, Some(n));
+            }
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn decode_threads_null_handle_returns_minus_one() {
+        // SAFETY: passing null is the contract — must not crash, must
+        // return -1, must surface a diagnostic via tdx_last_error().
+        unsafe {
+            let rc = super::tdx_config_set_decode_threads(std::ptr::null_mut(), 4);
+            assert_eq!(rc, -1);
+        }
+        let msg = last_error_text();
+        assert!(
+            msg.contains("null"),
+            "null-handle diagnostic must mention the failure mode, got {msg:?}"
+        );
+    }
+
+    #[test]
+    fn decode_queue_depth_zero_maps_to_none_sentinel() {
+        let cfg = super::tdx_config_production();
+        assert!(!cfg.is_null());
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            (*cfg).inner.mdds.decode_queue_depth = Some(1024);
+            let rc = super::tdx_config_set_decode_queue_depth(cfg, 0);
+            assert_eq!(rc, 0);
+            assert_eq!((*cfg).inner.mdds.decode_queue_depth, None);
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn decode_queue_depth_explicit_round_trips_as_some() {
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            for n in [1usize, 64, 128, 512, 2048, 8192, 65536] {
+                let rc = super::tdx_config_set_decode_queue_depth(cfg, n);
+                assert_eq!(rc, 0);
+                assert_eq!((*cfg).inner.mdds.decode_queue_depth, Some(n));
+            }
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn decode_queue_depth_null_handle_returns_minus_one() {
+        // SAFETY: passing null is the contract.
+        unsafe {
+            let rc = super::tdx_config_set_decode_queue_depth(std::ptr::null_mut(), 1024);
+            assert_eq!(rc, -1);
+        }
+        let msg = last_error_text();
+        assert!(
+            msg.contains("null"),
+            "null-handle diagnostic must mention the failure mode, got {msg:?}"
+        );
+    }
+
+    #[test]
+    fn decode_pipeline_setters_compose_with_legacy_pool_sizing() {
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            super::tdx_config_set_concurrent_requests(cfg, 8);
+            super::tdx_config_set_decoder_threads(cfg, 4);
+            super::tdx_config_set_decoder_ring_size(cfg, 1024);
+            assert_eq!(super::tdx_config_set_decode_threads(cfg, 16), 0);
+            assert_eq!(super::tdx_config_set_decode_queue_depth(cfg, 4096), 0);
+            assert_eq!((*cfg).inner.mdds.concurrent_requests, 8);
+            assert_eq!((*cfg).inner.mdds.decoder_threads, 4);
+            assert_eq!((*cfg).inner.mdds.decoder_ring_size, 1024);
+            assert_eq!((*cfg).inner.mdds.decode_threads, Some(16));
+            assert_eq!((*cfg).inner.mdds.decode_queue_depth, Some(4096));
+            super::tdx_config_free(cfg);
         }
     }
 }

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -600,6 +600,44 @@ void tdx_config_set_decoder_threads(TdxConfig* config, uint32_t n);
  */
 void tdx_config_set_decoder_ring_size(TdxConfig* config, uint32_t n);
 
+/* ── MDDS two-stage decode pipeline (Phase 3 / PR #587 #588) ── */
+
+/**
+ * Set the stage-2 worker thread count for the two-stage MDDS decode
+ * pipeline.
+ *
+ * Stage-2 runs prost decode + Tick build off a bounded MPSC queue
+ * fed by the stage-1 (per-channel zstd decompress) threads.
+ *
+ *   n=0 (default): auto-size to available_parallelism() at connect
+ *     time. Mirrors `MddsConfig::decode_threads = None` on the Rust
+ *     side.
+ *   n>0: explicit stage-2 worker count. The pool clamps internally
+ *     to a minimum of 1, so 1 and 0 produce the same runtime pool
+ *     shape; encode "explicit 1" with n=1 and "auto-size" with n=0.
+ *
+ * Returns 0 on success, -1 if `config` is NULL (tdx_last_error()
+ * carries the diagnostic).
+ */
+int32_t tdx_config_set_decode_threads(TdxConfig* config, size_t n);
+
+/**
+ * Set the bounded queue depth between stage-1 and stage-2 of the
+ * two-stage MDDS decode pipeline.
+ *
+ * When stage-2 cannot keep up, stage-1 parks rather than drops --
+ * silent drops on a market-data feed are unacceptable.
+ *
+ *   n=0 (default): auto-size to `concurrent_requests * 64` (floor
+ *     of 64) at connect time. Mirrors `MddsConfig::decode_queue_depth
+ *     = None` on the Rust side.
+ *   n>0: explicit queue depth. The queue clamps internally to a
+ *     minimum of 1, so 1 and 0 produce the same runtime queue shape.
+ *
+ * Returns 0 on success, -1 if `config` is NULL.
+ */
+int32_t tdx_config_set_decode_queue_depth(TdxConfig* config, size_t n);
+
 /* ── Client ── */
 
 /** Connect to ThetaData servers. Returns NULL on connection/auth failure. */

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -581,6 +581,61 @@ public:
         tdx_config_set_decoder_ring_size(handle_.get(), n);
     }
 
+    // ── MDDS two-stage decode pipeline (Phase 3 / PR #587 #588) ──
+
+    /**
+     * Set the stage-2 worker thread count for the two-stage MDDS
+     * decode pipeline.
+     *
+     * Stage-2 runs prost decode + Tick build off a bounded MPSC queue
+     * fed by the stage-1 (per-channel zstd decompress) threads. Pass
+     * @c std::nullopt for the auto-sized default
+     * (@c available_parallelism() on the Rust side); pass an explicit
+     * @c std::size_t for a pinned worker count. The pool clamps
+     * internally to a minimum of 1, so @c std::optional{0} and
+     * @c std::optional{1} produce the same runtime pool shape.
+     *
+     * Throws @c std::runtime_error if the underlying FFI handle is
+     * null (the caller should not be able to reach this with a
+     * destroyed @c Config -- the move-only RAII contract makes that
+     * a use-after-move bug at the call site).
+     */
+    void set_decode_threads(std::optional<std::size_t> n) {
+        const std::size_t arg = n.value_or(0);
+        const std::int32_t rc =
+            tdx_config_set_decode_threads(handle_.get(), arg);
+        if (rc != 0) {
+            const char* err = tdx_last_error();
+            throw std::runtime_error(
+                std::string("tdx_config_set_decode_threads failed: ") +
+                (err == nullptr ? "(null config handle)" : err));
+        }
+    }
+
+    /**
+     * Set the bounded queue depth between stage-1 and stage-2 of the
+     * two-stage MDDS decode pipeline.
+     *
+     * When stage-2 cannot keep up, stage-1 parks rather than drops --
+     * silent drops on a market-data feed are unacceptable. Pass
+     * @c std::nullopt for the auto-sized default
+     * (@c concurrent_requests * 64 with a floor of @c 64); pass an
+     * explicit @c std::size_t for a pinned depth.
+     *
+     * Throws @c std::runtime_error on null-handle FFI failure.
+     */
+    void set_decode_queue_depth(std::optional<std::size_t> n) {
+        const std::size_t arg = n.value_or(0);
+        const std::int32_t rc =
+            tdx_config_set_decode_queue_depth(handle_.get(), arg);
+        if (rc != 0) {
+            const char* err = tdx_last_error();
+            throw std::runtime_error(
+                std::string("tdx_config_set_decode_queue_depth failed: ") +
+                (err == nullptr ? "(null config handle)" : err));
+        }
+    }
+
     /**
      * Install a REST-fallback policy on this config (issue #571
      * mitigation). The policy is borrowed -- the caller retains

--- a/sdks/cpp/tests/CMakeLists.txt
+++ b/sdks/cpp/tests/CMakeLists.txt
@@ -36,6 +36,9 @@ set(THETADX_CPP_TEST_SOURCES
     fallback.cpp
     # MDDS pool-sizing setters on tdx::Config (issue #584).
     config_pool_sizing.cpp
+    # MDDS two-stage decode pipeline setters on tdx::Config
+    # (Phase 3 of 3, follow-up to PR #587 / #588).
+    config_decode_pipeline.cpp
     # Gate 3 (issue #546) - C++ doctest harness. Compiles + runs
     # `// @example` blocks extracted from the public headers.
     doctest_examples.cpp

--- a/sdks/cpp/tests/config_decode_pipeline.cpp
+++ b/sdks/cpp/tests/config_decode_pipeline.cpp
@@ -1,0 +1,118 @@
+// MDDS two-stage decode pipeline setters on tdx::Config
+// (Phase 3 of 3, follow-up to PR #587 / #588).
+//
+// Offline tests pin the contract that the two new setters exposed by
+// the `tdx::Config` C++ wrapper -- `set_decode_threads` and
+// `set_decode_queue_depth` -- accept both `std::nullopt` (auto-size
+// sentinel) and an explicit `std::size_t` (pinned worker count /
+// queue depth) without throwing.
+//
+// The round-trip is observable through the FFI handle's underlying
+// `MddsConfig` field, which the offline C++ test cannot reach
+// directly. The Rust-side `ffi::auth::decode_pipeline_tests` exercises
+// the actual round-trip; the C++ test here pins only that:
+//
+//   * Both setters accept `std::nullopt`, `std::optional{0}`,
+//     `std::optional{1}`, large explicit values without throwing.
+//   * The setters do NOT touch `tdx_last_error()` on success (so a
+//     subsequent error-classifier call observes the cleared state).
+//   * The setters compose with the legacy pool-sizing knobs on the
+//     same `Config` instance.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "thetadx.h"
+#include "thetadx.hpp"
+
+namespace {
+
+/// Read the current TLS error string. Returns the empty string when no
+/// error has been recorded since the last `tdx_clear_error()` (or
+/// since process start).
+std::string last_error_text() {
+    const char* raw = tdx_last_error();
+    return raw == nullptr ? std::string() : std::string(raw);
+}
+
+} // namespace
+
+TEST_CASE("Config::set_decode_threads accepts nullopt (auto-size sentinel)",
+          "[config][decode_pipeline][offline]") {
+    auto cfg = tdx::Config::production();
+    tdx_clear_error();
+    REQUIRE_NOTHROW(cfg.set_decode_threads(std::nullopt));
+    REQUIRE(last_error_text().empty());
+}
+
+TEST_CASE("Config::set_decode_threads accepts explicit values",
+          "[config][decode_pipeline][offline]") {
+    auto cfg = tdx::Config::production();
+    tdx_clear_error();
+    for (std::size_t n : {std::size_t{0}, std::size_t{1}, std::size_t{2},
+                          std::size_t{4}, std::size_t{8}, std::size_t{16},
+                          std::size_t{32}, std::size_t{4096}}) {
+        REQUIRE_NOTHROW(cfg.set_decode_threads(std::optional<std::size_t>{n}));
+        REQUIRE(last_error_text().empty());
+    }
+}
+
+TEST_CASE("Config::set_decode_threads round-trips nullopt after explicit",
+          "[config][decode_pipeline][offline]") {
+    auto cfg = tdx::Config::production();
+    tdx_clear_error();
+    REQUIRE_NOTHROW(cfg.set_decode_threads(std::optional<std::size_t>{8}));
+    REQUIRE_NOTHROW(cfg.set_decode_threads(std::nullopt));
+    REQUIRE_NOTHROW(cfg.set_decode_threads(std::optional<std::size_t>{16}));
+    REQUIRE(last_error_text().empty());
+}
+
+TEST_CASE("Config::set_decode_queue_depth accepts nullopt (auto-size sentinel)",
+          "[config][decode_pipeline][offline]") {
+    auto cfg = tdx::Config::production();
+    tdx_clear_error();
+    REQUIRE_NOTHROW(cfg.set_decode_queue_depth(std::nullopt));
+    REQUIRE(last_error_text().empty());
+}
+
+TEST_CASE("Config::set_decode_queue_depth accepts explicit values",
+          "[config][decode_pipeline][offline]") {
+    auto cfg = tdx::Config::production();
+    tdx_clear_error();
+    for (std::size_t n : {std::size_t{0}, std::size_t{1}, std::size_t{64},
+                          std::size_t{128}, std::size_t{512}, std::size_t{2048},
+                          std::size_t{8192}, std::size_t{65536}}) {
+        REQUIRE_NOTHROW(
+            cfg.set_decode_queue_depth(std::optional<std::size_t>{n}));
+        REQUIRE(last_error_text().empty());
+    }
+}
+
+TEST_CASE("Config::set_decode_queue_depth round-trips nullopt after explicit",
+          "[config][decode_pipeline][offline]") {
+    auto cfg = tdx::Config::production();
+    tdx_clear_error();
+    REQUIRE_NOTHROW(
+        cfg.set_decode_queue_depth(std::optional<std::size_t>{1024}));
+    REQUIRE_NOTHROW(cfg.set_decode_queue_depth(std::nullopt));
+    REQUIRE_NOTHROW(
+        cfg.set_decode_queue_depth(std::optional<std::size_t>{4096}));
+    REQUIRE(last_error_text().empty());
+}
+
+TEST_CASE("Config two-stage pipeline setters compose with legacy pool-sizing",
+          "[config][decode_pipeline][offline]") {
+    auto cfg = tdx::Config::production();
+    tdx_clear_error();
+    cfg.set_concurrent_requests(8);
+    cfg.set_decoder_threads(4);
+    cfg.set_decoder_ring_size(1024);
+    REQUIRE_NOTHROW(cfg.set_decode_threads(std::optional<std::size_t>{16}));
+    REQUIRE_NOTHROW(
+        cfg.set_decode_queue_depth(std::optional<std::size_t>{4096}));
+    REQUIRE(last_error_text().empty());
+}

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -72,6 +72,17 @@ class Config:
     concurrent_requests: int
     decoder_threads: int
     decoder_ring_size: int
+    # MDDS two-stage decode pipeline (Phase 3 / PRs #587 #588 #this).
+    # `decode_threads` controls the stage-2 prost-decode + Tick-build
+    # worker pool size; `decode_queue_depth` controls the bounded MPSC
+    # queue between stage-1 (per-channel zstd decompress) and stage-2.
+    # Both default to `None` (auto-size at connect time): stage-2 sizes
+    # to `os.process_cpu_count()`, queue depth sizes to
+    # `concurrent_requests * 64`. Explicit `int` values override; the
+    # underlying pool clamps `0` to `1` internally so a zero-worker
+    # pool cannot deadlock stage-1. Negative values raise ValueError.
+    decode_threads: Optional[int]
+    decode_queue_depth: Optional[int]
     # Reconnect tunables.
     reconnect_policy: str
     reconnect_max_attempts: int

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -420,6 +420,101 @@ impl Config {
         guard.mdds.decoder_ring_size
     }
 
+    // ── MDDS two-stage decode pipeline knobs — Phase 3 of 3 ────────
+    //
+    // Mirror of the Rust core's `MddsConfig::decode_threads` and
+    // `decode_queue_depth` fields, both `Option<usize>`. The Python
+    // surface accepts `None` for the auto-sized default and `int`
+    // for an explicit override. Setting `0` is legal — the core
+    // clamps `Some(0)` to `1` at pool-construction time so a
+    // zero-worker pool cannot deadlock stage-1 on the first push.
+    // Negatives are rejected at the setter rather than being
+    // silently coerced.
+
+    /// Set the stage-2 worker thread count for the two-stage MDDS
+    /// decode pipeline.
+    ///
+    /// Stage-2 runs `prost::Message::decode` and the downstream Tick
+    /// build off a bounded MPSC queue fed by the stage-1 (per-channel
+    /// zstd decompress) threads. Stage-2 is parser-bound rather than
+    /// IO-bound, so it scales independently of the channel pool size.
+    ///
+    /// ``None`` (the default) auto-sizes to
+    /// :py:func:`os.process_cpu_count` (the same number
+    /// :py:func:`std::thread::available_parallelism` reads on the
+    /// Rust side), matching how Bloomberg / LSEG feed handlers fan
+    /// parsing across every logical core. ``0`` is a legal explicit
+    /// value — the underlying pool clamps it to ``1`` internally so
+    /// stage-1 never deadlocks pushing into a zero-worker pool.
+    /// Explicit values are otherwise retained verbatim.
+    ///
+    /// Raises ``ValueError`` if ``n`` is negative.
+    #[setter]
+    fn set_decode_threads(&self, n: Option<isize>) -> PyResult<()> {
+        let resolved = match n {
+            Some(v) if v < 0 => {
+                return Err(PyValueError::new_err(format!(
+                    "decode_threads must be non-negative; got {v}"
+                )));
+            }
+            Some(v) => Some(v as usize),
+            None => None,
+        };
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.mdds.decode_threads = resolved;
+        Ok(())
+    }
+
+    /// Current `decode_threads` setting. ``None`` means auto-size at
+    /// connect time; an ``int`` is the explicit override.
+    #[getter]
+    fn get_decode_threads(&self) -> Option<usize> {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.mdds.decode_threads
+    }
+
+    /// Set the bounded queue depth between stage-1 and stage-2 of
+    /// the two-stage MDDS decode pipeline.
+    ///
+    /// Stage-1 pushes `DecodedPayload`s into the queue; stage-2
+    /// workers pull them out. When stage-2 cannot keep up, stage-1
+    /// parks rather than drops — silent drops on a market-data feed
+    /// are unacceptable, so the queue prefers backpressure.
+    ///
+    /// ``None`` (the default) sizes the queue to
+    /// ``concurrent_requests * 64`` (with a floor of ``64``), picked
+    /// so a 64-way burst on every configured channel pool has a
+    /// chunk-worth of headroom without leaving stage-2 starved.
+    /// ``0`` is a legal explicit value — the underlying queue clamps
+    /// to ``1`` (a zero-slot rendezvous would degenerate but stays
+    /// backpressure-preserving). Explicit values are otherwise
+    /// retained verbatim.
+    ///
+    /// Raises ``ValueError`` if ``n`` is negative.
+    #[setter]
+    fn set_decode_queue_depth(&self, n: Option<isize>) -> PyResult<()> {
+        let resolved = match n {
+            Some(v) if v < 0 => {
+                return Err(PyValueError::new_err(format!(
+                    "decode_queue_depth must be non-negative; got {v}"
+                )));
+            }
+            Some(v) => Some(v as usize),
+            None => None,
+        };
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.mdds.decode_queue_depth = resolved;
+        Ok(())
+    }
+
+    /// Current `decode_queue_depth` setting. ``None`` means
+    /// auto-size at connect time; an ``int`` is the explicit override.
+    #[getter]
+    fn get_decode_queue_depth(&self) -> Option<usize> {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.mdds.decode_queue_depth
+    }
+
     /// Install a REST-fallback policy for the four h2-cascading
     /// endpoints (issue #571).
     ///

--- a/sdks/python/tests/test_config_decode_pipeline.py
+++ b/sdks/python/tests/test_config_decode_pipeline.py
@@ -1,0 +1,195 @@
+"""MDDS two-stage decode pipeline knobs on ``Config`` (Phase 3 of 3).
+
+Pins the contract that the two new properties exposed by ``Config`` —
+``decode_threads`` (stage-2 prost-decode + Tick-build worker count) and
+``decode_queue_depth`` (bounded MPSC queue between stage-1 and stage-2)
+— round-trip through the pyo3 binding to the underlying Rust
+``MddsConfig`` correctly, including the ``None`` auto-size sentinel,
+the explicit-``0`` (clamps internally to ``1`` at pool construction)
+case, and the rejection of negative values at the setter boundary.
+
+Stage-1 thread count remains controlled by the legacy
+``decoder_threads`` knob (now deprecated-alias-only — see the rustdoc
+on ``MddsConfig::decoder_threads``); this file pins only the new
+Phase-3 stage-2 surface.
+
+Live behaviour (auto-sizing at connect time, the pool's
+``Some(0) -> max(1)`` clamp, queue depth defaulting to
+``concurrent_requests * 64``) is covered by the Rust unit tests under
+``crate::config::tests`` and ``crate::mdds::client``; this file pins
+only the Python surface contract.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _import_module():
+    """Import the freshly-built native module from ``maturin develop``."""
+    return importlib.import_module("thetadatadx")
+
+
+# ─── decode_threads ─────────────────────────────────────────────────
+
+
+def test_decode_threads_defaults_to_none_auto_size_sentinel():
+    """``decode_threads = None`` is the auto-size sentinel.
+
+    Matches the Rust core's ``MddsConfig::decode_threads = None``
+    default. The pool resolves ``None`` to
+    ``std::thread::available_parallelism()`` at connect time.
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    assert cfg.decode_threads is None
+
+
+def test_decode_threads_round_trips_with_none():
+    """Writing ``None`` after an explicit value returns to auto-size."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.decode_threads = 8
+    assert cfg.decode_threads == 8
+    cfg.decode_threads = None
+    assert cfg.decode_threads is None
+
+
+def test_decode_threads_round_trips_with_explicit_int():
+    """Explicit ``int`` values round-trip verbatim."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    for n in (1, 2, 4, 8, 16, 32, 64):
+        cfg.decode_threads = n
+        assert cfg.decode_threads == n
+
+
+def test_decode_threads_explicit_zero_is_legal():
+    """Explicit ``0`` is a legal value — the pool clamps to ``1`` internally.
+
+    The Python setter does NOT raise on ``0``: the Rust core's
+    ``Some(0) -> n.max(1)`` clamp at pool construction makes ``0`` a
+    semantically valid input distinct from ``None`` (auto-size).
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.decode_threads = 0
+    assert cfg.decode_threads == 0
+
+
+def test_decode_threads_rejects_negative_values():
+    """Negative ``decode_threads`` must raise ``ValueError`` at the setter."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    with pytest.raises(ValueError, match=r"decode_threads"):
+        cfg.decode_threads = -1
+
+
+def test_decode_threads_retains_large_value_verbatim():
+    """Operators on under-detected hosts may pin a large explicit count."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.decode_threads = 4096
+    assert cfg.decode_threads == 4096
+
+
+# ─── decode_queue_depth ─────────────────────────────────────────────
+
+
+def test_decode_queue_depth_defaults_to_none_auto_size_sentinel():
+    """``decode_queue_depth = None`` is the auto-size sentinel.
+
+    The pool resolves ``None`` to ``concurrent_requests * 64`` at
+    connect time (with a floor of 64).
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    assert cfg.decode_queue_depth is None
+
+
+def test_decode_queue_depth_round_trips_with_none():
+    """Writing ``None`` after an explicit value returns to auto-size."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.decode_queue_depth = 1024
+    assert cfg.decode_queue_depth == 1024
+    cfg.decode_queue_depth = None
+    assert cfg.decode_queue_depth is None
+
+
+def test_decode_queue_depth_round_trips_with_explicit_int():
+    """Explicit ``int`` values round-trip verbatim."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    for n in (1, 64, 128, 512, 2048, 8192):
+        cfg.decode_queue_depth = n
+        assert cfg.decode_queue_depth == n
+
+
+def test_decode_queue_depth_explicit_zero_is_legal():
+    """Explicit ``0`` is a legal value — the queue clamps to ``1`` internally.
+
+    Matches the ``Some(0) -> max(1)`` clamp in
+    ``crate::mdds::client::pool_with_decoders``.
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.decode_queue_depth = 0
+    assert cfg.decode_queue_depth == 0
+
+
+def test_decode_queue_depth_rejects_negative_values():
+    """Negative ``decode_queue_depth`` must raise ``ValueError`` at the setter."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    with pytest.raises(ValueError, match=r"decode_queue_depth"):
+        cfg.decode_queue_depth = -1
+
+
+def test_decode_queue_depth_retains_large_value_verbatim():
+    """Wide-strike backfills may pin a queue depth far above the default."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.decode_queue_depth = 65_536
+    assert cfg.decode_queue_depth == 65_536
+
+
+# ─── Combined invariants ────────────────────────────────────────────
+
+
+def test_decode_threads_and_queue_depth_are_independent():
+    """The two stage-2 setters do not interfere with each other.
+
+    Round-tripping each property after writing the other must return
+    the values last written.
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.decode_threads = 16
+    cfg.decode_queue_depth = 4096
+    assert cfg.decode_threads == 16
+    assert cfg.decode_queue_depth == 4096
+
+
+def test_decode_pipeline_setters_are_independent_from_legacy_pool_sizing():
+    """The Phase-3 setters do not collide with the legacy pool-sizing knobs.
+
+    ``concurrent_requests`` (channel pool), ``decoder_threads`` (stage-1
+    zstd decompress), and ``decoder_ring_size`` (per-thread Disruptor
+    depth) must round-trip unchanged when the two-stage knobs are also
+    set on the same ``Config``.
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.concurrent_requests = 8
+    cfg.decoder_threads = 4
+    cfg.decoder_ring_size = 1024
+    cfg.decode_threads = 16
+    cfg.decode_queue_depth = 4096
+    assert cfg.concurrent_requests == 8
+    assert cfg.decoder_threads == 4
+    assert cfg.decoder_ring_size == 1024
+    assert cfg.decode_threads == 16
+    assert cfg.decode_queue_depth == 4096

--- a/sdks/typescript/__tests__/decode_pool.test.mjs
+++ b/sdks/typescript/__tests__/decode_pool.test.mjs
@@ -1,0 +1,144 @@
+// MDDS two-stage decode pipeline knobs on `Config` (Phase 3 of 3).
+//
+// Locks the contract that the two new properties exposed by the
+// `Config` napi class — `decodeThreads` (stage-2 prost-decode +
+// Tick-build worker count) and `decodeQueueDepth` (bounded MPSC
+// queue between stage-1 and stage-2) — round-trip through napi-rs
+// to the underlying Rust `MddsConfig` correctly, including:
+//
+//   * `null` / `undefined` is the auto-size sentinel (the napi
+//     binding folds both to `None` on the Rust side).
+//   * A `number` is the explicit override, retained verbatim.
+//   * `0` is a legal explicit value (the pool clamps to `1`
+//     internally at connect time).
+//
+// Stage-1 thread count remains controlled by the legacy
+// `decoderThreads` knob; this file pins only the new Phase-3
+// stage-2 surface.
+//
+// Live behaviour (auto-sizing at connect time, the `Some(0) -> max(1)`
+// clamp, queue depth defaulting to `concurrent_requests * 64`) is
+// covered by the Rust unit tests; this file pins only the JS
+// surface contract.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+let mod;
+try {
+  mod = await import('../index.js');
+} catch {
+  console.log('SKIP: native addon not built (run `npm run build` first)');
+  process.exit(0);
+}
+
+const { Config } = mod;
+
+describe('Config.decodeThreads', () => {
+  it('defaults to null (auto-size sentinel)', () => {
+    const cfg = Config.production();
+    assert.equal(cfg.decodeThreads, null);
+  });
+
+  it('round-trips through the setter with an explicit number', () => {
+    const cfg = Config.production();
+    for (const n of [1, 2, 4, 8, 16, 32]) {
+      cfg.setDecodeThreads(n);
+      assert.equal(cfg.decodeThreads, n);
+    }
+  });
+
+  it('accepts null and returns to the auto-size sentinel', () => {
+    const cfg = Config.production();
+    cfg.setDecodeThreads(8);
+    assert.equal(cfg.decodeThreads, 8);
+    cfg.setDecodeThreads(null);
+    assert.equal(cfg.decodeThreads, null);
+  });
+
+  it('accepts undefined and returns to the auto-size sentinel', () => {
+    const cfg = Config.production();
+    cfg.setDecodeThreads(8);
+    assert.equal(cfg.decodeThreads, 8);
+    cfg.setDecodeThreads(undefined);
+    assert.equal(cfg.decodeThreads, null);
+  });
+
+  it('accepts an explicit 0 (pool clamps to 1 internally)', () => {
+    const cfg = Config.production();
+    cfg.setDecodeThreads(0);
+    assert.equal(cfg.decodeThreads, 0);
+  });
+
+  it('retains a large value verbatim', () => {
+    const cfg = Config.production();
+    cfg.setDecodeThreads(4096);
+    assert.equal(cfg.decodeThreads, 4096);
+  });
+});
+
+describe('Config.decodeQueueDepth', () => {
+  it('defaults to null (auto-size sentinel)', () => {
+    const cfg = Config.production();
+    assert.equal(cfg.decodeQueueDepth, null);
+  });
+
+  it('round-trips through the setter with an explicit number', () => {
+    const cfg = Config.production();
+    for (const n of [1, 64, 128, 512, 2048, 8192]) {
+      cfg.setDecodeQueueDepth(n);
+      assert.equal(cfg.decodeQueueDepth, n);
+    }
+  });
+
+  it('accepts null and returns to the auto-size sentinel', () => {
+    const cfg = Config.production();
+    cfg.setDecodeQueueDepth(1024);
+    assert.equal(cfg.decodeQueueDepth, 1024);
+    cfg.setDecodeQueueDepth(null);
+    assert.equal(cfg.decodeQueueDepth, null);
+  });
+
+  it('accepts undefined and returns to the auto-size sentinel', () => {
+    const cfg = Config.production();
+    cfg.setDecodeQueueDepth(1024);
+    assert.equal(cfg.decodeQueueDepth, 1024);
+    cfg.setDecodeQueueDepth(undefined);
+    assert.equal(cfg.decodeQueueDepth, null);
+  });
+
+  it('accepts an explicit 0 (queue clamps to 1 internally)', () => {
+    const cfg = Config.production();
+    cfg.setDecodeQueueDepth(0);
+    assert.equal(cfg.decodeQueueDepth, 0);
+  });
+
+  it('retains a large value verbatim', () => {
+    const cfg = Config.production();
+    cfg.setDecodeQueueDepth(65536);
+    assert.equal(cfg.decodeQueueDepth, 65536);
+  });
+});
+
+describe('Config two-stage pipeline setters are independent', () => {
+  it('do not interfere with each other', () => {
+    const cfg = Config.production();
+    cfg.setDecodeThreads(16);
+    cfg.setDecodeQueueDepth(4096);
+    assert.equal(cfg.decodeThreads, 16);
+    assert.equal(cfg.decodeQueueDepth, 4096);
+  });
+
+  it('do not interfere with the legacy pool-sizing knobs', () => {
+    const cfg = Config.production();
+    cfg.setConcurrentRequests(8);
+    cfg.setDecoderThreads(4);
+    cfg.setDecoderRingSize(1024);
+    cfg.setDecodeThreads(16);
+    cfg.setDecodeQueueDepth(4096);
+    assert.equal(cfg.concurrentRequests, 8);
+    assert.equal(cfg.decoderThreads, 4);
+    assert.equal(cfg.decoderRingSize, 1024);
+    assert.equal(cfg.decodeThreads, 16);
+    assert.equal(cfg.decodeQueueDepth, 4096);
+  });
+});

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -70,6 +70,41 @@ export declare class Config {
   setDecoderRingSize(n: number): void
   /** Current `decoder_ring_size` setting. */
   get decoderRingSize(): number
+  /**
+   * Set the stage-2 worker thread count for the two-stage MDDS
+   * decode pipeline.
+   *
+   * Stage-2 runs `prost::Message::decode` and the downstream Tick
+   * build off a bounded MPSC queue fed by the stage-1 (per-channel
+   * zstd decompress) threads. Pass `null` or `undefined` for the
+   * auto-sized default (`std::thread::available_parallelism()` on
+   * the Rust side); pass a `number` for an explicit override.
+   * `0` is a legal explicit value — the pool clamps it to `1`
+   * internally.
+   */
+  setDecodeThreads(n?: number | undefined | null): void
+  /**
+   * Current `decode_threads` setting. `null` means auto-size at
+   * connect time; a `number` is the explicit override.
+   */
+  get decodeThreads(): number | null
+  /**
+   * Set the bounded queue depth between stage-1 and stage-2 of
+   * the two-stage MDDS decode pipeline.
+   *
+   * Stage-1 pushes `DecodedPayload`s into the queue; stage-2
+   * workers pull them out. When stage-2 cannot keep up, stage-1
+   * parks rather than drops. Pass `null` or `undefined` for the
+   * auto-sized default (`concurrent_requests * 64` with a floor
+   * of `64`); pass a `number` for an explicit override. `0` is a
+   * legal explicit value — the queue clamps it to `1` internally.
+   */
+  setDecodeQueueDepth(n?: number | undefined | null): void
+  /**
+   * Current `decode_queue_depth` setting. `null` means auto-size
+   * at connect time; a `number` is the explicit override.
+   */
+  get decodeQueueDepth(): number | null
 }
 
 /**

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "napi build --platform --release && node scripts/postbuild_alias_contract.mjs",
     "build:debug": "napi build --platform && node scripts/postbuild_alias_contract.mjs",
-    "test": "node --test __tests__/basic.test.mjs __tests__/dropped_events.test.mjs __tests__/asyncdispose.test.mjs __tests__/util_helpers.test.mjs __tests__/iter_mode.test.mjs __tests__/fpss_control_variants.test.mjs __tests__/streaming-iter.test.mjs __tests__/typed-errors.test.mjs __tests__/fallback.test.mjs __tests__/config_pool_sizing.test.mjs",
+    "test": "node --test __tests__/basic.test.mjs __tests__/dropped_events.test.mjs __tests__/asyncdispose.test.mjs __tests__/util_helpers.test.mjs __tests__/iter_mode.test.mjs __tests__/fpss_control_variants.test.mjs __tests__/streaming-iter.test.mjs __tests__/typed-errors.test.mjs __tests__/fallback.test.mjs __tests__/config_pool_sizing.test.mjs __tests__/decode_pool.test.mjs",
     "version": "napi version"
   },
   "devDependencies": {

--- a/sdks/typescript/src/fallback.rs
+++ b/sdks/typescript/src/fallback.rs
@@ -253,6 +253,83 @@ impl Config {
         Ok(u32::try_from(guard.mdds.decoder_ring_size).unwrap_or(u32::MAX))
     }
 
+    // ── MDDS two-stage decode pipeline knobs — Phase 3 of 3 ────────
+    //
+    // Mirror of the Rust core's `MddsConfig::decode_threads` and
+    // `decode_queue_depth` fields, both `Option<usize>`. The JS
+    // surface accepts `null` / `undefined` (mapped to `None` on the
+    // napi side) for the auto-sized default and a `number` for an
+    // explicit override. `0` is a legal explicit input — the core
+    // clamps `Some(0)` to `1` at pool construction time so a
+    // zero-worker pool cannot deadlock stage-1 on the first push.
+
+    /// Set the stage-2 worker thread count for the two-stage MDDS
+    /// decode pipeline.
+    ///
+    /// Stage-2 runs `prost::Message::decode` and the downstream Tick
+    /// build off a bounded MPSC queue fed by the stage-1 (per-channel
+    /// zstd decompress) threads. Pass `null` or `undefined` for the
+    /// auto-sized default (`std::thread::available_parallelism()` on
+    /// the Rust side); pass a `number` for an explicit override.
+    /// `0` is a legal explicit value — the pool clamps it to `1`
+    /// internally.
+    #[napi(js_name = "setDecodeThreads")]
+    pub fn set_decode_threads(&self, n: Option<u32>) -> napi::Result<()> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.mdds.decode_threads = n.map(|v| v as usize);
+        Ok(())
+    }
+
+    /// Current `decode_threads` setting. `null` means auto-size at
+    /// connect time; a `number` is the explicit override.
+    #[napi(getter, js_name = "decodeThreads")]
+    pub fn decode_threads(&self) -> napi::Result<Option<u32>> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard
+            .mdds
+            .decode_threads
+            .map(|n| u32::try_from(n).unwrap_or(u32::MAX)))
+    }
+
+    /// Set the bounded queue depth between stage-1 and stage-2 of
+    /// the two-stage MDDS decode pipeline.
+    ///
+    /// Stage-1 pushes `DecodedPayload`s into the queue; stage-2
+    /// workers pull them out. When stage-2 cannot keep up, stage-1
+    /// parks rather than drops. Pass `null` or `undefined` for the
+    /// auto-sized default (`concurrent_requests * 64` with a floor
+    /// of `64`); pass a `number` for an explicit override. `0` is a
+    /// legal explicit value — the queue clamps it to `1` internally.
+    #[napi(js_name = "setDecodeQueueDepth")]
+    pub fn set_decode_queue_depth(&self, n: Option<u32>) -> napi::Result<()> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.mdds.decode_queue_depth = n.map(|v| v as usize);
+        Ok(())
+    }
+
+    /// Current `decode_queue_depth` setting. `null` means auto-size
+    /// at connect time; a `number` is the explicit override.
+    #[napi(getter, js_name = "decodeQueueDepth")]
+    pub fn decode_queue_depth(&self) -> napi::Result<Option<u32>> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard
+            .mdds
+            .decode_queue_depth
+            .map(|n| u32::try_from(n).unwrap_or(u32::MAX)))
+    }
+
     /// Take a snapshot of the underlying [`thetadatadx::DirectConfig`]
     /// for use by `ThetaDataDxClient.connectWithConfig`. Returns a
     /// fresh `DirectConfig` clone -- the napi `Config` remains usable


### PR DESCRIPTION
## Summary

Phase 3 (final) of the two-stage MDDS decode pipeline rollout. Mirrors `MddsConfig::decode_threads` and `MddsConfig::decode_queue_depth` (both `Option<usize>`, landed in PR #587, exercised by PR #588) onto the Python, TypeScript, C++, and FFI bindings so external callers can size the stage-2 prost-decode + Tick-build worker pool and the bounded MPSC queue independently of channel count.

## Surface per binding

| Binding | Setter | Auto-size sentinel | Explicit override |
|---------|--------|--------------------|-------------------|
| Python | `cfg.decode_threads = N` / `cfg.decode_queue_depth = N` | `None` | `int` (negatives raise `ValueError`; explicit `0` is legal) |
| TypeScript | `cfg.setDecodeThreads(N)` / `cfg.setDecodeQueueDepth(N)` | `null` / `undefined` | `number` |
| C++ | `cfg.set_decode_threads(std::optional<size_t>)` / `cfg.set_decode_queue_depth(std::optional<size_t>)` | `std::nullopt` | `std::size_t` |
| FFI | `tdx_config_set_decode_threads(*Config, size_t) -> int32_t` / `tdx_config_set_decode_queue_depth(*Config, size_t) -> int32_t` | `n = 0` | any `n > 0`. Returns `-1` on null-handle |

## Semantics

* `None` / `null` / `std::nullopt` / `n = 0` on the FFI encodes the auto-size default: stage-2 worker count resolves to `std::thread::available_parallelism()` and queue depth resolves to `concurrent_requests * 64` (floor 64) at connect time.
* Explicit values round-trip verbatim. The Rust core's pool-construction path clamps `Some(0)` to `1` internally so a zero-worker pool cannot deadlock stage-1 on the first push.
* Negatives are rejected at the Python setter boundary with `ValueError`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --tests --benches -- -D warnings`
- [x] `cargo doc --no-deps --workspace --locked`
- [x] `cargo run -p thetadatadx --bin generate_sdk_surfaces --locked -- --check` (wire-schema-drift)
- [x] `cargo bench --no-run --workspace` (criterion harness compiles)
- [x] `cd sdks/python && maturin develop --release && pytest tests/ -q` (325 passed, 30 skipped)
- [x] `python -m mypy.stubtest thetadatadx --allowlist stubtest_allowlist.txt`
- [x] `cd sdks/typescript && npm run build && npm test` (57 passed, 0 failed)
- [x] C++ Catch2 offline suite (29 / 29 passed, 7 live skipped)
- [x] `python3 scripts/check_c_abi_completeness.py` (160 symbols, all present in headers)
- [x] `python3 scripts/check_binding_parity.py` (clean, 30 explicit + 131 implicit rows)
- [x] CHANGELOG mirror (`diff CHANGELOG.md docs-site/docs/changelog.md` → empty)
- [x] Child Cargo.lock files audited via `cargo update -p thetadatadx` (no version drift)

## New tests landed

- 13 Python pytest cases under `sdks/python/tests/test_config_decode_pipeline.py`
- 13 TypeScript `node --test` cases under `sdks/typescript/__tests__/decode_pool.test.mjs`
- 7 C++ Catch2 cases under `sdks/cpp/tests/config_decode_pipeline.cpp`
- 7 FFI Rust unit tests under `ffi::auth::decode_pipeline_tests`

## Related

- PR #587 — Phase 1 (core scaffold)
- PR #588 — Phase 2 (criterion benches)
- This PR closes the two-stage decode pipeline rollout campaign

🤖 Generated with [Claude Code](https://claude.com/claude-code)