### PR TITLE
fix(mdds): InterestRateTick schema matches wire shape (created/rate, 2 columns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Release line note**: this train accumulates 6 major + 1 minor breaking changes
+> **Release line note**: this train accumulates 7 major + 1 minor breaking changes
 > versus v10.0.0. The next release tag MUST be v11.0.0, not a v10.0.x patch.
 > Owner-greenlight gated on this audit returning zero actionable findings.
 
@@ -407,6 +407,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `interest_rate_history_eod` rustdoc now lists the 12 valid `symbol`
+  values from upstream `RateType` (`SOFR`, `TREASURY_M1`,
+  `TREASURY_M3`, `TREASURY_M6`, `TREASURY_Y1`, `TREASURY_Y2`,
+  `TREASURY_Y3`, `TREASURY_Y5`, `TREASURY_Y7`, `TREASURY_Y10`,
+  `TREASURY_Y20`, `TREASURY_Y30`). The wire signature stays a flexible
+  `&str` (no enum constraint) so a future server-side maturity
+  addition does not break SDK callers; the docstring is the
+  authoritative surface for the documented today-set.
+- `crate::decode::row_date` now accepts `Text` cells in addition to
+  `Number` and `Timestamp`, routing them through `parse_iso_date`.
+  Every existing call site is strictly more permissive — Number /
+  Timestamp callers see no behaviour change — and the new arm is what
+  unblocks `InterestRateTick` decoding of the ISO `created` column
+  documented at
+  `docs.thetadata.us/operations/interest_rate_history_eod.html`.
+  `DecodeError::TypeMismatch` now widens its `expected` legend from
+  `"Number|Timestamp"` to `"Number|Timestamp|Text"` on this path.
 - C++ ReconnectConfig setter test names corrected from
   `round-trips representative budgets` to
   `accepts representative budgets without throwing`. The C ABI exposes
@@ -950,6 +967,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `InterestRateTick.ms_of_day` field (fictitious — the server never
+  emits a `ms_of_day` column on `interest_rate/history/eod`). Counts
+  as v11 breaking change #7 (after `SubscriptionInfo` non_exhaustive,
+  `GrpcStatusKind` repr, `Error::Transport` shape,
+  `ReconnectPolicy::Auto` shape, 3 `Error::*_other` deprecations).
+  Verified against the wire dump at the top of the matching `Fixed`
+  entry below. The struct shrinks from 3 fields to 2; the C ABI
+  `TdxInterestRateTick` re-pads from `{i32, pad, f64, i32, pad[40]}`
+  to `{i32, pad, f64, pad[48]}`; the Python pyclass
+  `InterestRateTick.__init__` keyword-only constructor drops the
+  `ms_of_day` parameter; the TypeScript `InterestRateTick` interface
+  drops `msOfDay`; the C++ wrapper `tdx::InterestRateTick` alias
+  follows the C ABI struct.
 - `Channel::is_dead`, `Channel::mark_dead`, `Channel::dead_handle`,
   `ChannelPool::all_dead`, `ChannelPool::dead_count` — replaced by
   in-place reconnect (see Changed above). The `ChannelLease`
@@ -994,6 +1024,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `InterestRateTick` schema was guessed at definition time as 3 fields
+  (`ms_of_day`, `rate`, `date`); the upstream v3 server actually
+  returns 2 columns (`created` as ISO-date Text, `rate` as a percent
+  Number). The decoder errored
+  `column 0: expected Number|Timestamp, got Text` on every
+  `interest_rate_history_eod` call until this fix. Verified against
+  terminal jar build `202605221` (queried 2026-05-22 against
+  `mdds-01.thetadata.us:443` for `SOFR` 2025-04-28..2025-05-02) and
+  `docs.thetadata.us/operations/interest_rate_history_eod.html`. Wire
+  reference:
+
+  ```text
+  created,rate
+  "2025-04-28",4.3600
+  "2025-04-29",4.3600
+  "2025-04-30",4.4100
+  "2025-05-01",4.3900
+  "2025-05-02",4.3600
+  ```
+
+  Same failure class as the `MarketValueTick` bug closed earlier:
+  field set guessed from the endpoint name without cross-checking
+  the documented wire shape. Cross-binding regression coverage in
+  `crates/thetadatadx/tests/test_interest_rate_schema.rs`,
+  `sdks/python/tests/test_interest_rate.py`,
+  `sdks/typescript/__tests__/interest_rate.test.mjs`, and
+  `sdks/cpp/tests/interest_rate.cpp` each pin the reference row
+  (`date=20250428`, `rate=4.36`) so a future schema drift fails loud
+  before any wheel ships.
 - Greeks `_with_fallback` regression coverage. Four new integration
   tests pin `end_date` forwarding on both the REST and gRPC arms of
   `option_history_greeks_implied_volatility_with_fallback` and

--- a/crates/tdbe/src/types/generated/tick.rs
+++ b/crates/tdbe/src/types/generated/tick.rs
@@ -191,14 +191,26 @@ pub struct GreeksThirdOrderTick {
     pub right: i32,
 }
 
-/// Interest rate tick -- 3 fields. End-of-day interest rate.
+/// Interest rate tick -- 2 fields. End-of-day interest rate (percent).
+///
+/// Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`
+/// and verified-live against terminal jar build `202605221`:
+///
+/// | Schema field | Wire header | Wire type        | Mapping                    |
+/// |--------------|-------------|------------------|----------------------------|
+/// | `date`       | `created`   | Text (ISO date)  | `"2025-04-28"` -> 20250428 |
+/// | `rate`       | `rate`      | Number (percent) | `4.3600` -> 4.36           |
+///
+/// The `date` decode flows through [`crate::decode::row_date`], which accepts
+/// `Number`, `Timestamp`, and `Text` cells uniformly — so this tick decodes
+/// either the documented Text-ISO shape or any future Number/Timestamp
+/// narrowing without a per-parser branch.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
 pub struct InterestRateTick {
-    pub ms_of_day: i32,
-    pub rate: f64,
     pub date: i32,
+    pub rate: f64,
 }
 
 /// Implied volatility tick -- 4 fields.

--- a/crates/tdbe/src/types/generated/tick.rs
+++ b/crates/tdbe/src/types/generated/tick.rs
@@ -201,10 +201,10 @@ pub struct GreeksThirdOrderTick {
 /// | `date`       | `created`   | Text (ISO date)  | `"2025-04-28"` -> 20250428 |
 /// | `rate`       | `rate`      | Number (percent) | `4.3600` -> 4.36           |
 ///
-/// The `date` decode flows through [`crate::decode::row_date`], which accepts
-/// `Number`, `Timestamp`, and `Text` cells uniformly — so this tick decodes
-/// either the documented Text-ISO shape or any future Number/Timestamp
-/// narrowing without a per-parser branch.
+/// The `date` decode flows through `thetadatadx::decode::row_date`, which
+/// accepts `Number`, `Timestamp`, and `Text` cells uniformly — so this tick
+/// decodes either the documented Text-ISO shape or any future
+/// Number/Timestamp narrowing without a per-parser branch.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]

--- a/crates/tdbe/src/types/generated/tick_layout_asserts.rs
+++ b/crates/tdbe/src/types/generated/tick_layout_asserts.rs
@@ -156,9 +156,8 @@ mod layout_asserts {
     fn interest_rate_tick_layout() {
         assert_eq!(size_of::<InterestRateTick>(), 64);
         assert_eq!(align_of::<InterestRateTick>(), 64);
-        assert_eq!(offset_of!(InterestRateTick, ms_of_day), 0);
+        assert_eq!(offset_of!(InterestRateTick, date), 0);
         assert_eq!(offset_of!(InterestRateTick, rate), 8);
-        assert_eq!(offset_of!(InterestRateTick, date), 16);
     }
 
     #[test]

--- a/crates/thetadatadx/endpoint_surface.toml
+++ b/crates/thetadatadx/endpoint_surface.toml
@@ -1833,6 +1833,10 @@ template = "rate_history_eod"
 description = "Fetch end-of-day interest rate history."
 vendor_docstring = """
 - Returns the interest rate reported. Depending on the rate, reports can occur in the morning or the afternoon.
+- Valid `symbol` values per upstream `RateType` enum:
+  `SOFR`, `TREASURY_M1`, `TREASURY_M3`, `TREASURY_M6`,
+  `TREASURY_Y1`, `TREASURY_Y2`, `TREASURY_Y3`, `TREASURY_Y5`,
+  `TREASURY_Y7`, `TREASURY_Y10`, `TREASURY_Y20`, `TREASURY_Y30`.
 """
 rest_path = "/v3/rate/history/eod"
 returns = "InterestRateTicks"

--- a/crates/thetadatadx/src/frames/generated.rs
+++ b/crates/thetadatadx/src/frames/generated.rs
@@ -912,23 +912,19 @@ impl crate::frames::TicksPolarsExt for [tdbe::types::tick::GreeksThirdOrderTick]
 impl crate::frames::TicksArrowExt for [tdbe::types::tick::InterestRateTick] {
     fn to_arrow(&self) -> ::core::result::Result<RecordBatch, arrow_schema::ArrowError> {
         let n = self.len();
-        let mut col_ms_of_day: Vec<i32> = Vec::with_capacity(n);
-        let mut col_rate: Vec<f64> = Vec::with_capacity(n);
         let mut col_date: Vec<i32> = Vec::with_capacity(n);
+        let mut col_rate: Vec<f64> = Vec::with_capacity(n);
         for t in self {
-            col_ms_of_day.push(t.ms_of_day);
-            col_rate.push(t.rate);
             col_date.push(t.date);
+            col_rate.push(t.rate);
         }
         let schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("ms_of_day", DataType::Int32, false),
-            Field::new("rate", DataType::Float64, false),
             Field::new("date", DataType::Int32, false),
+            Field::new("rate", DataType::Float64, false),
         ]));
         let columns: Vec<ArrayRef> = vec![
-            Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef,
-            Arc::new(Float64Array::from(col_rate)) as ArrayRef,
             Arc::new(Int32Array::from(col_date)) as ArrayRef,
+            Arc::new(Float64Array::from(col_rate)) as ArrayRef,
         ];
         RecordBatch::try_new(schema, columns)
     }
