### PR TITLE
refactor: close whole-repo audit wave 3 (grpc pub-mod narrow + MddsConfig binding parity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
       - uses: ./.github/actions/setup-rust-deps
       - name: Run tracked benches (mock-backed, no live creds)
         run: |
-          cargo bench -p thetadatadx --bench grpc_channel --locked -- \
+          cargo bench -p thetadatadx --features __test-helpers --bench grpc_channel --locked -- \
               "stock_list_symbols/in_house" --quick
           cargo bench -p thetadatadx --bench streaming_channels --locked -- \
               "streaming_channels/direct_callback/100k_events" --quick

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Release line note**: this train accumulates 10 major + 1 minor breaking
+> **Release line note**: this train accumulates 19 major + 1 minor breaking
 > changes versus v10.0.0. The next release tag MUST be v11.0.0, not a
 > v10.0.x patch. Owner-greenlight gated on this audit returning zero
-> actionable findings. Wave-2 of the audit-fix loop added the
-> `protocol::wire` public-API narrowing and the `__test_internals`
-> feature-gating to the v11 SemVer break list (one additional major break).
+> actionable findings. Wave-3 of the audit-fix loop completed the
+> `grpc` module narrowing started in Wave 2 (`#[doc(hidden)]` → full
+> `pub(crate)`), removing nine names from the public surface and
+> taking the count from 10 → 19 major breaks.
 
 ### Changed (BREAKING — v11)
+
+#### Audit closure wave 3
+
+- `grpc` module narrowed from `pub mod` (with `#[doc(hidden)]`) to
+  `pub(crate) mod` in the default-features build. Public visibility
+  re-opens only under the private `__test-helpers` feature.
+  Nine names lose their `thetadatadx::grpc::*` reachability:
+  `Channel`, `ChannelError`, `ChannelPool`, `ChannelLease`,
+  `DecoderHandle`, `DecoderPool`, `default_decoder_thread_count`,
+  `Status`, `ServerStreaming`. Errors flowing out of the transport
+  layer continue to reach consumers via `impl From<grpc::ChannelError>
+  for Error` at the crate boundary — pattern-match on the public
+  `crate::Error` type. Closes audit BL-1.
 
 #### Audit closure wave 2
 
@@ -54,6 +68,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default `vwap` to `0.0` via the optional-column path. Struct size
   unchanged (was already 128 bytes after alignment); field offsets
   shift past `count`. Closes audit BL-13.
+
+### Added
+
+#### Audit closure wave 3
+
+- `MddsConfig.warn_on_buffered_threshold_bytes` (Rust `usize`,
+  default 100 MiB) bound across every binding. New surface:
+  - FFI: `tdx_config_set_warn_on_buffered_threshold_bytes(*mut TdxConfig,
+    usize)` setter + `tdx_config_get_warn_on_buffered_threshold_bytes(
+    *const TdxConfig, *mut usize) -> i32` getter.
+  - C++: `tdx::Config::set_warn_on_buffered_threshold_bytes(std::size_t)` +
+    matching getter.
+  - Python: `Config.warn_on_buffered_threshold_bytes` (pyo3 `#[getter]`
+    + `#[setter]`) + `.pyi` type stub.
+  - TypeScript napi: `Config.setWarnOnBufferedThresholdBytes(BigInt)` +
+    `Config.warnOnBufferedThresholdBytes` getter (BigInt because the
+    underlying field is `usize`).
+  - `sdks/parity.toml` gains a new `MddsConfig.warn_on_buffered_
+    threshold_bytes` row marked all-true under a new MddsConfig
+    section header. Closes audit BL-8.
 
 ### Fixed
 

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -302,12 +302,20 @@ name = "streaming_throughput"
 harness = false
 
 [[bench]]
+# Drives the raw `Channel` / `ChannelPool` / `endpoints::bench_support`
+# surface against a mock h2c server; gated on `__test-helpers` so the
+# `grpc` module re-export stays out of the default rlib (BL-1 narrowing).
 name = "grpc_channel"
 harness = false
+required-features = ["__test-helpers"]
 
 [[bench]]
+# Drives `default_decoder_thread_count` + `Channel` + `ChannelPool` +
+# `DecoderPool` under concurrent burst load; gated on `__test-helpers`
+# for the same reason as `grpc_channel` (BL-1 narrowing).
 name = "grpc_concurrent_burst"
 harness = false
+required-features = ["__test-helpers"]
 
 [[bench]]
 # Drives `fpss::__test_internals::{decode_frame, DeltaState}` against
@@ -326,16 +334,23 @@ name = "bench_rest_decode"
 harness = false
 
 [[bench]]
+# Drives `DecoderPool` directly to measure prost-decode throughput;
+# gated on `__test-helpers` for the `grpc` re-export (BL-1 narrowing).
 name = "bench_decoder_pool"
 harness = false
+required-features = ["__test-helpers"]
 
 [[bench]]
 name = "bench_protobuf_decode"
 harness = false
 
 [[bench]]
+# Drives `Stage2Pool` + `DecodedPayload` head-to-head against the
+# single-stage decoder; gated on `__test-helpers` for the `grpc`
+# re-export (BL-1 narrowing).
 name = "bench_stage_pipeline"
 harness = false
+required-features = ["__test-helpers"]
 
 [[test]]
 # Builds `MddsClient` against mock REST + h2c servers. Depends on the
@@ -372,6 +387,25 @@ required-features = ["__test-helpers"]
 [[test]]
 name = "midframe_disconnect"
 path = "tests/midframe_disconnect.rs"
+required-features = ["__test-helpers"]
+
+# Integration tests that drive the raw `grpc::{Channel, ChannelPool,
+# DecoderPool, ChannelError, Status}` surface against a mock h2c server.
+# Gated on `__test-helpers` so the `grpc` module re-export stays out
+# of the default rlib (BL-1 narrowing — whole-repo audit wave 3).
+[[test]]
+name = "grpc_stock_list_symbols"
+path = "tests/grpc_stock_list_symbols.rs"
+required-features = ["__test-helpers"]
+
+[[test]]
+name = "test_pool_reconnect"
+path = "tests/test_pool_reconnect.rs"
+required-features = ["__test-helpers"]
+
+[[test]]
+name = "grpc_mock_server"
+path = "tests/grpc_mock_server.rs"
 required-features = ["__test-helpers"]
 
 [[bin]]

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -394,7 +394,7 @@ pub enum Error {
     /// Returned when a `with_deadline(d)` (Rust builder) or `timeout_ms`
     /// (FFI / Python / Go / C++) elapses while the gRPC call was in flight.
     /// The in-flight future is dropped before this error is returned, so the
-    /// underlying [`crate::grpc::Channel`] sends `RST_STREAM` and the
+    /// underlying gRPC channel sends `RST_STREAM` and the
     /// request-semaphore permit is released; subsequent calls on the same
     /// `MddsClient` succeed.
     #[error("Request deadline exceeded after {duration_ms} ms")]

--- a/crates/thetadatadx/src/grpc/channel.rs
+++ b/crates/thetadatadx/src/grpc/channel.rs
@@ -337,9 +337,35 @@ type ReconnectObserver = Arc<dyn Fn(ReconnectEvent) + Send + Sync>;
 /// Reconnect lifecycle event surfaced through
 /// [`Channel::set_reconnect_observer`]. Used by the channel-pool
 /// reconnect integration test to verify the single-flight invariant;
-/// production callers should not install an observer.
+/// production callers should not install an observer. Visibility is
+/// `pub` only under the `__test-helpers` private feature — `pub(crate)`
+/// otherwise so internal call sites continue to fire events without
+/// committing the enum to the SemVer surface.
+#[cfg(not(feature = "__test-helpers"))]
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum ReconnectEvent {
+    /// The current task won the single-flight CAS and is about to
+    /// open a fresh TCP+TLS+h2 session.
+    AttemptStart,
+    /// The reconnect succeeded; the channel's inner `SendRequest`
+    /// has been swapped.
+    AttemptSuccess,
+    /// The reconnect failed after exhausting the retry budget; the
+    /// inner `SendRequest` was NOT replaced and the next caller will
+    /// observe `ConnectionClosed` again.
+    AttemptExhausted,
+}
+
+/// `__test-helpers`-public mirror of the same enum. Same variants,
+/// same trait derives — only the visibility differs. Tests pattern
+/// match on the variants directly; SemVer commitment never includes
+/// this surface because the gating feature is unsupported downstream.
+#[cfg(feature = "__test-helpers")]
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
 pub enum ReconnectEvent {
     /// The current task won the single-flight CAS and is about to
     /// open a fresh TCP+TLS+h2 session.
@@ -366,6 +392,11 @@ impl Channel {
     ///
     /// Returns a [`ChannelError`] when the TCP connect or h2 handshake
     /// fails.
+    ///
+    /// Reachable only when the `__test-helpers` private feature is
+    /// enabled (see BL-1 narrowing); production callers use the
+    /// `_with_max_message_size` variant exclusively.
+    #[cfg(feature = "__test-helpers")]
     pub async fn connect_h2c(host: &str, port: u16) -> Result<Self, ChannelError> {
         Self::connect_h2c_with_max_message_size(host, port, super::codec::DEFAULT_MAX_MESSAGE_SIZE)
             .await
@@ -406,6 +437,11 @@ impl Channel {
     ///
     /// Returns a [`ChannelError`] when the TCP connect, TLS handshake,
     /// or h2 handshake fails.
+    ///
+    /// Reachable only when the `__test-helpers` private feature is
+    /// enabled (see BL-1 narrowing); production callers use the
+    /// `_with_max_message_size` variant exclusively.
+    #[cfg(feature = "__test-helpers")]
     pub async fn connect_tls(
         host: &str,
         port: u16,
@@ -562,6 +598,12 @@ impl Channel {
     /// this channel. Mirrors `DirectConfig::mdds.max_message_size`;
     /// each [`Codec`] this channel constructs uses this value rather
     /// than the codec module's compile-time default.
+    ///
+    /// Exposed under `__test-helpers` for integration tests that verify
+    /// the configured ceiling propagates from `DirectConfig` to every
+    /// channel construct. Production code reaches the same value via
+    /// `DirectConfig::mdds.max_message_size` directly.
+    #[cfg(feature = "__test-helpers")]
     #[must_use]
     pub const fn max_message_size(&self) -> usize {
         self.max_message_size
@@ -573,7 +615,8 @@ impl Channel {
     /// invariant.
     ///
     /// Hidden from public docs — production callers should never
-    /// install an observer.
+    /// install an observer. Reachable only under `__test-helpers`.
+    #[cfg(feature = "__test-helpers")]
     #[doc(hidden)]
     pub fn set_reconnect_observer<F>(&self, observer: F)
     where
@@ -648,7 +691,9 @@ impl Channel {
     ///
     /// Hidden from the public docs — exposed for integration tests
     /// that need to confirm the channel records the right scheme for
-    /// each transport.
+    /// each transport. Reachable only under `__test-helpers` (or in
+    /// unit tests).
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[doc(hidden)]
     #[must_use]
     pub fn scheme_str(&self) -> &'static str {
@@ -875,6 +920,11 @@ impl Channel {
     /// Same as [`Self::server_streaming`], plus
     /// [`ChannelError::DeadlineExceeded`] when the deadline elapses
     /// during the open phase.
+    ///
+    /// Reachable only under `__test-helpers` — production deadlines are
+    /// handled at the `MddsClient` layer via `tokio::time::timeout`
+    /// around the streaming consumer.
+    #[cfg(feature = "__test-helpers")]
     pub async fn server_streaming_with_deadline<Req, Resp>(
         &self,
         method: &'static str,

--- a/crates/thetadatadx/src/grpc/decoder_pool.rs
+++ b/crates/thetadatadx/src/grpc/decoder_pool.rs
@@ -852,6 +852,12 @@ impl DecoderPool {
     ///
     /// Returns [`DecoderPoolError`] when `n_decoders` is zero or the
     /// ring size fails validation.
+    ///
+    /// Reachable only under `__test-helpers` (or in unit tests) —
+    /// production paths go through [`Self::new_two_stage`] which fans
+    /// the decoded payload into a downstream
+    /// [`super::stage_pipeline::Stage2Pool`].
+    #[cfg(any(test, feature = "__test-helpers"))]
     pub fn new(n_decoders: usize, ring_size_per_decoder: usize) -> Result<Self, DecoderPoolError> {
         if n_decoders == 0 {
             return Err(DecoderPoolError::EmptyPool);
@@ -1002,6 +1008,9 @@ impl DecoderPool {
     /// rejects an empty pool at construction so this is normally
     /// `false`; the method exists for parity with the standard
     /// `len()` + `is_empty()` collection idiom.
+    ///
+    /// Reachable only under `__test-helpers` (or in unit tests).
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.handles.is_empty()

--- a/crates/thetadatadx/src/grpc/mod.rs
+++ b/crates/thetadatadx/src/grpc/mod.rs
@@ -83,20 +83,40 @@
 pub mod channel;
 pub mod codec;
 pub mod decoder_pool;
+// `endpoints` is a hand-written `stock_list_symbols` example plus
+// `bench_support` helpers used exclusively by the gRPC benches and
+// the `grpc_stock_list_symbols` integration test. Production RPCs go
+// through the macro-generated `crate::mdds::*` endpoints directly.
+// Gating on `__test-helpers` keeps the example out of the default rlib
+// (BL-1 narrowing — whole-repo audit wave 3).
+#[cfg(feature = "__test-helpers")]
 pub mod endpoints;
 pub mod pool;
 pub mod stage_pipeline;
 pub mod status;
 pub mod stream;
 
+// Production-path re-exports — used by `crate::mdds`, `crate::error`,
+// and the `flatfiles` session bootstrap. These names are reachable as
+// `thetadatadx::grpc::*` only when the `__test-helpers` private feature
+// is enabled (see the `pub(crate) mod grpc` guard in `lib.rs`); without
+// the feature they are crate-internal only.
 pub use channel::{Channel, ChannelError};
-pub use codec::{Codec, CodecError};
-pub use decoder_pool::{
-    default_decoder_thread_count, DecodeResult, DecoderHandle, DecoderPool, DecoderPoolError,
-    DecoderSubmitError, DecoderWaitStrategy,
-};
-pub use endpoints::stock_list_symbols;
+pub use decoder_pool::{default_decoder_thread_count, DecoderHandle, DecoderPool};
 pub use pool::{ChannelLease, ChannelPool};
-pub use stage_pipeline::{DecodedPayload, Stage2Counters, Stage2Pool};
-pub use status::{Status, StatusParseError};
+pub use status::Status;
 pub use stream::ServerStreaming;
+
+// Test-only re-exports — only reachable when the `__test-helpers` feature
+// is enabled. The underlying items are themselves cfg-gated; gating the
+// re-exports avoids `unused import` errors in the default-features build.
+#[cfg(feature = "__test-helpers")]
+pub use codec::{Codec, CodecError};
+#[cfg(feature = "__test-helpers")]
+pub use decoder_pool::{DecodeResult, DecoderPoolError, DecoderSubmitError, DecoderWaitStrategy};
+#[cfg(feature = "__test-helpers")]
+pub use endpoints::stock_list_symbols;
+#[cfg(feature = "__test-helpers")]
+pub use stage_pipeline::{DecodedPayload, Stage2Counters, Stage2Pool};
+#[cfg(feature = "__test-helpers")]
+pub use status::StatusParseError;

--- a/crates/thetadatadx/src/grpc/pool.rs
+++ b/crates/thetadatadx/src/grpc/pool.rs
@@ -74,6 +74,12 @@ impl ChannelPool {
     /// Panics if `channels` is empty. A pool must have at least one
     /// member; an empty pool has no semantics that would make
     /// `next()` succeed.
+    ///
+    /// Reachable only under `__test-helpers` (or in unit tests) —
+    /// production callers go through [`Self::from_channels_with_decoders`]
+    /// so decode runs on the dedicated decoder pool rather than inline
+    /// on the reactor.
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[must_use]
     pub fn from_channels(channels: Vec<Channel>) -> Self {
         assert!(
@@ -140,6 +146,11 @@ impl ChannelPool {
     }
 
     /// Number of channels in the pool.
+    ///
+    /// Reachable only under `__test-helpers` — production code uses the
+    /// pool through [`Self::next`] / [`Self::from_channels_with_decoders`]
+    /// and does not introspect membership.
+    #[cfg(feature = "__test-helpers")]
     #[must_use]
     pub fn len(&self) -> usize {
         self.inner.channels.len()
@@ -148,7 +159,9 @@ impl ChannelPool {
     /// `true` if the pool holds no channels. The constructor's
     /// `assert!` rules this out in practice; the method exists so
     /// callers using the `len() + is_empty()` clippy-friendly idiom
-    /// don't have to special-case the pool.
+    /// don't have to special-case the pool. Reachable only under
+    /// `__test-helpers`.
+    #[cfg(feature = "__test-helpers")]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.inner.channels.is_empty()
@@ -158,7 +171,8 @@ impl ChannelPool {
     /// exposed so integration tests can deterministically target a
     /// specific channel (e.g. fire a slow RPC against pool member 0
     /// to saturate it, then assert subsequent `next()` calls route
-    /// around it).
+    /// around it). Reachable only under `__test-helpers`.
+    #[cfg(feature = "__test-helpers")]
     #[doc(hidden)]
     #[must_use]
     pub fn member_for_test(&self, idx: usize) -> &Arc<Channel> {
@@ -294,6 +308,12 @@ impl<'a> ChannelLease<'a> {
     /// the reservation alive for the rest of the temporary scope;
     /// callers that need to thread `&Arc<Channel>` into a longer-lived
     /// future should keep the lease bound to a local `let`.
+    ///
+    /// Production code uses the `Deref<Target = Arc<Channel>>` impl
+    /// above instead; this explicit accessor is exposed under
+    /// `__test-helpers` so tests can name the borrow without going
+    /// through deref coercion.
+    #[cfg(feature = "__test-helpers")]
     #[must_use]
     pub fn channel(&self) -> &Arc<Channel> {
         self.channel

--- a/crates/thetadatadx/src/grpc/stage_pipeline.rs
+++ b/crates/thetadatadx/src/grpc/stage_pipeline.rs
@@ -97,18 +97,27 @@ impl Stage2Counters {
     /// Observed value of `total_decoded`. `Ordering::Relaxed` is
     /// correct for a monitoring snapshot — there is no
     /// happens-before relationship with other state to enforce.
+    ///
+    /// Reachable only under `__test-helpers` (or in unit tests) —
+    /// the production observability path emits these via the `metrics`
+    /// crate (see `observability.rs`), not by direct counter reads.
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[must_use]
     pub fn total_decoded(&self) -> u64 {
         self.total_decoded.load(Ordering::Relaxed)
     }
 
-    /// Observed value of `total_dropped`.
+    /// Observed value of `total_dropped`. Reachable only under
+    /// `__test-helpers`.
+    #[cfg(feature = "__test-helpers")]
     #[must_use]
     pub fn total_dropped(&self) -> u64 {
         self.total_dropped.load(Ordering::Relaxed)
     }
 
-    /// Observed value of `total_parked` (nanoseconds).
+    /// Observed value of `total_parked` (nanoseconds). Reachable only
+    /// under `__test-helpers` (or in unit tests).
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[must_use]
     pub fn total_parked_nanos(&self) -> u64 {
         self.total_parked.load(Ordering::Relaxed)
@@ -140,8 +149,17 @@ pub(crate) struct Stage2Job {
 pub struct Stage2Pool {
     sender: Option<Stage2PoolSender>,
     workers: Vec<JoinHandle<()>>,
+    /// Shared counter handle. Only read back from the bench harness
+    /// and the `__test-helpers`-gated accessor; production updates
+    /// them through `Stage2PoolSender` clones.
+    #[cfg(any(test, feature = "__test-helpers"))]
     counters: Arc<Stage2Counters>,
+    /// Configured worker thread count, surfaced only to the bench
+    /// harness for warm-up sizing assertions.
+    #[cfg(any(test, feature = "__test-helpers"))]
     worker_count: usize,
+    /// Configured queue depth, surfaced only to the bench harness.
+    #[cfg(any(test, feature = "__test-helpers"))]
     queue_depth: usize,
 }
 
@@ -327,8 +345,11 @@ impl Stage2Pool {
                 parked_in_slice_loop: Arc::new(AtomicU64::new(0)),
             }),
             workers,
+            #[cfg(any(test, feature = "__test-helpers"))]
             counters,
+            #[cfg(any(test, feature = "__test-helpers"))]
             worker_count,
+            #[cfg(any(test, feature = "__test-helpers"))]
             queue_depth,
         }
     }
@@ -355,24 +376,35 @@ impl Stage2Pool {
     /// Snapshot of the pipeline counters. Cheap — just clones an
     /// `Arc`. The returned handle reflects live state, not a frozen
     /// snapshot.
+    ///
+    /// Reachable only under `__test-helpers` (or in unit tests) —
+    /// production observability emits via the `metrics` crate inside
+    /// the worker loop.
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[must_use]
     pub fn counters(&self) -> Arc<Stage2Counters> {
         Arc::clone(&self.counters)
     }
 
-    /// Number of worker threads in this stage-2 pool.
+    /// Number of worker threads in this stage-2 pool. Reachable only
+    /// under `__test-helpers` (or in unit tests).
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[must_use]
     pub fn worker_count(&self) -> usize {
         self.worker_count
     }
 
-    /// Configured queue depth.
+    /// Configured queue depth. Reachable only under `__test-helpers`
+    /// (or in unit tests).
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[must_use]
     pub fn queue_depth(&self) -> usize {
         self.queue_depth
     }
 
-    /// `true` once any worker has caught a panic.
+    /// `true` once any worker has caught a panic. Reachable only
+    /// under `__test-helpers` (or in unit tests).
+    #[cfg(any(test, feature = "__test-helpers"))]
     #[must_use]
     pub fn is_poisoned(&self) -> bool {
         self.sender
@@ -392,7 +424,7 @@ impl Stage2Pool {
     ///
     /// Returns `Err` with the rejected payload if the pool is
     /// poisoned or fully torn down.
-    #[cfg(any(test, bench_internals))]
+    #[cfg(any(bench_internals, feature = "__test-helpers"))]
     pub fn submit_for_bench(
         &self,
         payload: DecodedPayload,

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -102,10 +102,24 @@ pub mod frames;
 // ChannelPool, DecoderPool, Stage2Pool, Codec, Status, ServerStreaming).
 // The user-facing path is `MddsClient::for_each_chunk(ServerStreaming<..>)`;
 // the remainder is consumed by the SDK's own integration tests + benches.
-// `#[doc(hidden)]` keeps the module out of rustdoc / `help()` output and
-// signals to consumers that names below are not a SemVer commitment.
-// Full narrowing to `pub(crate)` is deferred to v11 — see BL-1 in
-// `/tmp/whole_repo_audit_findings.md`.
+//
+// In shipped builds (default features) the module is `pub(crate)` so none
+// of its types appear in the SemVer commitment or in rendered rustdoc.
+// Errors flowing out of the transport layer are converted to the public
+// [`crate::Error`] type via `impl From<grpc::ChannelError> for Error` at
+// the crate boundary — consumers pattern-match on [`crate::Error`] only.
+//
+// The `__test-helpers` feature re-opens the module to integration tests
+// and bench harnesses inside this repo that need to drive the raw
+// `Channel` / `Pool` / `DecoderPool` surface against synthetic frames.
+// This feature is private and unsupported for downstream consumers; see
+// the [`__test-helpers`] feature notes in `Cargo.toml` for the
+// double-underscore convention.
+//
+// Closes BL-1 (whole-repo audit wave 3) — `pub mod grpc` SemVer rope.
+#[cfg(not(feature = "__test-helpers"))]
+pub(crate) mod grpc;
+#[cfg(feature = "__test-helpers")]
 #[doc(hidden)]
 pub mod grpc;
 pub(crate) mod observability;

--- a/crates/thetadatadx/src/mdds/decode/transport.rs
+++ b/crates/thetadatadx/src/mdds/decode/transport.rs
@@ -45,10 +45,10 @@ thread_local! {
 
 /// Decompress a `ResponseData` payload using the default ceiling.
 ///
-/// Equivalent to [`decompress_response_with_max`] with
-/// [`crate::grpc::codec::DEFAULT_MAX_MESSAGE_SIZE`]; new callers
-/// should prefer the `_with_max` variant so they thread their
-/// channel's configured ceiling through.
+/// Equivalent to [`decompress_response_with_max`] with the crate's
+/// built-in default per-frame ceiling; new callers should prefer the
+/// `_with_max` variant so they thread their channel's configured
+/// ceiling through.
 ///
 /// Takes the response by `&mut` so the identity-compression path can
 /// move the payload `Vec` out instead of cloning.
@@ -69,11 +69,11 @@ pub fn decompress_response(response: &mut proto::ResponseData) -> Result<Vec<u8>
 /// (`original_size = i32::MAX`, ≈ 2 GiB) cannot trigger a runaway
 /// allocation; the function returns `MessageTooLarge` first.
 ///
-/// `max_message_size` mirrors the channel's
-/// [`crate::grpc::codec::Codec::max_message_size`]. The frame-level
-/// codec rejects oversized FRAMES on the wire; this guard rejects
-/// oversized DECOMPRESSED PAYLOADS, which the codec cannot see
-/// because `original_size` rides inside the compressed payload.
+/// `max_message_size` mirrors the channel's per-frame ceiling.
+/// The frame-level codec rejects oversized FRAMES on the wire; this
+/// guard rejects oversized DECOMPRESSED PAYLOADS, which the codec
+/// cannot see because `original_size` rides inside the compressed
+/// payload.
 ///
 /// Prost's `.algo()` maps unknown enum values to `None`, so the
 /// branch dispatches on the raw `i32` instead.
@@ -152,10 +152,9 @@ pub fn decompress_response_with_max(
 }
 
 /// Decode a `ResponseData` into a `DataTable` (legacy signature;
-/// uses [`crate::grpc::codec::DEFAULT_MAX_MESSAGE_SIZE`] as the
-/// ceiling). Kept on the public API for backwards compatibility with
-/// v10.0.x consumers; new callers should prefer
-/// [`decode_data_table_with_max`].
+/// uses the crate's built-in default per-frame ceiling). Kept on the
+/// public API for backwards compatibility with v10.0.x consumers; new
+/// callers should prefer [`decode_data_table_with_max`].
 ///
 /// # Errors
 ///
@@ -169,10 +168,10 @@ pub fn decode_data_table(response: &mut proto::ResponseData) -> Result<proto::Da
 /// Decode a `ResponseData` into a `DataTable`, honouring the channel's
 /// `max_message_size` ceiling.
 ///
-/// `max_message_size` is propagated from the originating
-/// [`crate::grpc::Channel`] / [`crate::grpc::codec::Codec`]. Callers
-/// without a channel-bound ceiling (offline tests, bench fixtures)
-/// pass [`crate::grpc::codec::DEFAULT_MAX_MESSAGE_SIZE`].
+/// `max_message_size` is propagated from the originating gRPC
+/// channel's codec configuration. Callers without a channel-bound
+/// ceiling (offline tests, bench fixtures) pass the crate's built-in
+/// default per-frame ceiling.
 ///
 /// # Errors
 ///

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,14 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Release line note**: this train accumulates 10 major + 1 minor breaking
+> **Release line note**: this train accumulates 19 major + 1 minor breaking
 > changes versus v10.0.0. The next release tag MUST be v11.0.0, not a
 > v10.0.x patch. Owner-greenlight gated on this audit returning zero
-> actionable findings. Wave-2 of the audit-fix loop added the
-> `protocol::wire` public-API narrowing and the `__test_internals`
-> feature-gating to the v11 SemVer break list (one additional major break).
+> actionable findings. Wave-3 of the audit-fix loop completed the
+> `grpc` module narrowing started in Wave 2 (`#[doc(hidden)]` → full
+> `pub(crate)`), removing nine names from the public surface and
+> taking the count from 10 → 19 major breaks.
 
 ### Changed (BREAKING — v11)
+
+#### Audit closure wave 3
+
+- `grpc` module narrowed from `pub mod` (with `#[doc(hidden)]`) to
+  `pub(crate) mod` in the default-features build. Public visibility
+  re-opens only under the private `__test-helpers` feature.
+  Nine names lose their `thetadatadx::grpc::*` reachability:
+  `Channel`, `ChannelError`, `ChannelPool`, `ChannelLease`,
+  `DecoderHandle`, `DecoderPool`, `default_decoder_thread_count`,
+  `Status`, `ServerStreaming`. Errors flowing out of the transport
+  layer continue to reach consumers via `impl From<grpc::ChannelError>
+  for Error` at the crate boundary — pattern-match on the public
+  `crate::Error` type. Closes audit BL-1.
 
 #### Audit closure wave 2
 
@@ -54,6 +68,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default `vwap` to `0.0` via the optional-column path. Struct size
   unchanged (was already 128 bytes after alignment); field offsets
   shift past `count`. Closes audit BL-13.
+
+### Added
+
+#### Audit closure wave 3
+
+- `MddsConfig.warn_on_buffered_threshold_bytes` (Rust `usize`,
+  default 100 MiB) bound across every binding. New surface:
+  - FFI: `tdx_config_set_warn_on_buffered_threshold_bytes(*mut TdxConfig,
+    usize)` setter + `tdx_config_get_warn_on_buffered_threshold_bytes(
+    *const TdxConfig, *mut usize) -> i32` getter.
+  - C++: `tdx::Config::set_warn_on_buffered_threshold_bytes(std::size_t)` +
+    matching getter.
+  - Python: `Config.warn_on_buffered_threshold_bytes` (pyo3 `#[getter]`
+    + `#[setter]`) + `.pyi` type stub.
+  - TypeScript napi: `Config.setWarnOnBufferedThresholdBytes(BigInt)` +
+    `Config.warnOnBufferedThresholdBytes` getter (BigInt because the
+    underlying field is `usize`).
+  - `sdks/parity.toml` gains a new `MddsConfig.warn_on_buffered_
+    threshold_bytes` row marked all-true under a new MddsConfig
+    section header. Closes audit BL-8.
 
 ### Fixed
 

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -241,6 +241,49 @@ pub unsafe extern "C" fn tdx_config_set_concurrent_requests(config: *mut TdxConf
     })
 }
 
+/// Set the `warn_on_buffered_threshold_bytes` ceiling on a config
+/// handle. Streaming endpoints log a `tracing::warn!` when a
+/// pre-stream-API caller receives a buffered response whose decoded
+/// total size exceeds this threshold (default 100 MiB). The warning
+/// guides users towards the `.stream()` surface on large pulls; the
+/// data is still delivered.
+///
+/// `n = 0` disables the warning entirely.
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_set_warn_on_buffered_threshold_bytes(
+    config: *mut TdxConfig,
+    n: usize,
+) {
+    ffi_boundary!((), {
+        let config = require_config_mut!(config);
+        config.inner.mdds.warn_on_buffered_threshold_bytes = n;
+    })
+}
+
+/// Read the current `warn_on_buffered_threshold_bytes` setting.
+///
+/// Writes the configured byte count into `*out_n`. Returns `0` on
+/// success, `-1` if either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_get_warn_on_buffered_threshold_bytes(
+    config: *const TdxConfig,
+    out_n: *mut usize,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_n.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const TdxConfig` returned by `tdx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        // SAFETY: out_n null-checked above; caller pins the storage for the call duration.
+        unsafe {
+            *out_n = config.inner.mdds.warn_on_buffered_threshold_bytes;
+        }
+        0
+    })
+}
+
 /// Set the number of dedicated decoder threads in the MDDS pool.
 ///
 /// `n = 0` (default) auto-sizes to
@@ -543,6 +586,47 @@ mod pool_sizing_tests {
             assert_eq!((*cfg).inner.mdds.concurrent_requests, 8);
             super::tdx_config_set_concurrent_requests(cfg, 0);
             assert_eq!((*cfg).inner.mdds.concurrent_requests, 0);
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn warn_on_buffered_threshold_bytes_round_trips() {
+        let cfg = super::tdx_config_production();
+        assert!(!cfg.is_null());
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            // Default seeded at 100 MiB by `MddsConfig::default()`.
+            let mut current: usize = 0;
+            assert_eq!(
+                super::tdx_config_get_warn_on_buffered_threshold_bytes(cfg, &mut current),
+                0
+            );
+            assert_eq!(current, 100 * 1024 * 1024);
+            // Override.
+            super::tdx_config_set_warn_on_buffered_threshold_bytes(cfg, 50 * 1024 * 1024);
+            assert_eq!(
+                (*cfg).inner.mdds.warn_on_buffered_threshold_bytes,
+                50 * 1024 * 1024
+            );
+            assert_eq!(
+                super::tdx_config_get_warn_on_buffered_threshold_bytes(cfg, &mut current),
+                0
+            );
+            assert_eq!(current, 50 * 1024 * 1024);
+            // Disable.
+            super::tdx_config_set_warn_on_buffered_threshold_bytes(cfg, 0);
+            assert_eq!((*cfg).inner.mdds.warn_on_buffered_threshold_bytes, 0);
+            // Null-pointer guards: setter is a no-op (matches the
+            // ffi_boundary `()` return); getter returns -1.
+            super::tdx_config_set_warn_on_buffered_threshold_bytes(std::ptr::null_mut(), 4);
+            assert_eq!(
+                super::tdx_config_get_warn_on_buffered_threshold_bytes(
+                    std::ptr::null(),
+                    &mut current
+                ),
+                -1
+            );
             super::tdx_config_free(cfg);
         }
     }

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -607,6 +607,27 @@ void tdx_config_set_concurrent_requests(TdxConfig* config, uint32_t n);
 void tdx_config_set_decoder_threads(TdxConfig* config, uint32_t n);
 
 /**
+ * Set the warn_on_buffered_threshold_bytes ceiling on a config.
+ *
+ * Pre-stream-API endpoints (the non-`.stream()` shape) log a
+ * `tracing::warn!` when a buffered response's decoded total exceeds
+ * this threshold, guiding users to the streaming variant. The
+ * payload is still delivered.
+ *
+ *   n=0 disables the warning entirely.
+ *   default = 100 * 1024 * 1024 (100 MiB).
+ */
+void tdx_config_set_warn_on_buffered_threshold_bytes(TdxConfig* config, size_t n);
+
+/**
+ * Read the current warn_on_buffered_threshold_bytes setting.
+ *
+ * Writes the configured byte count into *out_n. Returns 0 on success,
+ * -1 if either pointer is null.
+ */
+int32_t tdx_config_get_warn_on_buffered_threshold_bytes(const TdxConfig* config, size_t* out_n);
+
+/**
  * Set the per-thread decoder ring size.
  *
  * Must be a power of two, >= 64. Invalid values are rejected at the

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -584,6 +584,32 @@ public:
         tdx_config_set_decoder_ring_size(handle_.get(), n);
     }
 
+    /**
+     * Set the warn_on_buffered_threshold_bytes ceiling.
+     *
+     * Pre-stream-API endpoints log a `tracing::warn!` when a buffered
+     * response's decoded total exceeds this threshold, guiding users
+     * to the streaming variant. The payload is still delivered.
+     *
+     * @p n = 0 disables the warning entirely.
+     * Default is `100 * 1024 * 1024` (100 MiB).
+     */
+    void set_warn_on_buffered_threshold_bytes(std::size_t n) {
+        tdx_config_set_warn_on_buffered_threshold_bytes(handle_.get(), n);
+    }
+
+    /**
+     * Read the current `warn_on_buffered_threshold_bytes` setting.
+     *
+     * Returns the configured byte count, or `0` on a null handle
+     * (matching the C ABI's `-1` failure mapping at the boundary).
+     */
+    std::size_t warn_on_buffered_threshold_bytes() const {
+        std::size_t n = 0;
+        tdx_config_get_warn_on_buffered_threshold_bytes(handle_.get(), &n);
+        return n;
+    }
+
     // ── MDDS two-stage decode pipeline ──
 
     /**

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -231,6 +231,23 @@ python = false
 typescript = false
 cpp = false
 
+# ─── MddsConfig cross-binding setters ──────────────────────────────────
+#
+# Tuning knobs on the MDDS sub-config exposed across every binding.
+# `concurrent_requests` / `decoder_threads` / `decoder_ring_size` /
+# `decode_threads_explicit` / `decode_queue_depth_explicit` are bound
+# via `Config.<name>` (Python), `Config.set<Name>` (TypeScript napi),
+# `tdx::Config::set_<name>` (C++ forwarder over the C ABI). The rows
+# below track the dotted-field state for the parity audit; the
+# parity script's class-existence check skips dotted rows pending the
+# per-field granularity tightening.
+
+[[class]]
+name = "MddsConfig.warn_on_buffered_threshold_bytes"
+python = true
+typescript = true
+cpp = true
+
 # ─── ReconnectConfig cross-binding setters ─────────────────────────────
 #
 # FPSS reconnect policy + per-class attempt budgets + stable-window

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -74,6 +74,11 @@ class Config:
     preserved for backward compatibility.
     """
     decoder_ring_size: int
+    # Byte ceiling above which a buffered (non-`.stream()`) historical
+    # response emits a Rust-side `tracing::warn!` pointing the caller
+    # at the streaming surface. `0` disables the warning; the default
+    # is `100 * 1024 * 1024` (100 MiB). The data is still delivered.
+    warn_on_buffered_threshold_bytes: int
     # MDDS two-stage decode pipeline. `decode_threads` sizes the
     # stage-2 prost-decode + Tick-build worker pool;
     # `decode_queue_depth` sizes the bounded MPSC queue between

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -359,6 +359,30 @@ impl Config {
         guard.mdds.concurrent_requests
     }
 
+    /// Set the warning threshold (in bytes) for buffered (non-streaming)
+    /// historical responses. Endpoints whose decoded total exceeds this
+    /// value log a `tracing::warn!` pointing the caller at the
+    /// ``.stream()`` surface; the data is still delivered. ``0``
+    /// disables the warning entirely. Default is ``100 * 1024 * 1024``
+    /// (100 MiB).
+    ///
+    /// Examples
+    /// --------
+    ///     cfg = Config.production()
+    ///     cfg.warn_on_buffered_threshold_bytes = 50 * 1024 * 1024
+    #[setter]
+    fn set_warn_on_buffered_threshold_bytes(&self, n: usize) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.mdds.warn_on_buffered_threshold_bytes = n;
+    }
+
+    /// Current ``warn_on_buffered_threshold_bytes`` setting (bytes).
+    #[getter]
+    fn get_warn_on_buffered_threshold_bytes(&self) -> usize {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.mdds.warn_on_buffered_threshold_bytes
+    }
+
     /// Deprecated since v10.0.1: set ``decode_threads`` instead. This
     /// field controls only the legacy stage-1 thread count and is
     /// preserved for backward compatibility.

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -50,6 +50,21 @@ export declare class Config {
   /** Current `concurrent_requests` setting (`0` = auto-detect). */
   get concurrentRequests(): number
   /**
+   * Set the warning threshold (in bytes) for buffered (non-streaming)
+   * historical responses. Endpoints whose decoded total exceeds this
+   * value emit a Rust-side `tracing::warn!` pointing the caller at
+   * the `.stream()` surface; the data is still delivered. `0n`
+   * disables the warning entirely. Default is `100n * 1024n * 1024n`
+   * (100 MiB). Byte budgets can exceed `u32::MAX`, so the setter
+   * takes a `BigInt` matching the underlying `usize` field.
+   */
+  setWarnOnBufferedThresholdBytes(n: bigint): void
+  /**
+   * Current `warn_on_buffered_threshold_bytes` setting (bytes,
+   * returned as a `BigInt`).
+   */
+  get warnOnBufferedThresholdBytes(): bigint
+  /**
    * Set the number of dedicated decoder threads in the MDDS pool.
    *
    * `0` (default) auto-sizes to `max(available_parallelism / 2, 1)`,

--- a/sdks/typescript/src/fallback.rs
+++ b/sdks/typescript/src/fallback.rs
@@ -192,6 +192,49 @@ impl Config {
         Ok(u32::try_from(guard.mdds.concurrent_requests).unwrap_or(u32::MAX))
     }
 
+    /// Set the warning threshold (in bytes) for buffered (non-streaming)
+    /// historical responses. Endpoints whose decoded total exceeds this
+    /// value emit a Rust-side `tracing::warn!` pointing the caller at
+    /// the `.stream()` surface; the data is still delivered. `0n`
+    /// disables the warning entirely. Default is `100n * 1024n * 1024n`
+    /// (100 MiB). Byte budgets can exceed `u32::MAX`, so the setter
+    /// takes a `BigInt` matching the underlying `usize` field.
+    #[napi(js_name = "setWarnOnBufferedThresholdBytes")]
+    pub fn set_warn_on_buffered_threshold_bytes(
+        &self,
+        n: napi::bindgen_prelude::BigInt,
+    ) -> napi::Result<()> {
+        let (_signed, value, lossless) = n.get_u64();
+        if !lossless {
+            return Err(napi::Error::from_reason(
+                "warn_on_buffered_threshold_bytes must fit in u64",
+            ));
+        }
+        let value = usize::try_from(value)
+            .map_err(|_| napi::Error::from_reason("value exceeds usize on this platform"))?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.mdds.warn_on_buffered_threshold_bytes = value;
+        Ok(())
+    }
+
+    /// Current `warn_on_buffered_threshold_bytes` setting (bytes,
+    /// returned as a `BigInt`).
+    #[napi(getter, js_name = "warnOnBufferedThresholdBytes")]
+    pub fn warn_on_buffered_threshold_bytes(
+        &self,
+    ) -> napi::Result<napi::bindgen_prelude::BigInt> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(napi::bindgen_prelude::BigInt::from(
+            guard.mdds.warn_on_buffered_threshold_bytes as u64,
+        ))
+    }
+
     /// Set the number of dedicated decoder threads in the MDDS pool.
     ///
     /// `0` (default) auto-sizes to `max(available_parallelism / 2, 1)`,


### PR DESCRIPTION
## Summary

Wave 3 of the whole-repo audit-fix loop. Closes 2 of the 12 remaining
BLOCKER findings:

- **BL-1** — `pub mod grpc` fully narrowed to `pub(crate)`. Wave 2
  landed `#[doc(hidden)]` as a half-fix that kept the transport
  infrastructure out of rendered docs but left every symbol on the
  SemVer commitment. Wave 3 completes the narrowing: the module
  re-opens to `pub` only under the private `__test-helpers` feature
  used by the SDK's own integration tests + benches. Nine names lose
  their `thetadatadx::grpc::*` reachability:
  - `Channel`, `ChannelError`, `ChannelPool`, `ChannelLease`,
    `DecoderHandle`, `DecoderPool`, `default_decoder_thread_count`,
    `Status`, `ServerStreaming`
  Errors flowing out of the transport layer continue to reach
  consumers via `impl From<grpc::ChannelError> for Error` at the
  crate boundary — pattern-match on the public `crate::Error` type.

- **BL-8** — `MddsConfig.warn_on_buffered_threshold_bytes` (Rust
  `usize`, default 100 MiB) bound across every binding (FFI getter +
  setter, C++ method, Python pyo3 setter/getter + `.pyi` stub,
  TypeScript napi BigInt setter + getter). New parity.toml row marks
  the field all-true under a new MddsConfig section header. Purely
  additive — no SemVer break.

## What deferred

Four BLOCKERs from the wave 3 scope are deferred to a follow-up PR
because the realistic combined LoC budget exceeds a single review-
tractable PR:

- **BL-9** `RuntimeConfig.tokio_worker_threads` — admittedly unwired
  pub field. The SDK requires a caller-provided tokio runtime (via
  `#[tokio::main]` or equivalent), so wiring this from inside the
  library has no natural insertion point. Will be deleted with a
  v11 deprecation note in a follow-up.
- **BL-10** `RetryPolicy` whole-type bind — 4 fields × 5 binding
  layers ≈ 20 implementations. Mechanical work, just sizable.
- **BL-11** `ReconnectConfig.wait_ms` / `wait_rate_limited_ms` —
  pub fields with `NOTE: Not automatically wired` doc-blocks.
  Wiring them requires threading `&ReconnectConfig` through
  `fpss/session::reconnect_delay` and the three io_loop call
  sites, which is a behavioral change that wants owner sign-off
  given the FPSS reconnect cadence is currently `RECONNECT_DELAY_MS`
  / `TOO_MANY_REQUESTS_DELAY_MS` constants.
- **BL-14** TradeGreeks sibling tick types — the largest piece
  (~30 files, ~2000 LoC, plus live capture against the v3 server
  + tdbe regen). Standalone PR follows.

## v11 break count

Updated from 10 major + 1 minor to **19 major + 1 minor** versus
v10.0.0. The 9 new breaks all derive from BL-1 — every name listed
above is no longer reachable from downstream code.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo build --workspace --locked` clean (default features).
- `cargo build --workspace --features thetadatadx/__test-helpers
  --locked` clean.
- `cargo clippy --workspace --locked --all-targets -- -D warnings`
  clean both default and `__test-helpers`.
- `cargo test --workspace --features thetadatadx/__test-helpers
  --locked` — 567 lib + 55 FFI + 166 integration tests pass (was
  560 lib pre-narrowing; the diff comes from now-gated test modules).
- `cargo doc --no-deps -p thetadatadx --features arrow,polars,frames,
  config-file` clean. `target/doc/thetadatadx/grpc/` no longer
  exists — the module is fully removed from rendered rustdoc and
  the SemVer commitment.
- `cargo run -p thetadatadx --features config-file --bin
  generate_sdk_surfaces --locked -- --check` clean.
- `scripts/check_c_abi_completeness.py` clean — 166 exported
  symbols (+2 new: the BL-8 setter + getter), bidirectional parity.
- `scripts/check_binding_parity.py` clean — 38 explicit rows (+1
  new) + 131 implicit-tracked pyclasses.
- `scripts/check_banned_vocab.py`, `check_safety_comment_boilerplate
  .py`, `check_lockfile_drift.py` clean.
- Python SDK + TypeScript napi addon build clean against the
  narrowed crate.

## Test plan

- [ ] CI green on `cargo fmt`, `cargo clippy`, `cargo test`,
  `cargo doc`.
- [ ] Cross-binding gates (C ABI completeness, binding parity,
  banned vocab, safety boilerplate, lockfile drift) green.
- [ ] Python SDK CI (maturin build + pytest + mypy stubtest) green
  on the new `warn_on_buffered_threshold_bytes` setter.
- [ ] TypeScript napi CI (napi build + npm test) green on the new
  `setWarnOnBufferedThresholdBytes` / `warnOnBufferedThresholdBytes`
  symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)