### PR TITLE
refactor: close 5-axis audit round 6 (C/C++ issue-ref strip + cross-binding test parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Python `test_reconnect_stable_window_secs_rejects_above_u64`
+  closes the last cross-binding gap on the
+  `reconnect_stable_window_secs` boundary surface. Mirrors the
+  TypeScript `setReconnectStableWindowSecs(1n << 65n)` rejection
+  case so magnitudes above `u64::MAX` raise `OverflowError` at the
+  pyo3 extraction boundary, instead of relying on the implicit
+  Python-int-is-unbounded behaviour.
+- FFI `reconnect_setters_compose_with_pool_sizing_setters` pins
+  the interleaved-survival contract on the C-ABI surface to match
+  the existing Python / TypeScript / C++ cases. Reconnect setter
+  calls and pool-sizing setter calls on the same `TdxConfig` must
+  land in `inner` independently and persist; the new test interleaves
+  `tdx_config_set_concurrent_requests`,
+  `tdx_config_set_decoder_ring_size`,
+  `tdx_config_set_reconnect_policy`,
+  `tdx_config_set_reconnect_max_attempts`,
+  `tdx_config_set_reconnect_max_rate_limited_attempts`,
+  and `tdx_config_set_reconnect_stable_window_secs`, then asserts
+  both mutation classes round-tripped via the underlying `MddsConfig`
+  and `ReconnectPolicy::Auto(limits)` paths.
 - Cross-binding ReconnectConfig setter test parity. The TypeScript
   `__tests__/config_reconnect.test.mjs` coverage that landed in
   round 3 now has matching siblings on every binding:
@@ -387,6 +407,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- C++ ReconnectConfig setter test names corrected from
+  `round-trips representative budgets` to
+  `accepts representative budgets without throwing`. The C ABI exposes
+  no `tdx_config_get_reconnect_*` getter, so the Catch2 cases only call
+  `REQUIRE_NOTHROW` on the setter — no round-trip is verified. The new
+  wording matches the existing TypeScript (`accepts non-zero budgets
+  without throwing`) and Python (`_accepts_non_zero_budgets`) names and
+  removes the misleading claim that a getter exists.
+- Issue-number attributions stripped from the seven remaining C/C++
+  surface sites (round-5 follow-up). The previous round closed `(issue
+  #N)` parentheticals on the Python / TypeScript / FFI binding crates
+  and on the two remaining `crates/thetadatadx/src/rest` module comments;
+  this round closes the C/C++ siblings: `sdks/cpp/include/thetadx.hpp`
+  (MDDS pool-sizing banner + cross-language utility helpers banner),
+  `sdks/cpp/include/thetadx.h` (two `volume/count` rationale blocks on
+  the OHLCVC and option-OHLCVC structs), `sdks/cpp/tests/CMakeLists.txt`
+  (doctest-harness comment), `sdks/cpp/tests/doctest_examples.cpp`
+  (file-banner comment), and `sdks/cpp/tests/config_pool_sizing.cpp`
+  (file-banner comment). `grep -rn 'issue #[0-9]\+' sdks/cpp/` now
+  matches only vendored Catch2 sources under `sdks/cpp/build/_deps/`.
 - ReconnectConfig setter docstrings unified across every binding. The
   per-class budget setters (`set_reconnect_max_attempts`,
   `set_reconnect_max_rate_limited_attempts`,

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -13,6 +13,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Python `test_reconnect_stable_window_secs_rejects_above_u64`
+  closes the last cross-binding gap on the
+  `reconnect_stable_window_secs` boundary surface. Mirrors the
+  TypeScript `setReconnectStableWindowSecs(1n << 65n)` rejection
+  case so magnitudes above `u64::MAX` raise `OverflowError` at the
+  pyo3 extraction boundary, instead of relying on the implicit
+  Python-int-is-unbounded behaviour.
+- FFI `reconnect_setters_compose_with_pool_sizing_setters` pins
+  the interleaved-survival contract on the C-ABI surface to match
+  the existing Python / TypeScript / C++ cases. Reconnect setter
+  calls and pool-sizing setter calls on the same `TdxConfig` must
+  land in `inner` independently and persist; the new test interleaves
+  `tdx_config_set_concurrent_requests`,
+  `tdx_config_set_decoder_ring_size`,
+  `tdx_config_set_reconnect_policy`,
+  `tdx_config_set_reconnect_max_attempts`,
+  `tdx_config_set_reconnect_max_rate_limited_attempts`,
+  and `tdx_config_set_reconnect_stable_window_secs`, then asserts
+  both mutation classes round-tripped via the underlying `MddsConfig`
+  and `ReconnectPolicy::Auto(limits)` paths.
 - Cross-binding ReconnectConfig setter test parity. The TypeScript
   `__tests__/config_reconnect.test.mjs` coverage that landed in
   round 3 now has matching siblings on every binding:
@@ -387,6 +407,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- C++ ReconnectConfig setter test names corrected from
+  `round-trips representative budgets` to
+  `accepts representative budgets without throwing`. The C ABI exposes
+  no `tdx_config_get_reconnect_*` getter, so the Catch2 cases only call
+  `REQUIRE_NOTHROW` on the setter — no round-trip is verified. The new
+  wording matches the existing TypeScript (`accepts non-zero budgets
+  without throwing`) and Python (`_accepts_non_zero_budgets`) names and
+  removes the misleading claim that a getter exists.
+- Issue-number attributions stripped from the seven remaining C/C++
+  surface sites (round-5 follow-up). The previous round closed `(issue
+  #N)` parentheticals on the Python / TypeScript / FFI binding crates
+  and on the two remaining `crates/thetadatadx/src/rest` module comments;
+  this round closes the C/C++ siblings: `sdks/cpp/include/thetadx.hpp`
+  (MDDS pool-sizing banner + cross-language utility helpers banner),
+  `sdks/cpp/include/thetadx.h` (two `volume/count` rationale blocks on
+  the OHLCVC and option-OHLCVC structs), `sdks/cpp/tests/CMakeLists.txt`
+  (doctest-harness comment), `sdks/cpp/tests/doctest_examples.cpp`
+  (file-banner comment), and `sdks/cpp/tests/config_pool_sizing.cpp`
+  (file-banner comment). `grep -rn 'issue #[0-9]\+' sdks/cpp/` now
+  matches only vendored Catch2 sources under `sdks/cpp/build/_deps/`.
 - ReconnectConfig setter docstrings unified across every binding. The
   per-class budget setters (`set_reconnect_max_attempts`,
   `set_reconnect_max_rate_limited_attempts`,

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -808,6 +808,46 @@ mod reconnect_setter_tests {
             super::tdx_config_set_reconnect_stable_window_secs(std::ptr::null_mut(), 60);
         }
     }
+
+    #[test]
+    fn reconnect_setters_compose_with_pool_sizing_setters() {
+        // Cross-binding interleaved-survival contract: reconnect setter
+        // calls and pool-sizing setter calls on the same `TdxConfig`
+        // must land in `inner` independently and persist. Mirrors the
+        // Python `test_reconnect_setter_state_survives_interleaved_calls`,
+        // TypeScript `Pool-sizing setter state survives interleaved
+        // reconnect setter calls`, and C++ `Reconnect setters compose
+        // with pool-sizing setters` cases.
+        let cfg = super::tdx_config_production();
+        assert!(!cfg.is_null());
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            // Apply pool-sizing knobs.
+            super::tdx_config_set_concurrent_requests(cfg, 8);
+            super::tdx_config_set_decoder_ring_size(cfg, 256);
+
+            // Apply reconnect knobs.
+            super::tdx_config_set_reconnect_policy(cfg, 0);
+            super::tdx_config_set_reconnect_max_attempts(cfg, 5);
+            super::tdx_config_set_reconnect_max_rate_limited_attempts(cfg, 3);
+            super::tdx_config_set_reconnect_stable_window_secs(cfg, 60);
+
+            // Pool-sizing mutations survived the reconnect setter sequence.
+            let mdds = &(*cfg).inner.mdds;
+            assert_eq!(mdds.concurrent_requests, 8);
+            assert_eq!(mdds.decoder_ring_size, 256);
+
+            // Reconnect mutations landed on `Auto(limits)`.
+            let thetadatadx::ReconnectPolicy::Auto(limits) = &(*cfg).inner.reconnect.policy else {
+                panic!("expected ReconnectPolicy::Auto after set_reconnect_policy(0)");
+            };
+            assert_eq!(limits.max_attempts, 5);
+            assert_eq!(limits.max_rate_limited_attempts, 3);
+            assert_eq!(limits.stable_window, std::time::Duration::from_secs(60));
+
+            super::tdx_config_free(cfg);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -69,8 +69,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     double high;
     double low;
     double close;
-    /* volume/count are int64 to match the core crate (issue #372) and
-     * prevent overflow on high-volume symbols (2.1B+ cumulative volume). */
+    /* volume/count are int64 to match the core crate and prevent
+     * overflow on high-volume symbols (2.1B+ cumulative volume). */
     int64_t volume;
     int64_t count;
     int32_t bid_size;
@@ -238,8 +238,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     double high;
     double low;
     double close;
-    /* volume/count are int64 to match the core crate (issue #372) and
-     * prevent overflow on high-volume symbols (2.1B+ cumulative volume). */
+    /* volume/count are int64 to match the core crate and prevent
+     * overflow on high-volume symbols (2.1B+ cumulative volume). */
     int64_t volume;
     int64_t count;
     int32_t date;

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -546,7 +546,7 @@ public:
     /** Set whether to derive OHLCVC bars locally from trades. */
     void set_derive_ohlcvc(bool enabled) { tdx_config_set_derive_ohlcvc(handle_.get(), enabled ? 1 : 0); }
 
-    // ── MDDS pool sizing (issue #584) ──
+    // ── MDDS pool sizing ──
 
     /**
      * Set the number of concurrent in-flight gRPC requests.
@@ -1964,7 +1964,7 @@ inline void FpssClient::unsubscribe_many(
     for (const auto& s : subs) unsubscribe(s);
 }
 
-// ── Cross-language utility helpers (issue #424) ─────────────────────────
+// ── Cross-language utility helpers ──────────────────────────────────────
 //
 // Thin std::string wrappers over the `'static` C-string accessors in
 // `thetadx.h`. Each call copies the table entry once into a

--- a/sdks/cpp/tests/CMakeLists.txt
+++ b/sdks/cpp/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ set(THETADX_CPP_TEST_SOURCES
     # MDDS two-stage decode pipeline setters on tdx::Config
     # (Phase 3 of 3, follow-up to PR #587 / #588).
     config_decode_pipeline.cpp
-    # Gate 3 (issue #546) - C++ doctest harness. Compiles + runs
+    # Gate 3 - C++ doctest harness. Compiles + runs
     # `// @example` blocks extracted from the public headers.
     doctest_examples.cpp
 )

--- a/sdks/cpp/tests/config_pool_sizing.cpp
+++ b/sdks/cpp/tests/config_pool_sizing.cpp
@@ -1,4 +1,4 @@
-// MDDS pool-sizing setters on tdx::Config (issue #584).
+// MDDS pool-sizing setters on tdx::Config.
 //
 // Offline tests pin the contract that the three new setters exposed by
 // the `tdx::Config` C++ wrapper — `set_concurrent_requests`,

--- a/sdks/cpp/tests/config_reconnect.cpp
+++ b/sdks/cpp/tests/config_reconnect.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Config::set_reconnect_policy treats unknown selectors as Auto",
     REQUIRE_NOTHROW(cfg.set_reconnect_policy(-1));
 }
 
-TEST_CASE("Config::set_reconnect_max_attempts round-trips representative budgets",
+TEST_CASE("Config::set_reconnect_max_attempts accepts representative budgets without throwing",
           "[config][reconnect][offline]") {
     auto cfg = tdx::Config::production();
     cfg.set_reconnect_policy(0); // Auto
@@ -47,7 +47,7 @@ TEST_CASE("Config::set_reconnect_max_attempts round-trips representative budgets
     }
 }
 
-TEST_CASE("Config::set_reconnect_max_rate_limited_attempts round-trips representative budgets",
+TEST_CASE("Config::set_reconnect_max_rate_limited_attempts accepts representative budgets without throwing",
           "[config][reconnect][offline]") {
     auto cfg = tdx::Config::production();
     cfg.set_reconnect_policy(0); // Auto

--- a/sdks/cpp/tests/doctest_examples.cpp
+++ b/sdks/cpp/tests/doctest_examples.cpp
@@ -1,4 +1,4 @@
-// Gate 3 (issue #546) - C++ side: doctest gate.
+// Gate 3 - C++ side: doctest gate.
 //
 // Compiles every `// @example` block extracted from the public C++
 // headers (`thetadx.hpp` + `.inc` includes). The C++ harness piggybacks

--- a/sdks/python/tests/test_config_reconnect.py
+++ b/sdks/python/tests/test_config_reconnect.py
@@ -136,6 +136,22 @@ def test_reconnect_stable_window_secs_rejects_negative():
         cfg.reconnect_stable_window_secs = -1
 
 
+def test_reconnect_stable_window_secs_rejects_above_u64() -> None:
+    """Magnitudes above ``u64::MAX`` must be rejected at the boundary.
+
+    Mirrors the TypeScript boundary case in
+    ``__tests__/config_reconnect.test.mjs`` that pins
+    ``setReconnectStableWindowSecs(1n << 65n)`` as a rejection. Python's
+    ``int`` is unbounded, so pyo3's ``u64`` extraction raises
+    ``OverflowError`` when the magnitude does not fit in 64 bits.
+    """
+    mod = _import_module()
+    cfg = mod.Config.production()
+    cfg.reconnect_policy = "auto"
+    with pytest.raises(OverflowError):
+        cfg.reconnect_stable_window_secs = 1 << 65
+
+
 # ─── Combined invariants ────────────────────────────────────────────
 
 


### PR DESCRIPTION
Round 7 of the audit-fix loop. Re-audit follows merge.

Closes four MINOR findings carried over from the round-6 5-axis audit:

## Summary

- **M1** C/C++ `(issue #N)` strip completion (round-5 N3 follow-up). Removed `(issue #N)` parentheticals from the seven remaining C/C++ surface sites. `grep -rn 'issue #[0-9]\+' sdks/cpp/` now matches only vendored Catch2 sources under `sdks/cpp/build/_deps/`.
- **M2** C++ ReconnectConfig test names corrected from `round-trips representative budgets` to `accepts representative budgets without throwing`. The C ABI exposes no `tdx_config_get_reconnect_*` getter, so the Catch2 cases only call `REQUIRE_NOTHROW` on the setter — no round-trip is verified. New wording matches TS / Python sibling test naming.
- **M3** Python `test_reconnect_stable_window_secs_rejects_above_u64` pins the magnitude-above-u64 boundary on the pyo3 surface, mirroring the existing TypeScript `setReconnectStableWindowSecs(1n << 65n)` rejection.
- **M4** FFI `reconnect_setters_compose_with_pool_sizing_setters` pins the interleaved-survival contract on the C-ABI surface, mirroring the Python / TypeScript / C++ siblings.

## Files

- `sdks/cpp/include/thetadx.h` — 2 `volume/count` rationale blocks neutralised
- `sdks/cpp/include/thetadx.hpp` — MDDS pool-sizing banner + utility helpers banner neutralised
- `sdks/cpp/tests/CMakeLists.txt` — doctest harness comment neutralised
- `sdks/cpp/tests/config_pool_sizing.cpp` — file banner neutralised
- `sdks/cpp/tests/doctest_examples.cpp` — file banner neutralised
- `sdks/cpp/tests/config_reconnect.cpp` — 2 TEST_CASE titles renamed
- `sdks/python/tests/test_config_reconnect.py` — `test_reconnect_stable_window_secs_rejects_above_u64` added
- `ffi/src/auth.rs` — `reconnect_setters_compose_with_pool_sizing_setters` added to `reconnect_setter_tests`
- `CHANGELOG.md` + `docs-site/docs/changelog.md` — `[Unreleased]` entries added under `Added` and `Changed`, mirrored byte-identical

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` — all crates green; FFI `reconnect_setter_tests` now reports 8 tests (was 7)
- [x] `cargo clippy --workspace --tests --benches -- -D warnings`
- [x] `cargo doc --no-deps -p thetadatadx --features arrow,polars,frames,config-file`
- [x] `generate_sdk_surfaces --check`
- [x] `pytest sdks/python/tests` — 336 passed / 30 skipped (was 335 / 30)
- [x] `mypy.stubtest thetadatadx` — no issues
- [x] `npm test` (TypeScript SDK) — 66/66
- [x] C++ Catch2 binary — 36/36 cases, 184/184 assertions; renamed reconnect cases listed correctly via `--list-tests`
- [x] `scripts/check_banned_vocab.py` clean
- [x] `scripts/check_safety_comment_boilerplate.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)