### PR TITLE
feat(fpss): direct-consumer single-ring streaming entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`connect`) and pull-iterator (`connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
+
 ## [11.0.0] - 2026-05-27
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`connect`) and pull-iterator (`connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
+- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
 
 ## [11.0.0] - 2026-05-27
 

--- a/crates/thetadatadx/src/fpss/connection.rs
+++ b/crates/thetadatadx/src/fpss/connection.rs
@@ -59,11 +59,12 @@ pub(crate) struct ConnectWithStreamArgs<'a> {
     pub connect_timeout: Duration,
     pub read_timeout: Duration,
     pub ping_interval: Duration,
-    /// Push-callback (`Delivery::Callback`) or pull-iter (`Delivery::Queue`)
-    /// delivery of decoded events. Captured at connect time and held
+    /// Consumer-side selector: an SDK-managed consumer thread running a
+    /// push-callback / pull-iter [`super::events::Delivery`], or a
+    /// caller-driven event poller. Captured at connect time and held
     /// for the lifetime of the [`super::FpssClient`]; switching modes
     /// requires `stop_streaming()` followed by a fresh `start_streaming*`.
-    pub delivery: super::events::Delivery,
+    pub consumer: super::events::StreamConsumer,
 }
 
 /// Install the process-global rustls crypto provider exactly once.

--- a/crates/thetadatadx/src/fpss/events.rs
+++ b/crates/thetadatadx/src/fpss/events.rs
@@ -554,6 +554,32 @@ pub(crate) enum Delivery {
     },
 }
 
+/// Consumer-side selector chosen at connect time.
+///
+/// Threaded through [`super::connection::ConnectWithStreamArgs`] so the
+/// shared `connect_with_stream` wiring can build the right ring
+/// producer:
+///
+/// * [`StreamConsumer::Managed`] — the SDK spawns a Disruptor consumer
+///   thread that runs the wrapped [`Delivery`] dispatch
+///   (`Callback` push or `Queue` pull-iter). This is the path
+///   [`super::FpssClient::connect`] / [`super::FpssClient::connect_iter`]
+///   take.
+/// * [`StreamConsumer::Poller`] — no consumer thread is spawned; the ring
+///   is built with an event poller and the caller drives it on its own
+///   thread via [`super::FpssEventPoller`]. This is the path
+///   [`super::FpssClient::connect_consumer`] takes.
+///
+/// Keeping the selector crate-private preserves the public surface: a
+/// caller never names this type, only the `connect*` entry points.
+pub(crate) enum StreamConsumer {
+    /// SDK-managed consumer thread running the [`Delivery`] dispatch.
+    Managed(Delivery),
+    /// Caller-driven event poller; the ring is the only buffer between
+    /// the wire reader and the caller's thread.
+    Poller,
+}
+
 // ---------------------------------------------------------------------------
 // Command channel -- FpssClient -> I/O thread
 // ---------------------------------------------------------------------------

--- a/crates/thetadatadx/src/fpss/io_loop/mod.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/mod.rs
@@ -42,7 +42,7 @@ use parking_lot::Mutex as ParkingLotMutex;
 use std::thread::{self, ThreadId};
 use std::time::{Duration, Instant};
 
-use disruptor::{build_single_producer, Producer, Sequence};
+use disruptor::{build_single_producer, EventPoller, Producer, Sequence, SingleProducerBarrier};
 use metrics::Counter;
 
 // ─── Hoisted I/O-loop counter handles ───────────────────────────────
@@ -119,14 +119,25 @@ type ActiveFullSubs = Arc<
 /// the framing-layer mid-frame stall budget honour the configured
 /// values, not the Java-parity hardcoded defaults).
 ///
