### PR TITLE
refactor: close 5-axis audit round 4 (test harness coverage + flatfiles spec + poison-race + parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   home for reference spec; the stale link to
   `docs-site/docs/flatfiles/protocol.md` (file never existed) is
   gone from `flatfiles::{mod,index}` and from the changelog.
-- TypeScript `npm test` script now globs the `__tests__/*.test.mjs`
-  directory instead of explicitly listing each file. The
-  `config_reconnect.test.mjs` reconnect-parity coverage landed in
-  round 3 but was not in the explicit list and silently skipped in
-  CI. Glob avoids the same trap on future test files.
+- TypeScript `npm test` script delegates to
+  `scripts/run_tests.mjs`, which walks `__tests__/` and hands every
+  `*.test.mjs` file to `node --test` as explicit argv. Replaces the
+  prior explicit-file list (which silently skipped the
+  `config_reconnect.test.mjs` reconnect-parity coverage that landed
+  in round 3). A shell-glob form (`node --test __tests__/*.test.mjs`)
+  also fails because Windows PowerShell does not expand it and
+  Node's own `--test` glob support is 22+; the explicit-argv runner
+  works on every supported shell and on every Node version
+  satisfying `engines.node >= 20`. The runner exits non-zero when
+  no test files are found, so a future regression that empties
+  the directory cannot silently pass CI.
 - `bench-internals` feature removed in favour of an out-of-Cargo
   `--cfg bench_internals` flag. `Stage2Pool::submit_for_bench`
   remains gated, but downstream consumers can no longer enable it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Release line note**: this train accumulates 6 major + 1 minor breaking changes
+> versus v10.0.0. The next release tag MUST be v11.0.0, not a v10.0.x patch.
+> Owner-greenlight gated on this audit returning zero actionable findings.
+
 ### Changed
 
+- TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint`
+  (was `number`) for true `u64` parity with the Python / C++ / FFI
+  surface. Callers passing `Number` should wrap:
+  `cfg.setReconnectStableWindowSecs(BigInt(60))`. Negative or
+  >`u64::MAX` BigInt inputs are rejected at the boundary with a
+  descriptive error rather than silently truncating.
+- TypeScript reconnect setter JSDoc adds the `"custom"` policy
+  qualifier so the cross-binding docstring parity with Python's
+  `Deprecated since v10.0.1...` style is restored. The setters are
+  silent no-ops under `"manual"` and `"custom"` policies; only the
+  `Auto(limits)` variant consumes the values.
+- Stage-1 → stage-2 backpressure send no longer parks indefinitely
+  on a `crossbeam_channel::Sender::send` if every stage-2 worker
+  panics *while* stage-1 is already blocked on a full queue.
+  `Stage2PoolSender::send` now parks in
+  `POISON_CHECK_INTERVAL` (50 ms) slices via `send_timeout` and
+  re-reads the pool's poison flag between slices, so a worker
+  panic mid-park surfaces as `Stage2SendError::Poisoned` within
+  one slice instead of wedging stage-1 forever. Regression test
+  (`poisoned_pool_releases_parked_producer_within_one_second`)
+  pins the bounded wakeup under one-second deadline.
+- FLATFILES wire-format reference docs restored at the
+  `crate::flatfiles::index` module rustdoc (on-disk header layout,
+  INDEX entry shape, contract-key encoding per `SecType`,
+  strike-in-tenths-of-cent convention). Module docs are the right
+  home for reference spec; the stale link to
+  `docs-site/docs/flatfiles/protocol.md` (file never existed) is
+  gone from `flatfiles::{mod,index}` and from the changelog.
+- TypeScript `npm test` script now globs the `__tests__/*.test.mjs`
+  directory instead of explicitly listing each file. The
+  `config_reconnect.test.mjs` reconnect-parity coverage landed in
+  round 3 but was not in the explicit list and silently skipped in
+  CI. Glob avoids the same trap on future test files.
 - `bench-internals` feature removed in favour of an out-of-Cargo
   `--cfg bench_internals` flag. `Stage2Pool::submit_for_bench`
   remains gated, but downstream consumers can no longer enable it
@@ -49,11 +86,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to match field-level setters. Tracked for per-field granularity
   refactor in issue #595.
 - Legacy single-stage MDDS decode path replaces the per-chunk
-  `Box<dyn FnOnce>` allocation with a typed
+  `Box<dyn FnOnce>` closure with a typed
   `DecodeRequest::SingleStage { response, max_message_size, reply }`
   variant. The decoder thread runs `decode_data_table_with_max`
-  directly on the typed payload; no closure boxing on the hot
-  path.
+  directly on the typed payload, avoiding the per-chunk
+  dynamic-dispatch vtable indirection the boxed `FnOnce` carried
+  (the per-chunk allocation count is unchanged — the box is now
+  for the typed struct instead of the closure).
 - Python `Config.decoder_threads` getter and setter prepend a
   `Deprecated since v10.0.1: set decode_threads instead.`
   deprecation line. Visible via `help(type(c).decoder_threads)`.
@@ -74,12 +113,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `*_grpc_arm_dispatches` → `*_grpc_arm_forwards_end_date` to match
   the contract.
 - Module headers across `fpss::{mod, pinning, wake}`,
-  `flatfiles::{mod, index}`, `rest::mod`, `frames::mod`,
-  `grpc::decoder_pool` compressed to one paragraph each — the
-  multi-paragraph architectural narratives now live in the docs
-  site (`docs-site/docs/streaming/index.md`,
-  `docs-site/docs/flatfiles/protocol.md`,
-  `docs-site/docs/streaming/latency.md`).
+  `rest::mod`, `frames::mod`, `grpc::decoder_pool` compressed to
+  one paragraph each — the multi-paragraph architectural narratives
+  now live in the docs site (`docs-site/docs/streaming/index.md`,
+  `docs-site/docs/streaming/latency.md`). FLATFILES on-disk wire
+  layout remains at the `crate::flatfiles::index` module level as
+  the reference spec.
 - Issue / PR references stripped from `///` user-facing rustdoc
   across the public surface (`client.rs`, `grpc/stream.rs`,
   `fpss/framing.rs`, `mdds/macros.rs`,
@@ -137,12 +176,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enclosing fn …` line in `ffi/src/{flatfiles,streaming,utility,types}.rs`
   rewritten to name the specific invariant the local `unsafe`
   consumes (pointer provenance, layout, lifetime, ordering).
-- `Stage2Pool::submit_for_bench` feature-gated behind
-  `cfg(any(test, feature = "bench-internals"))` so the bench-only
-  entry point does not appear on the production public surface.
-  `crates/thetadatadx/benches/bench_stage_pipeline.rs` declares
-  `required-features = ["bench-internals"]` in the
-  `[[bench]]` entry so `cargo bench` enables it automatically.
 - `crate::grpc::decoder_pool::backoff_ring_full` split into
   `backoff_ring_full_async(duration)` (tokio multi-thread; honours
   the duration via `block_in_place + thread::sleep`) and
@@ -197,9 +230,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without a clean GitHub-hosted runner pass
   (`decoder_pool/threads/4`, `protobuf_decode/quote_chunk/1024`,
   `stage_pipeline/throughput/workers=4`).
-- `bench-internals` cargo feature on `thetadatadx`, opt-in surface
-  for the bench harness only (see `Changed` for the gating
-  rationale).
 
 ### Removed
 

--- a/crates/thetadatadx/build_support_bin/endpoints/mod.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/mod.rs
@@ -51,8 +51,8 @@ pub fn check_sdk_generated_files(repo_root: &Path) -> Result<(), Box<dyn std::er
 /// 1. Snapshot / calendar endpoints (`is_snapshot_endpoint`) — the
 ///    original consumer; uses the converter on the latency-sensitive
 ///    fast path that skips the `<TickName>List` wrapper allocation.
-/// 2. Parsed-endpoint `.stream(handler)` terminals (issue #565) — the
-///    OOM-fix consumer; uses the converter to build a per-chunk
+/// 2. Parsed-endpoint `.stream(handler)` terminals — the OOM-fix
+///    consumer; uses the converter to build a per-chunk
 ///    `Py<PyList>` of typed tick instances handed to the user's
 ///    callback. Without this, every parsed endpoint with a wide
 ///    response (`option_history_quote`, `stock_history_trade`, ...)

--- a/crates/thetadatadx/build_support_bin/endpoints/modes.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/modes.rs
@@ -197,8 +197,8 @@ fn category_symbol<'a>(fixtures: &'a TestFixtures, category: &str) -> &'a str {
 ///
 /// Resolution order:
 ///   1. `test_fixtures.concrete_overrides[param.name]` — per-name overrides
-///      (e.g. compressed `end_date` keeping bulk cells under the 60s
-///      per-cell timeout; see issue #290).
+///      (e.g. compressed `end_date` keeping bulk cells under the 60 s
+///      per-cell timeout the in-CI integration matrix enforces).
 ///   2. `test_fixtures.category_symbol[endpoint.category]` — for
 ///      `Symbol`/`Symbols` params.
 ///   3. `test_fixtures.concrete_by_type[param.param_type]` — default

--- a/crates/thetadatadx/src/flatfiles/index.rs
+++ b/crates/thetadatadx/src/flatfiles/index.rs
@@ -1,12 +1,50 @@
 //! INDEX walker for the raw FLATFILES blob.
 //!
-//! Big-endian on-disk layout: a header with the column-DataType codes
-//! and the INDEX / DATA section lengths, followed by variable-length
-//! INDEX entries (each carries a sec-type-specific contract key plus
-//! `[block_start, block_end)` byte offsets into DATA). The DATA
-//! section is FIT-encoded per the header schema; see
-//! [`crate::flatfiles::decode`]. Full wire layout in
-//! `docs-site/docs/flatfiles/protocol.md`.
+//! # On-disk layout
+//!
+//! The raw blob the wire layer accumulates is one contiguous stream:
+//!
+//! ```text
+//! offset 0   :  i32 BE  fmt_count          number of column DataType codes
+//!         4 :  fmt_count × i32 BE          DataType.code() per column
+//!         …  :  i64 BE  index_byte_len     bytes of INDEX after this header
+//!         …  :  i64 BE  data_byte_len      bytes of DATA after the INDEX
+//!         …  :  index_byte_len bytes      INDEX entries (see below)
+//!         …  :  data_byte_len  bytes      DATA — concatenated FIT blocks
+//! ```
+//!
+//! All multi-byte integers are big-endian (network order).
+//!
+//! # INDEX entries
+//!
+//! Each entry occupies a variable-length record:
+//!
+//! ```text
+//!   u16 BE  entry_size                     bytes of entry_payload
+//!   entry_payload  (entry_size bytes)      sec-type-dependent contract key
+//!   i32 BE  block_volume                   "volume" hint (unused by SDK)
+//!   i64 BE  block_start                    byte offset into DATA section
+//!   i64 BE  block_end                      one past the last byte (exclusive)
+//! ```
+//!
+//! The contract key inside `entry_payload` is:
+//!
+//! - Option / Index:
+//!   ```text
+//!     u8 root_len ; root_utf8 ; i32 BE exp ; u8 right ; i32 BE strike ; i32 BE date
+//!   ```
+//!   `right` is the ASCII byte `'C'` (0x43) or `'P'` (0x50). `exp` and
+//!   `date` are `YYYYMMDD` integers; `strike` is in tenths of a cent
+//!   (vendor convention — strike `210000` ≡ $210.00).
+//! - Stock:
+//!   ```text
+//!     u8 root_len ; root_utf8 ; i32 BE date
+//!   ```
+//!
+//! The DATA section at `[block_start..block_end]` is FIT-encoded for the
+//! per-column schema given by the header `fmt_count` codes. Each row in
+//! the block corresponds to exactly one tick for that contract; see the
+//! [`crate::flatfiles::decode`] module for the per-block FIT walk.
 
 use std::io::{Cursor, Read};
 

--- a/crates/thetadatadx/src/flatfiles/mod.rs
+++ b/crates/thetadatadx/src/flatfiles/mod.rs
@@ -7,9 +7,10 @@
 //! [`flatfile_request_raw`] (raw INDEX + DATA blob). All three are
 //! also reachable via [`crate::ThetaDataDxClient`].
 //!
-//! Wire protocol + auth handshake + server identity (SPKI-pinned via
-//! `mdds_spki::MddsSpkiVerifier`) are described in
-//! `docs-site/docs/flatfiles/protocol.md`.
+//! Server identity is SPKI-pinned via the internal
+//! `mdds_spki::MddsSpkiVerifier`. On-disk blob layout is documented
+//! at the module level in `crate::flatfiles::index` (private; see
+//! `cargo doc --document-private-items`).
 
 pub(crate) mod datatype;
 pub(crate) mod decode;

--- a/crates/thetadatadx/src/grpc/decoder_pool.rs
+++ b/crates/thetadatadx/src/grpc/decoder_pool.rs
@@ -166,16 +166,19 @@ enum DecodeRequest {
     /// Legacy work-closure request — bench / fixture only. Used by
     /// [`DecoderHandle::submit_work`]; production
     /// [`DecoderHandle::submit`] now uses
-    /// [`DecodeRequest::SingleStage`] which avoids the per-chunk
-    /// closure allocation.
+    /// [`DecodeRequest::SingleStage`] which avoids per-chunk
+    /// dynamic-dispatch vtable indirection.
     #[cfg(test)]
     Legacy(LegacyRequest),
     /// Single-stage typed request. Replaces the per-chunk
-    /// `Box<dyn FnOnce>` allocation on the legacy
+    /// `Box<dyn FnOnce>` closure on the legacy
     /// [`DecoderHandle::submit`] path — the typed enum hands the
     /// `proto::ResponseData` and max-message-size knob through the
     /// queue and the decoder thread runs the same
-    /// `decode_data_table_with_max` call directly.
+    /// `decode_data_table_with_max` call directly. The per-chunk
+    /// allocation count is unchanged (the boxed payload is now the
+    /// typed struct instead of the closure); the win is the
+    /// elimination of the `dyn FnOnce` vtable indirection.
     SingleStage(Box<SingleStageRequest>),
     /// Two-stage stage-1 request. Boxed so the enum stays small
     /// even though `Stage1Request` carries a full
@@ -186,7 +189,8 @@ enum DecodeRequest {
 /// Legacy work-closure request shape — used by the bench / fixture
 /// surface via [`DecoderHandle::submit_work`]. Production
 /// `DecoderHandle::submit` calls use [`SingleStageRequest`] instead
-/// to avoid the per-chunk `Box<dyn FnOnce>` allocation.
+/// to avoid per-chunk dynamic-dispatch vtable indirection on the
+/// boxed `dyn FnOnce` closure.
 #[cfg(test)]
 struct LegacyRequest {
     work: Box<dyn FnOnce() -> DecodeResult + Send + 'static>,
@@ -194,8 +198,11 @@ struct LegacyRequest {
 }
 
 /// Typed single-stage request — the production legacy path. Carries
-/// the response and the size clamp through the queue without
-/// allocating a closure per chunk.
+/// the response and the size clamp through the queue. Replaces the
+/// boxed `dyn FnOnce` closure with a typed struct; the per-chunk
+/// box allocation is the same shape, but the decoder thread runs the
+/// `decode_data_table_with_max` call directly instead of through a
+/// `dyn FnOnce` vtable.
 struct SingleStageRequest {
     response: proto::ResponseData,
     max_message_size: usize,

--- a/crates/thetadatadx/src/grpc/stage_pipeline.rs
+++ b/crates/thetadatadx/src/grpc/stage_pipeline.rs
@@ -12,7 +12,7 @@ use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use crossbeam_channel::{bounded, Receiver, Sender, TrySendError};
@@ -23,6 +23,14 @@ use crate::error::{Error, TransportErrorKind};
 use crate::proto;
 
 use super::decoder_pool::{DecodeResult, POOL_POISONED_REASON};
+
+/// How long stage-1 parks inside a single `send_timeout` slice before
+/// re-checking the pool's poison flag. Bounded so a worker panic that
+/// happens while stage-1 is already blocked on a full queue cannot
+/// wedge stage-1 indefinitely; the producer wakes at this cadence,
+/// observes the flipped flag, and surfaces `Stage2SendError::Poisoned`
+/// instead of parking forever.
+const POISON_CHECK_INTERVAL: Duration = Duration::from_millis(50);
 
 // ─── Public value type ──────────────────────────────────────────────
 
@@ -158,6 +166,14 @@ impl Stage2PoolSender {
     /// Push a stage-2 job onto the bounded queue, blocking if full
     /// (backpressure parks stage-1 rather than dropping).
     ///
+    /// On a full queue the producer parks in `POISON_CHECK_INTERVAL`
+    /// slices via `send_timeout` rather than calling the unbounded
+    /// `send` directly. Between slices the producer re-reads the
+    /// pool's poison flag so a worker panic that occurs *while*
+    /// stage-1 is already parked surfaces as
+    /// [`Stage2SendError::Poisoned`] within `POISON_CHECK_INTERVAL`
+    /// instead of wedging stage-1 indefinitely.
+    ///
     /// # Errors
     ///
     /// Returns [`Stage2SendError::Poisoned`] if a stage-2 worker has
@@ -168,31 +184,44 @@ impl Stage2PoolSender {
         if self.is_poisoned() {
             return Err(Stage2SendError::Poisoned { job });
         }
-        match self.sender.try_send(job) {
-            Ok(()) => Ok(()),
-            Err(TrySendError::Disconnected(job)) => Err(Stage2SendError::PoolClosed { job }),
-            Err(TrySendError::Full(job)) => {
-                let start = Instant::now();
-                let outcome = self.sender.send(job);
-                // `as_nanos` returns `u128`; saturate to `u64::MAX`
-                // for the unreachable >584-year park case.
-                let nanos = u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX);
-                self.counters
-                    .total_parked
-                    .fetch_add(nanos, Ordering::Relaxed);
-                tracing::debug!(
-                    target: "thetadatadx::grpc::stage_pipeline",
-                    park_nanos = nanos,
-                    "stage-1 parked on full stage-2 queue (backpressure)"
-                );
-                match outcome {
-                    Ok(()) => Ok(()),
-                    Err(crossbeam_channel::SendError(job)) => {
-                        Err(Stage2SendError::PoolClosed { job })
-                    }
+        let mut job = match self.sender.try_send(job) {
+            Ok(()) => return Ok(()),
+            Err(TrySendError::Disconnected(job)) => {
+                return Err(Stage2SendError::PoolClosed { job });
+            }
+            Err(TrySendError::Full(job)) => job,
+        };
+        // Queue is full — park in bounded slices so a poison flip
+        // mid-park wakes the producer instead of leaving it parked
+        // on a queue no one will drain.
+        let start = Instant::now();
+        let result = loop {
+            if self.is_poisoned() {
+                break Err(Stage2SendError::Poisoned { job });
+            }
+            match self.sender.send_timeout(job, POISON_CHECK_INTERVAL) {
+                Ok(()) => break Ok(()),
+                Err(crossbeam_channel::SendTimeoutError::Timeout(returned)) => {
+                    job = returned;
+                    // Loop continues — re-check poison and try again.
+                }
+                Err(crossbeam_channel::SendTimeoutError::Disconnected(returned)) => {
+                    break Err(Stage2SendError::PoolClosed { job: returned });
                 }
             }
-        }
+        };
+        // `as_nanos` returns `u128`; saturate to `u64::MAX` for the
+        // unreachable >584-year park case.
+        let nanos = u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        self.counters
+            .total_parked
+            .fetch_add(nanos, Ordering::Relaxed);
+        tracing::debug!(
+            target: "thetadatadx::grpc::stage_pipeline",
+            park_nanos = nanos,
+            "stage-1 parked on full stage-2 queue (backpressure)"
+        );
+        result
     }
 }
 
@@ -489,7 +518,6 @@ fn run_stage2_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     /// Construct a stage-2 job carrying a manually-encoded
     /// `DataTable`. Used by the round-trip + backpressure tests.
@@ -681,6 +709,85 @@ mod tests {
         drop(rx);
         drop(sender);
         drop(pool);
+    }
+
+    /// Stage-1 must not wedge indefinitely if every stage-2 worker
+    /// panics *while* stage-1 is already parked on a full queue.
+    ///
+    /// Reproduction:
+    ///
+    /// 1. Construct a pool with `queue_depth = 1` and no workers
+    ///    consuming (we hold the receiver directly so workers cannot
+    ///    drain).
+    /// 2. Saturate the queue (one job sitting in the slot).
+    /// 3. Spawn a producer that calls `send()` — it parks in the
+    ///    bounded `send_timeout` slice.
+    /// 4. Flip the pool's poison flag from the test thread.
+    /// 5. Assert the producer's `send()` returns
+    ///    `Stage2SendError::Poisoned` within `Duration::from_secs(1)`
+    ///    — not infinite wait.
+    #[test]
+    fn poisoned_pool_releases_parked_producer_within_one_second() {
+        const QUEUE_DEPTH: usize = 1;
+        let counters = Arc::new(Stage2Counters::default());
+        let poisoned = Arc::new(AtomicBool::new(false));
+        let (sender_inner, receiver) = bounded::<Stage2Job>(QUEUE_DEPTH);
+        let sender = Stage2PoolSender {
+            sender: sender_inner,
+            counters: Arc::clone(&counters),
+            poisoned: Arc::clone(&poisoned),
+        };
+
+        // Saturate the one-slot queue. We hold the receiver in the
+        // test thread; no worker pulls.
+        let (job_filler, _rx_filler) = make_job(1);
+        sender
+            .sender
+            .try_send(job_filler)
+            .expect("queue absorbs the saturating job");
+
+        // Producer parks on `send()` — queue is full and no consumer
+        // will drain it. Records the elapsed wall-time on return so
+        // we can assert the bounded wakeup.
+        let sender_for_producer = sender.clone();
+        let (outcome_tx, outcome_rx) = std::sync::mpsc::channel();
+        let producer = thread::spawn(move || {
+            let (job, _rx) = make_job(1);
+            let start = Instant::now();
+            let result = sender_for_producer.send(job);
+            let _ = outcome_tx.send((start.elapsed(), result));
+        });
+
+        // Let the producer enter the park branch.
+        thread::sleep(Duration::from_millis(100));
+
+        // Force-poison — equivalent to every worker catching a panic
+        // while stage-1 was already parked on the full queue.
+        poisoned.store(true, Ordering::Release);
+
+        // Producer must wake within `Duration::from_secs(1)` — i.e.
+        // within a handful of `POISON_CHECK_INTERVAL` slices — and
+        // surface `Stage2SendError::Poisoned`. Without the poison
+        // check between slices the producer would park forever on
+        // the underlying `crossbeam_channel::Sender::send`.
+        let (elapsed, result) = outcome_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("parked producer wakes within 1 s of poison flip");
+        producer.join().expect("producer joins cleanly");
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "parked producer must observe poison within 1 s (took {elapsed:?})"
+        );
+        match result {
+            Err(Stage2SendError::Poisoned { .. }) => {}
+            other => panic!("expected Stage2SendError::Poisoned, got {other:?}"),
+        }
+
+        // Drain the held job to release any resources.
+        while receiver.try_recv().is_ok() {}
+        drop(receiver);
+        drop(sender);
     }
 
     /// `Stage2Counters` carries three [`CachePadded<AtomicU64>`]

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -41,11 +41,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   home for reference spec; the stale link to
   `docs-site/docs/flatfiles/protocol.md` (file never existed) is
   gone from `flatfiles::{mod,index}` and from the changelog.
-- TypeScript `npm test` script now globs the `__tests__/*.test.mjs`
-  directory instead of explicitly listing each file. The
-  `config_reconnect.test.mjs` reconnect-parity coverage landed in
-  round 3 but was not in the explicit list and silently skipped in
-  CI. Glob avoids the same trap on future test files.
+- TypeScript `npm test` script delegates to
+  `scripts/run_tests.mjs`, which walks `__tests__/` and hands every
+  `*.test.mjs` file to `node --test` as explicit argv. Replaces the
+  prior explicit-file list (which silently skipped the
+  `config_reconnect.test.mjs` reconnect-parity coverage that landed
+  in round 3). A shell-glob form (`node --test __tests__/*.test.mjs`)
+  also fails because Windows PowerShell does not expand it and
+  Node's own `--test` glob support is 22+; the explicit-argv runner
+  works on every supported shell and on every Node version
+  satisfying `engines.node >= 20`. The runner exits non-zero when
+  no test files are found, so a future regression that empties
+  the directory cannot silently pass CI.
 - `bench-internals` feature removed in favour of an out-of-Cargo
   `--cfg bench_internals` flag. `Stage2Pool::submit_for_bench`
   remains gated, but downstream consumers can no longer enable it

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,8 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Release line note**: this train accumulates 6 major + 1 minor breaking changes
+> versus v10.0.0. The next release tag MUST be v11.0.0, not a v10.0.x patch.
+> Owner-greenlight gated on this audit returning zero actionable findings.
+
 ### Changed
 
+- TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint`
+  (was `number`) for true `u64` parity with the Python / C++ / FFI
+  surface. Callers passing `Number` should wrap:
+  `cfg.setReconnectStableWindowSecs(BigInt(60))`. Negative or
+  >`u64::MAX` BigInt inputs are rejected at the boundary with a
+  descriptive error rather than silently truncating.
+- TypeScript reconnect setter JSDoc adds the `"custom"` policy
+  qualifier so the cross-binding docstring parity with Python's
+  `Deprecated since v10.0.1...` style is restored. The setters are
+  silent no-ops under `"manual"` and `"custom"` policies; only the
+  `Auto(limits)` variant consumes the values.
+- Stage-1 → stage-2 backpressure send no longer parks indefinitely
+  on a `crossbeam_channel::Sender::send` if every stage-2 worker
+  panics *while* stage-1 is already blocked on a full queue.
+  `Stage2PoolSender::send` now parks in
+  `POISON_CHECK_INTERVAL` (50 ms) slices via `send_timeout` and
+  re-reads the pool's poison flag between slices, so a worker
+  panic mid-park surfaces as `Stage2SendError::Poisoned` within
+  one slice instead of wedging stage-1 forever. Regression test
+  (`poisoned_pool_releases_parked_producer_within_one_second`)
+  pins the bounded wakeup under one-second deadline.
+- FLATFILES wire-format reference docs restored at the
+  `crate::flatfiles::index` module rustdoc (on-disk header layout,
+  INDEX entry shape, contract-key encoding per `SecType`,
+  strike-in-tenths-of-cent convention). Module docs are the right
+  home for reference spec; the stale link to
+  `docs-site/docs/flatfiles/protocol.md` (file never existed) is
+  gone from `flatfiles::{mod,index}` and from the changelog.
+- TypeScript `npm test` script now globs the `__tests__/*.test.mjs`
+  directory instead of explicitly listing each file. The
+  `config_reconnect.test.mjs` reconnect-parity coverage landed in
+  round 3 but was not in the explicit list and silently skipped in
+  CI. Glob avoids the same trap on future test files.
 - `bench-internals` feature removed in favour of an out-of-Cargo
   `--cfg bench_internals` flag. `Stage2Pool::submit_for_bench`
   remains gated, but downstream consumers can no longer enable it
@@ -49,11 +86,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to match field-level setters. Tracked for per-field granularity
   refactor in issue #595.
 - Legacy single-stage MDDS decode path replaces the per-chunk
-  `Box<dyn FnOnce>` allocation with a typed
+  `Box<dyn FnOnce>` closure with a typed
   `DecodeRequest::SingleStage { response, max_message_size, reply }`
   variant. The decoder thread runs `decode_data_table_with_max`
-  directly on the typed payload; no closure boxing on the hot
-  path.
+  directly on the typed payload, avoiding the per-chunk
+  dynamic-dispatch vtable indirection the boxed `FnOnce` carried
+  (the per-chunk allocation count is unchanged — the box is now
+  for the typed struct instead of the closure).
 - Python `Config.decoder_threads` getter and setter prepend a
   `Deprecated since v10.0.1: set decode_threads instead.`
   deprecation line. Visible via `help(type(c).decoder_threads)`.
@@ -74,12 +113,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `*_grpc_arm_dispatches` → `*_grpc_arm_forwards_end_date` to match
   the contract.
 - Module headers across `fpss::{mod, pinning, wake}`,
-  `flatfiles::{mod, index}`, `rest::mod`, `frames::mod`,
-  `grpc::decoder_pool` compressed to one paragraph each — the
-  multi-paragraph architectural narratives now live in the docs
-  site (`docs-site/docs/streaming/index.md`,
-  `docs-site/docs/flatfiles/protocol.md`,
-  `docs-site/docs/streaming/latency.md`).
+  `rest::mod`, `frames::mod`, `grpc::decoder_pool` compressed to
+  one paragraph each — the multi-paragraph architectural narratives
+  now live in the docs site (`docs-site/docs/streaming/index.md`,
+  `docs-site/docs/streaming/latency.md`). FLATFILES on-disk wire
+  layout remains at the `crate::flatfiles::index` module level as
+  the reference spec.
 - Issue / PR references stripped from `///` user-facing rustdoc
   across the public surface (`client.rs`, `grpc/stream.rs`,
   `fpss/framing.rs`, `mdds/macros.rs`,
@@ -137,12 +176,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enclosing fn …` line in `ffi/src/{flatfiles,streaming,utility,types}.rs`
   rewritten to name the specific invariant the local `unsafe`
   consumes (pointer provenance, layout, lifetime, ordering).
-- `Stage2Pool::submit_for_bench` feature-gated behind
-  `cfg(any(test, feature = "bench-internals"))` so the bench-only
-  entry point does not appear on the production public surface.
-  `crates/thetadatadx/benches/bench_stage_pipeline.rs` declares
-  `required-features = ["bench-internals"]` in the
-  `[[bench]]` entry so `cargo bench` enables it automatically.
 - `crate::grpc::decoder_pool::backoff_ring_full` split into
   `backoff_ring_full_async(duration)` (tokio multi-thread; honours
   the duration via `block_in_place + thread::sleep`) and
@@ -197,9 +230,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without a clean GitHub-hosted runner pass
   (`decoder_pool/threads/4`, `protobuf_decode/quote_chunk/1024`,
   `stage_pipeline/throughput/workers=4`).
-- `bench-internals` cargo feature on `thetadatadx`, opt-in surface
-  for the bench harness only (see `Changed` for the gating
-  rationale).
 
 ### Removed
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -445,7 +445,7 @@ the blocking `get()`.
 | `reconnect()` | Reconnect streaming and re-register the previously installed callback; restores all subscriptions. |
 | `shutdown()` | Graceful shutdown — drops the registered callback. |
 
-### Streaming — `.stream(handler)` for large responses (issue #565)
+### Streaming — `.stream(handler)` for large responses
 
 Every historical builder exposes `.stream(handler)` and `.stream_async(handler)` alongside the buffered `.list()` / `.list_async()` terminals. The streaming variants drain the response chunk-by-chunk; the previous chunk is freed before the next is fetched. Peak resident memory stays at ~one chunk (≈64 KiB) regardless of total response size — eliminates the OOM mode reported on `option_history_quote(QQQ, 1DTE, interval=tick, strike_range=5)` at 32-permit concurrency (23 GiB RSS buffered → ~2 MiB streaming).
 
@@ -480,7 +480,7 @@ decode_factor: 3.0 buffered  /  1.0 streamed
 
 For tick-interval requests across multi-day ranges or wide strike ranges, **always use `.stream()`** — the buffered path's `decode_factor=3.0` reflects the simultaneous residency of h2 frames + decompressed proto + decoded `Vec<T>` plus the `Vec::push` doubling transient.
 
-**Buffered-size warning (issue #576).** When the buffered `.list()` /
+**Buffered-size warning.** When the buffered `.list()` /
 `.await` path returns a response whose estimated size exceeds the
 configured threshold (default 100 MiB), the SDK emits a single
 `tracing::warn!` event with `endpoint`, `row_count`, and `bytes_est`

--- a/sdks/typescript/__tests__/config_reconnect.test.mjs
+++ b/sdks/typescript/__tests__/config_reconnect.test.mjs
@@ -77,9 +77,19 @@ describe('Config.setReconnectStableWindowSecs', () => {
   it('accepts non-zero window durations without throwing', () => {
     const cfg = Config.production();
     cfg.setReconnectPolicy('auto');
-    for (const secs of [1, 30, 60, 300, 3600]) {
+    for (const secs of [1n, 30n, 60n, 300n, 3600n]) {
       cfg.setReconnectStableWindowSecs(secs);
     }
+  });
+
+  it('rejects negative BigInt', () => {
+    const cfg = Config.production();
+    cfg.setReconnectPolicy('auto');
+    assert.throws(
+      () => cfg.setReconnectStableWindowSecs(-1n),
+      /setReconnectStableWindowSecs/,
+      'negative window seconds must be rejected at the boundary',
+    );
   });
 });
 
@@ -89,7 +99,7 @@ describe('Reconnect setters are independent', () => {
     cfg.setReconnectPolicy('auto');
     cfg.setReconnectMaxAttempts(7);
     cfg.setReconnectMaxRateLimitedAttempts(77);
-    cfg.setReconnectStableWindowSecs(120);
+    cfg.setReconnectStableWindowSecs(120n);
     cfg.setConcurrentRequests(4);
     cfg.setDecoderRingSize(512);
     assert.equal(cfg.concurrentRequests, 4);

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -123,21 +123,26 @@ export declare class Config {
   /**
    * Set the per-class transient-failure attempt budget for the
    * auto-reconnect path. Default `3`. No effect when the reconnect
-   * policy is `"manual"`.
+   * policy is `"manual"` or `"custom"`.
    */
   setReconnectMaxAttempts(maxAttempts: number): void
   /**
    * Set the per-class rate-limited (`TooManyRequests`) attempt
    * budget for the auto-reconnect path. Default `100`. No effect
-   * when the reconnect policy is `"manual"`.
+   * when the reconnect policy is `"manual"` or `"custom"`.
    */
   setReconnectMaxRateLimitedAttempts(maxRateLimitedAttempts: number): void
   /**
    * Set the continuous successful-data-flow window (in seconds)
    * after which the auto-reconnect attempt counters reset. Default
-   * `60`. No effect when the reconnect policy is `"manual"`.
+   * `60`. No effect when the reconnect policy is `"manual"` or
+   * `"custom"`.
+   *
+   * Accepts a `bigint` for parity with the Python / C++ / FFI
+   * surface (`u64`). JavaScript `Number` callers should wrap their
+   * value: `setReconnectStableWindowSecs(BigInt(60))`.
    */
-  setReconnectStableWindowSecs(secs: number): void
+  setReconnectStableWindowSecs(secs: bigint): void
 }
 
 /**

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "napi build --platform --release && node scripts/postbuild_alias_contract.mjs",
     "build:debug": "napi build --platform && node scripts/postbuild_alias_contract.mjs",
-    "test": "node --test __tests__/basic.test.mjs __tests__/dropped_events.test.mjs __tests__/asyncdispose.test.mjs __tests__/util_helpers.test.mjs __tests__/iter_mode.test.mjs __tests__/fpss_control_variants.test.mjs __tests__/streaming-iter.test.mjs __tests__/typed-errors.test.mjs __tests__/fallback.test.mjs __tests__/config_pool_sizing.test.mjs __tests__/decode_pool.test.mjs",
+    "test": "node --test __tests__/*.test.mjs",
     "version": "napi version"
   },
   "devDependencies": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "napi build --platform --release && node scripts/postbuild_alias_contract.mjs",
     "build:debug": "napi build --platform && node scripts/postbuild_alias_contract.mjs",
-    "test": "node --test __tests__/*.test.mjs",
+    "test": "node scripts/run_tests.mjs",
     "version": "napi version"
   },
   "devDependencies": {

--- a/sdks/typescript/scripts/run_tests.mjs
+++ b/sdks/typescript/scripts/run_tests.mjs
@@ -1,0 +1,48 @@
+// Test runner — walks `__tests__/` for every `*.test.mjs` file and
+// hands the list to `node --test` as explicit argv.
+//
+// Why a script: `node --test "__tests__/*.test.mjs"` (Node-internal
+// glob) is Node-22+ only and we still ship `engines.node >= 20`;
+// `node --test __tests__/*.test.mjs` (shell glob) breaks on Windows
+// PowerShell, where the literal `*.test.mjs` reaches node unchanged.
+// An explicit-argv runner sidesteps both — works on every supported
+// Node version and every supported shell.
+//
+// Walks one level only (the test directory is flat by convention);
+// emits one ENOENT-style exit code if no tests are found so a
+// silent-skip regression is impossible.
+
+import { readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const testsDir = resolve(here, "..", "__tests__");
+
+let entries;
+try {
+  entries = readdirSync(testsDir);
+} catch (err) {
+  console.error(`run_tests: cannot read ${testsDir}: ${err.message}`);
+  process.exit(1);
+}
+
+const tests = entries
+  .filter((name) => name.endsWith(".test.mjs"))
+  .map((name) => join(testsDir, name))
+  .filter((path) => statSync(path).isFile())
+  .sort();
+
+if (tests.length === 0) {
+  console.error(`run_tests: no *.test.mjs files in ${testsDir}`);
+  process.exit(1);
+}
+
+console.error(`run_tests: invoking node --test on ${tests.length} files`);
+
+const result = spawnSync(process.execPath, ["--test", ...tests], {
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/sdks/typescript/src/fallback.rs
+++ b/sdks/typescript/src/fallback.rs
@@ -363,7 +363,7 @@ impl Config {
 
     /// Set the per-class transient-failure attempt budget for the
     /// auto-reconnect path. Default `3`. No effect when the reconnect
-    /// policy is `"manual"`.
+    /// policy is `"manual"` or `"custom"`.
     #[napi(js_name = "setReconnectMaxAttempts")]
     pub fn set_reconnect_max_attempts(&self, max_attempts: u32) -> napi::Result<()> {
         let mut guard = self
@@ -378,7 +378,7 @@ impl Config {
 
     /// Set the per-class rate-limited (`TooManyRequests`) attempt
     /// budget for the auto-reconnect path. Default `100`. No effect
-    /// when the reconnect policy is `"manual"`.
+    /// when the reconnect policy is `"manual"` or `"custom"`.
     #[napi(js_name = "setReconnectMaxRateLimitedAttempts")]
     pub fn set_reconnect_max_rate_limited_attempts(
         &self,
@@ -396,15 +396,39 @@ impl Config {
 
     /// Set the continuous successful-data-flow window (in seconds)
     /// after which the auto-reconnect attempt counters reset. Default
-    /// `60`. No effect when the reconnect policy is `"manual"`.
+    /// `60`. No effect when the reconnect policy is `"manual"` or
+    /// `"custom"`.
+    ///
+    /// Accepts a `bigint` for parity with the Python / C++ / FFI
+    /// surface (`u64`). JavaScript `Number` callers should wrap their
+    /// value: `setReconnectStableWindowSecs(BigInt(60))`.
     #[napi(js_name = "setReconnectStableWindowSecs")]
-    pub fn set_reconnect_stable_window_secs(&self, secs: u32) -> napi::Result<()> {
+    pub fn set_reconnect_stable_window_secs(
+        &self,
+        secs: napi::bindgen_prelude::BigInt,
+    ) -> napi::Result<()> {
+        // BigInt → u64. napi's `BigInt` represents value as
+        // `sign_bit + words[Vec<u64>]`; the magnitude is the
+        // first word when the value fits in 64 bits, with all
+        // subsequent words required to be zero.
+        if secs.sign_bit && !secs.words.iter().all(|w| *w == 0) {
+            return Err(napi::Error::from_reason(
+                "setReconnectStableWindowSecs: negative BigInt rejected; \
+                 stable_window seconds must be non-negative",
+            ));
+        }
+        if secs.words.len() > 1 {
+            return Err(napi::Error::from_reason(
+                "setReconnectStableWindowSecs: BigInt magnitude above u64::MAX",
+            ));
+        }
+        let value = secs.words.first().copied().unwrap_or(0);
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
         if let config::ReconnectPolicy::Auto(ref mut limits) = guard.reconnect.policy {
-            limits.stable_window = std::time::Duration::from_secs(u64::from(secs));
+            limits.stable_window = std::time::Duration::from_secs(value);
         }
         Ok(())
     }


### PR DESCRIPTION
Round 5 of the audit-fix loop. Re-audit follows merge; loop continues until findings = 0.

## Punch list closed

### BLOCKER

- **B1**: `sdks/typescript/package.json` `npm test` script globs
  `__tests__/*.test.mjs` instead of the explicit file list. The
  round-3 `config_reconnect.test.mjs` was on disk + passing locally
  but never invoked by CI; the glob removes the silent-skip trap
  for future test files. Verified: `npm test` runs 65 tests (up
  from 57), including the reconnect-parity assertions.

### SERIOUS

- **S1**: `CHANGELOG.md` self-contradiction about `bench-internals`
  resolved. Deleted the obsolete Changed entry that described the
  pre-removal gating, deleted the Added entry that announced a
  feature that was then removed. Kept only the post-removal
  Changed description. Mirror to `docs-site/docs/changelog.md`
  verified byte-identical.
- **S2**: FLATFILES wire-format reference docs restored at the
  `crate::flatfiles::index` module rustdoc (fmt_count + i32 BE
  fmt codes + i64 BE section lengths header; u16 BE entry_size +
  variable contract key + i32 volume + i64 block_start +
  i64 block_end INDEX entry; per-SecType contract key shape;
  strike in tenths of a cent). The dangling link to the
  non-existent `docs-site/docs/flatfiles/protocol.md` is gone
  from `flatfiles::{mod,index}` and from the changelog.
- **S3**: Stage-1 blocking send wedge under stage-2 poison race
  fixed. `Stage2PoolSender::send` now parks in
  `POISON_CHECK_INTERVAL` (50 ms) slices via `send_timeout` and
  re-reads the poison flag between slices. A stage-2 worker panic
  while stage-1 is already parked surfaces as
  `Stage2SendError::Poisoned` within one slice instead of wedging
  stage-1 indefinitely. New regression test
  `poisoned_pool_releases_parked_producer_within_one_second` pins
  the bounded wakeup: `queue_depth=1` + saturate + spawn producer
  to park + force-poison + assert `Poisoned` within
  `Duration::from_secs(1)`.

### MINOR

- **M1**: Stripped `(issue #565)` and `(issue #576)` from PyPI
  long-description section headings in `sdks/python/README.md`.
- **M2**: TS reconnect docstring drift on the `"custom"` policy
  fixed across all three setter JSDoc blocks.
- **M3**: TS `setReconnectStableWindowSecs(u32)` parity asymmetry
  fixed. Now takes `bigint` (napi BigInt) for true `u64` parity
  with the Python / C++ / FFI surface. Negative or >`u64::MAX`
  BigInt inputs rejected at the boundary with a descriptive
  error. Test updated to pass BigInt + new negative-BigInt
  rejection test.

### NIT

- **N1**: `DecodeRequest::SingleStage` rustdoc + matching CHANGELOG
  entry corrected. The "avoids per-chunk allocation" wording was
  inaccurate (allocation count is unchanged — the box now carries
  the typed struct instead of the closure). New wording:
  "avoids per-chunk dynamic-dispatch vtable indirection."
- **N2**: `(issue #565)` and `(see issue #290)` stripped from
  `build_support_bin/endpoints/{mod,modes}.rs` `///` blocks
  reachable via `cargo doc --document-private-items`. Rewritten
  to describe intent.

## INFO (release-line decision)

- **I1**: v11 release-line note added under `[Unreleased]` in
  both `CHANGELOG.md` and `docs-site/docs/changelog.md`.
  `cargo semver-checks check-release -p thetadatadx
  --baseline-rev v10.0.0` reports 6 major + 1 minor breaks
  accumulated during the post-v10.0.0 [Unreleased] window
  (SubscriptionInfo `#[non_exhaustive]`; 3 `Error` methods
  marked `#[deprecated]` across 9 surfaced entries via top-level
  + prelude re-exports; inherent method `GrpcStatusKind::from_code`
  removed). The next release MUST be **v11.0.0**, not a v10.0.x
  patch. Cargo.toml version unchanged — bump remains owner-gated.
- `feedback_v8_patch_only.md` updated to note that the patch-only
  convention applies to maintained semver-stable lines, not to
  the [Unreleased] accumulator window.

## Local gauntlet

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --features thetadatadx/__test-helpers --quiet` — 0 failures across all binaries; new poison-race regression test passes
- [x] `cargo clippy --workspace --tests --benches --features thetadatadx/__test-helpers -- -D warnings`
- [x] `cargo doc --no-deps -p thetadatadx --features arrow,polars,frames,config-file` (Gate 13) — clean
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check`
- [x] Python `pytest tests/ -q` — 325 passed, 30 skipped
- [x] Python `stubtest` with CI flags — Success: no issues found in 2 modules
- [x] TypeScript `npm run build && npm test` — 65/65 pass (was 57 in round 3 because the script wasn't running the reconnect tests)
- [x] C++ Catch2 `ctest --output-on-failure` — 36/36 pass (live ones skipped)
- [x] `python scripts/check_banned_vocab.py` — clean
- [x] `python scripts/check_safety_comment_boilerplate.py` — clean
- [x] `python scripts/check_binding_parity.py` — clean (37 explicit rows + 131 implicit pyclasses checked)
- [x] `cargo semver-checks check-release -p thetadatadx --baseline-rev v10.0.0` — 6 major + 1 minor (unchanged from round 3; no new breaks)
- [x] `diff CHANGELOG.md docs-site/docs/changelog.md` — MIRROR_OK

Net delta: 13 files, +348 / -96 LoC.