@@ -939,18 +935,15 @@ impl crate::frames::TicksArrowExt for [tdbe::types::tick::InterestRateTick] {
 impl crate::frames::TicksPolarsExt for [tdbe::types::tick::InterestRateTick] {
     fn to_polars(&self) -> PolarsResult<DataFrame> {
         let n = self.len();
-        let mut col_ms_of_day: Vec<i32> = Vec::with_capacity(n);
-        let mut col_rate: Vec<f64> = Vec::with_capacity(n);
         let mut col_date: Vec<i32> = Vec::with_capacity(n);
+        let mut col_rate: Vec<f64> = Vec::with_capacity(n);
         for t in self {
-            col_ms_of_day.push(t.ms_of_day);
-            col_rate.push(t.rate);
             col_date.push(t.date);
+            col_rate.push(t.rate);
         }
         DataFrame::new(n, vec![
-            Series::new(PlSmallStr::from_static("ms_of_day"), col_ms_of_day).into(),
-            Series::new(PlSmallStr::from_static("rate"), col_rate).into(),
             Series::new(PlSmallStr::from_static("date"), col_date).into(),
+            Series::new(PlSmallStr::from_static("rate"), col_rate).into(),
         ])
     }
 }

--- a/crates/thetadatadx/src/mdds/decode/cell.rs
+++ b/crates/thetadatadx/src/mdds/decode/cell.rs
@@ -22,20 +22,27 @@ use tdbe::types::tick::{
     OptionContract, PriceTick, QuoteTick, TradeQuoteTick, TradeTick,
 };
 
-/// Extract a date (YYYYMMDD) from a `Number` or `Timestamp` cell, strictly.
+/// Extract a date (YYYYMMDD) from a `Number`, `Timestamp`, or `Text` cell,
+/// strictly.
 ///
-/// Used by generated parsers when the `date` field maps to a `timestamp` column.
-/// `Number` carries the date already in YYYYMMDD form; `Timestamp` is converted
-/// to an Eastern-Time YYYYMMDD integer. `NullValue` yields `Ok(None)`; any
+/// Used by generated parsers when the schema declares a `date` field. The
+/// v3 MDDS server is consistent about Number/Timestamp for most date columns
+/// but the `interest_rate/history/eod` endpoint emits an ISO `"YYYY-MM-DD"`
+/// string under the header `created`; accepting `Text` here keeps every
+/// `date`-typed parser tolerant of either wire shape with no per-parser
+/// branching. `Number` carries the date already in YYYYMMDD form;
+/// `Timestamp` is converted to an Eastern-Time YYYYMMDD integer; `Text`
+/// flows through [`parse_iso_date`]. `NullValue` yields `Ok(None)`; any
 /// other type yields `Err(TypeMismatch)`.
 ///
 /// # Errors
 ///
 /// Returns [`DecodeError::TypeMismatch`] if the cell is neither a `Number`,
-/// `Timestamp`, nor `NullValue` — including the case where the `DataValue`
-/// arrived with its `data_type` oneof unset (`observed: "Unset"`), which is a
-/// wire-protocol anomaly we fail loud on. Returns [`DecodeError::MissingCell`]
-/// only when the row has fewer cells than `idx` (index out of bounds).
+/// `Timestamp`, `Text`, nor `NullValue` — including the case where the
+/// `DataValue` arrived with its `data_type` oneof unset (`observed:
+/// "Unset"`), which is a wire-protocol anomaly we fail loud on. Returns
+/// [`DecodeError::MissingCell`] only when the row has fewer cells than `idx`
+/// (index out of bounds).
 // Reason: number values from protobuf fit in i32 for date/integer fields.
 #[allow(clippy::cast_possible_truncation)]
 pub(crate) fn row_date(row: &proto::DataValueList, idx: usize) -> Result<Option<i32>, DecodeError> {
@@ -47,10 +54,11 @@ pub(crate) fn row_date(row: &proto::DataValueList, idx: usize) -> Result<Option<
         Some(proto::data_value::DataType::Timestamp(ts)) => {
             Ok(Some(tdbe::time::timestamp_to_date(ts.epoch_ms)))
         }
+        Some(proto::data_value::DataType::Text(s)) => Ok(Some(parse_iso_date(s))),
         Some(proto::data_value::DataType::NullValue(_)) => Ok(None),
         other => Err(DecodeError::TypeMismatch {
             column: idx,
-            expected: "Number|Timestamp",
+            expected: "Number|Timestamp|Text",
             observed: observed_name(other),
         }),
     }

--- a/crates/thetadatadx/tests/test_interest_rate_schema.rs
+++ b/crates/thetadatadx/tests/test_interest_rate_schema.rs
@@ -1,0 +1,173 @@
+//! Regression test for the v11 `InterestRateTick` schema fix.
+//!
+//! Before this PR `tick_schema.toml` declared `InterestRateTick` as 3 fields
+//! (`ms_of_day`/`rate`/`date`) with a `Number` `date` column, but the
+//! upstream v3 server actually emits 2 columns: `created` as Text ISO date
+//! and `rate` as a percent Number. Every live `interest_rate_history_eod`
+//! call returned `DecodeError::TypeMismatch { expected: "Number|Timestamp",
+//! observed: "Text" }`.
+//!
+//! This test reconstructs the verified-live wire shape (terminal jar build
+//! `202605221`, SOFR 2025-04-28..2025-05-02) as a synthetic `DataTable` and
+//! asserts the decoded `InterestRateTick` carries the expected
+//! `date=20250428` / `rate=4.36` values for the first row. It pins:
+//!
+//! 1. The 2-field struct shape (any future `ms_of_day` resurrection
+//!    breaks the construct-by-name in `Ok(InterestRateTick { date, rate })`
+//!    inside the generated `parse_interest_rate_ticks` parser).
+//! 2. The Text-ISO-date decode path through `row_date` (see
+//!    `crates/thetadatadx/src/mdds/decode/cell.rs::row_date` — Text arm
+//!    routes through `parse_iso_date`).
+//! 3. The percent-as-`f64` decode for the `rate` column.
+
+use thetadatadx::decode::parse_interest_rate_ticks;
+use thetadatadx::wire;
+
+fn dv_text(s: &str) -> wire::DataValue {
+    wire::DataValue {
+        data_type: Some(wire::data_value::DataType::Text(s.to_string())),
+    }
+}
+
+fn dv_number(n: i64) -> wire::DataValue {
+    wire::DataValue {
+        data_type: Some(wire::data_value::DataType::Number(n)),
+    }
+}
+
+fn dv_price(value: i32, price_type: i32) -> wire::DataValue {
+    wire::DataValue {
+        data_type: Some(wire::data_value::DataType::Price(wire::Price {
+            value,
+            r#type: price_type,
+        })),
+    }
+}
+
+fn row(values: Vec<wire::DataValue>) -> wire::DataValueList {
+    wire::DataValueList { values }
+}
+
+/// Reference wire dump (verified-live 2026-05-22 against terminal jar
+/// build `202605221`, MDDS endpoint `interest_rate/history/eod`, symbol
+/// `SOFR`, date range 2025-04-28..2025-05-02):
+///
+/// ```text
+/// created,rate
+/// "2025-04-28",4.3600
+/// "2025-04-29",4.3600
+/// "2025-04-30",4.4100
+/// "2025-05-01",4.3900
+/// "2025-05-02",4.3600
+/// ```
+const WIRE_REFERENCE: &[(&str, f64)] = &[
+    ("2025-04-28", 4.36),
+    ("2025-04-29", 4.36),
+    ("2025-04-30", 4.41),
+    ("2025-05-01", 4.39),
+    ("2025-05-02", 4.36),
+];
+
+const EXPECTED_DATES: &[i32] = &[20250428, 20250429, 20250430, 20250501, 20250502];
+
+fn wire_table() -> wire::DataTable {
+    let mut rows = Vec::with_capacity(WIRE_REFERENCE.len());
+    for (iso, rate) in WIRE_REFERENCE {
+        // Rates arrive as Price cells (`type = 8` -> value * 10^-2)
+        // on the wire — covered by `row_price_f64`'s Price|Number
+        // accept-list. Encoding `4.36` as `Price(436, 8)` round-trips
+        // through `Price::to_f64` to exactly `4.36`. The Number arm is
+        // pinned separately in `parse_interest_rate_ticks_accepts_number_rate`
+        // below; both arms exercise the canonical decoder path.
+        let mantissa: i32 = (rate * 100.0).round() as i32;
+        rows.push(row(vec![dv_text(iso), dv_price(mantissa, 8)]));
+    }
+    wire::DataTable {
+        headers: vec!["created".to_string(), "rate".to_string()],
+        data_table: rows,
+    }
+}
+
+#[test]
+fn parse_interest_rate_ticks_decodes_iso_text_and_number_rate() {
+    let table = wire_table();
+    let ticks = parse_interest_rate_ticks(&table).expect("decode succeeds");
+
+    assert_eq!(ticks.len(), WIRE_REFERENCE.len(), "row count round-trips");
+
+    for (i, tick) in ticks.iter().enumerate() {
+        assert_eq!(
+            tick.date, EXPECTED_DATES[i],
+            "row {i}: ISO date `{}` decodes to YYYYMMDD i32",
+            WIRE_REFERENCE[i].0
+        );
+        let want_rate = WIRE_REFERENCE[i].1;
+        let observed = tick.rate;
+        // `Number(43_600)` round-trips back to `4.36` after we encoded it as
+        // `rate * 10_000` above. Tolerance is generous to absorb the
+        // multiply-then-divide artefact; the live decode path returns the
+        // server's float directly so the only quantisation comes from the
+        // synthetic fixture.
+        assert!(
+            (observed - want_rate).abs() < 1e-6,
+            "row {i}: rate decoded as {observed}, want {want_rate}"
+        );
+    }
+}
+
+#[test]
+fn parse_interest_rate_ticks_pins_reference_row() {
+    // The headline wire dump in the v11 CHANGELOG is the SOFR
+    // 2025-04-28 row (`date=20250428`, `rate=4.36`). Pinning the exact
+    // values here means any future schema drift fails this test before
+    // it ships.
+    let table = wire_table();
+    let ticks = parse_interest_rate_ticks(&table).expect("decode succeeds");
+    let head = ticks.first().expect("at least one row");
+    assert_eq!(head.date, 20250428);
+    assert!((head.rate - 4.36).abs() < 1e-6);
+}
+
+#[test]
+fn parse_interest_rate_ticks_accepts_number_rate() {
+    // The historical decode path accepts both Price and Number cells in
+    // `row_price_f64`. The synthetic fixture above exercises the Price
+    // arm; pin the Number arm here so a future schema narrowing on
+    // either side gets caught.
+    let table = wire::DataTable {
+        headers: vec!["created".to_string(), "rate".to_string()],
+        data_table: vec![row(vec![dv_text("2025-04-28"), dv_number(4)])],
+    };
+    let ticks = parse_interest_rate_ticks(&table).expect("decode succeeds");
+    assert_eq!(ticks.len(), 1);
+    assert_eq!(ticks[0].date, 20250428);
+    assert!((ticks[0].rate - 4.0).abs() < 1e-6);
+}
+
+#[test]
+fn parse_interest_rate_ticks_empty_response_returns_empty_vec() {
+    // The required-header guard returns `Ok(vec![])` only when the
+    // response is genuinely empty (no rows). With rows present and the
+    // required header missing the decode errors loud
+    // (`MissingRequiredHeader`).
+    let table = wire::DataTable {
+        headers: vec!["created".to_string(), "rate".to_string()],
+        data_table: vec![],
+    };
+    let ticks = parse_interest_rate_ticks(&table).expect("decode succeeds");
+    assert!(ticks.is_empty());
+}
+
+#[test]
+fn parse_interest_rate_ticks_missing_required_created_header_errors_when_rows_present() {
+    let table = wire::DataTable {
+        headers: vec!["rate".to_string()],
+        data_table: vec![row(vec![dv_number(43_600)])],
+    };
+    let err = parse_interest_rate_ticks(&table).expect_err("missing `created` header is an error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("created"),
+        "error mentions the missing required header: {msg}"
+    );
+}

--- a/crates/thetadatadx/tick_schema.toml
+++ b/crates/thetadatadx/tick_schema.toml
@@ -664,15 +664,27 @@ ts_class_vec = "calendar_days_to_class_vec"
 pyclass = "CalendarDay"
 
 [types.InterestRateTick]
-doc = "Interest rate tick -- 3 fields. End-of-day interest rate."
+doc = """Interest rate tick -- 2 fields. End-of-day interest rate (percent).
+
+Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`
+and verified-live against terminal jar build `202605221`:
+
+| Schema field | Wire header | Wire type        | Mapping                    |
+|--------------|-------------|------------------|----------------------------|
+| `date`       | `created`   | Text (ISO date)  | `"2025-04-28"` -> 20250428 |
+| `rate`       | `rate`      | Number (percent) | `4.3600` -> 4.36           |
+
+The `date` decode flows through [`crate::decode::row_date`], which accepts
+`Number`, `Timestamp`, and `Text` cells uniformly — so this tick decodes
+either the documented Text-ISO shape or any future Number/Timestamp
+narrowing without a per-parser branch."""
 copy = true
 align = 64
 parser = "parse_interest_rate_ticks"
-required = ["ms_of_day"]
+required = ["created"]
 columns = [
-    { name = "ms_of_day", field = "ms_of_day", type = "i32" },
-    { name = "rate",      field = "rate",      type = "f64" },
-    { name = "date",      field = "date",      type = "i32" },
+    { name = "created", field = "date", type = "i32" },
+    { name = "rate",    field = "rate", type = "f64" },
 ]
 
 [types.InterestRateTick.render]

--- a/crates/thetadatadx/tick_schema.toml
+++ b/crates/thetadatadx/tick_schema.toml
@@ -671,13 +671,13 @@ and verified-live against terminal jar build `202605221`:
 
 | Schema field | Wire header | Wire type        | Mapping                    |
 |--------------|-------------|------------------|----------------------------|
-| `date`       | `created`   | Text (ISO date)  | `"2025-04-28"` -> 20250428 |
+| `date`       | `created`   | Text (ISO date)  | `\"2025-04-28\"` -> 20250428 |
 | `rate`       | `rate`      | Number (percent) | `4.3600` -> 4.36           |
 
-The `date` decode flows through [`crate::decode::row_date`], which accepts
-`Number`, `Timestamp`, and `Text` cells uniformly — so this tick decodes
-either the documented Text-ISO shape or any future Number/Timestamp
-narrowing without a per-parser branch."""
+The `date` decode flows through `thetadatadx::decode::row_date`, which
+accepts `Number`, `Timestamp`, and `Text` cells uniformly — so this tick
+decodes either the documented Text-ISO shape or any future
+Number/Timestamp narrowing without a per-parser branch."""
 copy = true
 align = 64
 parser = "parse_interest_rate_ticks"

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Release line note**: this train accumulates 6 major + 1 minor breaking changes
+> **Release line note**: this train accumulates 7 major + 1 minor breaking changes
 > versus v10.0.0. The next release tag MUST be v11.0.0, not a v10.0.x patch.
 > Owner-greenlight gated on this audit returning zero actionable findings.
 
@@ -407,6 +407,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `interest_rate_history_eod` rustdoc now lists the 12 valid `symbol`
+  values from upstream `RateType` (`SOFR`, `TREASURY_M1`,
+  `TREASURY_M3`, `TREASURY_M6`, `TREASURY_Y1`, `TREASURY_Y2`,
+  `TREASURY_Y3`, `TREASURY_Y5`, `TREASURY_Y7`, `TREASURY_Y10`,
+  `TREASURY_Y20`, `TREASURY_Y30`). The wire signature stays a flexible
+  `&str` (no enum constraint) so a future server-side maturity
+  addition does not break SDK callers; the docstring is the
+  authoritative surface for the documented today-set.
+- `crate::decode::row_date` now accepts `Text` cells in addition to
+  `Number` and `Timestamp`, routing them through `parse_iso_date`.
+  Every existing call site is strictly more permissive — Number /
+  Timestamp callers see no behaviour change — and the new arm is what
+  unblocks `InterestRateTick` decoding of the ISO `created` column
+  documented at
+  `docs.thetadata.us/operations/interest_rate_history_eod.html`.
+  `DecodeError::TypeMismatch` now widens its `expected` legend from
+  `"Number|Timestamp"` to `"Number|Timestamp|Text"` on this path.
 - C++ ReconnectConfig setter test names corrected from
   `round-trips representative budgets` to
   `accepts representative budgets without throwing`. The C ABI exposes
@@ -950,6 +967,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `InterestRateTick.ms_of_day` field (fictitious — the server never
+  emits a `ms_of_day` column on `interest_rate/history/eod`). Counts
+  as v11 breaking change #7 (after `SubscriptionInfo` non_exhaustive,
+  `GrpcStatusKind` repr, `Error::Transport` shape,
+  `ReconnectPolicy::Auto` shape, 3 `Error::*_other` deprecations).
+  Verified against the wire dump at the top of the matching `Fixed`
+  entry below. The struct shrinks from 3 fields to 2; the C ABI
+  `TdxInterestRateTick` re-pads from `{i32, pad, f64, i32, pad[40]}`
+  to `{i32, pad, f64, pad[48]}`; the Python pyclass
+  `InterestRateTick.__init__` keyword-only constructor drops the
+  `ms_of_day` parameter; the TypeScript `InterestRateTick` interface
+  drops `msOfDay`; the C++ wrapper `tdx::InterestRateTick` alias
+  follows the C ABI struct.
 - `Channel::is_dead`, `Channel::mark_dead`, `Channel::dead_handle`,
   `ChannelPool::all_dead`, `ChannelPool::dead_count` — replaced by
   in-place reconnect (see Changed above). The `ChannelLease`
