### PR TITLE
refactor: close 5-axis audit round 5 (cross-binding test parity + race-free poison test + docstring unification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,215 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versus v10.0.0. The next release tag MUST be v11.0.0, not a v10.0.x patch.
 > Owner-greenlight gated on this audit returning zero actionable findings.
 
-### Changed
-
-- TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint`
-  (was `number`) for true `u64` parity with the Python / C++ / FFI
-  surface. Callers passing `Number` should wrap:
-  `cfg.setReconnectStableWindowSecs(BigInt(60))`. Negative or
-  >`u64::MAX` BigInt inputs are rejected at the boundary with a
-  descriptive error rather than silently truncating.
-- TypeScript reconnect setter JSDoc adds the `"custom"` policy
-  qualifier so the cross-binding docstring parity with Python's
-  `Deprecated since v10.0.1...` style is restored. The setters are
-  silent no-ops under `"manual"` and `"custom"` policies; only the
-  `Auto(limits)` variant consumes the values.
-- Stage-1 → stage-2 backpressure send no longer parks indefinitely
-  on a `crossbeam_channel::Sender::send` if every stage-2 worker
-  panics *while* stage-1 is already blocked on a full queue.
-  `Stage2PoolSender::send` now parks in
-  `POISON_CHECK_INTERVAL` (50 ms) slices via `send_timeout` and
-  re-reads the pool's poison flag between slices, so a worker
-  panic mid-park surfaces as `Stage2SendError::Poisoned` within
-  one slice instead of wedging stage-1 forever. Regression test
-  (`poisoned_pool_releases_parked_producer_within_one_second`)
-  pins the bounded wakeup under one-second deadline.
-- FLATFILES wire-format reference docs restored at the
-  `crate::flatfiles::index` module rustdoc (on-disk header layout,
-  INDEX entry shape, contract-key encoding per `SecType`,
-  strike-in-tenths-of-cent convention). Module docs are the right
-  home for reference spec; the stale link to
-  `docs-site/docs/flatfiles/protocol.md` (file never existed) is
-  gone from `flatfiles::{mod,index}` and from the changelog.
-- TypeScript `npm test` script delegates to
-  `scripts/run_tests.mjs`, which walks `__tests__/` and hands every
-  `*.test.mjs` file to `node --test` as explicit argv. Replaces the
-  prior explicit-file list (which silently skipped the
-  `config_reconnect.test.mjs` reconnect-parity coverage that landed
-  in round 3). A shell-glob form (`node --test __tests__/*.test.mjs`)
-  also fails because Windows PowerShell does not expand it and
-  Node's own `--test` glob support is 22+; the explicit-argv runner
-  works on every supported shell and on every Node version
-  satisfying `engines.node >= 20`. The runner exits non-zero when
-  no test files are found, so a future regression that empties
-  the directory cannot silently pass CI.
-- `bench-internals` feature removed in favour of an out-of-Cargo
-  `--cfg bench_internals` flag. `Stage2Pool::submit_for_bench`
-  remains gated, but downstream consumers can no longer enable it
-  from the published `[features]` graph. The bench at
-  `benches/bench_stage_pipeline.rs` activates via
-  `RUSTFLAGS='--cfg bench_internals' cargo bench
-  --bench bench_stage_pipeline`.
-- `[package.metadata.docs.rs]` switched from `all-features = true`
-  to an explicit feature list (`arrow`, `polars`, `frames`,
-  `config-file`) so the rendered docs.rs page no longer surfaces
-  bench-only or test-only symbols.
-- `__test-helpers` private feature gates the test-only
-  `MddsClient::for_fallback_test` constructor. The symbol no longer
-  enters the published rlib unless the (double-underscore-prefixed,
-  doc-hidden) feature is explicitly enabled.
-- ReconnectConfig setter parity on the TypeScript binding.
-  `Config.setReconnectPolicy`, `setReconnectMaxAttempts`,
-  `setReconnectMaxRateLimitedAttempts`, and
-  `setReconnectStableWindowSecs` mirror the Python / C++ / FFI
-  surface; `sdks/parity.toml` records the field-level cross-binding
-  state.
-- Gate 14 (`scripts/check_safety_comment_boilerplate.py`) drops the
-  wholesale `ffi/src/` exemption and replaces it with a per-site
-  allowlist file (`scripts/safety_comment_allowlist.txt`) listing
-  the genuinely-shared invariants (handle round-trip, symbol-array
-  contract, test-only factory pointer). Every other duplicate trips
-  the gate regardless of location. Extended the invariant-signal
-  patterns to recognise `NUL-terminated`, `CString::`, and `NUL`
-  references so legitimate FFI annotations are not flagged.
-- FFI `error::tests` module hoists the four duplicate stamped
-  `// SAFETY: tdx_last_error() ...` blocks into a single
-  `last_error_message()` helper with one comprehensive SAFETY
-  comment naming the thread-local-slot lifetime invariant.
-- Gate 2 (`scripts/check_binding_parity.py`) gains a
-  dotted-name carve-out so per-field parity rows
-  (`FlatFilesConfig.max_attempts`, `ReconnectConfig.policy`, etc.)
-  participate in the SSOT without forcing the class-existence check
-  to match field-level setters. Tracked for per-field granularity
-  refactor in issue #595.
-- Legacy single-stage MDDS decode path replaces the per-chunk
-  `Box<dyn FnOnce>` closure with a typed
-  `DecodeRequest::SingleStage { response, max_message_size, reply }`
-  variant. The decoder thread runs `decode_data_table_with_max`
-  directly on the typed payload, avoiding the per-chunk
-  dynamic-dispatch vtable indirection the boxed `FnOnce` carried
-  (the per-chunk allocation count is unchanged — the box is now
-  for the typed struct instead of the closure).
-- Python `Config.decoder_threads` getter and setter prepend a
-  `Deprecated since v10.0.1: set decode_threads instead.`
-  deprecation line. Visible via `help(type(c).decoder_threads)`.
-- `.pyi` stub converts the leading `#`-comment over
-  `decoder_threads` to a triple-quoted attribute docstring so the
-  deprecation surfaces in tooling that consumes attribute
-  docstrings.
-- Tier-clamp regression test
-  (`rest_arm_respects_tier_clamp_semaphore`) replaces the
-  120 ms sleep with an `Arc<Notify>` entry-side barrier
-  (`RestMock::wait_for_entry`) so the test waits deterministically
-  for "first call reached mock" instead of racing the sleep.
-- Greeks gRPC arm `end_date` tests pin the outgoing wire bytes via
-  a new `MockBehaviour::capture_request_bytes` hook: the test
-  captures the inbound request proto, decodes it with
-  `OptionHistory*Request::decode`, and asserts the `end_date` field
-  carries the expected value. Renamed
-  `*_grpc_arm_dispatches` → `*_grpc_arm_forwards_end_date` to match
-  the contract.
-- Module headers across `fpss::{mod, pinning, wake}`,
-  `rest::mod`, `frames::mod`, `grpc::decoder_pool` compressed to
-  one paragraph each — the multi-paragraph architectural narratives
-  now live in the docs site (`docs-site/docs/streaming/index.md`,
-  `docs-site/docs/streaming/latency.md`). FLATFILES on-disk wire
-  layout remains at the `crate::flatfiles::index` module level as
-  the reference spec.
-- Issue / PR references stripped from `///` user-facing rustdoc
-  across the public surface (`client.rs`, `grpc/stream.rs`,
-  `fpss/framing.rs`, `mdds/macros.rs`,
-  `streaming_async_batches.rs`, `streaming_async_session.rs`).
-  References remain on `//` internal comments and `#[test]` doc
-  blocks per the audit protocol.
-- Python codegen template stripped the hardcoded `(issue #565)`
-  attribution from 33 `.stream()` doc-blocks in
-  `historical_methods.rs`; the comparable references in the Rust
-  endpoint render, the Python streaming-terminal renderer, the
-  REST builder header, and the `mdds/macros.rs` streaming
-  variant macro doc-block were all rewritten to describe the
-  behaviour without the issue number.
-- `MddsConfig::decoder_threads` rustdoc compressed to the
-  deprecation message + redirect. The "why no `#[deprecated]`"
-  rationale moved to an internal `//` comment above the field.
-- REST `Vec::with_capacity` seed floor for the `Content-Length`-
-  advertised path: when the server emits a small `Content-Length`
-  (including `0`) but follows up with chunked DATA, the
-  accumulator now starts at the same 64 KiB floor the pure-chunked
-  path uses, instead of the advertised value.
-- `parse_legacy_six_field_quote_csv` test renamed to
-  `parse_six_field_quote_csv_zero_fills_missing_columns` so the
-  test name describes the invariant being pinned.
-- `decoder_threads` deprecation parity across every binding.
-  Rust rustdoc, Python `.pyi`, C++ Doxygen, and TypeScript JSDoc all
-  carry an identical `since v10.0.1, use decode_threads` note +
-  attribute (`[[deprecated]]` on C++, `@deprecated` JSDoc tag
-  propagated via napi-rs doc-comment forwarding).
-- `MddsConfig::decoder_threads` auto-sizing rustdoc + bench
-  + migration-doc rewrites match the post-v10.0.0 formula
-  (`(available_parallelism / 2).max(1)`, no channel cap).
-- `crate::mdds::decode::{decompress_response, decompress_response_with_max,
-  decode_data_table, decode_data_table_with_max}` take `&mut
-  ResponseData` so the identity-compression path can move
-  `compressed_data` out via `std::mem::take` instead of cloning.
-  Behaviour preserved on every existing call site; the move is
-  observable only when callers retain the `ResponseData` past the
-  decode (no in-tree consumer does so).
-- `crates/thetadatadx/src/rest/client.rs` seeds the chunked-transfer
-  body accumulator with a 64 KiB floor so the first DATA frame on a
-  chunked REST response does not trigger a per-chunk realloc.
-- `MddsClient` REST-fallback shims downgrade per-call `start_date` /
-  `end_date` logging from `tracing::debug!` to `tracing::trace!` so
-  routine operator-visible logs no longer echo request date ranges.
-- FFI codegen template emits `require_client!` + `require_symbol_array!`
-  macro calls in place of the 61 inline `// SAFETY: client is a
-  non-null pointer ...` blocks and the 7 inline
-  `// SAFETY: caller supplies a contiguous array ...` blocks the
-  prior endpoint shims carried. Regenerated
-  `ffi/src/endpoint_with_options.rs` keeps a single per-macro
-  invariant-naming SAFETY comment instead of stamping the same
-  boilerplate at every call site.
-- Every hand-written `// SAFETY: see FFI boundary doc on the
-  enclosing fn …` line in `ffi/src/{flatfiles,streaming,utility,types}.rs`
-  rewritten to name the specific invariant the local `unsafe`
-  consumes (pointer provenance, layout, lifetime, ordering).
-- `crate::grpc::decoder_pool::backoff_ring_full` split into
-  `backoff_ring_full_async(duration)` (tokio multi-thread; honours
-  the duration via `block_in_place + thread::sleep`) and
-  `backoff_ring_full_sync()` (current-thread / non-async; fixed
-  256-iter spin) so the sync arm does not silently discard a
-  parameter the async arm uses.
-
-- `crate::grpc::pool::ChannelPool` now reconnects channels on
-  `ConnectionClosed` in-place rather than marking them permanently
-  dead. Long-running clients no longer cascade after sustained load:
-  every transport-level fault (`GOAWAY`, IO failure, peer shutdown,
-  open-phase drop) triggers a single-flight reconnect of the
-  channel's inner `SendRequest<Bytes>` with bounded exponential
-  backoff (50 ms initial, 30 s cap, 8 attempts). The caller's retry
-  shell re-dispatches once and observes the fresh sender on the
-  next pool pick. Fixes the real root cause behind #571 / #577 /
-  #589 — the prior investigation pin
-  (`docs-site/docs/legacy-quote-577-investigation.md`)
-  misattributed the cascade to a server-side schema variant; the
-  actual cause was the SDK's own dead-channel mechanism introduced
-  in #578 with no recycling counterpart.
-
-### Fixed
-
-- Greeks `_with_fallback` regression coverage. Four new integration
-  tests pin `end_date` forwarding on both the REST and gRPC arms of
-  `option_history_greeks_implied_volatility_with_fallback` and
-  `option_history_greeks_first_order_with_fallback`, locking the
-  prior-round fix against silent regression.
-- Tier-clamp regression coverage. A new integration test runs two
-  concurrent `option_history_quote_with_fallback` calls against an
-  in-process REST mock with `concurrent_requests = 1`; the assertion
-  observes the second call parking on the semaphore until the first
-  completes.
-
 ### Added
 
+- Cross-binding ReconnectConfig setter test parity. The TypeScript
+  `__tests__/config_reconnect.test.mjs` coverage that landed in
+  round 3 now has matching siblings on every binding:
+  `sdks/python/tests/test_config_reconnect.py` (10 tests covering
+  policy round-trip, per-class budget round-trip, stable-window
+  acceptance + negative rejection, interleaved-setter independence),
+  `sdks/cpp/tests/config_reconnect.cpp` (6 Catch2 cases mirroring
+  the Python contract on the C++ wrapper), and a new
+  `reconnect_setter_tests` module in `ffi/src/auth.rs` (7 Rust
+  tests against the underlying `tdx_config_set_reconnect_*` C ABI).
+  The existing `lifecycle.cpp` smoke also expanded to call all four
+  reconnect setters with valid values.
+- TypeScript `setReconnectStableWindowSecs` BigInt boundary
+  coverage. Adds a magnitude-above-u64 rejection case
+  (`setReconnectStableWindowSecs(1n << 65n)`) alongside the
+  existing negative-BigInt rejection so the two boundary failures
+  are pinned independently.
 - `require_client!` and `require_symbol_array!` macros (with full
   unit-test coverage: null-pointer / valid / invalid-UTF-8 / Go-empty
   branches) alongside the existing `require_cstr!` macro. `require_cstr!`
@@ -237,65 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without a clean GitHub-hosted runner pass
   (`decoder_pool/threads/4`, `protobuf_decode/quote_chunk/1024`,
   `stage_pipeline/throughput/workers=4`).
-
-### Removed
-
-- `Channel::is_dead`, `Channel::mark_dead`, `Channel::dead_handle`,
-  `ChannelPool::all_dead`, `ChannelPool::dead_count` — replaced by
-  in-place reconnect (see Changed above). The `ChannelLease`
-  picker no longer scans for "live" channels separately; every
-  channel in the pool stays a valid pick because the channel
-  itself swaps its inner h2 session on observed faults.
-- `ChannelError::UpstreamCascade` — folded into the existing
-  `ChannelError::ConnectionClosed` variant. The mid-stream
-  classifier (`classify_h2_error_mid_stream`) is gone; the
-  open-phase classifier (`classify_h2_error`) covers both phases
-  via the new `classify_h2_error_ref` thin wrapper.
-- `FallbackPolicy::RestOnH2Disconnect` and
-  `FallbackPolicy::RestAlwaysForDateRange` — both variants were
-  built around a misdiagnosed cascade and never actually helped.
-  `FallbackPolicy::RestAlways` is retained as the user-facing
-  escape hatch for callers who want every historical-quote call
-  routed over a locally-running Terminal's REST surface.
-- `_with_fallback` per-endpoint shims (Python / TypeScript /
-  C++ / FFI) tied to the deleted variants. The four remaining
-  `option_history_*_with_fallback` methods dispatch on
-  `FallbackPolicy::RestAlways` vs `Disabled` only.
-- `docs-site/docs/legacy-quote-577-investigation.md`,
-  `docs-site/docs/legacy-quote-handling.md` — both documented the
-  wrong root cause. Replaced by
-  `docs-site/docs/channel-pool-design.md`, which honestly
-  describes the in-place reconnect contract and pins the
-  correction so the next contributor doesn't repeat the search.
-- `crates/thetadatadx/tests/test_577_2020_onward.rs` — built on
-  the wrong premise. Replaced by
-  `crates/thetadatadx/tests/test_pool_reconnect.rs`, which pins
-  the single-flight CAS, the lifecycle observer events, and the
-  classifier-triggered reconnect spawn.
-- `tools/local-terminal-patcher/` — patched a code path
-  (`QuoteTick(Tick t)` constructor strict-length throw) that
-  bytecode analysis of the upstream terminal jar shows is never
-  invoked on the `option_history_quote` gRPC response path.
-  Decompilation confirms the constructor's sole caller is
-  `MarketValueTick`. The patcher fixed a fictional problem; the
-  workspace member, its `clap` / `zip` / `sha2` dependencies, and
-  its patch sources are removed.
-
-### Retained
-
-- The lenient 6-/11-/12-field NBBO decoder added in #573 is
-  **kept** as defense-in-depth. `find_header` + `opt_number(row, None) -> 0`
-  is good API design regardless of cause; a subset NBBO layout
-  could surface from any upstream storage tier in the future. The
-  doc-comment attribution to "issue #571" / "patched terminal
-  `normalizeData()`" is stripped — the test name
-  `quote_tick_decodes_legacy_six_field_shape_with_zero_fill`
-  remains as a regression pin.
-- The REST transport (`crate::rest`) is **kept** as the
-  user-facing alternative transport reachable via
-  `FallbackPolicy::RestAlways`.
-
-### Added
 
 - Cross-binding parity for the two-stage MDDS decode pipeline knobs
   (Phase 3 of 3). The `MddsConfig::decode_threads` and
@@ -596,7 +347,281 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unit tests covering `contains_subsequence`, `newest_jar_in`, and
   `swap_classes_in_jar` (S3).
 
+- Standalone `FpssClient` and `MddsClient` pyclasses on the Python
+  binding. `FpssClient(creds, config)` opens ONLY the FPSS TLS
+  transport (no MDDS gRPC channel, no Nexus HTTP auth); `MddsClient(creds,
+  config)` opens ONLY the MDDS gRPC channel plus the Nexus
+  authentication and surfaces the historical / FLATFILES API while
+  raising `AttributeError` on every FPSS-touching method. The bundled
+  `ThetaDataDxClient` keeps its current behaviour — the new classes
+  are purely additive and align the Python surface with the
+  standalone clients already exposed by the C ABI (`tdx_fpss_*` /
+  `tdx_client_*`) and the C++ wrapper (`tdx::FpssClient` /
+  `tdx::Client`).
+- gRPC `grpc-timeout` header is now emitted on every
+  deadline-bearing RPC (`server_streaming_with_deadline`,
+  `mdds_client.with_deadline(...)`). The header carries the
+  smallest unit that fits the budget per the gRPC HTTP/2 spec
+  (`n` / `u` / `m` / `S` / `M` / `H`), so the server can
+  short-circuit on deadline elapse instead of completing work the
+  client will discard.
+- `TransportErrorKind` is exported from `thetadatadx::error` for
+  binding consumers and retry classifiers.
+- `tdbe::types::price::Price::with_value_and_type` constructor
+  rejects out-of-range `price_type` values with a typed
+  `PriceError` instead of clamping. `Price::value()` and
+  `Price::price_type()` accessors join the public API so future
+  field visibility changes do not break call sites.
+  `Price::is_unset()` and `Price::is_zero_value()` split the
+  previous `is_zero()` conflation into the two distinct signals
+  (sentinel vs real zero).
+- `Price` POW10 indexing paths carry `debug_assert!` invariant
+  guards so a hand-constructed `Price { value, price_type }`
+  outside `0..=MAX_PRICE_TYPE` traps in debug builds rather than
+  reading past the end of the lookup tables.
+- `AuthUser::max_concurrent_requests` now routes the
+  subscription-tier shift through `SubscriptionTier::from_wire`.
+  Hostile wire bytes (negative, `> 3`, `i32::MAX`) fold to
+  `Free=1` and emit a `warn` instead of panicking on the old
+  `1usize << tier` path.
+
 ### Changed
+
+- ReconnectConfig setter docstrings unified across every binding. The
+  per-class budget setters (`set_reconnect_max_attempts`,
+  `set_reconnect_max_rate_limited_attempts`,
+  `set_reconnect_stable_window_secs`) now carry the same
+  `"No effect unless the reconnect policy is Auto"` qualifier on the
+  Python, TypeScript, FFI, and C++ Doxygen surfaces. Replaces the
+  three previous phrasings (`"manual" or "custom"` on Python/TS,
+  `"not Auto"` on FFI/C++).
+- Stage-1 → stage-2 backpressure regression tests now block on a
+  deterministic `parked_in_slice_loop` barrier counter instead of a
+  fixed `thread::sleep`. Both `backpressure_parks_producer` and
+  `poisoned_pool_releases_parked_producer_within_one_second` wait for
+  the producer to enter the bounded `send_timeout` slice loop before
+  draining the queue or flipping the poison flag, so the test pins
+  the contract under test rather than racing the wall clock.
+- Issue-number attributions stripped from `//`/`//!` block comments
+  in the Python / TypeScript / FFI binding crates and from the two
+  remaining `crates/thetadatadx/src/rest` module comments. The
+  `(issue #N)` shape rendered in tooling that consumed module
+  docstrings; the cleanup tracks the same standard already applied
+  to `///` rustdoc on the public surface. Sites covered:
+  `sdks/python/src/util_helpers.rs`, `sdks/typescript/src/util_helpers.rs`,
+  `sdks/typescript/src/{lib,fallback}.rs`, `sdks/python/src/lib.rs`,
+  `ffi/src/{auth,utility}.rs`, `sdks/cpp/include/thetadx.h`,
+  `crates/thetadatadx/src/rest/{mod,client}.rs`.
+- CHANGELOG `[Unreleased]` section consolidated into the five canonical
+  Keep-a-Changelog buckets (`Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`). Successive PR appends had grown three duplicate `Changed`
+  buckets, three duplicate `Added` buckets, and two duplicate `Fixed`
+  buckets; non-canonical `Retained` and `CI` headings folded into
+  `Changed` per the changelog format policy. Every individual entry
+  is preserved verbatim — only the headings were merged.
+- TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint`
+  (was `number`) for true `u64` parity with the Python / C++ / FFI
+  surface. Callers passing `Number` should wrap:
+  `cfg.setReconnectStableWindowSecs(BigInt(60))`. Negative or
+  >`u64::MAX` BigInt inputs are rejected at the boundary with a
+  descriptive error rather than silently truncating.
+- TypeScript reconnect setter JSDoc adds the `"custom"` policy
+  qualifier so the cross-binding docstring parity with Python's
+  `Deprecated since v10.0.1...` style is restored. The setters are
+  silent no-ops under `"manual"` and `"custom"` policies; only the
+  `Auto(limits)` variant consumes the values.
+- Stage-1 → stage-2 backpressure send no longer parks indefinitely
+  on a `crossbeam_channel::Sender::send` if every stage-2 worker
+  panics *while* stage-1 is already blocked on a full queue.
+  `Stage2PoolSender::send` now parks in
+  `POISON_CHECK_INTERVAL` (50 ms) slices via `send_timeout` and
+  re-reads the pool's poison flag between slices, so a worker
+  panic mid-park surfaces as `Stage2SendError::Poisoned` within
+  one slice instead of wedging stage-1 forever. Regression test
+  (`poisoned_pool_releases_parked_producer_within_one_second`)
+  pins the bounded wakeup under one-second deadline.
+- FLATFILES wire-format reference docs restored at the
+  `crate::flatfiles::index` module rustdoc (on-disk header layout,
+  INDEX entry shape, contract-key encoding per `SecType`,
+  strike-in-tenths-of-cent convention). Module docs are the right
+  home for reference spec; the stale link to
+  `docs-site/docs/flatfiles/protocol.md` (file never existed) is
+  gone from `flatfiles::{mod,index}` and from the changelog.
+- TypeScript `npm test` script delegates to
+  `scripts/run_tests.mjs`, which walks `__tests__/` and hands every
+  `*.test.mjs` file to `node --test` as explicit argv. Replaces the
+  prior explicit-file list (which silently skipped the
+  `config_reconnect.test.mjs` reconnect-parity coverage that landed
+  in round 3). A shell-glob form (`node --test __tests__/*.test.mjs`)
+  also fails because Windows PowerShell does not expand it and
+  Node's own `--test` glob support is 22+; the explicit-argv runner
+  works on every supported shell and on every Node version
+  satisfying `engines.node >= 20`. The runner exits non-zero when
+  no test files are found, so a future regression that empties
+  the directory cannot silently pass CI.
+- `bench-internals` feature removed in favour of an out-of-Cargo
+  `--cfg bench_internals` flag. `Stage2Pool::submit_for_bench`
+  remains gated, but downstream consumers can no longer enable it
+  from the published `[features]` graph. The bench at
+  `benches/bench_stage_pipeline.rs` activates via
+  `RUSTFLAGS='--cfg bench_internals' cargo bench
+  --bench bench_stage_pipeline`.
+- `[package.metadata.docs.rs]` switched from `all-features = true`
+  to an explicit feature list (`arrow`, `polars`, `frames`,
+  `config-file`) so the rendered docs.rs page no longer surfaces
+  bench-only or test-only symbols.
+- `__test-helpers` private feature gates the test-only
+  `MddsClient::for_fallback_test` constructor. The symbol no longer
+  enters the published rlib unless the (double-underscore-prefixed,
+  doc-hidden) feature is explicitly enabled.
+- ReconnectConfig setter parity on the TypeScript binding.
+  `Config.setReconnectPolicy`, `setReconnectMaxAttempts`,
+  `setReconnectMaxRateLimitedAttempts`, and
+  `setReconnectStableWindowSecs` mirror the Python / C++ / FFI
+  surface; `sdks/parity.toml` records the field-level cross-binding
+  state.
+- Gate 14 (`scripts/check_safety_comment_boilerplate.py`) drops the
+  wholesale `ffi/src/` exemption and replaces it with a per-site
+  allowlist file (`scripts/safety_comment_allowlist.txt`) listing
+  the genuinely-shared invariants (handle round-trip, symbol-array
+  contract, test-only factory pointer). Every other duplicate trips
+  the gate regardless of location. Extended the invariant-signal
+  patterns to recognise `NUL-terminated`, `CString::`, and `NUL`
+  references so legitimate FFI annotations are not flagged.
+- FFI `error::tests` module hoists the four duplicate stamped
+  `// SAFETY: tdx_last_error() ...` blocks into a single
+  `last_error_message()` helper with one comprehensive SAFETY
+  comment naming the thread-local-slot lifetime invariant.
+- Gate 2 (`scripts/check_binding_parity.py`) gains a
+  dotted-name carve-out so per-field parity rows
+  (`FlatFilesConfig.max_attempts`, `ReconnectConfig.policy`, etc.)
+  participate in the SSOT without forcing the class-existence check
+  to match field-level setters. Tracked for per-field granularity
+  refactor in issue #595.
+- Legacy single-stage MDDS decode path replaces the per-chunk
+  `Box<dyn FnOnce>` closure with a typed
+  `DecodeRequest::SingleStage { response, max_message_size, reply }`
+  variant. The decoder thread runs `decode_data_table_with_max`
+  directly on the typed payload, avoiding the per-chunk
+  dynamic-dispatch vtable indirection the boxed `FnOnce` carried
+  (the per-chunk allocation count is unchanged — the box is now
+  for the typed struct instead of the closure).
+- Python `Config.decoder_threads` getter and setter prepend a
+  `Deprecated since v10.0.1: set decode_threads instead.`
+  deprecation line. Visible via `help(type(c).decoder_threads)`.
+- `.pyi` stub converts the leading `#`-comment over
+  `decoder_threads` to a triple-quoted attribute docstring so the
+  deprecation surfaces in tooling that consumes attribute
+  docstrings.
+- Tier-clamp regression test
+  (`rest_arm_respects_tier_clamp_semaphore`) replaces the
+  120 ms sleep with an `Arc<Notify>` entry-side barrier
+  (`RestMock::wait_for_entry`) so the test waits deterministically
+  for "first call reached mock" instead of racing the sleep.
+- Greeks gRPC arm `end_date` tests pin the outgoing wire bytes via
+  a new `MockBehaviour::capture_request_bytes` hook: the test
+  captures the inbound request proto, decodes it with
+  `OptionHistory*Request::decode`, and asserts the `end_date` field
+  carries the expected value. Renamed
+  `*_grpc_arm_dispatches` → `*_grpc_arm_forwards_end_date` to match
+  the contract.
+- Module headers across `fpss::{mod, pinning, wake}`,
+  `rest::mod`, `frames::mod`, `grpc::decoder_pool` compressed to
+  one paragraph each — the multi-paragraph architectural narratives
+  now live in the docs site (`docs-site/docs/streaming/index.md`,
+  `docs-site/docs/streaming/latency.md`). FLATFILES on-disk wire
+  layout remains at the `crate::flatfiles::index` module level as
+  the reference spec.
+- Issue / PR references stripped from `///` user-facing rustdoc
+  across the public surface (`client.rs`, `grpc/stream.rs`,
+  `fpss/framing.rs`, `mdds/macros.rs`,
+  `streaming_async_batches.rs`, `streaming_async_session.rs`).
+  References remain on `//` internal comments and `#[test]` doc
+  blocks per the audit protocol.
+- Python codegen template stripped the hardcoded `(issue #565)`
+  attribution from 33 `.stream()` doc-blocks in
+  `historical_methods.rs`; the comparable references in the Rust
+  endpoint render, the Python streaming-terminal renderer, the
+  REST builder header, and the `mdds/macros.rs` streaming
+  variant macro doc-block were all rewritten to describe the
+  behaviour without the issue number.
+- `MddsConfig::decoder_threads` rustdoc compressed to the
+  deprecation message + redirect. The "why no `#[deprecated]`"
+  rationale moved to an internal `//` comment above the field.
+- REST `Vec::with_capacity` seed floor for the `Content-Length`-
+  advertised path: when the server emits a small `Content-Length`
+  (including `0`) but follows up with chunked DATA, the
+  accumulator now starts at the same 64 KiB floor the pure-chunked
+  path uses, instead of the advertised value.
+- `parse_legacy_six_field_quote_csv` test renamed to
+  `parse_six_field_quote_csv_zero_fills_missing_columns` so the
+  test name describes the invariant being pinned.
+- `decoder_threads` deprecation parity across every binding.
+  Rust rustdoc, Python `.pyi`, C++ Doxygen, and TypeScript JSDoc all
+  carry an identical `since v10.0.1, use decode_threads` note +
+  attribute (`[[deprecated]]` on C++, `@deprecated` JSDoc tag
+  propagated via napi-rs doc-comment forwarding).
+- `MddsConfig::decoder_threads` auto-sizing rustdoc + bench
+  + migration-doc rewrites match the post-v10.0.0 formula
+  (`(available_parallelism / 2).max(1)`, no channel cap).
+- `crate::mdds::decode::{decompress_response, decompress_response_with_max,
+  decode_data_table, decode_data_table_with_max}` take `&mut
+  ResponseData` so the identity-compression path can move
+  `compressed_data` out via `std::mem::take` instead of cloning.
+  Behaviour preserved on every existing call site; the move is
+  observable only when callers retain the `ResponseData` past the
+  decode (no in-tree consumer does so).
+- `crates/thetadatadx/src/rest/client.rs` seeds the chunked-transfer
+  body accumulator with a 64 KiB floor so the first DATA frame on a
+  chunked REST response does not trigger a per-chunk realloc.
+- `MddsClient` REST-fallback shims downgrade per-call `start_date` /
+  `end_date` logging from `tracing::debug!` to `tracing::trace!` so
+  routine operator-visible logs no longer echo request date ranges.
+- FFI codegen template emits `require_client!` + `require_symbol_array!`
+  macro calls in place of the 61 inline `// SAFETY: client is a
+  non-null pointer ...` blocks and the 7 inline
+  `// SAFETY: caller supplies a contiguous array ...` blocks the
+  prior endpoint shims carried. Regenerated
+  `ffi/src/endpoint_with_options.rs` keeps a single per-macro
+  invariant-naming SAFETY comment instead of stamping the same
+  boilerplate at every call site.
+- Every hand-written `// SAFETY: see FFI boundary doc on the
+  enclosing fn …` line in `ffi/src/{flatfiles,streaming,utility,types}.rs`
+  rewritten to name the specific invariant the local `unsafe`
+  consumes (pointer provenance, layout, lifetime, ordering).
+- `crate::grpc::decoder_pool::backoff_ring_full` split into
+  `backoff_ring_full_async(duration)` (tokio multi-thread; honours
+  the duration via `block_in_place + thread::sleep`) and
+  `backoff_ring_full_sync()` (current-thread / non-async; fixed
+  256-iter spin) so the sync arm does not silently discard a
+  parameter the async arm uses.
+
+- `crate::grpc::pool::ChannelPool` now reconnects channels on
+  `ConnectionClosed` in-place rather than marking them permanently
+  dead. Long-running clients no longer cascade after sustained load:
+  every transport-level fault (`GOAWAY`, IO failure, peer shutdown,
+  open-phase drop) triggers a single-flight reconnect of the
+  channel's inner `SendRequest<Bytes>` with bounded exponential
+  backoff (50 ms initial, 30 s cap, 8 attempts). The caller's retry
+  shell re-dispatches once and observes the fresh sender on the
+  next pool pick. Fixes the real root cause behind #571 / #577 /
+  #589 — the prior investigation pin
+  (`docs-site/docs/legacy-quote-577-investigation.md`)
+  misattributed the cascade to a server-side schema variant; the
+  actual cause was the SDK's own dead-channel mechanism introduced
+  in #578 with no recycling counterpart.
+
+- The lenient 6-/11-/12-field NBBO decoder added in #573 is
+  **kept** as defense-in-depth. `find_header` + `opt_number(row, None) -> 0`
+  is good API design regardless of cause; a subset NBBO layout
+  could surface from any upstream storage tier in the future. The
+  doc-comment attribution to "issue #571" / "patched terminal
+  `normalizeData()`" is stripped — the test name
+  `quote_tick_decodes_legacy_six_field_shape_with_zero_fill`
+  remains as a regression pin.
+- The REST transport (`crate::rest`) is **kept** as the
+  user-facing alternative transport reachable via
+  `FallbackPolicy::RestAlways`.
 
 - REST endpoint builders are now codegen-driven from
   `endpoint_surface.toml` (#580). The four hand-written
@@ -800,8 +825,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of events dropped under non-`Block` policies without holding a
   `FpssClient` reference.
 
-### Changed
-
 - `QuoteTick` decoder is now explicit about lenient column extraction
   for the legacy 6-field NBBO layout (#571). The `bid_exchange`,
   `bid_condition`, `ask_exchange`, `ask_condition` columns were
@@ -860,45 +883,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   channel-index context (`"channel {idx}: ..."`) is preserved on
   the `Transport`-shaped output.
 
-### Added
+- Workspace clippy invocation widened to
+  `cargo clippy --workspace --all-targets --locked -- -D warnings`
+  so `[[bench]]` and `#[cfg(test)]` unsafe blocks travel through
+  `clippy::undocumented_unsafe_blocks` on every PR. Adds SAFETY
+  comments on five bench-only `unsafe impl GlobalAlloc` blocks
+  and two test-only unsafe deref sites that previously escaped
+  the lint.
+- `scripts/check_banned_vocab.py` rejects the verbatim string
+  "see FFI boundary doc on the enclosing fn — raw pointers
+  satisfy the documented caller contract" outside `ffi/src/`.
+  The string was landed across 31 sites including 8 that are
+  not FFI raw-pointer contexts; the gate prevents future
+  bot-stamping from reintroducing the boilerplate.
 
-- Standalone `FpssClient` and `MddsClient` pyclasses on the Python
-  binding. `FpssClient(creds, config)` opens ONLY the FPSS TLS
-  transport (no MDDS gRPC channel, no Nexus HTTP auth); `MddsClient(creds,
-  config)` opens ONLY the MDDS gRPC channel plus the Nexus
-  authentication and surfaces the historical / FLATFILES API while
-  raising `AttributeError` on every FPSS-touching method. The bundled
-  `ThetaDataDxClient` keeps its current behaviour — the new classes
-  are purely additive and align the Python surface with the
-  standalone clients already exposed by the C ABI (`tdx_fpss_*` /
-  `tdx_client_*`) and the C++ wrapper (`tdx::FpssClient` /
-  `tdx::Client`).
-- gRPC `grpc-timeout` header is now emitted on every
-  deadline-bearing RPC (`server_streaming_with_deadline`,
-  `mdds_client.with_deadline(...)`). The header carries the
-  smallest unit that fits the budget per the gRPC HTTP/2 spec
-  (`n` / `u` / `m` / `S` / `M` / `H`), so the server can
-  short-circuit on deadline elapse instead of completing work the
-  client will discard.
-- `TransportErrorKind` is exported from `thetadatadx::error` for
-  binding consumers and retry classifiers.
-- `tdbe::types::price::Price::with_value_and_type` constructor
-  rejects out-of-range `price_type` values with a typed
-  `PriceError` instead of clamping. `Price::value()` and
-  `Price::price_type()` accessors join the public API so future
-  field visibility changes do not break call sites.
-  `Price::is_unset()` and `Price::is_zero_value()` split the
-  previous `is_zero()` conflation into the two distinct signals
-  (sentinel vs real zero).
-- `Price` POW10 indexing paths carry `debug_assert!` invariant
-  guards so a hand-constructed `Price { value, price_type }`
-  outside `0..=MAX_PRICE_TYPE` traps in debug builds rather than
-  reading past the end of the lookup tables.
-- `AuthUser::max_concurrent_requests` now routes the
-  subscription-tier shift through `SubscriptionTier::from_wire`.
-  Hostile wire bytes (negative, `> 3`, `i32::MAX`) fold to
-  `Free=1` and emit a `warn` instead of panicking on the old
-  `1usize << tier` path.
 
 ### Deprecated
 
@@ -909,7 +907,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `decompress_zstd`, etc.). The constructors will be removed in
   the next major release.
 
+
+### Removed
+
+- `Channel::is_dead`, `Channel::mark_dead`, `Channel::dead_handle`,
+  `ChannelPool::all_dead`, `ChannelPool::dead_count` — replaced by
+  in-place reconnect (see Changed above). The `ChannelLease`
+  picker no longer scans for "live" channels separately; every
+  channel in the pool stays a valid pick because the channel
+  itself swaps its inner h2 session on observed faults.
+- `ChannelError::UpstreamCascade` — folded into the existing
+  `ChannelError::ConnectionClosed` variant. The mid-stream
+  classifier (`classify_h2_error_mid_stream`) is gone; the
+  open-phase classifier (`classify_h2_error`) covers both phases
+  via the new `classify_h2_error_ref` thin wrapper.
+- `FallbackPolicy::RestOnH2Disconnect` and
+  `FallbackPolicy::RestAlwaysForDateRange` — both variants were
+  built around a misdiagnosed cascade and never actually helped.
+  `FallbackPolicy::RestAlways` is retained as the user-facing
+  escape hatch for callers who want every historical-quote call
+  routed over a locally-running Terminal's REST surface.
+- `_with_fallback` per-endpoint shims (Python / TypeScript /
+  C++ / FFI) tied to the deleted variants. The four remaining
+  `option_history_*_with_fallback` methods dispatch on
+  `FallbackPolicy::RestAlways` vs `Disabled` only.
+- `docs-site/docs/legacy-quote-577-investigation.md`,
+  `docs-site/docs/legacy-quote-handling.md` — both documented the
+  wrong root cause. Replaced by
+  `docs-site/docs/channel-pool-design.md`, which honestly
+  describes the in-place reconnect contract and pins the
+  correction so the next contributor doesn't repeat the search.
+- `crates/thetadatadx/tests/test_577_2020_onward.rs` — built on
+  the wrong premise. Replaced by
+  `crates/thetadatadx/tests/test_pool_reconnect.rs`, which pins
+  the single-flight CAS, the lifecycle observer events, and the
+  classifier-triggered reconnect spawn.
+- `tools/local-terminal-patcher/` — patched a code path
+  (`QuoteTick(Tick t)` constructor strict-length throw) that
+  bytecode analysis of the upstream terminal jar shows is never
+  invoked on the `option_history_quote` gRPC response path.
+  Decompilation confirms the constructor's sole caller is
+  `MarketValueTick`. The patcher fixed a fictional problem; the
+  workspace member, its `clap` / `zip` / `sha2` dependencies, and
+  its patch sources are removed.
+
+
 ### Fixed
+
+- Greeks `_with_fallback` regression coverage. Four new integration
+  tests pin `end_date` forwarding on both the REST and gRPC arms of
+  `option_history_greeks_implied_volatility_with_fallback` and
+  `option_history_greeks_first_order_with_fallback`, locking the
+  prior-round fix against silent regression.
+- Tier-clamp regression coverage. A new integration test runs two
+  concurrent `option_history_quote_with_fallback` calls against an
+  in-process REST mock with `concurrent_requests = 1`; the assertion
+  observes the second call parking on the semaphore until the first
+  completes.
 
 - Documentation did not flag which historical builder terminal to
   use for which workload, so users reached for the buffered `.await`
@@ -1014,22 +1068,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mem::size_of::<FpssEventInternal>() = 96` bytes on the current
   64-bit layout; the per-`FpssClient` ring footprint at the
   default `ring_size = 4096` is now documented as ~ 384 KiB.
-
-### CI
-
-- Workspace clippy invocation widened to
-  `cargo clippy --workspace --all-targets --locked -- -D warnings`
-  so `[[bench]]` and `#[cfg(test)]` unsafe blocks travel through
-  `clippy::undocumented_unsafe_blocks` on every PR. Adds SAFETY
-  comments on five bench-only `unsafe impl GlobalAlloc` blocks
-  and two test-only unsafe deref sites that previously escaped
-  the lint.
-- `scripts/check_banned_vocab.py` rejects the verbatim string
-  "see FFI boundary doc on the enclosing fn — raw pointers
-  satisfy the documented caller contract" outside `ffi/src/`.
-  The string was landed across 31 sites including 8 that are
-  not FFI raw-pointer contexts; the gate prevents future
-  bot-stamping from reintroducing the boilerplate.
 
 ## [10.0.0] - 2026-05-09
 

--- a/crates/thetadatadx/src/grpc/stage_pipeline.rs
+++ b/crates/thetadatadx/src/grpc/stage_pipeline.rs
@@ -152,6 +152,15 @@ pub(crate) struct Stage2PoolSender {
     sender: Sender<Stage2Job>,
     counters: Arc<Stage2Counters>,
     poisoned: Arc<AtomicBool>,
+    /// Test-only barrier counter incremented once per
+    /// `send_timeout` slice entry inside the blocking-send loop.
+    /// Lets the poison-race regression test (see
+    /// `poisoned_pool_releases_parked_producer_within_one_second`)
+    /// observe deterministically that the producer reached the
+    /// slice loop before flipping the poison flag — replacing the
+    /// prior `thread::sleep(100ms)` barrier that races under load.
+    #[cfg(test)]
+    parked_in_slice_loop: Arc<AtomicU64>,
 }
 
 impl Stage2PoolSender {
@@ -199,6 +208,8 @@ impl Stage2PoolSender {
             if self.is_poisoned() {
                 break Err(Stage2SendError::Poisoned { job });
             }
+            #[cfg(test)]
+            self.parked_in_slice_loop.fetch_add(1, Ordering::Release);
             match self.sender.send_timeout(job, POISON_CHECK_INTERVAL) {
                 Ok(()) => break Ok(()),
                 Err(crossbeam_channel::SendTimeoutError::Timeout(returned)) => {
@@ -312,6 +323,8 @@ impl Stage2Pool {
                 sender,
                 counters: Arc::clone(&counters),
                 poisoned,
+                #[cfg(test)]
+                parked_in_slice_loop: Arc::new(AtomicU64::new(0)),
             }),
             workers,
             counters,
@@ -580,16 +593,26 @@ mod tests {
 
     /// Pin: when the queue is full, `send()` parks the producer
     /// (records `total_parked`) rather than dropping the payload.
+    ///
+    /// Uses the `parked_in_slice_loop` test-only barrier counter on
+    /// `Stage2PoolSender` (incremented once per `send_timeout` slice
+    /// entry inside the blocking-send arm) to wait deterministically
+    /// for the producer to reach the park branch before draining a
+    /// slot. The prior `thread::sleep(50ms)` barrier races on busy
+    /// runners: under contention the producer may not have entered
+    /// the slice loop within 50 ms, masking the actual park path.
     #[test]
     fn backpressure_parks_producer() {
         const QUEUE_DEPTH: usize = 2;
         let counters = Arc::new(Stage2Counters::default());
         let poisoned = Arc::new(AtomicBool::new(false));
+        let parked_in_slice_loop = Arc::new(AtomicU64::new(0));
         let (sender_inner, receiver) = bounded::<Stage2Job>(QUEUE_DEPTH);
         let sender = Stage2PoolSender {
             sender: sender_inner,
             counters: Arc::clone(&counters),
             poisoned: Arc::clone(&poisoned),
+            parked_in_slice_loop: Arc::clone(&parked_in_slice_loop),
         };
 
         // Fill the queue to capacity with synthetic jobs (no
@@ -613,10 +636,18 @@ mod tests {
                 .expect("eventually accepted after consumer pulls one")
         });
 
-        // Give the producer time to enter the park branch — the
-        // `try_send` fails fast, then the producer falls into the
-        // blocking-send arm and starts the `Instant::now()` timer.
-        thread::sleep(Duration::from_millis(50));
+        // Wait deterministically for the producer to enter the
+        // slice loop. The barrier counter is incremented exactly
+        // once per `send_timeout` slice entry; spin (with a 5 s
+        // overall deadline) until we observe >= 1.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while parked_in_slice_loop.load(Ordering::Acquire) == 0 {
+            assert!(
+                Instant::now() < deadline,
+                "producer did not enter slice loop within 5 s"
+            );
+            thread::yield_now();
+        }
 
         // Drain ONE slot so the parked producer unblocks. We
         // pull a job, then immediately drop it (replies are
@@ -630,6 +661,10 @@ mod tests {
         assert!(
             parked > 0,
             "stage-1 must park on a full queue (total_parked = {parked})"
+        );
+        assert!(
+            parked_in_slice_loop.load(Ordering::Acquire) >= 1,
+            "producer must have entered the slice loop at least once"
         );
 
         // Drain remaining jobs to release any held resources.
@@ -731,11 +766,13 @@ mod tests {
         const QUEUE_DEPTH: usize = 1;
         let counters = Arc::new(Stage2Counters::default());
         let poisoned = Arc::new(AtomicBool::new(false));
+        let parked_in_slice_loop = Arc::new(AtomicU64::new(0));
         let (sender_inner, receiver) = bounded::<Stage2Job>(QUEUE_DEPTH);
         let sender = Stage2PoolSender {
             sender: sender_inner,
             counters: Arc::clone(&counters),
             poisoned: Arc::clone(&poisoned),
+            parked_in_slice_loop: Arc::clone(&parked_in_slice_loop),
         };
 
         // Saturate the one-slot queue. We hold the receiver in the
@@ -758,8 +795,20 @@ mod tests {
             let _ = outcome_tx.send((start.elapsed(), result));
         });
 
-        // Let the producer enter the park branch.
-        thread::sleep(Duration::from_millis(100));
+        // Wait deterministically for the producer to enter the
+        // slice loop before flipping the poison flag. Using the
+        // barrier counter rather than a fixed `thread::sleep` pins
+        // the contract under test (poison-while-parked) instead of
+        // racing the producer's fast-path `is_poisoned()` check
+        // against an arbitrary wall-clock window.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while parked_in_slice_loop.load(Ordering::Acquire) == 0 {
+            assert!(
+                Instant::now() < deadline,
+                "producer did not enter slice loop within 5 s"
+            );
+            thread::yield_now();
+        }
 
         // Force-poison — equivalent to every worker catching a panic
         // while stage-1 was already parked on the full queue.
@@ -778,6 +827,10 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(1),
             "parked producer must observe poison within 1 s (took {elapsed:?})"
+        );
+        assert!(
+            parked_in_slice_loop.load(Ordering::Acquire) >= 1,
+            "producer must have entered the slice loop at least once"
         );
         match result {
             Err(Stage2SendError::Poisoned { .. }) => {}

--- a/crates/thetadatadx/src/rest/client.rs
+++ b/crates/thetadatadx/src/rest/client.rs
@@ -120,7 +120,7 @@ impl RestClient {
 // `OptionHistoryGreeksFirstOrderRestBuilder`) are emitted by
 // `build_support_bin/endpoints/sdk_render/rest_builder.rs` from
 // `endpoint_surface.toml` and live in `super::_generated::rest_endpoints`.
-// See issue #580 — adding a new REST endpoint is now one TOML row.
+// Adding a new REST endpoint is now one TOML row.
 
 // ─── Transport helper ────────────────────────────────────────────────
 

--- a/crates/thetadatadx/src/rest/mod.rs
+++ b/crates/thetadatadx/src/rest/mod.rs
@@ -12,10 +12,10 @@ pub mod error;
 
 // Generated builder structs + their `RestClient` constructor methods.
 // Emitted by `build_support_bin/endpoints/sdk_render/rest_builder.rs`
-// from `endpoint_surface.toml`; see issue #580. The module is wired in
-// here (not at file scope from `client.rs`) so the `impl RestClient`
-// block inside it sits in the same crate-public namespace as the
-// hand-written `impl RestClient` in `client.rs`.
+// from `endpoint_surface.toml`. The module is wired in here (not at
+// file scope from `client.rs`) so the `impl RestClient` block inside
+// it sits in the same crate-public namespace as the hand-written
+// `impl RestClient` in `client.rs`.
 mod _generated {
     pub mod rest_endpoints;
 }

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -11,215 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > versus v10.0.0. The next release tag MUST be v11.0.0, not a v10.0.x patch.
 > Owner-greenlight gated on this audit returning zero actionable findings.
 
-### Changed
-
-- TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint`
-  (was `number`) for true `u64` parity with the Python / C++ / FFI
-  surface. Callers passing `Number` should wrap:
-  `cfg.setReconnectStableWindowSecs(BigInt(60))`. Negative or
-  >`u64::MAX` BigInt inputs are rejected at the boundary with a
-  descriptive error rather than silently truncating.
-- TypeScript reconnect setter JSDoc adds the `"custom"` policy
-  qualifier so the cross-binding docstring parity with Python's
-  `Deprecated since v10.0.1...` style is restored. The setters are
-  silent no-ops under `"manual"` and `"custom"` policies; only the
-  `Auto(limits)` variant consumes the values.
-- Stage-1 → stage-2 backpressure send no longer parks indefinitely
-  on a `crossbeam_channel::Sender::send` if every stage-2 worker
-  panics *while* stage-1 is already blocked on a full queue.
-  `Stage2PoolSender::send` now parks in
-  `POISON_CHECK_INTERVAL` (50 ms) slices via `send_timeout` and
-  re-reads the pool's poison flag between slices, so a worker
-  panic mid-park surfaces as `Stage2SendError::Poisoned` within
-  one slice instead of wedging stage-1 forever. Regression test
-  (`poisoned_pool_releases_parked_producer_within_one_second`)
-  pins the bounded wakeup under one-second deadline.
-- FLATFILES wire-format reference docs restored at the
-  `crate::flatfiles::index` module rustdoc (on-disk header layout,
-  INDEX entry shape, contract-key encoding per `SecType`,
-  strike-in-tenths-of-cent convention). Module docs are the right
-  home for reference spec; the stale link to
-  `docs-site/docs/flatfiles/protocol.md` (file never existed) is
-  gone from `flatfiles::{mod,index}` and from the changelog.
-- TypeScript `npm test` script delegates to
-  `scripts/run_tests.mjs`, which walks `__tests__/` and hands every
-  `*.test.mjs` file to `node --test` as explicit argv. Replaces the
-  prior explicit-file list (which silently skipped the
-  `config_reconnect.test.mjs` reconnect-parity coverage that landed
-  in round 3). A shell-glob form (`node --test __tests__/*.test.mjs`)
-  also fails because Windows PowerShell does not expand it and
-  Node's own `--test` glob support is 22+; the explicit-argv runner
-  works on every supported shell and on every Node version
-  satisfying `engines.node >= 20`. The runner exits non-zero when
-  no test files are found, so a future regression that empties
-  the directory cannot silently pass CI.
-- `bench-internals` feature removed in favour of an out-of-Cargo
-  `--cfg bench_internals` flag. `Stage2Pool::submit_for_bench`
-  remains gated, but downstream consumers can no longer enable it
-  from the published `[features]` graph. The bench at
-  `benches/bench_stage_pipeline.rs` activates via
-  `RUSTFLAGS='--cfg bench_internals' cargo bench
-  --bench bench_stage_pipeline`.
-- `[package.metadata.docs.rs]` switched from `all-features = true`
-  to an explicit feature list (`arrow`, `polars`, `frames`,
-  `config-file`) so the rendered docs.rs page no longer surfaces
-  bench-only or test-only symbols.
-- `__test-helpers` private feature gates the test-only
-  `MddsClient::for_fallback_test` constructor. The symbol no longer
-  enters the published rlib unless the (double-underscore-prefixed,
-  doc-hidden) feature is explicitly enabled.
-- ReconnectConfig setter parity on the TypeScript binding.
-  `Config.setReconnectPolicy`, `setReconnectMaxAttempts`,
-  `setReconnectMaxRateLimitedAttempts`, and
-  `setReconnectStableWindowSecs` mirror the Python / C++ / FFI
-  surface; `sdks/parity.toml` records the field-level cross-binding
-  state.
-- Gate 14 (`scripts/check_safety_comment_boilerplate.py`) drops the
-  wholesale `ffi/src/` exemption and replaces it with a per-site
-  allowlist file (`scripts/safety_comment_allowlist.txt`) listing
-  the genuinely-shared invariants (handle round-trip, symbol-array
-  contract, test-only factory pointer). Every other duplicate trips
-  the gate regardless of location. Extended the invariant-signal
-  patterns to recognise `NUL-terminated`, `CString::`, and `NUL`
-  references so legitimate FFI annotations are not flagged.
-- FFI `error::tests` module hoists the four duplicate stamped
-  `// SAFETY: tdx_last_error() ...` blocks into a single
-  `last_error_message()` helper with one comprehensive SAFETY
-  comment naming the thread-local-slot lifetime invariant.
-- Gate 2 (`scripts/check_binding_parity.py`) gains a
-  dotted-name carve-out so per-field parity rows
-  (`FlatFilesConfig.max_attempts`, `ReconnectConfig.policy`, etc.)
-  participate in the SSOT without forcing the class-existence check
-  to match field-level setters. Tracked for per-field granularity
-  refactor in issue #595.
-- Legacy single-stage MDDS decode path replaces the per-chunk
-  `Box<dyn FnOnce>` closure with a typed
-  `DecodeRequest::SingleStage { response, max_message_size, reply }`
-  variant. The decoder thread runs `decode_data_table_with_max`
-  directly on the typed payload, avoiding the per-chunk
-  dynamic-dispatch vtable indirection the boxed `FnOnce` carried
-  (the per-chunk allocation count is unchanged — the box is now
-  for the typed struct instead of the closure).
-- Python `Config.decoder_threads` getter and setter prepend a
-  `Deprecated since v10.0.1: set decode_threads instead.`
-  deprecation line. Visible via `help(type(c).decoder_threads)`.
-- `.pyi` stub converts the leading `#`-comment over
-  `decoder_threads` to a triple-quoted attribute docstring so the
-  deprecation surfaces in tooling that consumes attribute
-  docstrings.
-- Tier-clamp regression test
-  (`rest_arm_respects_tier_clamp_semaphore`) replaces the
-  120 ms sleep with an `Arc<Notify>` entry-side barrier
-  (`RestMock::wait_for_entry`) so the test waits deterministically
-  for "first call reached mock" instead of racing the sleep.
-- Greeks gRPC arm `end_date` tests pin the outgoing wire bytes via
-  a new `MockBehaviour::capture_request_bytes` hook: the test
-  captures the inbound request proto, decodes it with
-  `OptionHistory*Request::decode`, and asserts the `end_date` field
-  carries the expected value. Renamed
-  `*_grpc_arm_dispatches` → `*_grpc_arm_forwards_end_date` to match
-  the contract.
-- Module headers across `fpss::{mod, pinning, wake}`,
-  `rest::mod`, `frames::mod`, `grpc::decoder_pool` compressed to
-  one paragraph each — the multi-paragraph architectural narratives
-  now live in the docs site (`docs-site/docs/streaming/index.md`,
-  `docs-site/docs/streaming/latency.md`). FLATFILES on-disk wire
-  layout remains at the `crate::flatfiles::index` module level as
-  the reference spec.
-- Issue / PR references stripped from `///` user-facing rustdoc
-  across the public surface (`client.rs`, `grpc/stream.rs`,
-  `fpss/framing.rs`, `mdds/macros.rs`,
-  `streaming_async_batches.rs`, `streaming_async_session.rs`).
-  References remain on `//` internal comments and `#[test]` doc
-  blocks per the audit protocol.
-- Python codegen template stripped the hardcoded `(issue #565)`
-  attribution from 33 `.stream()` doc-blocks in
-  `historical_methods.rs`; the comparable references in the Rust
-  endpoint render, the Python streaming-terminal renderer, the
-  REST builder header, and the `mdds/macros.rs` streaming
-  variant macro doc-block were all rewritten to describe the
-  behaviour without the issue number.
-- `MddsConfig::decoder_threads` rustdoc compressed to the
-  deprecation message + redirect. The "why no `#[deprecated]`"
-  rationale moved to an internal `//` comment above the field.
-- REST `Vec::with_capacity` seed floor for the `Content-Length`-
-  advertised path: when the server emits a small `Content-Length`
-  (including `0`) but follows up with chunked DATA, the
-  accumulator now starts at the same 64 KiB floor the pure-chunked
-  path uses, instead of the advertised value.
-- `parse_legacy_six_field_quote_csv` test renamed to
-  `parse_six_field_quote_csv_zero_fills_missing_columns` so the
-  test name describes the invariant being pinned.
-- `decoder_threads` deprecation parity across every binding.
-  Rust rustdoc, Python `.pyi`, C++ Doxygen, and TypeScript JSDoc all
-  carry an identical `since v10.0.1, use decode_threads` note +
-  attribute (`[[deprecated]]` on C++, `@deprecated` JSDoc tag
-  propagated via napi-rs doc-comment forwarding).
-- `MddsConfig::decoder_threads` auto-sizing rustdoc + bench
-  + migration-doc rewrites match the post-v10.0.0 formula
-  (`(available_parallelism / 2).max(1)`, no channel cap).
-- `crate::mdds::decode::{decompress_response, decompress_response_with_max,
-  decode_data_table, decode_data_table_with_max}` take `&mut
-  ResponseData` so the identity-compression path can move
-  `compressed_data` out via `std::mem::take` instead of cloning.
-  Behaviour preserved on every existing call site; the move is
-  observable only when callers retain the `ResponseData` past the
-  decode (no in-tree consumer does so).
-- `crates/thetadatadx/src/rest/client.rs` seeds the chunked-transfer
-  body accumulator with a 64 KiB floor so the first DATA frame on a
-  chunked REST response does not trigger a per-chunk realloc.
-- `MddsClient` REST-fallback shims downgrade per-call `start_date` /
-  `end_date` logging from `tracing::debug!` to `tracing::trace!` so
-  routine operator-visible logs no longer echo request date ranges.
-- FFI codegen template emits `require_client!` + `require_symbol_array!`
-  macro calls in place of the 61 inline `// SAFETY: client is a
-  non-null pointer ...` blocks and the 7 inline
-  `// SAFETY: caller supplies a contiguous array ...` blocks the
-  prior endpoint shims carried. Regenerated
-  `ffi/src/endpoint_with_options.rs` keeps a single per-macro
-  invariant-naming SAFETY comment instead of stamping the same
-  boilerplate at every call site.
-- Every hand-written `// SAFETY: see FFI boundary doc on the
-  enclosing fn …` line in `ffi/src/{flatfiles,streaming,utility,types}.rs`
-  rewritten to name the specific invariant the local `unsafe`
-  consumes (pointer provenance, layout, lifetime, ordering).
-- `crate::grpc::decoder_pool::backoff_ring_full` split into
-  `backoff_ring_full_async(duration)` (tokio multi-thread; honours
-  the duration via `block_in_place + thread::sleep`) and
-  `backoff_ring_full_sync()` (current-thread / non-async; fixed
-  256-iter spin) so the sync arm does not silently discard a
-  parameter the async arm uses.
-
-- `crate::grpc::pool::ChannelPool` now reconnects channels on
-  `ConnectionClosed` in-place rather than marking them permanently
-  dead. Long-running clients no longer cascade after sustained load:
-  every transport-level fault (`GOAWAY`, IO failure, peer shutdown,
-  open-phase drop) triggers a single-flight reconnect of the
-  channel's inner `SendRequest<Bytes>` with bounded exponential
-  backoff (50 ms initial, 30 s cap, 8 attempts). The caller's retry
-  shell re-dispatches once and observes the fresh sender on the
-  next pool pick. Fixes the real root cause behind #571 / #577 /
-  #589 — the prior investigation pin
-  (`docs-site/docs/legacy-quote-577-investigation.md`)
-  misattributed the cascade to a server-side schema variant; the
-  actual cause was the SDK's own dead-channel mechanism introduced
-  in #578 with no recycling counterpart.
-
-### Fixed
-
-- Greeks `_with_fallback` regression coverage. Four new integration
-  tests pin `end_date` forwarding on both the REST and gRPC arms of
-  `option_history_greeks_implied_volatility_with_fallback` and
-  `option_history_greeks_first_order_with_fallback`, locking the
-  prior-round fix against silent regression.
-- Tier-clamp regression coverage. A new integration test runs two
-  concurrent `option_history_quote_with_fallback` calls against an
-  in-process REST mock with `concurrent_requests = 1`; the assertion
-  observes the second call parking on the semaphore until the first
-  completes.
-
 ### Added
 
+- Cross-binding ReconnectConfig setter test parity. The TypeScript
+  `__tests__/config_reconnect.test.mjs` coverage that landed in
+  round 3 now has matching siblings on every binding:
+  `sdks/python/tests/test_config_reconnect.py` (10 tests covering
+  policy round-trip, per-class budget round-trip, stable-window
+  acceptance + negative rejection, interleaved-setter independence),
+  `sdks/cpp/tests/config_reconnect.cpp` (6 Catch2 cases mirroring
+  the Python contract on the C++ wrapper), and a new
+  `reconnect_setter_tests` module in `ffi/src/auth.rs` (7 Rust
+  tests against the underlying `tdx_config_set_reconnect_*` C ABI).
+  The existing `lifecycle.cpp` smoke also expanded to call all four
+  reconnect setters with valid values.
+- TypeScript `setReconnectStableWindowSecs` BigInt boundary
+  coverage. Adds a magnitude-above-u64 rejection case
+  (`setReconnectStableWindowSecs(1n << 65n)`) alongside the
+  existing negative-BigInt rejection so the two boundary failures
+  are pinned independently.
 - `require_client!` and `require_symbol_array!` macros (with full
   unit-test coverage: null-pointer / valid / invalid-UTF-8 / Go-empty
   branches) alongside the existing `require_cstr!` macro. `require_cstr!`
@@ -237,65 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without a clean GitHub-hosted runner pass
   (`decoder_pool/threads/4`, `protobuf_decode/quote_chunk/1024`,
   `stage_pipeline/throughput/workers=4`).
-
-### Removed
-
-- `Channel::is_dead`, `Channel::mark_dead`, `Channel::dead_handle`,
-  `ChannelPool::all_dead`, `ChannelPool::dead_count` — replaced by
-  in-place reconnect (see Changed above). The `ChannelLease`
-  picker no longer scans for "live" channels separately; every
-  channel in the pool stays a valid pick because the channel
-  itself swaps its inner h2 session on observed faults.
-- `ChannelError::UpstreamCascade` — folded into the existing
-  `ChannelError::ConnectionClosed` variant. The mid-stream
-  classifier (`classify_h2_error_mid_stream`) is gone; the
-  open-phase classifier (`classify_h2_error`) covers both phases
-  via the new `classify_h2_error_ref` thin wrapper.
-- `FallbackPolicy::RestOnH2Disconnect` and
-  `FallbackPolicy::RestAlwaysForDateRange` — both variants were
-  built around a misdiagnosed cascade and never actually helped.
-  `FallbackPolicy::RestAlways` is retained as the user-facing
-  escape hatch for callers who want every historical-quote call
-  routed over a locally-running Terminal's REST surface.
-- `_with_fallback` per-endpoint shims (Python / TypeScript /
-  C++ / FFI) tied to the deleted variants. The four remaining
-  `option_history_*_with_fallback` methods dispatch on
-  `FallbackPolicy::RestAlways` vs `Disabled` only.
-- `docs-site/docs/legacy-quote-577-investigation.md`,
-  `docs-site/docs/legacy-quote-handling.md` — both documented the
-  wrong root cause. Replaced by
-  `docs-site/docs/channel-pool-design.md`, which honestly
-  describes the in-place reconnect contract and pins the
-  correction so the next contributor doesn't repeat the search.
-- `crates/thetadatadx/tests/test_577_2020_onward.rs` — built on
-  the wrong premise. Replaced by
-  `crates/thetadatadx/tests/test_pool_reconnect.rs`, which pins
-  the single-flight CAS, the lifecycle observer events, and the
-  classifier-triggered reconnect spawn.
-- `tools/local-terminal-patcher/` — patched a code path
-  (`QuoteTick(Tick t)` constructor strict-length throw) that
-  bytecode analysis of the upstream terminal jar shows is never
-  invoked on the `option_history_quote` gRPC response path.
-  Decompilation confirms the constructor's sole caller is
-  `MarketValueTick`. The patcher fixed a fictional problem; the
-  workspace member, its `clap` / `zip` / `sha2` dependencies, and
-  its patch sources are removed.
-
-### Retained
-
-- The lenient 6-/11-/12-field NBBO decoder added in #573 is
-  **kept** as defense-in-depth. `find_header` + `opt_number(row, None) -> 0`
-  is good API design regardless of cause; a subset NBBO layout
-  could surface from any upstream storage tier in the future. The
-  doc-comment attribution to "issue #571" / "patched terminal
-  `normalizeData()`" is stripped — the test name
-  `quote_tick_decodes_legacy_six_field_shape_with_zero_fill`
-  remains as a regression pin.
-- The REST transport (`crate::rest`) is **kept** as the
-  user-facing alternative transport reachable via
-  `FallbackPolicy::RestAlways`.
-
-### Added
 
 - Cross-binding parity for the two-stage MDDS decode pipeline knobs
   (Phase 3 of 3). The `MddsConfig::decode_threads` and
@@ -596,7 +347,281 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unit tests covering `contains_subsequence`, `newest_jar_in`, and
   `swap_classes_in_jar` (S3).
 
+- Standalone `FpssClient` and `MddsClient` pyclasses on the Python
+  binding. `FpssClient(creds, config)` opens ONLY the FPSS TLS
+  transport (no MDDS gRPC channel, no Nexus HTTP auth); `MddsClient(creds,
+  config)` opens ONLY the MDDS gRPC channel plus the Nexus
+  authentication and surfaces the historical / FLATFILES API while
+  raising `AttributeError` on every FPSS-touching method. The bundled
+  `ThetaDataDxClient` keeps its current behaviour — the new classes
+  are purely additive and align the Python surface with the
+  standalone clients already exposed by the C ABI (`tdx_fpss_*` /
+  `tdx_client_*`) and the C++ wrapper (`tdx::FpssClient` /
+  `tdx::Client`).
+- gRPC `grpc-timeout` header is now emitted on every
+  deadline-bearing RPC (`server_streaming_with_deadline`,
+  `mdds_client.with_deadline(...)`). The header carries the
+  smallest unit that fits the budget per the gRPC HTTP/2 spec
+  (`n` / `u` / `m` / `S` / `M` / `H`), so the server can
+  short-circuit on deadline elapse instead of completing work the
+  client will discard.
+- `TransportErrorKind` is exported from `thetadatadx::error` for
+  binding consumers and retry classifiers.
+- `tdbe::types::price::Price::with_value_and_type` constructor
+  rejects out-of-range `price_type` values with a typed
+  `PriceError` instead of clamping. `Price::value()` and
+  `Price::price_type()` accessors join the public API so future
+  field visibility changes do not break call sites.
+  `Price::is_unset()` and `Price::is_zero_value()` split the
+  previous `is_zero()` conflation into the two distinct signals
+  (sentinel vs real zero).
+- `Price` POW10 indexing paths carry `debug_assert!` invariant
+  guards so a hand-constructed `Price { value, price_type }`
+  outside `0..=MAX_PRICE_TYPE` traps in debug builds rather than
+  reading past the end of the lookup tables.
+- `AuthUser::max_concurrent_requests` now routes the
+  subscription-tier shift through `SubscriptionTier::from_wire`.
+  Hostile wire bytes (negative, `> 3`, `i32::MAX`) fold to
+  `Free=1` and emit a `warn` instead of panicking on the old
+  `1usize << tier` path.
+
 ### Changed
+
+- ReconnectConfig setter docstrings unified across every binding. The
+  per-class budget setters (`set_reconnect_max_attempts`,
+  `set_reconnect_max_rate_limited_attempts`,
+  `set_reconnect_stable_window_secs`) now carry the same
+  `"No effect unless the reconnect policy is Auto"` qualifier on the
+  Python, TypeScript, FFI, and C++ Doxygen surfaces. Replaces the
+  three previous phrasings (`"manual" or "custom"` on Python/TS,
+  `"not Auto"` on FFI/C++).
+- Stage-1 → stage-2 backpressure regression tests now block on a
+  deterministic `parked_in_slice_loop` barrier counter instead of a
+  fixed `thread::sleep`. Both `backpressure_parks_producer` and
+  `poisoned_pool_releases_parked_producer_within_one_second` wait for
+  the producer to enter the bounded `send_timeout` slice loop before
+  draining the queue or flipping the poison flag, so the test pins
+  the contract under test rather than racing the wall clock.
+- Issue-number attributions stripped from `//`/`//!` block comments
+  in the Python / TypeScript / FFI binding crates and from the two
+  remaining `crates/thetadatadx/src/rest` module comments. The
+  `(issue #N)` shape rendered in tooling that consumed module
+  docstrings; the cleanup tracks the same standard already applied
+  to `///` rustdoc on the public surface. Sites covered:
+  `sdks/python/src/util_helpers.rs`, `sdks/typescript/src/util_helpers.rs`,
+  `sdks/typescript/src/{lib,fallback}.rs`, `sdks/python/src/lib.rs`,
+  `ffi/src/{auth,utility}.rs`, `sdks/cpp/include/thetadx.h`,
+  `crates/thetadatadx/src/rest/{mod,client}.rs`.
+- CHANGELOG `[Unreleased]` section consolidated into the five canonical
+  Keep-a-Changelog buckets (`Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`). Successive PR appends had grown three duplicate `Changed`
+  buckets, three duplicate `Added` buckets, and two duplicate `Fixed`
+  buckets; non-canonical `Retained` and `CI` headings folded into
+  `Changed` per the changelog format policy. Every individual entry
+  is preserved verbatim — only the headings were merged.
+- TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint`
+  (was `number`) for true `u64` parity with the Python / C++ / FFI
+  surface. Callers passing `Number` should wrap:
+  `cfg.setReconnectStableWindowSecs(BigInt(60))`. Negative or
+  >`u64::MAX` BigInt inputs are rejected at the boundary with a
+  descriptive error rather than silently truncating.
+- TypeScript reconnect setter JSDoc adds the `"custom"` policy
+  qualifier so the cross-binding docstring parity with Python's
+  `Deprecated since v10.0.1...` style is restored. The setters are
+  silent no-ops under `"manual"` and `"custom"` policies; only the
+  `Auto(limits)` variant consumes the values.
+- Stage-1 → stage-2 backpressure send no longer parks indefinitely
+  on a `crossbeam_channel::Sender::send` if every stage-2 worker
+  panics *while* stage-1 is already blocked on a full queue.
+  `Stage2PoolSender::send` now parks in
+  `POISON_CHECK_INTERVAL` (50 ms) slices via `send_timeout` and
+  re-reads the pool's poison flag between slices, so a worker
+  panic mid-park surfaces as `Stage2SendError::Poisoned` within
+  one slice instead of wedging stage-1 forever. Regression test
+  (`poisoned_pool_releases_parked_producer_within_one_second`)
+  pins the bounded wakeup under one-second deadline.
+- FLATFILES wire-format reference docs restored at the
+  `crate::flatfiles::index` module rustdoc (on-disk header layout,
+  INDEX entry shape, contract-key encoding per `SecType`,
+  strike-in-tenths-of-cent convention). Module docs are the right
+  home for reference spec; the stale link to
+  `docs-site/docs/flatfiles/protocol.md` (file never existed) is
+  gone from `flatfiles::{mod,index}` and from the changelog.
+- TypeScript `npm test` script delegates to
+  `scripts/run_tests.mjs`, which walks `__tests__/` and hands every
+  `*.test.mjs` file to `node --test` as explicit argv. Replaces the
+  prior explicit-file list (which silently skipped the
+  `config_reconnect.test.mjs` reconnect-parity coverage that landed
+  in round 3). A shell-glob form (`node --test __tests__/*.test.mjs`)
+  also fails because Windows PowerShell does not expand it and
+  Node's own `--test` glob support is 22+; the explicit-argv runner
+  works on every supported shell and on every Node version
+  satisfying `engines.node >= 20`. The runner exits non-zero when
+  no test files are found, so a future regression that empties
+  the directory cannot silently pass CI.
+- `bench-internals` feature removed in favour of an out-of-Cargo
+  `--cfg bench_internals` flag. `Stage2Pool::submit_for_bench`
+  remains gated, but downstream consumers can no longer enable it
+  from the published `[features]` graph. The bench at
+  `benches/bench_stage_pipeline.rs` activates via
+  `RUSTFLAGS='--cfg bench_internals' cargo bench
+  --bench bench_stage_pipeline`.
+- `[package.metadata.docs.rs]` switched from `all-features = true`
+  to an explicit feature list (`arrow`, `polars`, `frames`,
+  `config-file`) so the rendered docs.rs page no longer surfaces
+  bench-only or test-only symbols.
+- `__test-helpers` private feature gates the test-only
+  `MddsClient::for_fallback_test` constructor. The symbol no longer
+  enters the published rlib unless the (double-underscore-prefixed,
+  doc-hidden) feature is explicitly enabled.
+- ReconnectConfig setter parity on the TypeScript binding.
+  `Config.setReconnectPolicy`, `setReconnectMaxAttempts`,
+  `setReconnectMaxRateLimitedAttempts`, and
+  `setReconnectStableWindowSecs` mirror the Python / C++ / FFI
+  surface; `sdks/parity.toml` records the field-level cross-binding
+  state.
+- Gate 14 (`scripts/check_safety_comment_boilerplate.py`) drops the
+  wholesale `ffi/src/` exemption and replaces it with a per-site
+  allowlist file (`scripts/safety_comment_allowlist.txt`) listing
+  the genuinely-shared invariants (handle round-trip, symbol-array
+  contract, test-only factory pointer). Every other duplicate trips
+  the gate regardless of location. Extended the invariant-signal
+  patterns to recognise `NUL-terminated`, `CString::`, and `NUL`
+  references so legitimate FFI annotations are not flagged.
+- FFI `error::tests` module hoists the four duplicate stamped
+  `// SAFETY: tdx_last_error() ...` blocks into a single
+  `last_error_message()` helper with one comprehensive SAFETY
+  comment naming the thread-local-slot lifetime invariant.
+- Gate 2 (`scripts/check_binding_parity.py`) gains a
+  dotted-name carve-out so per-field parity rows
+  (`FlatFilesConfig.max_attempts`, `ReconnectConfig.policy`, etc.)
+  participate in the SSOT without forcing the class-existence check
+  to match field-level setters. Tracked for per-field granularity
+  refactor in issue #595.
+- Legacy single-stage MDDS decode path replaces the per-chunk
+  `Box<dyn FnOnce>` closure with a typed
+  `DecodeRequest::SingleStage { response, max_message_size, reply }`
+  variant. The decoder thread runs `decode_data_table_with_max`
+  directly on the typed payload, avoiding the per-chunk
+  dynamic-dispatch vtable indirection the boxed `FnOnce` carried
+  (the per-chunk allocation count is unchanged — the box is now
+  for the typed struct instead of the closure).
+- Python `Config.decoder_threads` getter and setter prepend a
+  `Deprecated since v10.0.1: set decode_threads instead.`
+  deprecation line. Visible via `help(type(c).decoder_threads)`.
+- `.pyi` stub converts the leading `#`-comment over
+  `decoder_threads` to a triple-quoted attribute docstring so the
+  deprecation surfaces in tooling that consumes attribute
+  docstrings.
+- Tier-clamp regression test
+  (`rest_arm_respects_tier_clamp_semaphore`) replaces the
+  120 ms sleep with an `Arc<Notify>` entry-side barrier
+  (`RestMock::wait_for_entry`) so the test waits deterministically
+  for "first call reached mock" instead of racing the sleep.
+- Greeks gRPC arm `end_date` tests pin the outgoing wire bytes via
+  a new `MockBehaviour::capture_request_bytes` hook: the test
+  captures the inbound request proto, decodes it with
+  `OptionHistory*Request::decode`, and asserts the `end_date` field
+  carries the expected value. Renamed
+  `*_grpc_arm_dispatches` → `*_grpc_arm_forwards_end_date` to match
+  the contract.
+- Module headers across `fpss::{mod, pinning, wake}`,
+  `rest::mod`, `frames::mod`, `grpc::decoder_pool` compressed to
+  one paragraph each — the multi-paragraph architectural narratives
+  now live in the docs site (`docs-site/docs/streaming/index.md`,
+  `docs-site/docs/streaming/latency.md`). FLATFILES on-disk wire
+  layout remains at the `crate::flatfiles::index` module level as
+  the reference spec.
+- Issue / PR references stripped from `///` user-facing rustdoc
+  across the public surface (`client.rs`, `grpc/stream.rs`,
+  `fpss/framing.rs`, `mdds/macros.rs`,
+  `streaming_async_batches.rs`, `streaming_async_session.rs`).
+  References remain on `//` internal comments and `#[test]` doc
+  blocks per the audit protocol.
+- Python codegen template stripped the hardcoded `(issue #565)`
+  attribution from 33 `.stream()` doc-blocks in
+  `historical_methods.rs`; the comparable references in the Rust
+  endpoint render, the Python streaming-terminal renderer, the
+  REST builder header, and the `mdds/macros.rs` streaming
+  variant macro doc-block were all rewritten to describe the
+  behaviour without the issue number.
+- `MddsConfig::decoder_threads` rustdoc compressed to the
+  deprecation message + redirect. The "why no `#[deprecated]`"
+  rationale moved to an internal `//` comment above the field.
+- REST `Vec::with_capacity` seed floor for the `Content-Length`-
+  advertised path: when the server emits a small `Content-Length`
+  (including `0`) but follows up with chunked DATA, the
+  accumulator now starts at the same 64 KiB floor the pure-chunked
+  path uses, instead of the advertised value.
+- `parse_legacy_six_field_quote_csv` test renamed to
+  `parse_six_field_quote_csv_zero_fills_missing_columns` so the
+  test name describes the invariant being pinned.
+- `decoder_threads` deprecation parity across every binding.
+  Rust rustdoc, Python `.pyi`, C++ Doxygen, and TypeScript JSDoc all
+  carry an identical `since v10.0.1, use decode_threads` note +
+  attribute (`[[deprecated]]` on C++, `@deprecated` JSDoc tag
+  propagated via napi-rs doc-comment forwarding).
+- `MddsConfig::decoder_threads` auto-sizing rustdoc + bench
+  + migration-doc rewrites match the post-v10.0.0 formula
+  (`(available_parallelism / 2).max(1)`, no channel cap).
+- `crate::mdds::decode::{decompress_response, decompress_response_with_max,
+  decode_data_table, decode_data_table_with_max}` take `&mut
+  ResponseData` so the identity-compression path can move
+  `compressed_data` out via `std::mem::take` instead of cloning.
+  Behaviour preserved on every existing call site; the move is
+  observable only when callers retain the `ResponseData` past the
+  decode (no in-tree consumer does so).
+- `crates/thetadatadx/src/rest/client.rs` seeds the chunked-transfer
+  body accumulator with a 64 KiB floor so the first DATA frame on a
+  chunked REST response does not trigger a per-chunk realloc.
+- `MddsClient` REST-fallback shims downgrade per-call `start_date` /
+  `end_date` logging from `tracing::debug!` to `tracing::trace!` so
+  routine operator-visible logs no longer echo request date ranges.
+- FFI codegen template emits `require_client!` + `require_symbol_array!`
+  macro calls in place of the 61 inline `// SAFETY: client is a
+  non-null pointer ...` blocks and the 7 inline
+  `// SAFETY: caller supplies a contiguous array ...` blocks the
+  prior endpoint shims carried. Regenerated
+  `ffi/src/endpoint_with_options.rs` keeps a single per-macro
+  invariant-naming SAFETY comment instead of stamping the same
+  boilerplate at every call site.
+- Every hand-written `// SAFETY: see FFI boundary doc on the
+  enclosing fn …` line in `ffi/src/{flatfiles,streaming,utility,types}.rs`
+  rewritten to name the specific invariant the local `unsafe`
+  consumes (pointer provenance, layout, lifetime, ordering).
+- `crate::grpc::decoder_pool::backoff_ring_full` split into
+  `backoff_ring_full_async(duration)` (tokio multi-thread; honours
+  the duration via `block_in_place + thread::sleep`) and
+  `backoff_ring_full_sync()` (current-thread / non-async; fixed
+  256-iter spin) so the sync arm does not silently discard a
+  parameter the async arm uses.
+
+- `crate::grpc::pool::ChannelPool` now reconnects channels on
+  `ConnectionClosed` in-place rather than marking them permanently
+  dead. Long-running clients no longer cascade after sustained load:
+  every transport-level fault (`GOAWAY`, IO failure, peer shutdown,
+  open-phase drop) triggers a single-flight reconnect of the
+  channel's inner `SendRequest<Bytes>` with bounded exponential
+  backoff (50 ms initial, 30 s cap, 8 attempts). The caller's retry
+  shell re-dispatches once and observes the fresh sender on the
+  next pool pick. Fixes the real root cause behind #571 / #577 /
+  #589 — the prior investigation pin
+  (`docs-site/docs/legacy-quote-577-investigation.md`)
+  misattributed the cascade to a server-side schema variant; the
+  actual cause was the SDK's own dead-channel mechanism introduced
+  in #578 with no recycling counterpart.
+
+- The lenient 6-/11-/12-field NBBO decoder added in #573 is
+  **kept** as defense-in-depth. `find_header` + `opt_number(row, None) -> 0`
+  is good API design regardless of cause; a subset NBBO layout
+  could surface from any upstream storage tier in the future. The
+  doc-comment attribution to "issue #571" / "patched terminal
+  `normalizeData()`" is stripped — the test name
+  `quote_tick_decodes_legacy_six_field_shape_with_zero_fill`
+  remains as a regression pin.
+- The REST transport (`crate::rest`) is **kept** as the
+  user-facing alternative transport reachable via
+  `FallbackPolicy::RestAlways`.
 
 - REST endpoint builders are now codegen-driven from
   `endpoint_surface.toml` (#580). The four hand-written
@@ -800,8 +825,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of events dropped under non-`Block` policies without holding a
   `FpssClient` reference.
 
-### Changed
-
 - `QuoteTick` decoder is now explicit about lenient column extraction
   for the legacy 6-field NBBO layout (#571). The `bid_exchange`,
   `bid_condition`, `ask_exchange`, `ask_condition` columns were
@@ -860,45 +883,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   channel-index context (`"channel {idx}: ..."`) is preserved on
   the `Transport`-shaped output.
 
-### Added
+- Workspace clippy invocation widened to
+  `cargo clippy --workspace --all-targets --locked -- -D warnings`
+  so `[[bench]]` and `#[cfg(test)]` unsafe blocks travel through
+  `clippy::undocumented_unsafe_blocks` on every PR. Adds SAFETY
+  comments on five bench-only `unsafe impl GlobalAlloc` blocks
+  and two test-only unsafe deref sites that previously escaped
+  the lint.
+- `scripts/check_banned_vocab.py` rejects the verbatim string
+  "see FFI boundary doc on the enclosing fn — raw pointers
+  satisfy the documented caller contract" outside `ffi/src/`.
+  The string was landed across 31 sites including 8 that are
+  not FFI raw-pointer contexts; the gate prevents future
+  bot-stamping from reintroducing the boilerplate.
 
-- Standalone `FpssClient` and `MddsClient` pyclasses on the Python
-  binding. `FpssClient(creds, config)` opens ONLY the FPSS TLS
-  transport (no MDDS gRPC channel, no Nexus HTTP auth); `MddsClient(creds,
-  config)` opens ONLY the MDDS gRPC channel plus the Nexus
-  authentication and surfaces the historical / FLATFILES API while
-  raising `AttributeError` on every FPSS-touching method. The bundled
-  `ThetaDataDxClient` keeps its current behaviour — the new classes
-  are purely additive and align the Python surface with the
-  standalone clients already exposed by the C ABI (`tdx_fpss_*` /
-  `tdx_client_*`) and the C++ wrapper (`tdx::FpssClient` /
-  `tdx::Client`).
-- gRPC `grpc-timeout` header is now emitted on every
-  deadline-bearing RPC (`server_streaming_with_deadline`,
-  `mdds_client.with_deadline(...)`). The header carries the
-  smallest unit that fits the budget per the gRPC HTTP/2 spec
-  (`n` / `u` / `m` / `S` / `M` / `H`), so the server can
-  short-circuit on deadline elapse instead of completing work the
-  client will discard.
-- `TransportErrorKind` is exported from `thetadatadx::error` for
-  binding consumers and retry classifiers.
-- `tdbe::types::price::Price::with_value_and_type` constructor
-  rejects out-of-range `price_type` values with a typed
-  `PriceError` instead of clamping. `Price::value()` and
-  `Price::price_type()` accessors join the public API so future
-  field visibility changes do not break call sites.
-  `Price::is_unset()` and `Price::is_zero_value()` split the
-  previous `is_zero()` conflation into the two distinct signals
-  (sentinel vs real zero).
-- `Price` POW10 indexing paths carry `debug_assert!` invariant
-  guards so a hand-constructed `Price { value, price_type }`
-  outside `0..=MAX_PRICE_TYPE` traps in debug builds rather than
-  reading past the end of the lookup tables.
-- `AuthUser::max_concurrent_requests` now routes the
-  subscription-tier shift through `SubscriptionTier::from_wire`.
-  Hostile wire bytes (negative, `> 3`, `i32::MAX`) fold to
-  `Free=1` and emit a `warn` instead of panicking on the old
-  `1usize << tier` path.
 
 ### Deprecated
 
@@ -909,7 +907,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `decompress_zstd`, etc.). The constructors will be removed in
   the next major release.
 
+
+### Removed
+
+- `Channel::is_dead`, `Channel::mark_dead`, `Channel::dead_handle`,
+  `ChannelPool::all_dead`, `ChannelPool::dead_count` — replaced by
+  in-place reconnect (see Changed above). The `ChannelLease`
+  picker no longer scans for "live" channels separately; every
+  channel in the pool stays a valid pick because the channel
+  itself swaps its inner h2 session on observed faults.
+- `ChannelError::UpstreamCascade` — folded into the existing
+  `ChannelError::ConnectionClosed` variant. The mid-stream
+  classifier (`classify_h2_error_mid_stream`) is gone; the
+  open-phase classifier (`classify_h2_error`) covers both phases
+  via the new `classify_h2_error_ref` thin wrapper.
+- `FallbackPolicy::RestOnH2Disconnect` and
+  `FallbackPolicy::RestAlwaysForDateRange` — both variants were
+  built around a misdiagnosed cascade and never actually helped.
+  `FallbackPolicy::RestAlways` is retained as the user-facing
+  escape hatch for callers who want every historical-quote call
+  routed over a locally-running Terminal's REST surface.
+- `_with_fallback` per-endpoint shims (Python / TypeScript /
+  C++ / FFI) tied to the deleted variants. The four remaining
+  `option_history_*_with_fallback` methods dispatch on
+  `FallbackPolicy::RestAlways` vs `Disabled` only.
+- `docs-site/docs/legacy-quote-577-investigation.md`,
+  `docs-site/docs/legacy-quote-handling.md` — both documented the
+  wrong root cause. Replaced by
+  `docs-site/docs/channel-pool-design.md`, which honestly
+  describes the in-place reconnect contract and pins the
+  correction so the next contributor doesn't repeat the search.
+- `crates/thetadatadx/tests/test_577_2020_onward.rs` — built on
+  the wrong premise. Replaced by
+  `crates/thetadatadx/tests/test_pool_reconnect.rs`, which pins
+  the single-flight CAS, the lifecycle observer events, and the
+  classifier-triggered reconnect spawn.
+- `tools/local-terminal-patcher/` — patched a code path
+  (`QuoteTick(Tick t)` constructor strict-length throw) that
+  bytecode analysis of the upstream terminal jar shows is never
+  invoked on the `option_history_quote` gRPC response path.
+  Decompilation confirms the constructor's sole caller is
+  `MarketValueTick`. The patcher fixed a fictional problem; the
+  workspace member, its `clap` / `zip` / `sha2` dependencies, and
+  its patch sources are removed.
+
+
 ### Fixed
+
+- Greeks `_with_fallback` regression coverage. Four new integration
+  tests pin `end_date` forwarding on both the REST and gRPC arms of
+  `option_history_greeks_implied_volatility_with_fallback` and
+  `option_history_greeks_first_order_with_fallback`, locking the
+  prior-round fix against silent regression.
+- Tier-clamp regression coverage. A new integration test runs two
+  concurrent `option_history_quote_with_fallback` calls against an
+  in-process REST mock with `concurrent_requests = 1`; the assertion
+  observes the second call parking on the semaphore until the first
+  completes.
 
 - Documentation did not flag which historical builder terminal to
   use for which workload, so users reached for the buffered `.await`
@@ -1014,22 +1068,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mem::size_of::<FpssEventInternal>() = 96` bytes on the current
   64-bit layout; the per-`FpssClient` ring footprint at the
   default `ring_size = 4096` is now documented as ~ 384 KiB.
-
-### CI
-
-- Workspace clippy invocation widened to
-  `cargo clippy --workspace --all-targets --locked -- -D warnings`
-  so `[[bench]]` and `#[cfg(test)]` unsafe blocks travel through
-  `clippy::undocumented_unsafe_blocks` on every PR. Adds SAFETY
-  comments on five bench-only `unsafe impl GlobalAlloc` blocks
-  and two test-only unsafe deref sites that previously escaped
-  the lint.
-- `scripts/check_banned_vocab.py` rejects the verbatim string
-  "see FFI boundary doc on the enclosing fn — raw pointers
-  satisfy the documented caller contract" outside `ffi/src/`.
-  The string was landed across 31 sites including 8 that are
-  not FFI raw-pointer contexts; the gate prevents future
-  bot-stamping from reintroducing the boilerplate.
 
 ## [10.0.0] - 2026-05-09
 

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -174,8 +174,8 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_policy(config: *mut TdxConfig,
 }
 
 /// Set the per-class transient-failure attempt budget for the
-/// auto-reconnect path. Default `3`. Has no effect when the reconnect
-/// policy is not `Auto`.
+/// auto-reconnect path. Default `3`. No effect unless the reconnect
+/// policy is `Auto`.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_config_set_reconnect_max_attempts(
     config: *mut TdxConfig,
@@ -194,8 +194,8 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_max_attempts(
 }
 
 /// Set the per-class rate-limited (`TooManyRequests`) attempt budget
-/// for the auto-reconnect path. Default `100`. Has no effect when the
-/// reconnect policy is not `Auto`.
+/// for the auto-reconnect path. Default `100`. No effect unless the
+/// reconnect policy is `Auto`.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_config_set_reconnect_max_rate_limited_attempts(
     config: *mut TdxConfig,
@@ -214,8 +214,8 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_max_rate_limited_attempts(
 }
 
 /// Set the continuous successful-data-flow window (in seconds) after
-/// which the auto-reconnect attempt counters reset. Default `60`. Has
-/// no effect when the reconnect policy is not `Auto`.
+/// which the auto-reconnect attempt counters reset. Default `60`. No
+/// effect unless the reconnect policy is `Auto`.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_config_set_reconnect_stable_window_secs(
     config: *mut TdxConfig,
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn tdx_config_set_derive_ohlcvc(config: *mut TdxConfig, en
     })
 }
 
-// ── MDDS pool sizing — issue #584 ──────────────────────────────────
+// ── MDDS pool sizing ───────────────────────────────────────────────
 
 /// Set the number of concurrent in-flight gRPC requests on a config
 /// handle.
@@ -540,7 +540,7 @@ pub unsafe extern "C" fn tdx_client_free(client: *mut TdxClient) {
 
 #[cfg(test)]
 mod pool_sizing_tests {
-    //! Offline tests for the MDDS pool-sizing setters (issue #584).
+    //! Offline tests for the MDDS pool-sizing setters.
     //!
     //! Each test allocates a fresh `TdxConfig` via `tdx_config_production`,
     //! calls the setter under test, then reads the underlying Rust
@@ -662,6 +662,150 @@ mod pool_sizing_tests {
             super::tdx_config_set_concurrent_requests(std::ptr::null_mut(), 4);
             super::tdx_config_set_decoder_threads(std::ptr::null_mut(), 4);
             super::tdx_config_set_decoder_ring_size(std::ptr::null_mut(), 256);
+        }
+    }
+}
+
+#[cfg(test)]
+mod reconnect_setter_tests {
+    //! Offline tests for the FPSS ReconnectConfig setters on the FFI
+    //! surface — cross-binding parity with Python / TypeScript / C++.
+    //!
+    //! Each test allocates a fresh `TdxConfig` via
+    //! `tdx_config_production`, calls the setter under test, then reads
+    //! the underlying `ReconnectConfig` to confirm the value
+    //! round-tripped (or that the silent-no-op contract is honoured
+    //! under non-Auto policies).
+    //!
+    //! Failure-class semantics (per-class budget enforcement and the
+    //! stable-window timer reset) are exercised by the Rust unit tests
+    //! under `fpss::session::tests` and
+    //! `fpss::protocol::reconnect_delays_match_policy`; this module
+    //! pins only the C-ABI forwarding contract.
+
+    #[test]
+    fn reconnect_policy_round_trips_auto_and_manual() {
+        let cfg = super::tdx_config_production();
+        assert!(!cfg.is_null());
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            super::tdx_config_set_reconnect_policy(cfg, 1);
+            assert!(matches!(
+                (*cfg).inner.reconnect.policy,
+                thetadatadx::ReconnectPolicy::Manual
+            ));
+            super::tdx_config_set_reconnect_policy(cfg, 0);
+            assert!(matches!(
+                (*cfg).inner.reconnect.policy,
+                thetadatadx::ReconnectPolicy::Auto(_)
+            ));
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn reconnect_policy_unknown_selector_falls_through_to_auto() {
+        // The C ABI accepts an int selector; values other than 0/1
+        // resolve to the documented default (`Auto`). Pin the
+        // behaviour so the FFI cannot drift away from the documented
+        // contract without trapping the test.
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            super::tdx_config_set_reconnect_policy(cfg, 1);
+            super::tdx_config_set_reconnect_policy(cfg, 7);
+            assert!(matches!(
+                (*cfg).inner.reconnect.policy,
+                thetadatadx::ReconnectPolicy::Auto(_)
+            ));
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn reconnect_max_attempts_round_trips_on_auto_policy() {
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            super::tdx_config_set_reconnect_policy(cfg, 0);
+            for n in [0u32, 1, 3, 10, 100, 1000] {
+                super::tdx_config_set_reconnect_max_attempts(cfg, n);
+                let thetadatadx::ReconnectPolicy::Auto(limits) = &(*cfg).inner.reconnect.policy
+                else {
+                    panic!("policy must remain Auto across setter calls");
+                };
+                assert_eq!(limits.max_attempts, n);
+            }
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn reconnect_max_rate_limited_attempts_round_trips_on_auto_policy() {
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            super::tdx_config_set_reconnect_policy(cfg, 0);
+            for n in [0u32, 1, 10, 100, 1000] {
+                super::tdx_config_set_reconnect_max_rate_limited_attempts(cfg, n);
+                let thetadatadx::ReconnectPolicy::Auto(limits) = &(*cfg).inner.reconnect.policy
+                else {
+                    panic!("policy must remain Auto across setter calls");
+                };
+                assert_eq!(limits.max_rate_limited_attempts, n);
+            }
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn reconnect_stable_window_secs_round_trips_on_auto_policy() {
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            super::tdx_config_set_reconnect_policy(cfg, 0);
+            for secs in [0u64, 1, 60, 3600, 86_400] {
+                super::tdx_config_set_reconnect_stable_window_secs(cfg, secs);
+                let thetadatadx::ReconnectPolicy::Auto(limits) = &(*cfg).inner.reconnect.policy
+                else {
+                    panic!("policy must remain Auto across setter calls");
+                };
+                assert_eq!(limits.stable_window, std::time::Duration::from_secs(secs));
+            }
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn per_class_budget_setters_are_silent_noop_on_manual_policy() {
+        // Matches the cross-binding contract: per-class budget setters
+        // only mutate `ReconnectAttemptLimits` when the policy variant
+        // is `Auto`. Under `Manual` the calls are silently absorbed;
+        // the underlying policy variant must not transition.
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            super::tdx_config_set_reconnect_policy(cfg, 1);
+            super::tdx_config_set_reconnect_max_attempts(cfg, 5);
+            super::tdx_config_set_reconnect_max_rate_limited_attempts(cfg, 50);
+            super::tdx_config_set_reconnect_stable_window_secs(cfg, 120);
+            assert!(matches!(
+                (*cfg).inner.reconnect.policy,
+                thetadatadx::ReconnectPolicy::Manual
+            ));
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn null_handle_is_safe() {
+        // SAFETY: passing null is the contract — the setters must
+        // return without crashing.
+        unsafe {
+            super::tdx_config_set_reconnect_policy(std::ptr::null_mut(), 0);
+            super::tdx_config_set_reconnect_max_attempts(std::ptr::null_mut(), 3);
+            super::tdx_config_set_reconnect_max_rate_limited_attempts(std::ptr::null_mut(), 100);
+            super::tdx_config_set_reconnect_stable_window_secs(std::ptr::null_mut(), 60);
         }
     }
 }

--- a/ffi/src/utility.rs
+++ b/ffi/src/utility.rs
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn tdx_implied_volatility(
 // ═══════════════════════════════════════════════════════════════════════
 //  Condition / exchange / sequence helper accessors
 //
-//  Cross-language utility parity (issue #424). The lookup tables live in
+//  Cross-language utility parity. The lookup tables live in
 //  `tdbe::{conditions, exchange, sequences}`. The C ABI wraps them as
 //  string-returning entry points (returning `'static` UTF-8 NUL-terminated
 //  C strings — the underlying tables are `&'static str`, so the caller

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -532,24 +532,24 @@ void tdx_config_set_reconnect_policy(TdxConfig* config, int policy);
 
 /**
  * Set the per-class transient-failure attempt budget for the
- * auto-reconnect path. Default 3. Has no effect when the reconnect
- * policy is not Auto.
+ * auto-reconnect path. Default 3. No effect unless the reconnect
+ * policy is Auto.
  */
 void tdx_config_set_reconnect_max_attempts(TdxConfig* config,
                                            uint32_t max_attempts);
 
 /**
  * Set the per-class rate-limited (`TooManyRequests`) attempt budget for
- * the auto-reconnect path. Default 100. Has no effect when the
- * reconnect policy is not Auto.
+ * the auto-reconnect path. Default 100. No effect unless the reconnect
+ * policy is Auto.
  */
 void tdx_config_set_reconnect_max_rate_limited_attempts(
     TdxConfig* config, uint32_t max_rate_limited_attempts);
 
 /**
  * Set the continuous successful-data-flow window (in seconds) after
- * which the auto-reconnect attempt counters reset. Default 60. Has no
- * effect when the reconnect policy is not Auto.
+ * which the auto-reconnect attempt counters reset. Default 60. No
+ * effect unless the reconnect policy is Auto.
  */
 void tdx_config_set_reconnect_stable_window_secs(TdxConfig* config,
                                                  uint64_t secs);
@@ -568,7 +568,7 @@ void tdx_config_set_flush_mode(TdxConfig* config, int mode);
  */
 void tdx_config_set_derive_ohlcvc(TdxConfig* config, int enabled);
 
-/* ── MDDS pool sizing (issue #584) ── */
+/* ── MDDS pool sizing ── */
 
 /**
  * Set the number of concurrent in-flight gRPC requests.

--- a/sdks/cpp/tests/CMakeLists.txt
+++ b/sdks/cpp/tests/CMakeLists.txt
@@ -35,6 +35,9 @@ set(THETADX_CPP_TEST_SOURCES
     fallback.cpp
     # MDDS pool-sizing setters on tdx::Config.
     config_pool_sizing.cpp
+    # ReconnectConfig setters on tdx::Config — cross-binding parity
+    # with Python / TypeScript / FFI.
+    config_reconnect.cpp
     # MDDS two-stage decode pipeline setters on tdx::Config
     # (Phase 3 of 3, follow-up to PR #587 / #588).
     config_decode_pipeline.cpp

--- a/sdks/cpp/tests/config_reconnect.cpp
+++ b/sdks/cpp/tests/config_reconnect.cpp
@@ -1,0 +1,95 @@
+// ReconnectConfig setters on tdx::Config — C++ binding parity
+// with Python / TypeScript / FFI.
+//
+// Pins the C++ surface contract for `set_reconnect_policy`,
+// `set_reconnect_max_attempts`,
+// `set_reconnect_max_rate_limited_attempts`, and
+// `set_reconnect_stable_window_secs`. Failure-class semantics
+// (transient vs rate-limited budget split, stable-window timer
+// reset) are exercised in the Rust unit tests under
+// `fpss::session::tests` and
+// `fpss::protocol::reconnect_delays_match_policy`; this file pins
+// only that the C++ wrapper forwards the inputs without crashing
+// and that invalid policy ints fall through to the documented
+// default behaviour without raising.
+
+#include <cstdint>
+#include <limits>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "thetadx.h"
+#include "thetadx.hpp"
+
+TEST_CASE("Config::set_reconnect_policy accepts Auto and Manual selectors",
+          "[config][reconnect][offline]") {
+    auto cfg = tdx::Config::production();
+    REQUIRE_NOTHROW(cfg.set_reconnect_policy(0)); // Auto
+    REQUIRE_NOTHROW(cfg.set_reconnect_policy(1)); // Manual
+}
+
+TEST_CASE("Config::set_reconnect_policy treats unknown selectors as Auto",
+          "[config][reconnect][offline]") {
+    // The C ABI accepts an int selector; values other than 0/1 fall
+    // through to the documented default (Auto). The wrapper must not
+    // throw on the unknown input.
+    auto cfg = tdx::Config::production();
+    REQUIRE_NOTHROW(cfg.set_reconnect_policy(7));
+    REQUIRE_NOTHROW(cfg.set_reconnect_policy(-1));
+}
+
+TEST_CASE("Config::set_reconnect_max_attempts round-trips representative budgets",
+          "[config][reconnect][offline]") {
+    auto cfg = tdx::Config::production();
+    cfg.set_reconnect_policy(0); // Auto
+    for (std::uint32_t n : {0u, 1u, 3u, 10u, 100u, 1000u}) {
+        REQUIRE_NOTHROW(cfg.set_reconnect_max_attempts(n));
+    }
+}
+
+TEST_CASE("Config::set_reconnect_max_rate_limited_attempts round-trips representative budgets",
+          "[config][reconnect][offline]") {
+    auto cfg = tdx::Config::production();
+    cfg.set_reconnect_policy(0); // Auto
+    for (std::uint32_t n : {0u, 1u, 10u, 100u, 1000u}) {
+        REQUIRE_NOTHROW(cfg.set_reconnect_max_rate_limited_attempts(n));
+    }
+}
+
+TEST_CASE("Config::set_reconnect_stable_window_secs accepts u64 values",
+          "[config][reconnect][offline]") {
+    auto cfg = tdx::Config::production();
+    cfg.set_reconnect_policy(0); // Auto
+    for (std::uint64_t secs : {std::uint64_t{0}, std::uint64_t{1},
+                               std::uint64_t{60}, std::uint64_t{3600},
+                               std::uint64_t{86'400},
+                               std::numeric_limits<std::uint64_t>::max()}) {
+        REQUIRE_NOTHROW(cfg.set_reconnect_stable_window_secs(secs));
+    }
+}
+
+TEST_CASE("Reconnect setters under Manual policy are silent no-ops",
+          "[config][reconnect][offline]") {
+    // Matches the cross-binding contract: per-class budget setters
+    // only mutate `ReconnectAttemptLimits` when the policy is
+    // `Auto(limits)`. Under `Manual` the calls are silently absorbed;
+    // the wrapper surface must not throw.
+    auto cfg = tdx::Config::production();
+    cfg.set_reconnect_policy(1); // Manual
+    REQUIRE_NOTHROW(cfg.set_reconnect_max_attempts(5));
+    REQUIRE_NOTHROW(cfg.set_reconnect_max_rate_limited_attempts(50));
+    REQUIRE_NOTHROW(cfg.set_reconnect_stable_window_secs(120));
+}
+
+TEST_CASE("Reconnect setters compose with pool-sizing setters",
+          "[config][reconnect][offline]") {
+    // Interleaved reconnect setter and pool-sizing setter calls on
+    // the same `tdx::Config` must not interfere with each other.
+    auto cfg = tdx::Config::production();
+    cfg.set_reconnect_policy(0);
+    cfg.set_reconnect_max_attempts(7);
+    cfg.set_reconnect_max_rate_limited_attempts(77);
+    cfg.set_reconnect_stable_window_secs(120);
+    REQUIRE_NOTHROW(cfg.set_concurrent_requests(4));
+    REQUIRE_NOTHROW(cfg.set_decoder_ring_size(512));
+}

--- a/sdks/cpp/tests/lifecycle.cpp
+++ b/sdks/cpp/tests/lifecycle.cpp
@@ -30,6 +30,9 @@ TEST_CASE("Config::production builds without network access", "[lifecycle][offli
 TEST_CASE("Config setters do not throw on a fresh config handle", "[lifecycle][offline]") {
     auto config = tdx::Config::production();
     REQUIRE_NOTHROW(config.set_reconnect_policy(0));
+    REQUIRE_NOTHROW(config.set_reconnect_max_attempts(5));
+    REQUIRE_NOTHROW(config.set_reconnect_max_rate_limited_attempts(50));
+    REQUIRE_NOTHROW(config.set_reconnect_stable_window_secs(120));
     REQUIRE_NOTHROW(config.set_flush_mode(0));
     REQUIRE_NOTHROW(config.set_derive_ohlcvc(true));
 }

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -242,8 +242,8 @@ impl Config {
     }
 
     /// Set the per-class transient-failure attempt budget for the
-    /// auto-reconnect path. Default `3`. Has no effect when the
-    /// reconnect policy is `"manual"` or `"custom"`.
+    /// auto-reconnect path. Default `3`. No effect unless the
+    /// reconnect policy is `Auto`.
     #[setter]
     fn set_reconnect_max_attempts(&self, max_attempts: u32) -> PyResult<()> {
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
@@ -254,8 +254,8 @@ impl Config {
     }
 
     /// Set the per-class rate-limited (`TooManyRequests`) attempt budget
-    /// for the auto-reconnect path. Default `100`. Has no effect when
-    /// the reconnect policy is `"manual"` or `"custom"`.
+    /// for the auto-reconnect path. Default `100`. No effect unless the
+    /// reconnect policy is `Auto`.
     #[setter]
     fn set_reconnect_max_rate_limited_attempts(
         &self,
@@ -270,8 +270,7 @@ impl Config {
 
     /// Set the continuous successful-data-flow window (in seconds)
     /// after which the auto-reconnect attempt counters reset. Default
-    /// `60`. Has no effect when the reconnect policy is `"manual"` or
-    /// `"custom"`.
+    /// `60`. No effect unless the reconnect policy is `Auto`.
     #[setter]
     fn set_reconnect_stable_window_secs(&self, secs: u64) -> PyResult<()> {
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
@@ -330,7 +329,7 @@ impl Config {
         guard.mdds.port
     }
 
-    // ── MDDS pool sizing — issue #584 ──────────────────────────────
+    // ── MDDS pool sizing ───────────────────────────────────────────
 
     /// Set the number of concurrent in-flight gRPC requests.
     ///

--- a/sdks/python/src/util_helpers.rs
+++ b/sdks/python/src/util_helpers.rs
@@ -1,4 +1,4 @@
-//! Cross-language utility helpers — Python bindings (issue #424).
+//! Cross-language utility helpers — Python bindings.
 //!
 //! Wraps the lookup tables in `tdbe::{conditions, exchange, sequences}`
 //! and exposes them under the `thetadatadx.util` Python submodule:
@@ -11,8 +11,8 @@
 //! util.sequence_signed_to_unsigned(-1)
 //! ```
 //!
-//! Hand-written rather than codegen'd (per issue #424). The function set
-//! is finite and the codegen pipeline targets dynamic-schema endpoints.
+//! Hand-written rather than codegen'd. The function set is finite and
+//! the codegen pipeline targets dynamic-schema endpoints.
 
 use pyo3::prelude::*;
 

--- a/sdks/python/tests/test_config_reconnect.py
+++ b/sdks/python/tests/test_config_reconnect.py
@@ -1,0 +1,162 @@
+"""ReconnectConfig setters on ``Config`` — Python binding parity with
+TypeScript / C++ / FFI.
+
+Pins the Python surface contract for ``reconnect_policy``,
+``reconnect_max_attempts``, ``reconnect_max_rate_limited_attempts``,
+and ``reconnect_stable_window_secs``. Failure-class semantics
+(transient vs rate-limited budget split, stable-window timer reset)
+are exercised in the Rust unit tests under
+``fpss::session::tests`` and
+``fpss::protocol::reconnect_delays_match_policy``; this file pins
+only that the Python surface forwards the inputs without dropping
+them and rejects invalid policy strings at the boundary.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _import_module():
+    """Import the freshly-built native module from ``maturin develop``."""
+    return importlib.import_module("thetadatadx")
+
+
+# ─── reconnect_policy ───────────────────────────────────────────────
+
+
+def test_reconnect_policy_round_trips_auto_and_manual():
+    """``reconnect_policy`` accepts ``"auto"`` and ``"manual"`` (case-insensitive)."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    for value in ("auto", "AUTO", "manual", "Manual"):
+        cfg.reconnect_policy = value
+    # Getter normalises to lowercase canonical form.
+    cfg.reconnect_policy = "auto"
+    assert cfg.reconnect_policy == "auto"
+    cfg.reconnect_policy = "manual"
+    assert cfg.reconnect_policy == "manual"
+
+
+def test_reconnect_policy_rejects_unknown_value():
+    """An unknown policy string must raise ``ValueError`` at the setter."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    with pytest.raises(ValueError, match=r"reconnect_policy"):
+        cfg.reconnect_policy = "linear-backoff"
+
+
+# ─── reconnect_max_attempts ─────────────────────────────────────────
+
+
+def test_reconnect_max_attempts_accepts_non_zero_budgets():
+    """``reconnect_max_attempts = N`` accepts every plausible budget."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "auto"
+    for n in (1, 3, 10, 100, 1000):
+        cfg.reconnect_max_attempts = n
+
+
+def test_reconnect_max_attempts_accepts_zero():
+    """``reconnect_max_attempts = 0`` is a legal ``u32`` and must not raise.
+
+    The Rust core treats ``0`` as a budget value the auto-driver
+    enforces verbatim; the setter is write-only and the Python
+    binding does not own the semantic interpretation. Verifying
+    round-trip absence-of-error is the contract pinned here.
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "auto"
+    cfg.reconnect_max_attempts = 0
+
+
+def test_reconnect_max_attempts_is_silent_noop_on_manual_policy():
+    """The setter is a silent no-op when the policy is not ``Auto(limits)``.
+
+    Matches the cross-binding contract: the setter only mutates
+    ``ReconnectAttemptLimits`` fields when the policy variant is
+    ``Auto``; under ``Manual`` (or the Rust-only ``Custom``) the
+    call is silently absorbed. The Python surface has no getter on
+    this knob (parity with FFI / TS / C++ which are all write-only
+    on the per-class budgets), so the contract is "does not raise".
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "manual"
+    cfg.reconnect_max_attempts = 5
+
+
+# ─── reconnect_max_rate_limited_attempts ────────────────────────────
+
+
+def test_reconnect_max_rate_limited_attempts_accepts_non_zero_budgets():
+    """``reconnect_max_rate_limited_attempts = N`` accepts every plausible budget."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "auto"
+    for n in (1, 10, 100, 1000):
+        cfg.reconnect_max_rate_limited_attempts = n
+
+
+def test_reconnect_max_rate_limited_attempts_accepts_zero():
+    """``reconnect_max_rate_limited_attempts = 0`` is a legal ``u32``."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "auto"
+    cfg.reconnect_max_rate_limited_attempts = 0
+
+
+# ─── reconnect_stable_window_secs ───────────────────────────────────
+
+
+def test_reconnect_stable_window_secs_accepts_u64_values():
+    """``reconnect_stable_window_secs`` accepts the full ``u64`` range."""
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "auto"
+    for secs in (0, 1, 30, 60, 300, 3600, 86_400):
+        cfg.reconnect_stable_window_secs = secs
+
+
+def test_reconnect_stable_window_secs_rejects_negative():
+    """Negative seconds must be rejected at the Python type level.
+
+    pyo3 maps ``u64`` to a Python integer with a non-negative
+    contract; passing a negative value raises ``OverflowError``
+    before the setter body runs.
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "auto"
+    with pytest.raises(OverflowError):
+        cfg.reconnect_stable_window_secs = -1
+
+
+# ─── Combined invariants ────────────────────────────────────────────
+
+
+def test_reconnect_setter_state_survives_interleaved_calls():
+    """Interleaved reconnect setter and pool-sizing setter calls
+    must not interfere with each other.
+
+    Mirrors the TS ``Reconnect setters are independent`` case: the
+    reconnect setters have no getters, so we assert via the
+    pool-sizing getters that the pool-sizing state survives a
+    reconnect setter sequence.
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "auto"
+    cfg.reconnect_max_attempts = 7
+    cfg.reconnect_max_rate_limited_attempts = 77
+    cfg.reconnect_stable_window_secs = 120
+    cfg.concurrent_requests = 4
+    cfg.decoder_ring_size = 512
+    assert cfg.concurrent_requests == 4
+    assert cfg.decoder_ring_size == 512
+    # Reconnect policy getter still reads the policy we set.
+    assert cfg.reconnect_policy == "auto"

--- a/sdks/typescript/__tests__/config_reconnect.test.mjs
+++ b/sdks/typescript/__tests__/config_reconnect.test.mjs
@@ -8,9 +8,10 @@
 // the Rust core consumes at connect time. Failure-class semantics
 // (transient vs rate-limited budget split, stable-window timer reset)
 // are exercised in the Rust unit tests under
-// `streaming::reconnect::reconnect_tests`; this file pins only that
-// the JS surface forwards the inputs without dropping them and
-// rejects invalid policy strings at the boundary.
+// `fpss::session::tests` and
+// `fpss::protocol::reconnect_delays_match_policy`; this file pins
+// only that the JS surface forwards the inputs without dropping them
+// and rejects invalid policy strings at the boundary.
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -91,10 +92,27 @@ describe('Config.setReconnectStableWindowSecs', () => {
       'negative window seconds must be rejected at the boundary',
     );
   });
+
+  it('rejects BigInt magnitudes above u64::MAX', () => {
+    // A BigInt that does not fit in 64 bits must be rejected at
+    // the boundary rather than silently truncating to the low
+    // 64 bits of the magnitude.
+    const cfg = Config.production();
+    cfg.setReconnectPolicy('auto');
+    assert.throws(
+      () => cfg.setReconnectStableWindowSecs(1n << 65n),
+      /setReconnectStableWindowSecs/,
+      'magnitude above u64::MAX must be rejected at the boundary',
+    );
+  });
 });
 
-describe('Reconnect setters are independent', () => {
-  it('do not interfere with each other or with pool-sizing setters', () => {
+describe('Pool-sizing setter state survives interleaved reconnect setter calls', () => {
+  it('reconnect setters do not interfere with pool-sizing getters', () => {
+    // The reconnect setters expose no getters, so the contract
+    // we can verify is: after interleaving reconnect setter
+    // calls with pool-sizing setter calls, the pool-sizing
+    // getters still observe the values that were last written.
     const cfg = Config.production();
     cfg.setReconnectPolicy('auto');
     cfg.setReconnectMaxAttempts(7);

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -122,21 +122,20 @@ export declare class Config {
   setReconnectPolicy(policy: string): void
   /**
    * Set the per-class transient-failure attempt budget for the
-   * auto-reconnect path. Default `3`. No effect when the reconnect
-   * policy is `"manual"` or `"custom"`.
+   * auto-reconnect path. Default `3`. No effect unless the
+   * reconnect policy is `Auto`.
    */
   setReconnectMaxAttempts(maxAttempts: number): void
   /**
    * Set the per-class rate-limited (`TooManyRequests`) attempt
    * budget for the auto-reconnect path. Default `100`. No effect
-   * when the reconnect policy is `"manual"` or `"custom"`.
+   * unless the reconnect policy is `Auto`.
    */
   setReconnectMaxRateLimitedAttempts(maxRateLimitedAttempts: number): void
   /**
    * Set the continuous successful-data-flow window (in seconds)
    * after which the auto-reconnect attempt counters reset. Default
-   * `60`. No effect when the reconnect policy is `"manual"` or
-   * `"custom"`.
+   * `60`. No effect unless the reconnect policy is `Auto`.
    *
    * Accepts a `bigint` for parity with the Python / C++ / FFI
    * surface (`u64`). JavaScript `Number` callers should wrap their

--- a/sdks/typescript/src/fallback.rs
+++ b/sdks/typescript/src/fallback.rs
@@ -165,7 +165,7 @@ impl Config {
         })
     }
 
-    // ── MDDS pool sizing — issue #584 ──────────────────────────────
+    // ── MDDS pool sizing ───────────────────────────────────────────
 
     /// Set the number of concurrent in-flight gRPC requests.
     ///
@@ -362,8 +362,8 @@ impl Config {
     }
 
     /// Set the per-class transient-failure attempt budget for the
-    /// auto-reconnect path. Default `3`. No effect when the reconnect
-    /// policy is `"manual"` or `"custom"`.
+    /// auto-reconnect path. Default `3`. No effect unless the
+    /// reconnect policy is `Auto`.
     #[napi(js_name = "setReconnectMaxAttempts")]
     pub fn set_reconnect_max_attempts(&self, max_attempts: u32) -> napi::Result<()> {
         let mut guard = self
@@ -378,7 +378,7 @@ impl Config {
 
     /// Set the per-class rate-limited (`TooManyRequests`) attempt
     /// budget for the auto-reconnect path. Default `100`. No effect
-    /// when the reconnect policy is `"manual"` or `"custom"`.
+    /// unless the reconnect policy is `Auto`.
     #[napi(js_name = "setReconnectMaxRateLimitedAttempts")]
     pub fn set_reconnect_max_rate_limited_attempts(
         &self,
@@ -396,8 +396,7 @@ impl Config {
 
     /// Set the continuous successful-data-flow window (in seconds)
     /// after which the auto-reconnect attempt counters reset. Default
-    /// `60`. No effect when the reconnect policy is `"manual"` or
-    /// `"custom"`.
+    /// `60`. No effect unless the reconnect policy is `Auto`.
     ///
     /// Accepts a `bigint` for parity with the Python / C++ / FFI
     /// surface (`u64`). JavaScript `Number` callers should wrap their

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -295,9 +295,9 @@ pub use fallback::{Config, FallbackPolicy, DEFAULT_REST_BASE_URL};
 mod fluent;
 pub use fluent::{ContractRef, SecType, Subscription};
 
-// Cross-language utility helpers (issue #424). Adds the `Util` napi
-// class re-exporting `tdbe::{conditions, exchange, sequences}` lookup
-// tables under camelCase JS method names.
+// Cross-language utility helpers. Adds the `Util` napi class
+// re-exporting `tdbe::{conditions, exchange, sequences}` lookup tables
+// under camelCase JS method names.
 mod util_helpers;
 pub use util_helpers::Util;
 

--- a/sdks/typescript/src/util_helpers.rs
+++ b/sdks/typescript/src/util_helpers.rs
@@ -1,4 +1,4 @@
-//! Cross-language utility helpers — TypeScript / napi-rs bindings (issue #424).
+//! Cross-language utility helpers — TypeScript / napi-rs bindings.
 //!
 //! Wraps `tdbe::{conditions, exchange, sequences}` lookup tables and
 //! exposes them under a `Util` JS namespace:


### PR DESCRIPTION
Round 6 of the audit-fix loop. Re-audit follows merge.

## Summary

Closes the round-5 punch list returned by the 5-axis audit since the round-4 merge (PR #597). 5 MINOR / NIT findings closed plus the CHANGELOG bucket consolidation INFO finding. No version bump.

### MINOR

- **M1**. Cross-binding ReconnectConfig setter test parity. `sdks/python/tests/test_config_reconnect.py` (10 tests) + `sdks/cpp/tests/config_reconnect.cpp` (7 Catch2 cases) mirror the existing TypeScript coverage. New `reconnect_setter_tests` module in `ffi/src/auth.rs` (7 Rust tests) covers the C ABI. `sdks/cpp/tests/lifecycle.cpp` smoke expanded to all four setters.
- **M2**. `config_reconnect.test.mjs` Rust-module reference corrected from the non-existent `streaming::reconnect::reconnect_tests` path to `fpss::session::tests` + `fpss::protocol::reconnect_delays_match_policy`.
- **M3**. Poison-race test sleep-race obliterated. New test-only `parked_in_slice_loop: Arc<AtomicU64>` counter on `Stage2PoolSender` increments once per `send_timeout` slice entry; both `backpressure_parks_producer` and `poisoned_pool_releases_parked_producer_within_one_second` now spin on the counter (5 s deadline) instead of `thread::sleep`, so the tests pin the contract under test rather than racing the wall clock.

### NIT

- **N1**. Cross-binding ReconnectConfig docstring phrasing unified to `No effect unless the reconnect policy is Auto` across all 12 sites (3 setters x 4 bindings). `sdks/typescript/index.d.ts` re-rendered by `napi build`.
- **N2**. `(issue #N)` references stripped from `//`/`//!` block comments in the Python / TypeScript / FFI binding crates plus the two `crates/thetadatadx/src/rest` module headers. Verification grep on binding crates returns zero matches.
- **N3**. C++ header banner `MDDS pool sizing (issue #584)` rewritten to neutral `MDDS pool sizing`.
- **N4**. TS test renamed from `Reconnect setters are independent` to `Pool-sizing setter state survives interleaved reconnect setter calls` so the name describes what is verified.
- **N5**. TS `setReconnectStableWindowSecs(1n << 65n)` magnitude-above-u64 rejection case added.

### INFO

- **I1**. CHANGELOG `[Unreleased]` consolidated into the five canonical Keep-a-Changelog buckets (Added, Changed, Deprecated, Removed, Fixed). Non-canonical `Retained` and `CI` headings folded into `Changed`. Every individual entry preserved verbatim. `docs-site/docs/changelog.md` mirror byte-identical.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (every existing test passes; 7 new FFI reconnect tests + the modified stage_pipeline tests all green)
- [x] `cargo clippy --workspace --tests --benches -- -D warnings`
- [x] `cargo doc --no-deps -p thetadatadx --features arrow,polars,frames,config-file` (clean under `RUSTDOCFLAGS=-D warnings`)
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check` (no drift)
- [x] Python: `maturin develop` + `pytest tests/ -q` (335 passed, 30 skipped) + `mypy.stubtest` clean
- [x] TypeScript: `npm run build` + `npm test` (66 passed, 0 failed)
- [x] C++: `ctest --output-on-failure` (43 passed; 7 live-only skipped)
- [x] `scripts/check_banned_vocab.py` + `scripts/check_safety_comment_boilerplate.py` clean
- [x] CHANGELOG mirror diff returns `MIRROR_OK`