-/// `delivery` selects between push-callback and pull-iter modes; see
-/// [`super::events::Delivery`]. The io_loop itself is mode-agnostic
-/// after this dispatch — both modes share the same Disruptor ring,
-/// reader, and producer.
-pub(in crate::fpss) struct IoLoopArgs {
+/// `producer` is the ring publisher built by the caller. It is generic
+/// over [`Producer<RingEvent>`] so the io_loop drives both delivery
+/// shapes through the same blocking-read + reconnect state machine:
+///
+/// * The **callback** and **pull-iter** modes build the producer via
+///   [`build_consumer_producer`], which spawns a Disruptor consumer
+///   thread that runs the [`Delivery`] dispatch.
+/// * The **direct-consumer** mode builds the producer via
+///   [`build_poller_producer`], which spawns no consumer thread; the
+///   caller drives the ring on its own thread through an
+///   [`super::FpssEventPoller`].
+///
+/// The io_loop only ever calls [`Producer::try_publish`] on it, so the
+/// reader path is identical across modes — only the consumer side
+/// differs, and that difference is fixed at producer-build time.
+pub(in crate::fpss) struct IoLoopArgs<P> {
     pub stream: connection::FpssStream,
     pub cmd_rx: std_mpsc::Receiver<IoCommand>,
-    pub delivery: Delivery,
+    pub producer: P,
     pub ring_size: usize,
     pub shutdown: Arc<AtomicBool>,
     pub authenticated: Arc<AtomicBool>,
@@ -149,10 +160,6 @@ pub(in crate::fpss) struct IoLoopArgs {
     pub active_subs: ActiveSubs,
     pub active_full_subs: ActiveFullSubs,
     pub dropped: Arc<AtomicU64>,
-    pub panics: Arc<AtomicU64>,
-    pub consumer_thread_id: Arc<OnceLock<ThreadId>>,
-    pub slow_callback_threshold_ns: Arc<AtomicU64>,
-    pub slow_callback_count: Arc<AtomicU64>,
     pub connect_timeout: Duration,
     pub read_timeout: Duration,
     /// Shared monotonic request-id counter. The auto-reconnect path
@@ -168,11 +175,14 @@ pub(in crate::fpss) struct IoLoopArgs {
 
 // Reason: all parameters are moved into this function from a spawned thread closure.
 #[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
-pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
+pub(in crate::fpss) fn io_loop<P>(args: IoLoopArgs<P>)
+where
+    P: Producer<RingEvent>,
+{
     let IoLoopArgs {
         stream,
         cmd_rx,
-        delivery,
+        mut producer,
         ring_size,
         shutdown,
         authenticated,
@@ -189,10 +199,6 @@ pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
         active_subs,
         active_full_subs,
         dropped,
-        panics,
-        consumer_thread_id,
-        slow_callback_threshold_ns,
-        slow_callback_count,
         connect_timeout,
         read_timeout,
         next_req_id,
@@ -205,213 +211,14 @@ pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
         "io_loop received unvalidated ring_size {ring_size}; check upstream FpssClient::connect",
     );
 
-    let factory = RingEvent::default;
-    let wait_strategy = AdaptiveWaitStrategy::fpss_default();
-
-    // The Disruptor consumer thread is the SINGLE consumer between the
-    // TLS reader and the user-facing delivery sink. The reader publishes
-    // events into the ring; this closure runs on the consumer thread,
-    // filters internal-only events, and dispatches to the
-    // [`Delivery`] mode chosen at `connect` time:
-    //
-    // * [`Delivery::Callback`] — invoke the user closure under
-    //   `catch_unwind` so a panic from user code (or binding glue such
-    //   as PyO3 / napi `ThreadsafeFunction`) is counted on `panics` and
-    //   surfaced via `tracing::error!` rather than killing the consumer.
-    // * [`Delivery::Queue`] — `force_push` the cloned public event into
-    //   the bounded `ArrayQueue` shared with the
-    //   [`super::EventIterator`], incrementing the shared `dropped`
-    //   counter when overflow forces an evict-oldest.
-    //
-    // The `Mutex` wrap on the [`Delivery`] sink mirrors the previous
-    // `Mutex<F>` shape — `Producer::handle_events_with` requires the
-    // closure to be `Fn`, so the captured sink lives behind a Mutex even
-    // though the Disruptor's single consumer thread is the only acquirer
-    // (single-locker pattern; the lock collapses to one unlocked
-    // acquire/release per event).
-    // Pull-iter mode wires a drop guard into the consumer closure that
-    // flips an `Arc<AtomicBool>` when the closure is dropped — i.e.,
-    // when the Disruptor producer is dropped at io_loop exit and the
-    // consumer thread is wound down. That moment is the ONLY observable
-    // "no more `queue.push` will ever fire" point in the system, which
-    // is what the [`super::EventIterator`] needs as its terminal-EOF
-    // predicate. Earlier the iterator polled the global I/O-thread
-    // shutdown flag instead, which fired BEFORE the consumer had
-    // finished pushing the tail of in-flight events into the queue and
-    // produced false-EOFs that dropped tail events. See
-    // `super::events::Delivery::Queue::iter_closed` for the wiring.
-    let iter_closed_for_guard: Option<Arc<AtomicBool>> = match &delivery {
-        Delivery::Queue { iter_closed, .. } => Some(Arc::clone(iter_closed)),
-        Delivery::Callback(_) => None,
-    };
-    // Single-consumer hot path: parking_lot's Mutex avoids the
-    // ~20-40ns overhead std::sync::Mutex carries per
-    // lock/unlock pair. The lock is acquired once per ring event on
-    // the Disruptor consumer thread; the runtime cost compounds at
-    // event rates of 100k+/s.
-    let delivery_cell = ParkingLotMutex::new(delivery);
-    let panics_consumer = Arc::clone(&panics);
-    let dropped_consumer = Arc::clone(&dropped);
-    let consumer_thread_id_cell = Arc::clone(&consumer_thread_id);
-    let slow_threshold_ns_consumer = Arc::clone(&slow_callback_threshold_ns);
-    let slow_count_consumer = Arc::clone(&slow_callback_count);
-
-    // Flips `iter_closed` to `true` when the consumer closure is
-    // dropped — the EventIterator's terminal-EOF predicate.
-    struct IterCloseGuard {
-        iter_closed: Arc<AtomicBool>,
-    }
-    impl Drop for IterCloseGuard {
-        fn drop(&mut self) {
-            // Release ordering pairs with the iterator's Acquire load.
-            self.iter_closed.store(true, Ordering::Release);
-        }
-    }
-    let iter_close_guard: Option<IterCloseGuard> =
-        iter_closed_for_guard.map(|iter_closed| IterCloseGuard { iter_closed });
-
-    let mut producer = build_single_producer(ring_size, factory, wait_strategy)
-        .handle_events_with(
-            move |ring_event: &RingEvent, _sequence: Sequence, _eob: bool| {
-                // Touch the guard so the closure captures it (and so it
-                // is dropped on consumer-thread exit). The branch is
-                // never taken — `Option::None` for the callback path,
-                // and the guard never matches `Some(_)`-returning
-                // cleanup logic at runtime.
-                let _guard_anchor = &iter_close_guard;
-                // Capture the Disruptor consumer thread's `ThreadId`
-                // exactly once, on first dispatch. `FpssClient::drop`
-                // reads this to detect the self-join case (callback
-                // dropping the last `Arc<FpssClient>` from inside this
-                // closure) and detach the I/O-handle join onto a helper
-                // thread instead of deadlocking.
-                consumer_thread_id_cell.get_or_init(|| thread::current().id());
-
-                // Reborrow the ring slot to the public `&FpssEvent`.
-                // `as_public` returns `None` for the `Empty`
-                // ring-buffer placeholder and the `Unparseable`
-                // decode-fallback variant, so neither escapes into the
-                // delivery sink. Discriminants `Data` and `Control`
-                // are layout-compatible with the public enum (both
-                // `#[repr(C, u8)]`, see `events::FpssEventInternal`),
-                // which is what makes the reborrow zero-clone.
-                if let Some(evt) = ring_event.event.as_public() {
-                    // parking_lot's Mutex never poisons on panic, so
-                    // there is no `PoisonError` recovery path to thread
-                    // through; the guard is the lock result directly.
-                    let mut delivery = delivery_cell.lock();
-                    match &mut *delivery {
-                        Delivery::Callback(handler) => {
-                            let threshold_ns = slow_threshold_ns_consumer.load(Ordering::Relaxed);
-                            // `AssertUnwindSafe` is sound here because
-                            // the user callback's captured state lives
-                            // behind the `Mutex<Delivery>`; any side
-                            // effects observable across a panic
-                            // boundary are the user's responsibility,
-                            // not the SDK's.
-                            let start = if threshold_ns > 0 {
-                                Some(std::time::Instant::now())
-                            } else {
-                                None
-                            };
-                            if catch_unwind(AssertUnwindSafe(|| handler(evt))).is_err() {
-                                panics_consumer.fetch_add(1, Ordering::Relaxed);
-                                tracing::error!(
-                                    target: "thetadatadx::fpss::io_loop",
-                                    "user callback panicked on Disruptor consumer thread; \
-                                     panic_count incremented, consumer continuing",
-                                );
-                            }
-                            if let Some(start) = start {
-                                // Resilience: slow-callback
-                                // observability. Threshold is opt-in
-                                // via `set_slow_callback_threshold`.
-                                let elapsed_ns =
-                                    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX);
-                                if elapsed_ns > threshold_ns {
-                                    let prev = slow_count_consumer.fetch_add(1, Ordering::Relaxed);
-                                    // Rate-limit per 1024 over-budget
-                                    // events so a sustained slow
-                                    // callback regression does not
-                                    // amplify the log stream.
-                                    if prev.is_multiple_of(1024) {
-                                        tracing::warn!(
-                                            target: "thetadatadx::fpss::io_loop",
-                                            elapsed_ns,
-                                            threshold_ns,
-                                            slow_callback_count = prev + 1,
-                                            "user callback exceeded slow-callback threshold",
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                        Delivery::Queue {
-                            queue,
-                            wake_fd,
-                            policy,
-                            ..
-                        } => {
-                            // Pull-iter delivery. Clone the public event
-                            // into the bounded queue; `Arc<Contract>` /
-                            // `String` payloads collapse the clone to
-                            // refcount bumps so the per-event cost stays
-                            // in the low hundreds of nanoseconds.
-                            //
-                            // Overflow is governed by the configured
-                            // [`BackpressurePolicy`]. `Block` parks the
-                            // consumer thread on push until space frees
-                            // up; `DropOldest` evicts the head before
-                            // push so the queue stays full of fresh
-                            // data; `DropNewest` skips the new event
-                            // when full (legacy behaviour). The shared
-                            // `dropped` counter increments on every
-                            // eviction / skipped push so operators see
-                            // one signal for queue-overflow pressure.
-                            let pushed = match *policy {
-                                BackpressurePolicy::Block => push_with_block(queue, evt.clone()),
-                                BackpressurePolicy::DropOldest => {
-                                    // `force_push` returns `Some(old)`
-                                    // when the queue was full and the
-                                    // head was evicted — count the
-                                    // eviction as a drop so the metric
-                                    // stays comparable to `DropNewest`.
-                                    if queue.force_push(evt.clone()).is_some() {
-                                        dropped_consumer.fetch_add(1, Ordering::Relaxed);
-                                    }
-                                    true
-                                }
-                                BackpressurePolicy::DropNewest => {
-                                    if queue.push(evt.clone()).is_err() {
-                                        dropped_consumer.fetch_add(1, Ordering::Relaxed);
-                                        false
-                                    } else {
-                                        true
-                                    }
-                                }
-                            };
-                            if pushed {
-                                if let Some(wake) = wake_fd.as_ref() {
-                                    // Wake the asyncio reader. `signal()`
-                                    // coalesces under load — at most one
-                                    // wake byte is in the pipe at a time
-                                    // (see `super::wake::WakeFd`) — so
-                                    // the hot-path cost compresses to
-                                    // one atomic compare-exchange and a
-                                    // never-taken branch on subsequent
-                                    // pushes until the reader drains
-                                    // and re-arms. The sync pull-iter
-                                    // path leaves `wake_fd: None` and
-                                    // pays zero overhead.
-                                    wake.signal();
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-        )
-        .build();
+    // The producer was built by the caller — either
+    // [`build_consumer_producer`] (callback / pull-iter modes, which
+    // spawn a Disruptor consumer thread) or [`build_poller_producer`]
+    // (direct-consumer mode, no spawned thread). From here on the
+    // io_loop is mode-agnostic: it only publishes into the ring via
+    // [`Producer::try_publish`], and the consumer side — whether a
+    // spawned thread or the caller's own thread driving an
+    // [`super::FpssEventPoller`] — drains it independently.
 
     // Publish every handshake-time typed control frame in wire order.
     // Emitted BEFORE LoginSuccess so the user sees exactly the sequence
@@ -1073,8 +880,308 @@ pub(in crate::fpss) fn io_loop(args: IoLoopArgs) {
         // Continue 'session loop: the inner read/write loop will run on the new stream.
     } // end 'session loop
 
-    // Producer drop joins the Disruptor consumer thread and drains remaining events.
+    // Dropping the producer at scope exit stores the shutdown sequence on
+    // the ring. In callback / pull-iter modes that also joins the spawned
+    // Disruptor consumer thread after it drains the remaining events; in
+    // direct-consumer (poller) mode there is no spawned thread, so the
+    // store simply lets the caller's [`super::FpssEventPoller`] observe
+    // `Polling::Shutdown` once it has drained every published event.
+    drop(producer);
     tracing::debug!("fpss-io thread exiting");
+}
+
+/// A ring producer the I/O thread can own and drive: a
+/// [`Producer<RingEvent>`] that is `Send` (moved into the spawned I/O
+/// thread) and `'static` (outlives the thread it is moved into).
+///
+/// Both producer shapes returned by [`build_consumer_producer`] and
+/// [`build_poller_producer`] satisfy this via the blanket impl below,
+/// so the shared spawn helper in [`super::FpssClient`] can stay generic
+/// over the consumer mode with a single bound.
+pub(in crate::fpss) trait RingProducer:
+    Producer<RingEvent> + Send + 'static
+{
+}
+
+impl<T> RingProducer for T where T: Producer<RingEvent> + Send + 'static {}
+
+/// Build the ring producer for callback / pull-iter delivery.
+///
+/// Spawns the single Disruptor consumer thread (via
+/// [`disruptor::builder::single::SPBuilder::handle_events_with`]) that
+/// runs the [`Delivery`] dispatch: it reborrows each published
+/// [`RingEvent`] to a public `&FpssEvent` (filtering the internal-only
+/// `Empty` / `Unparseable` slots) and either invokes the user callback
+/// under `catch_unwind` ([`Delivery::Callback`]) or pushes a clone onto
+/// the bounded pull-iter queue ([`Delivery::Queue`]). The returned
+/// [`disruptor::SingleProducer`] is handed to [`io_loop`] as its ring
+/// publisher; dropping it at io_loop exit joins this consumer thread
+/// after the ring drains.
+///
+/// The closure-captured `Arc`s mirror the public surfaces on
+/// [`super::FpssClient`]: `panics` ([`super::FpssClient::panic_count`]),
+/// `dropped` ([`super::FpssClient::dropped_count`]),
+/// `consumer_thread_id` (read by [`super::FpssClient`]'s `Drop`
+/// self-join guard), and the slow-callback watchdog counters
+/// ([`super::FpssClient::set_slow_callback_threshold`] /
+/// [`super::FpssClient::slow_callback_count`]).
+pub(in crate::fpss) struct ConsumerProducerArgs {
+    pub ring_size: usize,
+    pub delivery: Delivery,
+    pub dropped: Arc<AtomicU64>,
+    pub panics: Arc<AtomicU64>,
+    pub consumer_thread_id: Arc<OnceLock<ThreadId>>,
+    pub slow_callback_threshold_ns: Arc<AtomicU64>,
+    pub slow_callback_count: Arc<AtomicU64>,
+}
+
+#[allow(clippy::too_many_lines)]
+pub(in crate::fpss) fn build_consumer_producer(args: ConsumerProducerArgs) -> impl RingProducer {
+    let ConsumerProducerArgs {
+        ring_size,
+        delivery,
+        dropped,
+        panics,
+        consumer_thread_id,
+        slow_callback_threshold_ns,
+        slow_callback_count,
+    } = args;
+
+    let factory = RingEvent::default;
+    let wait_strategy = AdaptiveWaitStrategy::fpss_default();
+
+    // The Disruptor consumer thread is the SINGLE consumer between the
+    // TLS reader and the user-facing delivery sink. The reader publishes
+    // events into the ring; this closure runs on the consumer thread,
+    // filters internal-only events, and dispatches to the
+    // [`Delivery`] mode chosen at `connect` time:
+    //
+    // * [`Delivery::Callback`] — invoke the user closure under
+    //   `catch_unwind` so a panic from user code (or binding glue such
+    //   as PyO3 / napi `ThreadsafeFunction`) is counted on `panics` and
+    //   surfaced via `tracing::error!` rather than killing the consumer.
+    // * [`Delivery::Queue`] — `force_push` the cloned public event into
+    //   the bounded `ArrayQueue` shared with the
+    //   [`super::EventIterator`], incrementing the shared `dropped`
+    //   counter when overflow forces an evict-oldest.
+    //
+    // The `Mutex` wrap on the [`Delivery`] sink mirrors the previous
+    // `Mutex<F>` shape — `Producer::handle_events_with` requires the
+    // closure to be `Fn`, so the captured sink lives behind a Mutex even
+    // though the Disruptor's single consumer thread is the only acquirer
+    // (single-locker pattern; the lock collapses to one unlocked
+    // acquire/release per event).
+    // Pull-iter mode wires a drop guard into the consumer closure that
+    // flips an `Arc<AtomicBool>` when the closure is dropped — i.e.,
+    // when the Disruptor producer is dropped at io_loop exit and the
+    // consumer thread is wound down. That moment is the ONLY observable
+    // "no more `queue.push` will ever fire" point in the system, which
+    // is what the [`super::EventIterator`] needs as its terminal-EOF
+    // predicate. Earlier the iterator polled the global I/O-thread
+    // shutdown flag instead, which fired BEFORE the consumer had
+    // finished pushing the tail of in-flight events into the queue and
+    // produced false-EOFs that dropped tail events. See
+    // `super::events::Delivery::Queue::iter_closed` for the wiring.
+    let iter_closed_for_guard: Option<Arc<AtomicBool>> = match &delivery {
+        Delivery::Queue { iter_closed, .. } => Some(Arc::clone(iter_closed)),
+        Delivery::Callback(_) => None,
+    };
+    // Single-consumer hot path: parking_lot's Mutex avoids the
+    // ~20-40ns overhead std::sync::Mutex carries per
+    // lock/unlock pair. The lock is acquired once per ring event on
+    // the Disruptor consumer thread; the runtime cost compounds at
+    // event rates of 100k+/s.
+    let delivery_cell = ParkingLotMutex::new(delivery);
+    let panics_consumer = panics;
+    let dropped_consumer = dropped;
+    let consumer_thread_id_cell = consumer_thread_id;
+    let slow_threshold_ns_consumer = slow_callback_threshold_ns;
+    let slow_count_consumer = slow_callback_count;
+
+    // Flips `iter_closed` to `true` when the consumer closure is
+    // dropped — the EventIterator's terminal-EOF predicate.
+    struct IterCloseGuard {
+        iter_closed: Arc<AtomicBool>,
+    }
+    impl Drop for IterCloseGuard {
+        fn drop(&mut self) {
+            // Release ordering pairs with the iterator's Acquire load.
+            self.iter_closed.store(true, Ordering::Release);
+        }
+    }
+    let iter_close_guard: Option<IterCloseGuard> =
+        iter_closed_for_guard.map(|iter_closed| IterCloseGuard { iter_closed });
+
+    build_single_producer(ring_size, factory, wait_strategy)
+        .handle_events_with(
+            move |ring_event: &RingEvent, _sequence: Sequence, _eob: bool| {
+                // Touch the guard so the closure captures it (and so it
+                // is dropped on consumer-thread exit). The branch is
+                // never taken — `Option::None` for the callback path,
+                // and the guard never matches `Some(_)`-returning
+                // cleanup logic at runtime.
+                let _guard_anchor = &iter_close_guard;
+                // Capture the Disruptor consumer thread's `ThreadId`
+                // exactly once, on first dispatch. `FpssClient::drop`
+                // reads this to detect the self-join case (callback
+                // dropping the last `Arc<FpssClient>` from inside this
+                // closure) and detach the I/O-handle join onto a helper
+                // thread instead of deadlocking.
+                consumer_thread_id_cell.get_or_init(|| thread::current().id());
+
+                // Reborrow the ring slot to the public `&FpssEvent`.
+                // `as_public` returns `None` for the `Empty`
+                // ring-buffer placeholder and the `Unparseable`
+                // decode-fallback variant, so neither escapes into the
+                // delivery sink. Discriminants `Data` and `Control`
+                // are layout-compatible with the public enum (both
+                // `#[repr(C, u8)]`, see `events::FpssEventInternal`),
+                // which is what makes the reborrow zero-clone.
+                if let Some(evt) = ring_event.event.as_public() {
+                    // parking_lot's Mutex never poisons on panic, so
+                    // there is no `PoisonError` recovery path to thread
+                    // through; the guard is the lock result directly.
+                    let mut delivery = delivery_cell.lock();
+                    match &mut *delivery {
+                        Delivery::Callback(handler) => {
+                            let threshold_ns = slow_threshold_ns_consumer.load(Ordering::Relaxed);
+                            // `AssertUnwindSafe` is sound here because
+                            // the user callback's captured state lives
+                            // behind the `Mutex<Delivery>`; any side
+                            // effects observable across a panic
+                            // boundary are the user's responsibility,
+                            // not the SDK's.
+                            let start = if threshold_ns > 0 {
+                                Some(std::time::Instant::now())
+                            } else {
+                                None
+                            };
+                            if catch_unwind(AssertUnwindSafe(|| handler(evt))).is_err() {
+                                panics_consumer.fetch_add(1, Ordering::Relaxed);
+                                tracing::error!(
+                                    target: "thetadatadx::fpss::io_loop",
+                                    "user callback panicked on Disruptor consumer thread; \
+                                     panic_count incremented, consumer continuing",
+                                );
+                            }
+                            if let Some(start) = start {
+                                // Resilience: slow-callback
+                                // observability. Threshold is opt-in
+                                // via `set_slow_callback_threshold`.
+                                let elapsed_ns =
+                                    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX);
+                                if elapsed_ns > threshold_ns {
+                                    let prev = slow_count_consumer.fetch_add(1, Ordering::Relaxed);
+                                    // Rate-limit per 1024 over-budget
+                                    // events so a sustained slow
+                                    // callback regression does not
+                                    // amplify the log stream.
+                                    if prev.is_multiple_of(1024) {
+                                        tracing::warn!(
+                                            target: "thetadatadx::fpss::io_loop",
+                                            elapsed_ns,
+                                            threshold_ns,
+                                            slow_callback_count = prev + 1,
+                                            "user callback exceeded slow-callback threshold",
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Delivery::Queue {
+                            queue,
+                            wake_fd,
+                            policy,
+                            ..
+                        } => {
+                            // Pull-iter delivery. Clone the public event
+                            // into the bounded queue; `Arc<Contract>` /
+                            // `String` payloads collapse the clone to
+                            // refcount bumps so the per-event cost stays
+                            // in the low hundreds of nanoseconds.
+                            //
+                            // Overflow is governed by the configured
+                            // [`BackpressurePolicy`]. `Block` parks the
+                            // consumer thread on push until space frees
+                            // up; `DropOldest` evicts the head before
+                            // push so the queue stays full of fresh
+                            // data; `DropNewest` skips the new event
+                            // when full (legacy behaviour). The shared
+                            // `dropped` counter increments on every
+                            // eviction / skipped push so operators see
+                            // one signal for queue-overflow pressure.
+                            let pushed = match *policy {
+                                BackpressurePolicy::Block => push_with_block(queue, evt.clone()),
+                                BackpressurePolicy::DropOldest => {
+                                    // `force_push` returns `Some(old)`
+                                    // when the queue was full and the
+                                    // head was evicted — count the
+                                    // eviction as a drop so the metric
+                                    // stays comparable to `DropNewest`.
+                                    if queue.force_push(evt.clone()).is_some() {
+                                        dropped_consumer.fetch_add(1, Ordering::Relaxed);
+                                    }
+                                    true
+                                }
+                                BackpressurePolicy::DropNewest => {
+                                    if queue.push(evt.clone()).is_err() {
+                                        dropped_consumer.fetch_add(1, Ordering::Relaxed);
+                                        false
+                                    } else {
+                                        true
+                                    }
+                                }
+                            };
+                            if pushed {
+                                if let Some(wake) = wake_fd.as_ref() {
+                                    // Wake the asyncio reader. `signal()`
+                                    // coalesces under load — at most one
+                                    // wake byte is in the pipe at a time
+                                    // (see `super::wake::WakeFd`) — so
+                                    // the hot-path cost compresses to
+                                    // one atomic compare-exchange and a
+                                    // never-taken branch on subsequent
+                                    // pushes until the reader drains
+                                    // and re-arms. The sync pull-iter
+                                    // path leaves `wake_fd: None` and
+                                    // pays zero overhead.
+                                    wake.signal();
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        .build()
+}
+
+/// Build the ring producer for direct-consumer (poller) delivery.
+///
+/// Constructs the single-producer ring with
+/// [`disruptor::builder::single::SPBuilder::new_event_poller`] instead
+/// of `handle_events_with`, so **no** Disruptor consumer thread is
+/// spawned and **no** intermediate queue is allocated. The returned
+/// [`disruptor::SingleProducer`] is the io_loop's ring publisher
+/// exactly as in the other modes; the returned [`EventPoller`] is
+/// wrapped in a [`super::FpssEventPoller`] and handed to the caller,
+/// whose own thread drains the ring directly.
+///
+/// Dropping the producer at io_loop exit stores the shutdown sequence
+/// on the ring (it has no consumer thread to join); the poller then
+/// drains every published event and observes [`disruptor::Polling::Shutdown`]
+/// once it reaches that sequence — the EOF-drain guarantee.
+pub(in crate::fpss) fn build_poller_producer(
+    ring_size: usize,
+) -> (
+    impl RingProducer,
+    EventPoller<RingEvent, SingleProducerBarrier>,
+) {
+    let factory = RingEvent::default;
+    let wait_strategy = AdaptiveWaitStrategy::fpss_default();
+    let (poller, builder) =
+        build_single_producer(ring_size, factory, wait_strategy).new_event_poller();
+    (builder.build(), poller)
 }
 
 /// Per-class consecutive-reconnect counters with a stable-window reset

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -1074,7 +1074,10 @@ impl FpssClient {
             slow_callback_count,
             next_req_id,
         })?;
-        let event_poller = FpssEventPoller { poller };
+        let event_poller = FpssEventPoller {
+            poller,
+            panic_count: 0,
+        };
         Ok((client, Some(event_poller)))
     }
 
@@ -2036,6 +2039,12 @@ pub struct FpssEventPoller {
     /// single source of truth for the EOF-drain guarantee, with no
     /// separate flag that could race ahead of the in-flight tail.
     poller: EventPoller<RingEvent, SingleProducerBarrier>,
+    /// Count of caught panics from the user handler. The drain isolates
+    /// each `on_event` call under `catch_unwind` (mirroring the managed
+    /// consumer), so a panicking handler skips its own event and the
+    /// drain continues — the unread tail of the in-flight batch is never
+    /// lost. Surfaced via [`FpssEventPoller::panic_count`].
+    panic_count: u64,
 }
 
 // Note (no `unsafe` here): `EventPoller` is `Send` because its
@@ -2115,8 +2124,31 @@ impl FpssEventPoller {
                 // frees the slots for the producer to reuse.
                 for ring_event in &mut guard {
                     if let Some(evt) = ring_event.event.as_public() {
-                        on_event(evt);
-                        delivered += 1;
+                        // Isolate each handler call under `catch_unwind`,
+                        // mirroring the managed consumer. The guard's drop
+                        // advances the cursor to the end of the batch
+                        // unconditionally, so a panic that unwound across
+                        // the loop would commit — and silently skip — the
+                        // unread tail. Catching here keeps the drain going
+                        // so every event in the batch is delivered or
+                        // accounted; a panicking handler loses only its
+                        // own event and bumps `panic_count`.
+                        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            on_event(evt);
+                        }))
+                        .is_err()
+                        {
+                            self.panic_count += 1;
+                            if self.panic_count == 1 || self.panic_count.is_multiple_of(1024) {
+                                tracing::warn!(
+                                    target: "thetadatadx::fpss::poller",
+                                    panic_count = self.panic_count,
+                                    "user poller handler panicked; event skipped, drain continuing"
+                                );
+                            }
+                        } else {
+                            delivered += 1;
+                        }
                     }
                 }
                 PollOutcome::Drained(delivered)
@@ -2136,6 +2168,15 @@ impl FpssEventPoller {
         }
     }
 
+    /// Number of user-handler panics caught and isolated during draining.
+    /// Mirrors [`FpssClient::panic_count`] for the direct-consumer mode:
+    /// each panic skips its own event without aborting the drain or
+    /// losing the rest of the in-flight batch.
+    #[must_use]
+    pub fn panic_count(&self) -> u64 {
+        self.panic_count
+    }
+
     /// Test-only constructor that wraps an [`EventPoller`] built directly
     /// from [`io_loop::build_poller_producer`], bypassing the TLS +
     /// I/O-thread plumbing of [`FpssClient::connect_consumer`]. Soak /
@@ -2145,7 +2186,10 @@ impl FpssEventPoller {
     #[cfg(test)]
     #[doc(hidden)]
     pub(in crate::fpss) fn for_test(poller: EventPoller<RingEvent, SingleProducerBarrier>) -> Self {
-        Self { poller }
+        Self {
+            poller,
+            panic_count: 0,
+        }
     }
 }
 

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -2050,10 +2050,13 @@ impl FpssEventPoller {
     ///
     /// Blocks the calling thread. Each available batch is drained in
     /// order; on a momentarily-empty ring the loop applies the same
-    /// three-phase adaptive wait the SDK's managed consumer uses
-    /// (spin, then yield, then `spin_loop` hint) so an idle pre-market
-    /// stream does not burn a core while an active stream stays
-    /// low-latency.
+    /// three-phase wait the SDK's managed consumer uses (spin, then
+    /// `yield_now`, then a `spin_loop` hint). This keeps an active
+    /// stream low-latency and yields to other runnable threads on a
+    /// quiet stream, but it does NOT park — the loop stays runnable
+    /// rather than idling at zero CPU. A consumer that wants to release
+    /// the core while the stream is idle should drive
+    /// [`Self::poll_batch`] behind its own parking strategy instead.
     ///
     /// Returns once [`FpssClient::shutdown`] (or dropping the
     /// [`FpssClient`]) has fired AND every event already published into
@@ -2066,14 +2069,14 @@ impl FpssEventPoller {
             match self.poll_batch(&mut on_event) {
                 PollOutcome::Shutdown => return,
                 PollOutcome::Drained(0) => {
-                    // Ring momentarily empty. The producer-drop sets the
-                    // ring's shutdown sequence, which `poll_batch`
-                    // surfaces as `Shutdown` on the *next* call once the
-                    // cursor reaches it; the `shutdown` flag is the
-                    // belt-and-braces signal for the idle case. Either
-                    // way, re-poll after one adaptive wait cycle so a
-                    // terminal state is observed promptly without a busy
-                    // spin on a quiet stream.
+                    // Ring momentarily empty. Producer-drop (on client
+                    // shutdown or disconnect) stores the ring's shutdown
+                    // sequence; `poll_batch` surfaces that as `Shutdown`
+                    // once the consumer cursor reaches it. That stored
+                    // sequence is the sole termination signal here — the
+                    // poller holds no separate shutdown flag. Re-poll
+                    // after one wait cycle so a terminal state is observed
+                    // promptly without spinning hard on a quiet stream.
                     waiter.wait_for(0);
                 }
                 PollOutcome::Drained(_) => {

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -55,6 +55,13 @@ pub use self::framing::{read_frame, write_frame, Frame};
 use self::io_loop::{io_loop, ping_loop, wait_for_login, LoginResult};
 pub use self::session::{reconnect_delay, reconnect_delay_for};
 
+// Direct-consumer (single-ring) poller plumbing. The third-party
+// `disruptor` poller types are wrapped by `FpssEventPoller` and never
+// appear on the public surface; these imports are crate-internal only.
+use self::ring::RingEvent;
+use disruptor::wait_strategies::WaitStrategy;
+use disruptor::{EventPoller, Polling, SingleProducerBarrier};
+
 /// Hidden test-internals surface for vendor-failure-mode resilience tests
 /// in `crates/thetadatadx/tests/`.
 ///
@@ -253,6 +260,45 @@ pub enum HarnessPublishMode {
     /// incrementing the shared `dropped` counter on every rejection
     /// the same way `io_loop` does on the live reader path.
     TryPublishBurst,
+}
+
+/// Argument bundle for [`FpssClient::spawn_io_and_assemble`].
+///
+/// Carries the already-built ring `producer` plus every shared `Arc`,
+/// channel end, and tuning value the I/O + ping threads and the
+/// assembled [`FpssClient`] need. Bundled into one struct so the shared
+/// spawn helper reads linearly rather than as a long positional list,
+/// matching the [`FpssConnectArgs`] convention.
+struct SpawnArgs<'a, P> {
+    producer: P,
+    stream: connection::FpssStream,
+    cmd_rx: std_mpsc::Receiver<IoCommand>,
+    cmd_tx: std_mpsc::Sender<IoCommand>,
+    ping_cmd_tx: std_mpsc::Sender<IoCommand>,
+    ring_size: usize,
+    permissions: String,
+    pending_control: Vec<FpssControl>,
+    server_addr: String,
+    creds: &'a Credentials,
+    hosts: &'a [(String, u16)],
+    derive_ohlcvc: bool,
+    flush_mode: FpssFlushMode,
+    policy: ReconnectPolicy,
+    wait_ms: u64,
+    wait_rate_limited_ms: u64,
+    connect_timeout: Duration,
+    read_timeout: Duration,
+    ping_interval: Duration,
+    shutdown: Arc<AtomicBool>,
+    authenticated: Arc<AtomicBool>,
+    active_subs: Arc<Mutex<Vec<(SubscriptionKind, Contract)>>>,
+    active_full_subs: Arc<Mutex<Vec<(SubscriptionKind, tdbe::types::enums::SecType)>>>,
+    dropped: Arc<AtomicU64>,
+    panics: Arc<AtomicU64>,
+    consumer_thread_id: Arc<OnceLock<ThreadId>>,
+    slow_callback_threshold_ns: Arc<AtomicU64>,
+    slow_callback_count: Arc<AtomicU64>,
+    next_req_id: Arc<AtomicI64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -622,6 +668,117 @@ impl FpssClient {
         Ok((client, iterator, wake_arc))
     }
 
+    /// Connect and return the client paired with a single-consumer
+    /// poller. The caller's own thread drives the ring directly via
+    /// [`FpssEventPoller::run`] (or [`FpssEventPoller::poll_batch`]) —
+    /// no Disruptor consumer thread is spawned and no intermediate queue
+    /// is allocated, so the SDK ring is the only buffer between the wire
+    /// reader and the caller.
+    ///
+    /// This is the lowest-overhead delivery mode for an embedded Rust
+    /// consumer that owns its own dispatch loop: an event handed to the
+    /// caller is a borrow into the ring slot itself (zero-copy), valid
+    /// for the duration of the per-event call. Contrast with:
+    ///
+    /// * [`Self::connect`] (push-callback) — the SDK runs your closure
+    ///   on a spawned consumer thread.
+    /// * [`Self::connect_iter`] (pull-iter) — the SDK clones each event
+    ///   into a bounded queue an [`EventIterator`] drains.
+    ///
+    /// Both of those own a second buffer / thread for the consumer;
+    /// `connect_consumer` removes both.
+    ///
+    /// # Thread affinity
+    ///
+    /// The returned [`FpssEventPoller`] is the single consumer of the
+    /// ring: drive it from exactly one thread (the same single-consumer
+    /// contract the pull-iter [`EventIterator`] documents). It is
+    /// `Send`, so it may be moved to the thread that will own the drain
+    /// loop; the `&mut self` / `self` receivers on its drive methods
+    /// enforce the single-consumer invariant at compile time.
+    ///
+    /// # Shutdown
+    ///
+    /// [`Self::shutdown`] (or dropping the [`FpssClient`]) makes
+    /// [`FpssEventPoller::run`] return and
+    /// [`FpssEventPoller::poll_batch`] report
+    /// [`PollOutcome::Shutdown`] — but only after every event already
+    /// published into the ring has been drained, mirroring the
+    /// EOF-drain guarantee the pull-iter path provides.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same set of errors as [`Self::connect`] (TLS, login,
+    /// config validation).
+    pub fn connect_consumer(args: FpssConnectArgs<'_>) -> Result<(Self, FpssEventPoller), Error> {
+        let FpssConnectArgs {
+            creds,
+            hosts,
+            ring_size,
+            flush_mode,
+            policy,
+            wait_ms,
+            wait_rate_limited_ms,
+            derive_ohlcvc,
+            connect_timeout_ms,
+            read_timeout_ms,
+            ping_interval_ms,
+        } = args;
+        let ring_size = ring::check_ring_size(ring_size)
+            .map_err(|e| Error::config_invalid("fpss.ring_size", e.to_string()))?;
+        let to_i64 = |v: u64| i64::try_from(v).unwrap_or(i64::MAX);
+        if !crate::config::fpss_bounds::TIMEOUT_MS.contains(&read_timeout_ms) {
+            return Err(Error::config_out_of_range(
+                "fpss.read_timeout_ms",
+                to_i64(read_timeout_ms),
+                to_i64(*crate::config::fpss_bounds::TIMEOUT_MS.start()),
+                to_i64(*crate::config::fpss_bounds::TIMEOUT_MS.end()),
+            ));
+        }
+        if !crate::config::fpss_bounds::CONNECT_TIMEOUT_MS.contains(&connect_timeout_ms) {
+            return Err(Error::config_out_of_range(
+                "fpss.connect_timeout_ms",
+                to_i64(connect_timeout_ms),
+                to_i64(*crate::config::fpss_bounds::CONNECT_TIMEOUT_MS.start()),
+                to_i64(*crate::config::fpss_bounds::CONNECT_TIMEOUT_MS.end()),
+            ));
+        }
+        if !crate::config::fpss_bounds::PING_INTERVAL_MS.contains(&ping_interval_ms) {
+            return Err(Error::config_out_of_range(
+                "fpss.ping_interval_ms",
+                to_i64(ping_interval_ms),
+                to_i64(*crate::config::fpss_bounds::PING_INTERVAL_MS.start()),
+                to_i64(*crate::config::fpss_bounds::PING_INTERVAL_MS.end()),
+            ));
+        }
+        let borrowed: Vec<(&str, u16)> = hosts.iter().map(|(h, p)| (h.as_str(), *p)).collect();
+        let connect_timeout = Duration::from_millis(connect_timeout_ms);
+        let read_timeout = Duration::from_millis(read_timeout_ms);
+        let (stream, server_addr) =
+            connection::connect_to_servers(&borrowed, connect_timeout, read_timeout)?;
+        let (client, poller) = Self::connect_with_stream(connection::ConnectWithStreamArgs {
+            creds,
+            stream,
+            server_addr,
+            hosts,
+            ring_size,
+            derive_ohlcvc,
+            flush_mode,
+            policy,
+            wait_ms,
+            wait_rate_limited_ms,
+            connect_timeout,
+            read_timeout,
+            ping_interval: Duration::from_millis(ping_interval_ms),
+            consumer: events::StreamConsumer::Poller,
+        })?;
+        let poller = poller.ok_or_else(|| Error::Fpss {
+            kind: crate::error::FpssErrorKind::ConnectionRefused,
+            message: "poller-mode connect did not return an FpssEventPoller".to_string(),
+        })?;
+        Ok((client, poller))
+    }
+
     fn connect_with_delivery(
         args: FpssConnectArgs<'_>,
         delivery: events::Delivery,
@@ -680,7 +837,7 @@ impl FpssClient {
         let read_timeout = Duration::from_millis(read_timeout_ms);
         let (stream, server_addr) =
             connection::connect_to_servers(&borrowed, connect_timeout, read_timeout)?;
-        Self::connect_with_stream(connection::ConnectWithStreamArgs {
+        let (client, _poller) = Self::connect_with_stream(connection::ConnectWithStreamArgs {
             creds,
             stream,
             server_addr,
@@ -694,17 +851,30 @@ impl FpssClient {
             connect_timeout,
             read_timeout,
             ping_interval: Duration::from_millis(ping_interval_ms),
-            delivery,
-        })
+            consumer: events::StreamConsumer::Managed(delivery),
+        })?;
+        // Managed-consumer modes never yield a poller; the SDK spawned a
+        // consumer thread that runs the `Delivery` dispatch.
+        debug_assert!(
+            _poller.is_none(),
+            "managed-consumer connect must not produce an FpssEventPoller",
+        );
+        Ok(client)
     }
 
     /// Connect using a pre-established stream (for testing with mock sockets).
     ///
     /// `hosts` is the full FPSS server list, needed for auto-reconnect to try
     /// all servers. Pass an empty slice to disable reconnection to other servers.
+    ///
+    /// Returns the connected client and, for the direct-consumer
+    /// ([`events::StreamConsumer::Poller`]) path, the
+    /// [`FpssEventPoller`] the caller drives on its own thread. The
+    /// managed-consumer paths (`Callback` / `Queue`) return `None` for
+    /// the poller — the SDK spawned a consumer thread instead.
     pub(crate) fn connect_with_stream(
         args: connection::ConnectWithStreamArgs<'_>,
-    ) -> Result<Self, Error> {
+    ) -> Result<(Self, Option<FpssEventPoller>), Error> {
         let connection::ConnectWithStreamArgs {
             creds,
             mut stream,
@@ -719,7 +889,7 @@ impl FpssClient {
             connect_timeout,
             read_timeout,
             ping_interval,
-            delivery,
+            consumer,
         } = args;
         // Send CREDENTIALS (code 0).
         let cred_payload = build_credentials_payload(&creds.email, &creds.password);
@@ -812,7 +982,145 @@ impl FpssClient {
         // Ping command channel: ping thread -> I/O thread
         let ping_cmd_tx = cmd_tx.clone();
 
-        // Spawn the I/O thread: blocking TLS read + Disruptor publish + command drain.
+        // Build the ring producer for the chosen consumer mode. The
+        // managed path spawns a Disruptor consumer thread that runs the
+        // `Delivery` dispatch; the poller path spawns no consumer thread
+        // and hands the caller an `EventPoller` to drive the ring on its
+        // own thread. Both produce a `Producer<RingEvent>` the io_loop
+        // drives identically via `try_publish`.
+        // Only the poller arm's value escapes this `match`; the managed
+        // arm diverges via `return`, so its arm type is `!` and the
+        // expression type is fixed by the poller arm — a single
+        // `EventPoller<RingEvent, SingleProducerBarrier>`.
+        let (producer, poller) = match consumer {
+            events::StreamConsumer::Managed(delivery) => {
+                let producer = io_loop::build_consumer_producer(io_loop::ConsumerProducerArgs {
+                    ring_size,
+                    delivery,
+                    dropped: Arc::clone(&dropped),
+                    panics: Arc::clone(&panics),
+                    consumer_thread_id: Arc::clone(&consumer_thread_id),
+                    slow_callback_threshold_ns: Arc::clone(&slow_callback_threshold_ns),
+                    slow_callback_count: Arc::clone(&slow_callback_count),
+                });
+                // Spawn the I/O thread + ping thread and assemble the
+                // client. No poller for the managed path.
+                let client = Self::spawn_io_and_assemble(SpawnArgs {
+                    producer,
+                    stream,
+                    cmd_rx,
+                    cmd_tx,
+                    ping_cmd_tx,
+                    ring_size,
+                    permissions,
+                    pending_control,
+                    server_addr,
+                    creds,
+                    hosts,
+                    derive_ohlcvc,
+                    flush_mode,
+                    policy,
+                    wait_ms,
+                    wait_rate_limited_ms,
+                    connect_timeout,
+                    read_timeout,
+                    ping_interval,
+                    shutdown,
+                    authenticated,
+                    active_subs,
+                    active_full_subs,
+                    dropped,
+                    panics,
+                    consumer_thread_id,
+                    slow_callback_threshold_ns,
+                    slow_callback_count,
+                    next_req_id,
+                })?;
+                return Ok((client, None));
+            }
+            events::StreamConsumer::Poller => io_loop::build_poller_producer(ring_size),
+        };
+
+        // Poller path: build the client around the poller-mode producer,
+        // then wrap the `EventPoller` for the caller's own thread.
+        let client = Self::spawn_io_and_assemble(SpawnArgs {
+            producer,
+            stream,
+            cmd_rx,
+            cmd_tx,
+            ping_cmd_tx,
+            ring_size,
+            permissions,
+            pending_control,
+            server_addr,
+            creds,
+            hosts,
+            derive_ohlcvc,
+            flush_mode,
+            policy,
+            wait_ms,
+            wait_rate_limited_ms,
+            connect_timeout,
+            read_timeout,
+            ping_interval,
+            shutdown,
+            authenticated,
+            active_subs,
+            active_full_subs,
+            dropped,
+            panics,
+            consumer_thread_id,
+            slow_callback_threshold_ns,
+            slow_callback_count,
+            next_req_id,
+        })?;
+        let event_poller = FpssEventPoller { poller };
+        Ok((client, Some(event_poller)))
+    }
+
+    /// Spawn the I/O + ping threads for an already-built ring producer
+    /// and assemble the [`FpssClient`] handle. Shared verbatim by the
+    /// managed-consumer and direct-consumer (poller) paths so the
+    /// thread wiring lives in exactly one place — only the producer the
+    /// io_loop drives differs between modes, and that difference is
+    /// fixed before this call.
+    fn spawn_io_and_assemble<P>(args: SpawnArgs<'_, P>) -> Result<Self, Error>
+    where
+        P: io_loop::RingProducer,
+    {
+        let SpawnArgs {
+            producer,
+            stream,
+            cmd_rx,
+            cmd_tx,
+            ping_cmd_tx,
+            ring_size,
+            permissions,
+            pending_control,
+            server_addr,
+            creds,
+            hosts,
+            derive_ohlcvc,
+            flush_mode,
+            policy,
+            wait_ms,
+            wait_rate_limited_ms,
+            connect_timeout,
+            read_timeout,
+            ping_interval,
+            shutdown,
+            authenticated,
+            active_subs,
+            active_full_subs,
+            dropped,
+            panics,
+            consumer_thread_id,
+            slow_callback_threshold_ns,
+            slow_callback_count,
+            next_req_id,
+        } = args;
+
+        // Spawn the I/O thread: blocking TLS read + ring publish + command drain.
         let io_shutdown = Arc::clone(&shutdown);
         let io_authenticated = Arc::clone(&authenticated);
         let io_server_addr = server_addr.clone();
@@ -821,10 +1129,6 @@ impl FpssClient {
         let io_active_subs = Arc::clone(&active_subs);
         let io_active_full_subs = Arc::clone(&active_full_subs);
         let io_dropped = Arc::clone(&dropped);
-        let io_panics = Arc::clone(&panics);
-        let io_consumer_thread_id = Arc::clone(&consumer_thread_id);
-        let io_slow_threshold_ns = Arc::clone(&slow_callback_threshold_ns);
-        let io_slow_count = Arc::clone(&slow_callback_count);
         let io_next_req_id = Arc::clone(&next_req_id);
 
         let io_handle = thread::Builder::new()
@@ -833,7 +1137,7 @@ impl FpssClient {
                 io_loop(io_loop::IoLoopArgs {
                     stream,
                     cmd_rx,
-                    delivery,
+                    producer,
                     ring_size,
                     shutdown: io_shutdown,
                     authenticated: io_authenticated,
@@ -850,10 +1154,6 @@ impl FpssClient {
                     active_subs: io_active_subs,
                     active_full_subs: io_active_full_subs,
                     dropped: io_dropped,
-                    panics: io_panics,
-                    consumer_thread_id: io_consumer_thread_id,
-                    slow_callback_threshold_ns: io_slow_threshold_ns,
-                    slow_callback_count: io_slow_count,
                     connect_timeout,
                     read_timeout,
                     next_req_id: io_next_req_id,
@@ -1657,6 +1957,195 @@ impl Iterator for EventIterator {
     }
 }
 
+// ---------------------------------------------------------------------------
+// FpssEventPoller -- direct-consumer (single-ring) delivery handle
+// ---------------------------------------------------------------------------
+
+/// Outcome of a single non-blocking [`FpssEventPoller::poll_batch`] drain.
+///
+/// Lets a caller integrating the ring drive into its own loop tell
+/// "drained `n` events, more may come" apart from "the session has
+/// terminated and the ring is empty":
+///
+/// * [`PollOutcome::Drained`] — the currently-available batch was
+///   handed to the closure; the wrapped count is how many events were
+///   delivered this call (`0` when the ring was momentarily empty but
+///   the session is still live — re-poll later).
+/// * [`PollOutcome::Shutdown`] — the [`FpssClient`] has shut down AND
+///   every published event has been drained. No further events will
+///   ever arrive; stop polling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PollOutcome {
+    /// The available batch was drained into the closure. Carries the
+    /// number of events delivered on this call (may be `0`).
+    Drained(usize),
+    /// Terminal: the session has shut down and the ring is fully
+    /// drained. Mirrors [`NextEvent::Closed`] on the pull-iter path.
+    Shutdown,
+}
+
+/// Direct-consumer drain handle for a single-ring streaming session.
+///
+/// Returned by [`FpssClient::connect_consumer`]. The caller's own thread
+/// drives the SDK ring through this handle — there is no SDK-spawned
+/// consumer thread and no intermediate queue, so the ring is the only
+/// buffer between the wire reader and the caller.
+///
+/// Two drive shapes are offered:
+///
+/// * [`Self::run`] — block on the calling thread until the session shuts
+///   down and the ring is fully drained, handing each event to a
+///   closure. The simplest shape for a thread dedicated to consumption.
+/// * [`Self::poll_batch`] — non-blocking single drain of the currently
+///   available batch, returning a [`PollOutcome`] so the caller can
+///   interleave the drive with its own work in a bespoke loop.
+///
+/// # Thread affinity
+///
+/// `FpssEventPoller` is the single consumer of the ring — drive it from
+/// exactly one thread, the same single-consumer contract the pull-iter
+/// [`EventIterator`] documents. It is `Send`, so you may build it on the
+/// connect thread and move it to the thread that owns the drain loop.
+/// The single-consumer invariant is enforced by the method receivers:
+/// [`Self::poll_batch`] takes `&mut self` and [`Self::run`] takes `self`
+/// by value, so the borrow checker already prevents two threads driving
+/// the same poller concurrently.
+///
+/// # Zero-copy borrow lifetime
+///
+/// Each `&FpssEvent` handed to the closure is a borrow directly into the
+/// ring slot, valid only for the duration of that call. The wrapped
+/// poller advances the ring's consumer cursor when the per-batch guard
+/// is dropped (at the end of the drain), so the closure must not stash
+/// the reference past its own invocation — clone the event if you need
+/// to retain it. This is enforced by the closure signature
+/// (`FnMut(&FpssEvent)`); the borrow cannot outlive the call.
+pub struct FpssEventPoller {
+    /// The wrapped third-party ring poller. The `disruptor::EventPoller`
+    /// / `EventGuard` / `Polling` types never appear on any public
+    /// signature — this field is private and every method maps the
+    /// poller's output to the SDK's own `FpssEvent` / [`PollOutcome`]
+    /// types.
+    ///
+    /// Terminal shutdown is observed entirely through this poller: when
+    /// the I/O thread exits (on [`FpssClient::shutdown`], a server
+    /// disconnect, or reconnect exhaustion) it drops the ring producer,
+    /// which stores the ring's shutdown sequence. The poller drains
+    /// every event published before that sequence and only then reports
+    /// [`disruptor::Polling::Shutdown`] — so the ring itself is the
+    /// single source of truth for the EOF-drain guarantee, with no
+    /// separate flag that could race ahead of the in-flight tail.
+    poller: EventPoller<RingEvent, SingleProducerBarrier>,
+}
+
+// Note (no `unsafe` here): `EventPoller` is `Send` because its
+// `Arc`-held ring buffer and cursors are `Send`, and `RingEvent: Sync`
+// (see `ring.rs`). We do NOT implement `Sync` for `FpssEventPoller`;
+// the single-consumer ring sequencing requires one draining thread,
+// mirroring `EventIterator`.
+
+impl FpssEventPoller {
+    /// Drive the ring on the calling thread until the session shuts down
+    /// and the ring is fully drained, handing each event to `on_event`.
+    ///
+    /// Blocks the calling thread. Each available batch is drained in
+    /// order; on a momentarily-empty ring the loop applies the same
+    /// three-phase adaptive wait the SDK's managed consumer uses
+    /// (spin, then yield, then `spin_loop` hint) so an idle pre-market
+    /// stream does not burn a core while an active stream stays
+    /// low-latency.
+    ///
+    /// Returns once [`FpssClient::shutdown`] (or dropping the
+    /// [`FpssClient`]) has fired AND every event already published into
+    /// the ring has been delivered — the EOF-drain guarantee. Each
+    /// `&FpssEvent` is a zero-copy borrow into the ring slot, valid only
+    /// for the `on_event` call.
+    pub fn run(mut self, mut on_event: impl FnMut(&FpssEvent)) {
+        let waiter = ring::AdaptiveWaitStrategy::fpss_default();
+        loop {
+            match self.poll_batch(&mut on_event) {
+                PollOutcome::Shutdown => return,
+                PollOutcome::Drained(0) => {
+                    // Ring momentarily empty. The producer-drop sets the
+                    // ring's shutdown sequence, which `poll_batch`
+                    // surfaces as `Shutdown` on the *next* call once the
+                    // cursor reaches it; the `shutdown` flag is the
+                    // belt-and-braces signal for the idle case. Either
+                    // way, re-poll after one adaptive wait cycle so a
+                    // terminal state is observed promptly without a busy
+                    // spin on a quiet stream.
+                    waiter.wait_for(0);
+                }
+                PollOutcome::Drained(_) => {
+                    // Delivered a batch; loop straight back to drain any
+                    // events that arrived while this batch was processed.
+                }
+            }
+        }
+    }
+
+    /// Non-blocking drain of the currently-available batch into
+    /// `on_event`. Returns a [`PollOutcome`] so a caller integrating the
+    /// ring drive into its own loop can tell a drained batch (and how
+    /// many events it carried) apart from terminal shutdown.
+    ///
+    /// Does not sleep or spin: if the ring is momentarily empty the call
+    /// returns [`PollOutcome::Drained`]`(0)` immediately and the caller
+    /// decides when to re-poll. Once the [`FpssClient`] has shut down
+    /// and every published event has been drained, returns
+    /// [`PollOutcome::Shutdown`]; subsequent calls keep returning
+    /// `Shutdown`.
+    ///
+    /// Each `&FpssEvent` handed to `on_event` is a zero-copy borrow into
+    /// the ring slot, valid only for that call.
+    pub fn poll_batch(&mut self, mut on_event: impl FnMut(&FpssEvent)) -> PollOutcome {
+        match self.poller.poll() {
+            Ok(mut guard) => {
+                let mut delivered = 0usize;
+                // `&mut EventGuard` is an `Iterator<Item = &RingEvent>`
+                // borrowing the ring slots for the lifetime of the
+                // guard. Reborrow each slot to the public `&FpssEvent`
+                // via `as_public`, filtering the internal-only `Empty` /
+                // `Unparseable` discriminants exactly as the managed
+                // consumer does. The guard is dropped at the end of this
+                // block, which advances the ring's consumer cursor and
+                // frees the slots for the producer to reuse.
+                for ring_event in &mut guard {
+                    if let Some(evt) = ring_event.event.as_public() {
+                        on_event(evt);
+                        delivered += 1;
+                    }
+                }
+                PollOutcome::Drained(delivered)
+            }
+            Err(Polling::NoEvents) => {
+                // Ring empty right now. If the client has shut down, the
+                // producer has been (or is being) dropped; the ring's
+                // shutdown sequence will surface as `Polling::Shutdown`
+                // once the cursor reaches it. Until then report a
+                // zero-length drain so a `run` loop waits and re-polls
+                // rather than false-terminating mid-drain. The drained
+                // tail is delivered through the `Ok(guard)` arm on the
+                // poll that follows the last publish.
+                PollOutcome::Drained(0)
+            }
+            Err(Polling::Shutdown) => PollOutcome::Shutdown,
+        }
+    }
+
+    /// Test-only constructor that wraps an [`EventPoller`] built directly
+    /// from [`io_loop::build_poller_producer`], bypassing the TLS +
+    /// I/O-thread plumbing of [`FpssClient::connect_consumer`]. Soak /
+    /// unit tests drive the poller's `run` / `poll_batch` loops against a
+    /// producer they publish into by hand, then drop the producer to
+    /// assert the EOF-drain + terminal-shutdown contract.
+    #[cfg(test)]
+    #[doc(hidden)]
+    pub(in crate::fpss) fn for_test(poller: EventPoller<RingEvent, SingleProducerBarrier>) -> Self {
+        Self { poller }
+    }
+}
+
 impl Drop for FpssClient {
     fn drop(&mut self) {
         // Signal shutdown if not already done.
@@ -1666,11 +2155,14 @@ impl Drop for FpssClient {
 
         // Self-join guard.
         //
-        // The exit path of the I/O thread drops the Disruptor producer
-        // (`crates/thetadatadx/src/fpss/io_loop/mod.rs:640`), and
-        // `disruptor::Producer::drop` joins the consumer thread
-        // (`disruptor` 4.x `single.rs`). So `self.io_handle.join()`
-        // transitively joins the consumer thread.
+        // The exit path of the I/O thread drops the ring producer
+        // (`drop(producer)` at the end of `io_loop`), and in the
+        // managed-consumer modes `disruptor::Producer::drop` joins the
+        // spawned consumer thread (`disruptor` 4.x `single.rs`). So
+        // `self.io_handle.join()` transitively joins that consumer
+        // thread. (In direct-consumer / poller mode there is no spawned
+        // consumer thread, so this guard simply never matches a
+        // consumer id.)
         //
         // If `Drop` is running on either of those threads — the I/O
         // thread itself, or the Disruptor consumer thread (the thread

--- a/crates/thetadatadx/src/fpss/streaming_soak_tests.rs
+++ b/crates/thetadatadx/src/fpss/streaming_soak_tests.rs
@@ -1673,6 +1673,59 @@ fn poller_run_receives_events_in_order_then_returns() {
     assert_eq!(*got, expected, "run must preserve publish order");
 }
 
+/// A handler that panics mid-batch must not lose the unread tail of that
+/// batch. The Disruptor `EventGuard` advances the consumer cursor to the
+/// end of the available batch on drop regardless of how many events were
+/// read, so an unwind across the drain loop would silently skip the
+/// remaining events. `poll_batch` isolates each handler call under
+/// `catch_unwind`, so the panicking event is the only one dropped and the
+/// rest of the batch is still delivered.
+#[test]
+fn poller_poll_batch_isolates_handler_panic_and_keeps_batch_tail() {
+    use super::events::FpssControl;
+    use super::{FpssEventPoller, PollOutcome};
+    use disruptor::Producer;
+
+    let (mut producer, poller) = super::io_loop::build_poller_producer(256);
+    let mut poller = FpssEventPoller::for_test(poller);
+
+    // Publish a 5-event batch BEFORE polling so a single `poll_batch`
+    // call drains all five under one `EventGuard`.
+    for i in 0..5i32 {
+        let msg = i.to_string();
+        producer.publish(|slot| {
+            slot.event = super::events::FpssEventInternal::Control(FpssControl::ServerError {
+                message: msg,
+            });
+        });
+    }
+
+    let mut received: Vec<i32> = Vec::new();
+    let outcome = poller.poll_batch(|evt| {
+        if let FpssEvent::Control(FpssControl::ServerError { message }) = evt {
+            let seq: i32 = message.parse().expect("sequence message must parse");
+            // Panic on the middle event of the batch.
+            assert_ne!(seq, 2, "handler panics on event 2");
+            received.push(seq);
+        }
+    });
+
+    // The four non-panicking events were delivered; only event 2 was lost.
+    assert_eq!(
+        received,
+        vec![0, 1, 3, 4],
+        "tail after the panic must survive"
+    );
+    assert_eq!(
+        outcome,
+        PollOutcome::Drained(4),
+        "drained count excludes the panicking event"
+    );
+    assert_eq!(poller.panic_count(), 1, "one caught handler panic");
+
+    drop(producer);
+}
+
 /// `run` returns promptly once the producer is dropped on another
 /// thread mid-stream, after draining the in-flight tail. Guards against
 /// a `run` loop that hangs when the producer goes away.

--- a/crates/thetadatadx/src/fpss/streaming_soak_tests.rs
+++ b/crates/thetadatadx/src/fpss/streaming_soak_tests.rs
@@ -1503,3 +1503,273 @@ fn iter_does_not_false_eof_during_drain() {
         "queue fully drained once iterator surfaced Closed"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Direct-consumer (single-ring) poller soak tests
+// ---------------------------------------------------------------------------
+//
+// These drive `FpssEventPoller` against a producer built by
+// `io_loop::build_poller_producer` and published into by hand — no TLS,
+// no I/O thread — so the poller's drain ordering, the EOF-drain
+// guarantee, and the terminal `PollOutcome::Shutdown` contract are
+// pinned without live credentials. Dropping the producer is the test's
+// stand-in for the I/O thread exiting and dropping the ring producer at
+// `io_loop` scope exit, which is what stores the ring's shutdown
+// sequence.
+
+/// `poll_batch` drains the currently-available batch in publish order,
+/// then reports `Shutdown` only after the producer has been dropped AND
+/// every published event has been drained — the EOF-drain guarantee.
+#[test]
+fn poller_poll_batch_drains_then_reports_shutdown() {
+    use super::events::FpssControl;
+    use super::{FpssEventPoller, PollOutcome};
+    use disruptor::Producer;
+
+    let (mut producer, poller) = super::io_loop::build_poller_producer(64);
+    let mut poller = FpssEventPoller::for_test(poller);
+
+    // Publish three control frames the projection surfaces publicly.
+    let kinds = [
+        FpssControl::MarketOpen,
+        FpssControl::MarketClose,
+        FpssControl::Reconnected,
+    ];
+    for k in &kinds {
+        let k = k.clone();
+        producer.publish(|slot| {
+            slot.event = super::events::FpssEventInternal::Control(k);
+        });
+    }
+
+    // Drain the available batch. With a single producer publishing
+    // three events before any poll, the batch should carry all three.
+    let mut seen: Vec<FpssEvent> = Vec::new();
+    let outcome = poller.poll_batch(|evt| seen.push(evt.clone()));
+    assert_eq!(
+        outcome,
+        PollOutcome::Drained(3),
+        "poll_batch must drain the full available batch"
+    );
+    assert!(
+        matches!(
+            seen.as_slice(),
+            [
+                FpssEvent::Control(FpssControl::MarketOpen),
+                FpssEvent::Control(FpssControl::MarketClose),
+                FpssEvent::Control(FpssControl::Reconnected),
+            ]
+        ),
+        "events must arrive in publish order, got {seen:?}"
+    );
+
+    // Empty ring, producer still live → zero-length drain, NOT shutdown.
+    let outcome = poller.poll_batch(|_| panic!("no events expected on empty live ring"));
+    assert_eq!(
+        outcome,
+        PollOutcome::Drained(0),
+        "empty-but-live ring must report Drained(0), not Shutdown"
+    );
+
+    // Drop the producer: this stores the ring's shutdown sequence (no
+    // consumer thread to join in poller mode). The poller now reports
+    // terminal shutdown.
+    drop(producer);
+    let outcome = poller.poll_batch(|_| panic!("no events expected after shutdown"));
+    assert_eq!(
+        outcome,
+        PollOutcome::Shutdown,
+        "poll_batch must report Shutdown once the producer is dropped and the ring is drained"
+    );
+    // Idempotent terminal.
+    assert_eq!(poller.poll_batch(|_| {}), PollOutcome::Shutdown);
+}
+
+/// A tail of events published right before the producer drop must all be
+/// delivered before `poll_batch` reports `Shutdown` — the drain happens
+/// on the poll that follows the last publish, never lost to a premature
+/// terminal.
+#[test]
+fn poller_poll_batch_drains_tail_published_before_drop() {
+    use super::events::FpssControl;
+    use super::{FpssEventPoller, PollOutcome};
+    use disruptor::Producer;
+
+    let (mut producer, poller) = super::io_loop::build_poller_producer(64);
+    let mut poller = FpssEventPoller::for_test(poller);
+
+    const TAIL: usize = 10;
+    for _ in 0..TAIL {
+        producer.publish(|slot| {
+            slot.event = super::events::FpssEventInternal::Control(FpssControl::MarketOpen);
+        });
+    }
+    // Drop BEFORE the first poll: the shutdown sequence is set, but the
+    // tail is still in the ring and must drain first.
+    drop(producer);
+
+    let mut delivered = 0usize;
+    while let PollOutcome::Drained(n) = poller.poll_batch(|_| {}) {
+        delivered += n;
+    }
+    assert_eq!(
+        delivered, TAIL,
+        "every event published before the drop must drain before Shutdown"
+    );
+}
+
+/// `run` blocks the calling thread, drains every event a separate
+/// producer thread publishes (in order), and returns once the producer
+/// is dropped and the ring is empty.
+#[test]
+fn poller_run_receives_events_in_order_then_returns() {
+    use super::events::FpssControl;
+    use super::FpssEventPoller;
+    use disruptor::Producer;
+
+    let (mut producer, poller) = super::io_loop::build_poller_producer(256);
+    let poller = FpssEventPoller::for_test(poller);
+
+    const N: i32 = 500;
+    // Publish on a separate thread; `run` drives the ring on this one.
+    let producer_thread = thread::spawn(move || {
+        for i in 0..N {
+            // Encode the sequence number in `ServerError.message` so the
+            // consumer can assert exact ordering.
+            let msg = i.to_string();
+            producer.publish(|slot| {
+                slot.event = super::events::FpssEventInternal::Control(FpssControl::ServerError {
+                    message: msg,
+                });
+            });
+        }
+        // Drop the producer to set the ring shutdown sequence so `run`
+        // returns after draining.
+        drop(producer);
+    });
+
+    let received: Arc<Mutex<Vec<i32>>> = Arc::new(Mutex::new(Vec::new()));
+    let received_run = Arc::clone(&received);
+    poller.run(move |evt| {
+        if let FpssEvent::Control(FpssControl::ServerError { message }) = evt {
+            received_run
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(message.parse().expect("sequence message must parse"));
+        }
+    });
+
+    producer_thread.join().expect("producer thread must join");
+
+    let got = received
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_eq!(
+        got.len(),
+        N as usize,
+        "run must deliver every published event"
+    );
+    let expected: Vec<i32> = (0..N).collect();
+    assert_eq!(*got, expected, "run must preserve publish order");
+}
+
+/// `run` returns promptly once the producer is dropped on another
+/// thread mid-stream, after draining the in-flight tail. Guards against
+/// a `run` loop that hangs when the producer goes away.
+#[test]
+fn poller_run_terminates_when_producer_dropped() {
+    use super::events::FpssControl;
+    use super::FpssEventPoller;
+    use disruptor::Producer;
+
+    let (mut producer, poller) = super::io_loop::build_poller_producer(64);
+    let poller = FpssEventPoller::for_test(poller);
+
+    let producer_thread = thread::spawn(move || {
+        for _ in 0..5 {
+            producer.publish(|slot| {
+                slot.event = super::events::FpssEventInternal::Control(FpssControl::MarketOpen);
+            });
+        }
+        // Hold the producer briefly so `run` observes an idle ring and
+        // exercises its adaptive-wait branch, then drop to terminate.
+        thread::sleep(Duration::from_millis(20));
+        drop(producer);
+    });
+
+    let count = Arc::new(AtomicU64::new(0));
+    let count_run = Arc::clone(&count);
+    let start = Instant::now();
+    poller.run(move |_evt| {
+        count_run.fetch_add(1, Ordering::Relaxed);
+    });
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "run must return promptly after the producer is dropped"
+    );
+    assert_eq!(
+        count.load(Ordering::Relaxed),
+        5,
+        "run must deliver the in-flight events before returning"
+    );
+    producer_thread.join().expect("producer thread must join");
+}
+
+/// The projection filters the internal-only `Empty` / `Unparseable`
+/// ring slots: a published `Unparseable` event is never surfaced to the
+/// poller closure, only `Data` / `Control` reach it. Pins the same
+/// internal/public split the managed consumer enforces, on the poller
+/// drain path.
+#[test]
+fn poller_poll_batch_filters_internal_only_variants() {
+    use super::events::{FpssControl, FpssEventInternal};
+    use super::{FpssEventPoller, PollOutcome};
+    use disruptor::Producer;
+
+    let (mut producer, poller) = super::io_loop::build_poller_producer(64);
+    let mut poller = FpssEventPoller::for_test(poller);
+
+    // Interleave a public Control with an internal-only Unparseable.
+    producer.publish(|slot| {
+        slot.event = FpssEventInternal::Control(FpssControl::MarketOpen);
+    });
+    producer.publish(|slot| {
+        slot.event = FpssEventInternal::Unparseable;
+    });
+    producer.publish(|slot| {
+        slot.event = FpssEventInternal::Control(FpssControl::MarketClose);
+    });
+
+    let mut seen: Vec<FpssEvent> = Vec::new();
+    let outcome = poller.poll_batch(|evt| seen.push(evt.clone()));
+    // Three slots advanced, but only the two public ones are delivered.
+    assert_eq!(
+        outcome,
+        PollOutcome::Drained(2),
+        "Unparseable must not count toward delivered events"
+    );
+    assert!(
+        matches!(
+            seen.as_slice(),
+            [
+                FpssEvent::Control(FpssControl::MarketOpen),
+                FpssEvent::Control(FpssControl::MarketClose),
+            ]
+        ),
+        "internal-only variants must be filtered before the closure, got {seen:?}"
+    );
+}
+
+/// `FpssEventPoller` is `Send` so a caller can build it on the connect
+/// thread and move it to the thread that will own the drain loop.
+/// Single-consumer safety does not rely on `!Sync`: both drive methods
+/// take `&mut self` (`poll_batch`) or `self` (`run`), so the borrow
+/// checker already forbids two threads draining the same poller at once
+/// without unsynchronised aliasing the caller would have to construct
+/// deliberately.
+#[test]
+fn poller_is_send() {
+    use super::FpssEventPoller;
+    fn assert_send<T: Send>() {}
+    assert_send::<FpssEventPoller>();
+}

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`connect`) and pull-iterator (`connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
+
 ## [11.0.0] - 2026-05-27
 
 ### Breaking changes

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`connect`) and pull-iterator (`connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
+- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
 
 ## [11.0.0] - 2026-05-27
 

--- a/docs-site/docs/streaming/index.md
+++ b/docs-site/docs/streaming/index.md
@@ -48,6 +48,45 @@ If you are porting code between SDKs: anywhere a Rust example calls `client.subs
 C++ receives typed `#[repr(C)]` structs directly from Rust -- not JSON. All field access is zero-copy struct member access.
 :::
 
+## Direct-consumer mode (embedded Rust)
+
+For an embedded Rust consumer that owns its own dispatch loop, the Rust SDK offers a third delivery shape: **drive the ring on your own thread, with no intermediate queue.**
+
+`FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller`. Instead of the SDK spawning a consumer thread (push-callback mode) or cloning each event into a bounded queue (pull-iterator mode), *your* thread becomes the ring consumer — the streaming ring is the only buffer between the wire reader and your code, and each event is a zero-copy borrow into the ring slot, valid for the duration of your handler call.
+
+```rust [Rust]
+use thetadatadx::fpss::{FpssClient, FpssConnectArgs, FpssEvent, FpssData};
+use thetadatadx::fpss::protocol::Contract;
+use thetadatadx::auth::Credentials;
+
+fn main() -> Result<(), thetadatadx::Error> {
+    let creds = Credentials::from_file("creds.txt")?;
+    let hosts = thetadatadx::config::DirectConfig::production().fpss.hosts;
+    let args = FpssConnectArgs::new(&creds, &hosts);
+
+    // No consumer thread is spawned; this thread will drive the ring.
+    let (client, poller) = FpssClient::connect_consumer(args)?;
+    client.subscribe(Contract::stock("AAPL").quote())?;
+
+    // `run` blocks this thread, draining every event until the session
+    // shuts down and the ring is fully drained.
+    poller.run(|event: &FpssEvent| {
+        if let FpssEvent::Data(FpssData::Quote { contract, bid, ask, .. }) = event {
+            println!("Quote: {} bid={bid:.2} ask={ask:.2}", contract.symbol);
+        }
+    });
+    Ok(())
+}
+```
+
+To interleave the drain with your own loop, use the non-blocking `poller.poll_batch(|event| ...)`, which drains the currently-available batch and returns a `PollOutcome` (`Drained(n)` or `Shutdown`) so you decide when to re-poll. Calling `client.shutdown()` (or dropping the client) makes `run` return and `poll_batch` report `Shutdown` — but only after every event already in the ring has been delivered, so no in-flight events are lost.
+
+The `FpssEventPoller` is the single consumer of the ring: drive it from exactly one thread. It is `Send`, so you can build it on one thread and move it to the thread that owns the drain loop.
+
+::: tip When to use which mode
+Use **push-callback** (`start_streaming`) for the simplest integration, **pull-iterator** (`start_streaming_iter`) when you want a `for event in iter` loop or cross-language parity, and **direct-consumer** (`connect_consumer`) when you are embedding the Rust SDK and want the lowest-overhead path with no extra thread or queue on the hot path.
+:::
+
 ## Available Data Streams
 
 | Stream | Event Type | Description |

--- a/docs-site/docs/streaming/index.md
+++ b/docs-site/docs/streaming/index.md
@@ -84,7 +84,7 @@ To interleave the drain with your own loop, use the non-blocking `poller.poll_ba
 The `FpssEventPoller` is the single consumer of the ring: drive it from exactly one thread. It is `Send`, so you can build it on one thread and move it to the thread that owns the drain loop.
 
 ::: tip When to use which mode
-Use **push-callback** (`start_streaming`) for the simplest integration, **pull-iterator** (`start_streaming_iter`) when you want a `for event in iter` loop or cross-language parity, and **direct-consumer** (`connect_consumer`) when you are embedding the Rust SDK and want the lowest-overhead path with no extra thread or queue on the hot path.
+On the embedded Rust `FpssClient` surface, use **push-callback** (`FpssClient::connect`) for the simplest integration, **pull-iterator** (`FpssClient::connect_iter`) when you want a `for event in iter` loop, and **direct-consumer** (`FpssClient::connect_consumer`) when you want the lowest-overhead path with no extra thread or queue on the hot path. On the unified `ThetaDataDxClient`, the equivalent push and pull entries are `start_streaming` and `start_streaming_iter`.
 :::
 
 ## Available Data Streams


### PR DESCRIPTION
## Summary

Adds a third streaming delivery shape for embedded Rust consumers: `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` / `poll_batch` loop drives the ring on the **caller's own thread**. No consumer thread is spawned and no intermediate queue is allocated, so the streaming ring is the single buffer between the wire reader and the caller — each event is a zero-copy borrow into the ring slot, valid for the handler call.

The existing **push-callback** (`start_streaming`) and **pull-iterator** (`start_streaming_iter`) modes are unchanged. The I/O producer thread, reconnect, and re-subscribe paths are shared with both modes via a generic `io_loop`; only the consumer side moves onto the caller's thread. The `disruptor` poller is fully wrapped — no third-party type appears on the public surface.

Rust-embedding API only; the foreign-language bindings keep the callback / pull-iterator surfaces (a borrowed-slot run loop does not cross the FFI boundary cleanly).

### Public API
```rust
impl FpssClient {
    pub fn connect_consumer(args: FpssConnectArgs<'_>) -> Result<(Self, FpssEventPoller), Error>;
}
impl FpssEventPoller {
    pub fn run(self, on_event: impl FnMut(&FpssEvent));               // blocks, drains until shutdown
    pub fn poll_batch(&mut self, on_event: impl FnMut(&FpssEvent)) -> PollOutcome;  // non-blocking batch drain
}
pub enum PollOutcome { Drained(usize), Shutdown }
```

Shutdown drains in-flight events before reporting terminal (`Shutdown`), matching the pull-iterator EOF guarantee.

## Test plan

- [x] `poller_run_receives_events_in_order_then_returns` (500 events, order-checked)
- [x] `poller_poll_batch_drains_then_reports_shutdown`
- [x] `poller_poll_batch_drains_tail_published_before_drop` (EOF-drain: producer dropped before first poll, full tail still delivered)
- [x] `poller_run_terminates_when_producer_dropped`
- [x] `poller_poll_batch_filters_internal_only_variants`
- [x] `poller_is_send`
- [x] Existing callback + pull-iterator tests unchanged (panic-isolation, slow-callback watchdog, `iter_*`)
- [x] fmt, clippy (`--workspace --all-targets`, plus the TS-target clippy), `cargo test --workspace`, binding-parity, C-ABI, banned-vocab, docs-consistency, SDK-surface check, `cargo-semver-checks` (additive, no bump required)

Closes #612