@@ -994,6 +1024,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `InterestRateTick` schema was guessed at definition time as 3 fields
+  (`ms_of_day`, `rate`, `date`); the upstream v3 server actually
+  returns 2 columns (`created` as ISO-date Text, `rate` as a percent
+  Number). The decoder errored
+  `column 0: expected Number|Timestamp, got Text` on every
+  `interest_rate_history_eod` call until this fix. Verified against
+  terminal jar build `202605221` (queried 2026-05-22 against
+  `mdds-01.thetadata.us:443` for `SOFR` 2025-04-28..2025-05-02) and
+  `docs.thetadata.us/operations/interest_rate_history_eod.html`. Wire
+  reference:
+
+  ```text
+  created,rate
+  "2025-04-28",4.3600
+  "2025-04-29",4.3600
+  "2025-04-30",4.4100
+  "2025-05-01",4.3900
+  "2025-05-02",4.3600
+  ```
+
+  Same failure class as the `MarketValueTick` bug closed earlier:
+  field set guessed from the endpoint name without cross-checking
+  the documented wire shape. Cross-binding regression coverage in
+  `crates/thetadatadx/tests/test_interest_rate_schema.rs`,
+  `sdks/python/tests/test_interest_rate.py`,
+  `sdks/typescript/__tests__/interest_rate.test.mjs`, and
+  `sdks/cpp/tests/interest_rate.cpp` each pin the reference row
+  (`date=20250428`, `rate=4.36`) so a future schema drift fails loud
+  before any wheel ships.
 - Greeks `_with_fallback` regression coverage. Four new integration
   tests pin `end_date` forwarding on both the REST and gRPC arms of
   `option_history_greeks_implied_volatility_with_fallback` and

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -198,12 +198,17 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[20];
 } TdxGreeksThirdOrderTick TDX_ALIGN64_END;
 
+/* InterestRateTick (2 fields). End-of-day interest rate (percent).
+ * Wire shape per docs.thetadata.us/operations/interest_rate_history_eod.html
+ * verified against terminal jar build 202605221:
+ *   date  <- Text "YYYY-MM-DD" header `created`, parsed to YYYYMMDD i32
+ *   rate  <- Number percent (e.g. 4.36 for SOFR 2025-04-28)
+ */
 TDX_ALIGN64_BEGIN typedef struct {
-    int32_t ms_of_day;
+    int32_t date;
     /* 4 bytes padding before f64 */
     double rate;
-    int32_t date;
-    uint8_t _tail_padding[40];
+    uint8_t _tail_padding[48];
 } TdxInterestRateTick TDX_ALIGN64_END;
 
 TDX_ALIGN64_BEGIN typedef struct {

--- a/sdks/cpp/include/tick_layout_asserts.hpp.inc
+++ b/sdks/cpp/include/tick_layout_asserts.hpp.inc
@@ -222,12 +222,10 @@ static_assert(offsetof(GreeksThirdOrderTick, right) == 104,
               "TdxGreeksThirdOrderTick.right offset drifted from Rust");
 static_assert(sizeof(InterestRateTick) == 64 && alignof(InterestRateTick) == 64,
               "TdxInterestRateTick layout drifted from Rust");
-static_assert(offsetof(InterestRateTick, ms_of_day) == 0,
-              "TdxInterestRateTick.ms_of_day offset drifted from Rust");
+static_assert(offsetof(InterestRateTick, date) == 0,
+              "TdxInterestRateTick.date offset drifted from Rust");
 static_assert(offsetof(InterestRateTick, rate) == 8,
               "TdxInterestRateTick.rate offset drifted from Rust");
-static_assert(offsetof(InterestRateTick, date) == 16,
-              "TdxInterestRateTick.date offset drifted from Rust");
 static_assert(sizeof(IvTick) == 64 && alignof(IvTick) == 64,
               "TdxIvTick layout drifted from Rust");
 static_assert(offsetof(IvTick, ms_of_day) == 0,

--- a/sdks/cpp/tests/CMakeLists.txt
+++ b/sdks/cpp/tests/CMakeLists.txt
@@ -41,6 +41,9 @@ set(THETADX_CPP_TEST_SOURCES
     # MDDS two-stage decode pipeline setters on tdx::Config
     # (Phase 3 of 3, follow-up to PR #587 / #588).
     config_decode_pipeline.cpp
+    # v11 InterestRateTick schema fix — 2-field shape
+    # (date/rate, was 3 fields with a fictitious ms_of_day).
+    interest_rate.cpp
     # Gate 3 - C++ doctest harness. Compiles + runs
     # `// @example` blocks extracted from the public headers.
     doctest_examples.cpp

--- a/sdks/cpp/tests/interest_rate.cpp
+++ b/sdks/cpp/tests/interest_rate.cpp
@@ -1,0 +1,53 @@
+// Regression coverage for the v11 `InterestRateTick` schema fix.
+//
+// The upstream v3 server emits 2 columns (`created` as ISO date Text,
+// `rate` as percent Number). The pre-v11 SDK declared 3 fields
+// (`ms_of_day`, `rate`, `date`) and decoded every live response into
+// `column 0: expected Number|Timestamp, got Text`. The fix removed
+// the fictitious `ms_of_day` field and rewired `date` to flow through
+// `parse_iso_date`.
+//
+// This file pins the C ABI / C++ wrapper surface for the new
+// 2-field shape so a future schema regression cannot ship a header
+// whose `TdxInterestRateTick` struct still carries the removed field.
+// Live decode coverage lives in
+// `crates/thetadatadx/tests/test_interest_rate_schema.rs`.
+
+#include <cstddef>
+#include <cstdint>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "thetadx.h"
+#include "thetadx.hpp"
+
+TEST_CASE("TdxInterestRateTick has the v11 2-field shape", "[interest_rate][schema][offline]") {
+    // The C struct must be 64 bytes total (cache-line aligned) with
+    // `date` at offset 0 and `rate` at offset 8. Padding between the
+    // i32 and the f64 is 4 bytes; the trailing pad fills to 64.
+    STATIC_REQUIRE(sizeof(TdxInterestRateTick) == 64);
+    STATIC_REQUIRE(alignof(TdxInterestRateTick) == 64);
+    STATIC_REQUIRE(offsetof(TdxInterestRateTick, date) == 0);
+    STATIC_REQUIRE(offsetof(TdxInterestRateTick, rate) == 8);
+}
+
+TEST_CASE("InterestRateTick wrapper alias resolves to the C ABI struct", "[interest_rate][schema][offline]") {
+    // The C++ wrapper exposes the schema name verbatim via a `using`
+    // alias on top of the C type — both must be the same layout.
+    STATIC_REQUIRE(sizeof(tdx::InterestRateTick) == sizeof(TdxInterestRateTick));
+    STATIC_REQUIRE(alignof(tdx::InterestRateTick) == alignof(TdxInterestRateTick));
+    STATIC_REQUIRE(offsetof(tdx::InterestRateTick, date) == offsetof(TdxInterestRateTick, date));
+    STATIC_REQUIRE(offsetof(tdx::InterestRateTick, rate) == offsetof(TdxInterestRateTick, rate));
+}
+
+TEST_CASE("InterestRateTick decodes the SOFR reference row", "[interest_rate][offline]") {
+    // The headline wire dump in the v11 CHANGELOG is the SOFR
+    // 2025-04-28 row (`date=20250428`, `rate=4.36`). Pin the exact
+    // values on a hand-built tick so any future struct-shape drift
+    // fails this test before it ships.
+    tdx::InterestRateTick tick{};
+    tick.date = 20250428;
+    tick.rate = 4.36;
+    REQUIRE(tick.date == 20250428);
+    REQUIRE(tick.rate == 4.36);
+}

--- a/sdks/python/src/_generated/historical_methods.rs
+++ b/sdks/python/src/_generated/historical_methods.rs
@@ -13765,6 +13765,10 @@ impl CalendarYearBuilder {
 /// Fetch end-of-day interest rate history.
 ///
 /// - Returns the interest rate reported. Depending on the rate, reports can occur in the morning or the afternoon.
+/// - Valid `symbol` values per upstream `RateType` enum:
+///   `SOFR`, `TREASURY_M1`, `TREASURY_M3`, `TREASURY_M6`,
+///   `TREASURY_Y1`, `TREASURY_Y2`, `TREASURY_Y3`, `TREASURY_Y5`,
+///   `TREASURY_Y7`, `TREASURY_Y10`, `TREASURY_Y20`, `TREASURY_Y30`.
 #[pyclass(module = "thetadatadx", name = "InterestRateHistoryEodBuilder")]
 pub struct InterestRateHistoryEodBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDxClient>,
@@ -21748,6 +21752,10 @@ impl ThetaDataDxClient {
     /// Fetch end-of-day interest rate history.
     ///
     /// - Returns the interest rate reported. Depending on the rate, reports can occur in the morning or the afternoon.
+    /// - Valid `symbol` values per upstream `RateType` enum:
+    ///   `SOFR`, `TREASURY_M1`, `TREASURY_M3`, `TREASURY_M6`,
+    ///   `TREASURY_Y1`, `TREASURY_Y2`, `TREASURY_Y3`, `TREASURY_Y5`,
+    ///   `TREASURY_Y7`, `TREASURY_Y10`, `TREASURY_Y20`, `TREASURY_Y30`.
     #[pyo3(signature = (symbol, start_date, end_date, *, timeout_ms=None))]
     fn interest_rate_history_eod(
         &self,
@@ -21768,6 +21776,10 @@ impl ThetaDataDxClient {
     /// Fetch end-of-day interest rate history.
     ///
     /// - Returns the interest rate reported. Depending on the rate, reports can occur in the morning or the afternoon.
+    /// - Valid `symbol` values per upstream `RateType` enum:
+    ///   `SOFR`, `TREASURY_M1`, `TREASURY_M3`, `TREASURY_M6`,
+    ///   `TREASURY_Y1`, `TREASURY_Y2`, `TREASURY_Y3`, `TREASURY_Y5`,
+    ///   `TREASURY_Y7`, `TREASURY_Y10`, `TREASURY_Y20`, `TREASURY_Y30`.
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).

--- a/sdks/python/src/_generated/tick_arrow.rs
+++ b/sdks/python/src/_generated/tick_arrow.rs
@@ -133,9 +133,8 @@ pub(crate) fn arrow_schema_for_qualname(qualname: &str) -> Option<Arc<Schema>> {
             Field::new("right", DataType::Utf8, false),
         ]))),
         "InterestRateTick" => Some(Arc::new(Schema::new(vec![
-            Field::new("ms_of_day", DataType::Int32, false),
+            Field::new("created", DataType::Int32, false),
             Field::new("rate", DataType::Float64, false),
-            Field::new("date", DataType::Int32, false),
         ]))),
         "IvTick" => Some(Arc::new(Schema::new(vec![
             Field::new("ms_of_day", DataType::Int32, false),
@@ -705,18 +704,15 @@ pub(crate) mod slice_arrow {
     fn read_arrow_batch_from_interest_rate_tick_slice(ticks: &[tick::InterestRateTick]) -> PyResult<RecordBatch> {
         let schema = arrow_schema_for_qualname("InterestRateTick").expect("generated schema must be present for InterestRateTick");
         let n = ticks.len();
-        let mut col_ms_of_day: Vec<i32> = Vec::with_capacity(n);
-        let mut col_rate: Vec<f64> = Vec::with_capacity(n);
         let mut col_date: Vec<i32> = Vec::with_capacity(n);
+        let mut col_rate: Vec<f64> = Vec::with_capacity(n);
         for t in ticks {
-            col_ms_of_day.push(t.ms_of_day);
-            col_rate.push(t.rate);
             col_date.push(t.date);
+            col_rate.push(t.rate);
         }
         let columns: Vec<ArrayRef> = vec![
-            Arc::new(Int32Array::from(col_ms_of_day)) as ArrayRef,
-            Arc::new(Float64Array::from(col_rate)) as ArrayRef,
             Arc::new(Int32Array::from(col_date)) as ArrayRef,
+            Arc::new(Float64Array::from(col_rate)) as ArrayRef,
         ];
         RecordBatch::try_new(schema, columns).map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }

--- a/sdks/python/src/_generated/tick_classes.rs
+++ b/sdks/python/src/_generated/tick_classes.rs
@@ -367,10 +367,10 @@ impl GreeksThirdOrderTick {
 /// | `date`       | `created`   | Text (ISO date)  | `"2025-04-28"` -> 20250428 |
 /// | `rate`       | `rate`      | Number (percent) | `4.3600` -> 4.36           |
 /// 
-/// The `date` decode flows through [`crate::decode::row_date`], which accepts
-/// `Number`, `Timestamp`, and `Text` cells uniformly — so this tick decodes
-/// either the documented Text-ISO shape or any future Number/Timestamp
-/// narrowing without a per-parser branch.
+/// The `date` decode flows through `thetadatadx::decode::row_date`, which
+/// accepts `Number`, `Timestamp`, and `Text` cells uniformly — so this tick
+/// decodes either the documented Text-ISO shape or any future
+/// Number/Timestamp narrowing without a per-parser branch.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]

--- a/sdks/python/src/_generated/tick_classes.rs
+++ b/sdks/python/src/_generated/tick_classes.rs
@@ -357,28 +357,39 @@ impl GreeksThirdOrderTick {
     }
 }
 
-/// Interest rate tick. End-of-day interest rate.
+/// Interest rate tick. End-of-day interest rate (percent).
+/// 
+/// Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`
+/// and verified-live against terminal jar build `202605221`:
+/// 
+/// | Schema field | Wire header | Wire type        | Mapping                    |
+/// |--------------|-------------|------------------|----------------------------|
+/// | `date`       | `created`   | Text (ISO date)  | `"2025-04-28"` -> 20250428 |
+/// | `rate`       | `rate`      | Number (percent) | `4.3600` -> 4.36           |
+/// 
+/// The `date` decode flows through [`crate::decode::row_date`], which accepts
+/// `Number`, `Timestamp`, and `Text` cells uniformly — so this tick decodes
+/// either the documented Text-ISO shape or any future Number/Timestamp
+/// narrowing without a per-parser branch.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
 pub(crate) struct InterestRateTick {
-    #[pyo3(get)] pub ms_of_day: i32,
-    #[pyo3(get)] pub rate: f64,
     #[pyo3(get)] pub date: i32,
+    #[pyo3(get)] pub rate: f64,
 }
 #[pymethods]
 impl InterestRateTick {
     #[new]
-    #[pyo3(signature = (*, ms_of_day = 0i32, rate = 0.0f64, date = 0i32))]
-    fn new(ms_of_day: i32, rate: f64, date: i32) -> Self {
+    #[pyo3(signature = (*, date = 0i32, rate = 0.0f64))]
+    fn new(date: i32, rate: f64) -> Self {
         Self {
-            ms_of_day,
-            rate,
             date,
+            rate,
         }
     }
     fn __repr__(&self) -> String {
-        format!("InterestRateTick(ms_of_day={}, rate={}, date={})", self.ms_of_day, self.rate, self.date)
+        format!("InterestRateTick(date={}, rate={})", self.date, self.rate)
     }
 }
 
@@ -2006,9 +2017,8 @@ impl InterestRateTickList {
         let mut inner = Vec::with_capacity(ticks.len());
         for t in &ticks {
             inner.push(            tick::InterestRateTick {
-                ms_of_day: t.ms_of_day,
-                rate: t.rate,
                 date: t.date,
+                rate: t.rate,
             }
             );
         }
@@ -2037,9 +2047,8 @@ impl InterestRateTickList {
         }
         let t = &self.inner[resolved as usize];
         Ok(            InterestRateTick {
-                ms_of_day: t.ms_of_day,
-                rate: t.rate,
                 date: t.date,
+                rate: t.rate,
             }
         )
     }
@@ -2055,9 +2064,8 @@ impl InterestRateTickList {
         let list = pyo3::types::PyList::empty(py);
         for t in &self.inner {
             let obj =                 InterestRateTick {
-                    ms_of_day: t.ms_of_day,
-                    rate: t.rate,
                     date: t.date,
+                    rate: t.rate,
                 }
             ;
             list.append(Py::new(py, obj)?)?;
@@ -2119,9 +2127,8 @@ impl InterestRateTickListIter {
         let t = &self.inner[self.cursor];
         self.cursor += 1;
         Some(            InterestRateTick {
-                ms_of_day: t.ms_of_day,
-                rate: t.rate,
                 date: t.date,
+                rate: t.rate,
             }
         )
     }
@@ -3991,9 +3998,8 @@ pub(crate) fn interest_rate_ticks_vec_to_pylist(py: Python<'_>, ticks: Vec<tick:
     let list = pyo3::types::PyList::empty(py);
     for t in &ticks {
         let obj =             InterestRateTick {
-                ms_of_day: t.ms_of_day,
-                rate: t.rate,
                 date: t.date,
+                rate: t.rate,
             }
         ;
         list.append(Py::new(py, obj)?)?;

--- a/sdks/python/tests/test_interest_rate.py
+++ b/sdks/python/tests/test_interest_rate.py
@@ -1,0 +1,119 @@
+"""Regression coverage for the v11 `InterestRateTick` schema fix.
+
+Before this PR the `tick_schema.toml` definition advertised three fields
+(`ms_of_day`, `rate`, `date`) but the upstream v3 server actually emits
+two columns: an ISO-date `created` header and a `rate` percent value.
+Every live `interest_rate_history_eod` call therefore failed inside the
+decoder with `expected: "Number|Timestamp", got Text`.
+
+The fix is cross-binding by design — the Python `InterestRateTick`
+pyclass is regenerated from `tick_schema.toml`, so the shape of the
+pyclass itself is the single source of truth this test pins. Liveness
+of the decode is covered upstream in
+`crates/thetadatadx/tests/test_interest_rate_schema.rs`; here we lock
+the Python-facing surface so a future schema regression cannot ship a
+wheel whose `InterestRateTick(...)` constructor still accepts the
+removed `ms_of_day` keyword.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def InterestRateTick():
+    mod = importlib.import_module("thetadatadx")
+    cls = getattr(mod, "InterestRateTick", None)
+    assert cls is not None, "thetadatadx.InterestRateTick must be exported"
+    return cls
+
+
+def test_interest_rate_tick_constructs_with_two_kw_fields(InterestRateTick) -> None:
+    """The keyword-only constructor accepts `date` and `rate` (and only
+    those). The reference row from the v11 wire dump is SOFR
+    `2025-04-28` -> `date=20250428`, `rate=4.36`."""
+    tick = InterestRateTick(date=20250428, rate=4.36)
+    assert tick.date == 20250428
+    assert tick.rate == pytest.approx(4.36)
+
+
+def test_interest_rate_tick_default_constructor_zero_fields(InterestRateTick) -> None:
+    """The keyword-only `__new__` defaults every field to zero. Prior
+    versions also defaulted the (now-removed) `ms_of_day` field — this
+    test pins that the constructor no longer requires or accepts it."""
+    tick = InterestRateTick()
+    assert tick.date == 0
+    assert tick.rate == 0.0
+
+
+def test_interest_rate_tick_rejects_removed_ms_of_day_kw(InterestRateTick) -> None:
+    """Pin the v11 breaking change: `ms_of_day` was a fictitious field
+    (server never sent it) and has been removed. A keyword call that
+    targets the removed field must raise `TypeError` — the wheel is
+    explicitly NOT backward-compatible with v10.x `InterestRateTick(
+    ms_of_day=...)` call sites."""
+    with pytest.raises(TypeError):
+        InterestRateTick(ms_of_day=34_200_000, rate=4.36, date=20250428)
+
+
+def test_interest_rate_tick_has_no_ms_of_day_attribute(InterestRateTick) -> None:
+    """Instances no longer expose `ms_of_day`. A live decode of a SOFR
+    response previously surfaced a `.ms_of_day` zero on every tick;
+    callers that read it should now read `.date` (YYYYMMDD)."""
+    tick = InterestRateTick(date=20250428, rate=4.36)
+    assert not hasattr(tick, "ms_of_day"), (
+        "InterestRateTick must not carry the fictitious `ms_of_day` field"
+    )
+
+
+def test_interest_rate_tick_repr_uses_two_fields(InterestRateTick) -> None:
+    """`__repr__` advertises the new 2-field shape; downstream log
+    scrapers / debug dumps that grep for the field set break loud rather
+    than silently miss the schema change."""
+    tick = InterestRateTick(date=20250428, rate=4.36)
+    rep = repr(tick)
+    assert "date=20250428" in rep
+    assert "rate=4.36" in rep
+    assert "ms_of_day" not in rep
+
+
+def test_interest_rate_tick_signature_pins_two_params(InterestRateTick) -> None:
+    """The synthesised `__init__` signature lists exactly `date` and
+    `rate` (both keyword-only with defaults)."""
+    sig = inspect.signature(InterestRateTick)
+    names = list(sig.parameters)
+    assert names == ["date", "rate"], (
+        f"InterestRateTick constructor params drifted: {names!r}"
+    )
+
+
+def test_interest_rate_tick_list_round_trips(InterestRateTick) -> None:
+    """The `InterestRateTickList` companion accepts the new 2-field
+    pyclass and round-trips through `__getitem__`. This is the path
+    that historical methods return to Python callers; it must stay
+    indexable and yield instances whose `date`/`rate` survive the
+    round-trip."""
+    mod = importlib.import_module("thetadatadx")
+    InterestRateTickList = getattr(mod, "InterestRateTickList", None)
+    assert InterestRateTickList is not None, (
+        "thetadatadx.InterestRateTickList must be exported"
+    )
+
+    reference_rows = [
+        (20250428, 4.36),
+        (20250429, 4.36),
+        (20250430, 4.41),
+        (20250501, 4.39),
+        (20250502, 4.36),
+    ]
+    ticks = [InterestRateTick(date=d, rate=r) for d, r in reference_rows]
+    tick_list = InterestRateTickList(ticks)
+    assert len(tick_list) == len(reference_rows)
+    for i, (d, r) in enumerate(reference_rows):
+        got = tick_list[i]
+        assert got.date == d
+        assert got.rate == pytest.approx(r)

--- a/sdks/typescript/__tests__/interest_rate.test.mjs
+++ b/sdks/typescript/__tests__/interest_rate.test.mjs
@@ -1,0 +1,88 @@
+// Regression coverage for the v11 `InterestRateTick` schema fix.
+//
+// The upstream v3 server emits 2 columns (`created` as ISO date Text,
+// `rate` as percent Number). The pre-v11 SDK schema declared 3 fields
+// (`ms_of_day`, `rate`, `date`) and decoded every live response into
+// `column 0: expected Number|Timestamp, got Text`. The fix removed the
+// fictitious `ms_of_day` field and rewired `date` to flow through
+// `parse_iso_date`. This test pins the napi-rs `InterestRateTick`
+// interface so a future schema regression cannot ship a JS bundle whose
+// type still carries the removed field.
+//
+// Live decode coverage lives in
+// `crates/thetadatadx/tests/test_interest_rate_schema.rs`.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dtsPath = path.join(__dirname, '..', 'index.d.ts');
+const dts = fs.readFileSync(dtsPath, 'utf8');
+
+let mod;
+try {
+  mod = await import('../index.js');
+} catch {
+  console.log('SKIP: native addon not built (run `npm run build` first)');
+  process.exit(0);
+}
+
+describe('InterestRateTick (index.d.ts)', () => {
+  it('declares exactly the 2-field shape (date + rate, no ms_of_day)', () => {
+    // Locate the `export interface InterestRateTick { ... }` block.
+    const match = dts.match(/export interface InterestRateTick\s*\{([^}]+)\}/);
+    assert.ok(match, 'InterestRateTick must be declared in index.d.ts');
+    const body = match[1];
+    // The two expected fields (camelCased per napi-rs convention).
+    assert.match(body, /\bdate:\s*number\b/, 'date: number must be present');
+    assert.match(body, /\brate:\s*number\b/, 'rate: number must be present');
+    // The removed field must NOT appear.
+    assert.doesNotMatch(
+      body,
+      /\bmsOfDay\b/,
+      'msOfDay was removed in v11; index.d.ts still advertises it',
+    );
+  });
+
+  it('interestRateHistoryEOD returns Array<InterestRateTick>', () => {
+    // Pin that the historical endpoint signature still returns the new
+    // tick type (no accidental rename / collection mismatch).
+    assert.match(
+      dts,
+      /interestRateHistoryEOD\([^)]*\):\s*Array<InterestRateTick>/,
+      'interestRateHistoryEOD must return Array<InterestRateTick>',
+    );
+  });
+});
+
+describe('InterestRateTick (runtime shape)', () => {
+  it('hand-built tick objects round-trip the v11 wire reference row', () => {
+    // napi exposes `InterestRateTick` as a structural type
+    // (`#[napi(object)]`) rather than a constructable class — runtime
+    // values are plain `{ date, rate }` objects produced by the
+    // decoder. We pin the structural shape on a hand-built tick using
+    // the SOFR 2025-04-28 reference row from the CHANGELOG.
+    const tick = { date: 20250428, rate: 4.36 };
+    assert.equal(tick.date, 20250428);
+    assert.equal(tick.rate, 4.36);
+    assert.equal(tick.msOfDay, undefined);
+    assert.equal(tick.ms_of_day, undefined);
+  });
+
+  it('native addon exposes a client class', () => {
+    // Smoke-check that the addon imported at module top level is the
+    // actual native binding (not the SKIP path) and exports at least
+    // one historical-data client class. The exact entry-point name
+    // varies across major versions; accept any of the canonical
+    // ThetaDataDx client names.
+    assert.ok(
+      typeof mod.ThetaDataDxClient === 'function'
+        || typeof mod.HistoricalClient === 'function'
+        || typeof mod.Client === 'function'
+        || typeof mod.MddsClient === 'function',
+      'native addon should expose at least one ThetaDataDx client class',
+    );
+  });
+});

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -1116,6 +1116,10 @@ export declare class ThetaDataDxClient {
    * Fetch end-of-day interest rate history.
    *
    * - Returns the interest rate reported. Depending on the rate, reports can occur in the morning or the afternoon.
+   * - Valid `symbol` values per upstream `RateType` enum:
+   *   `SOFR`, `TREASURY_M1`, `TREASURY_M3`, `TREASURY_M6`,
+   *   `TREASURY_Y1`, `TREASURY_Y2`, `TREASURY_Y3`, `TREASURY_Y5`,
+   *   `TREASURY_Y7`, `TREASURY_Y10`, `TREASURY_Y20`, `TREASURY_Y30`.
    */
   interestRateHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, timeoutMs?: number | undefined | null): Array<InterestRateTick>
   /**
@@ -1535,11 +1539,10 @@ export interface GreeksThirdOrderTick {
   right: string
 }
 
-/** Interest rate tick. End-of-day interest rate. */
+/** Interest rate tick. End-of-day interest rate (percent). */
 export interface InterestRateTick {
-  msOfDay: number
-  rate: number
   date: number
+  rate: number
 }
 
 export declare const enum Interval {

--- a/sdks/typescript/src/_generated/historical_methods.rs
+++ b/sdks/typescript/src/_generated/historical_methods.rs
@@ -2902,6 +2902,10 @@ impl ThetaDataDxClient {
     /// Fetch end-of-day interest rate history.
     ///
     /// - Returns the interest rate reported. Depending on the rate, reports can occur in the morning or the afternoon.
+    /// - Valid `symbol` values per upstream `RateType` enum:
+    ///   `SOFR`, `TREASURY_M1`, `TREASURY_M3`, `TREASURY_M6`,
+    ///   `TREASURY_Y1`, `TREASURY_Y2`, `TREASURY_Y3`, `TREASURY_Y5`,
+    ///   `TREASURY_Y7`, `TREASURY_Y10`, `TREASURY_Y20`, `TREASURY_Y30`.
     #[napi(js_name = "interestRateHistoryEOD")]
     pub fn interest_rate_history_eod(
         &self,

--- a/sdks/typescript/src/_generated/tick_classes.rs
+++ b/sdks/typescript/src/_generated/tick_classes.rs
@@ -150,14 +150,13 @@ pub struct GreeksThirdOrderTick {
     pub right: String,
 }
 
-/// Interest rate tick. End-of-day interest rate.
+/// Interest rate tick. End-of-day interest rate (percent).
 #[must_use]
 #[napi(object)]
 #[derive(Clone)]
 pub struct InterestRateTick {
-    pub ms_of_day: i32,
-    pub rate: f64,
     pub date: i32,
+    pub rate: f64,
 }
 
 /// Implied volatility tick.
@@ -490,9 +489,8 @@ fn interest_rate_ticks_to_class_vec(ticks: &[tick::InterestRateTick]) -> Vec<Int
         .iter()
         .map(|t| {
             InterestRateTick {
-                ms_of_day: t.ms_of_day,
-                rate: t.rate,
                 date: t.date,
+                rate: t.rate,
             }
         })
         .collect()

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -1223,18 +1223,14 @@ fn render_calendar(days: &[tdbe::types::tick::CalendarDay], fmt: &OutputFormat) 
 }
 
 fn render_interest_rates(ticks: &[tdbe::types::tick::InterestRateTick], fmt: &OutputFormat) {
-    let mut td = TabularData::new(vec!["date", "ms_of_day", "rate"]);
-    // Canonical schema -- matches sdks/python/src/tick_columnar.rs:125-134
-    // (interest_rate_ticks_to_columnar).
+    let mut td = TabularData::new(vec!["date", "rate"]);
+    // Canonical schema -- matches `INTEREST_RATE_TICK_RAW_HEADERS`
+    // (regenerated from `tick_schema.toml`).
     td.set_raw_headers(INTEREST_RATE_TICK_RAW_HEADERS.to_vec());
     for t in ticks {
         td.push_with_raw(
-            vec![
-                format_date(t.date),
-                format_ms(t.ms_of_day),
-                format!("{:.6}", t.rate),
-            ],
-            vec![raw_ms(t.ms_of_day), raw_f64(t.rate), raw_date(t.date)],
+            vec![format_date(t.date), format!("{:.6}", t.rate)],
+            vec![raw_date(t.date), raw_f64(t.rate)],
         );
     }
     td.render(fmt);

--- a/tools/cli/src/raw_headers_generated.rs
+++ b/tools/cli/src/raw_headers_generated.rs
@@ -123,9 +123,8 @@ pub(crate) const GREEKS_THIRD_ORDER_TICK_RAW_HEADERS: &[&str] = &[
 ];
 
 pub(crate) const INTEREST_RATE_TICK_RAW_HEADERS: &[&str] = &[
-    "ms_of_day",
-    "rate",
     "date",
+    "rate",
 ];
 
 pub(crate) const IV_TICK_RAW_HEADERS: &[&str] = &[

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -726,7 +726,7 @@ fn serialize_calendar_days(days: &[tdbe::types::tick::CalendarDay]) -> Value {
 fn serialize_interest_rate_ticks(ticks: &[tdbe::types::tick::InterestRateTick]) -> Value {
     let rows: Vec<Value> = ticks
         .iter()
-        .map(|t| json!({"date": t.date, "ms_of_day": t.ms_of_day, "rate": t.rate}))
+        .map(|t| json!({"date": t.date, "rate": t.rate}))
         .collect();
     json!({ "ticks": rows, "count": rows.len() })
 }

--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -453,9 +453,8 @@ pub fn interest_rate_ticks_to_json(ticks: &[InterestRateTick]) -> Vec<sonic_rs::
         .iter()
         .map(|t| {
             sonic_rs::json!({
-                "ms_of_day": t.ms_of_day,
-                "rate": t.rate,
-                "date": t.date
+                "date": t.date,
+                "rate": t.rate
             })
         })
         .collect()


### PR DESCRIPTION
## Summary

The pre-fix `tick_schema.toml` declared `InterestRateTick` as 3 fields
(`ms_of_day`/`rate`/`date`, the `date` column typed as `Number`), but the v3
`interest_rate/history/eod` endpoint actually emits 2 columns: an ISO-date
`created` header (Text) and a percent `rate` (Number). Every live call failed
inside the decoder with `column 0: expected Number|Timestamp, got Text`.

Same bug class as the `MarketValueTick` regression closed earlier — schema
guessed from the endpoint name without cross-checking the documented wire
shape. The 5-axis audit cycle that has been running clean for 7 rounds did
NOT catch this; the lesson and a recommended 6th audit axis ("live schema vs
server response") are written up in
`memory/feedback_verify_against_upstream.md`.

## Verification against upstream

- **Docs**: <https://docs.thetadata.us/operations/interest_rate_history_eod.html>
  (2 columns: `created`, `rate`).
- **Live wire dump** (terminal jar build `202605221`, queried 2026-05-22
  against `mdds-01.thetadata.us:443` for `SOFR` 2025-04-28..2025-05-02):

  ```text
  created,rate
  "2025-04-28",4.3600
  "2025-04-29",4.3600
  "2025-04-30",4.4100
  "2025-05-01",4.3900
  "2025-05-02",4.3600
  ```

## Before / after — `InterestRateTick` field list

Before (`tdbe::types::tick::InterestRateTick` v10.0.0):

```rust
pub struct InterestRateTick {
    pub ms_of_day: i32,  // fictitious — server never sends it
    pub rate: f64,
    pub date: i32,
}
```

After (this PR):

```rust
pub struct InterestRateTick {
    pub date: i32,  // `created` Text ISO -> YYYYMMDD via parse_iso_date
    pub rate: f64,
}
```

## Fix scope

- `tick_schema.toml::InterestRateTick`: 2 columns, `required = ["created"]`,
  `name = "created", field = "date"` so the codegen routes through `row_date`
  (which now accepts `Text`).
- `decode::row_date`: extended to accept `Text` via `parse_iso_date` in
  addition to `Number` / `Timestamp`. Backward-compatible.
- `endpoint_surface.toml::interest_rate_history_eod`: vendor docstring now
  lists the 12 valid `symbol` values per upstream `RateType` enum (`SOFR`,
  `TREASURY_M1..M6`, `TREASURY_Y1..Y30`). Wire signature stays a flexible
  `&str` so future maturities don't break callers.
- Generated SDK surfaces (Python pyclass, TypeScript napi + index.d.ts, C++
  struct + C ABI, tdbe struct + layout asserts, Polars/Arrow frame impls,
  CLI raw headers, server JSON formatter) all shrink from 3 fields to 2.
  C ABI `TdxInterestRateTick` re-pads from `{i32, pad, f64, i32, pad[40]}`
  to `{i32, pad, f64, pad[48]}`.

## Cross-binding regression coverage

| Binding | File | Cases |
|---|---|---|
| Rust | `crates/thetadatadx/tests/test_interest_rate_schema.rs` | 5 |
| Python | `sdks/python/tests/test_interest_rate.py` | 7 |
| TypeScript | `sdks/typescript/__tests__/interest_rate.test.mjs` | 4 |
| C++ | `sdks/cpp/tests/interest_rate.cpp` | 3 |

Each test pins the headline wire reference row (`date=20250428`,
`rate=4.36`) so any future schema drift fails loud before a wheel ships.

## v11 release-line accounting

`[Unreleased]` release-line note bumped from "6 major + 1 minor" to
**7 major + 1 minor**. The new breaking change is the removal of the
fictitious `InterestRateTick.ms_of_day` field.

`cargo-semver-checks check-release -p thetadatadx --baseline-rev v10.0.0`
still reports 6 major (no change) — the lint does not follow cross-crate
re-exports, so a removed field on `tdbe::InterestRateTick` only fires on
the `tdbe` crate (`struct_pub_field_missing`). Running against tdbe
confirms the new break:

```
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---
  field ms_of_day of struct InterestRateTick
```

## 12-symbol live smoke

Smoke harness at `/tmp/rate_smoke/` exercises every documented `RateType`
symbol against production MDDS:

```
PASS SOFR: 5 rows, date head=20250428, rate head=4.3600
PASS TREASURY_M1: 5 rows, date head=20250428, rate head=4.3500
PASS TREASURY_M3: 5 rows, date head=20250428, rate head=4.3200
PASS TREASURY_M6: 5 rows, date head=20250428, rate head=4.2200
PASS TREASURY_Y1: 5 rows, date head=20250428, rate head=3.9200
PASS TREASURY_Y2: 5 rows, date head=20250428, rate head=3.6700
PASS TREASURY_Y3: 5 rows, date head=20250428, rate head=3.6700
PASS TREASURY_Y5: 5 rows, date head=20250428, rate head=3.8100
PASS TREASURY_Y7: 5 rows, date head=20250428, rate head=4.0100
PASS TREASURY_Y10: 5 rows, date head=20250428, rate head=4.2300
PASS TREASURY_Y20: 5 rows, date head=20250428, rate head=4.7100
PASS TREASURY_Y30: 5 rows, date head=20250428, rate head=4.6900

==== smoke summary: 12 pass, 0 fail, 0 permission_denied out of 12 symbols ====
```

SOFR decodes exactly to the wire dump (`4.3600`). Treasuries land in the
3.6-4.7% band, consistent with upstream curve data for the test window.
No symbol returned `PermissionDenied`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --quiet`
- [x] `cargo clippy --workspace --tests --benches -- -D warnings`
- [x] `cargo doc --no-deps -p thetadatadx --features arrow,polars,frames,config-file`
- [x] `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check`
- [x] `python scripts/check_banned_vocab.py` (clean)
- [x] `python scripts/check_safety_comment_boilerplate.py` (clean)
- [x] `cd sdks/python && maturin develop --quiet && pytest tests/ -q` (343 passed, 30 skipped)
- [x] `python -m mypy.stubtest thetadatadx --allowlist stubtest_allowlist.txt --ignore-missing-stub --ignore-disjoint-bases --ignore-positional-only` (clean)
- [x] `cd sdks/typescript && npm run build:debug && npm test` (70 passed)
- [x] C++ via `sdks/cpp/build/tests/thetadatadx_cpp_tests` (46 cases, 7 live-only skipped, 39 passed)
- [x] `cargo semver-checks check-release -p thetadatadx --baseline-rev v10.0.0` (6 major + 1 minor; field removal caught on `tdbe` crate at 1 major)
- [x] Live smoke: 12 symbols × 5-day range, all pass