### PR TITLE
chore(ci): ungate network bench + raise Python floor to 3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -84,14 +84,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && !endsWith(matrix.python, 't')
         uses: PyO3/maturin-action@v1
         with:
-          # `--interpreter python3.9` targets the abi3 floor declared in
-          # `sdks/python/Cargo.toml` (pyo3/abi3-py39). The default
+          # `--interpreter python3.12` targets the abi3 floor declared in
+          # `sdks/python/Cargo.toml` (pyo3/abi3-py312). The default
           # `python` binary inside the manylinux2014 Docker image is
           # Python 2.7, which lacks `sys.implementation` and breaks
-          # maturin's interpreter probe; `python3.9` resolves cleanly
+          # maturin's interpreter probe; `python3.12` resolves cleanly
           # inside the image.
           command: build
-          args: --release -m sdks/python/Cargo.toml -o dist/ --interpreter python3.9
+          args: --release -m sdks/python/Cargo.toml -o dist/ --interpreter python3.12
           manylinux: '2014'
           target: x86_64
           # The manylinux2014 CentOS 7 image ships no `protoc`, which
@@ -299,7 +299,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.9", "3.14"]
+        python: ["3.12", "3.14"]
     steps:
       - uses: actions/setup-python@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Minimum supported Python raised to 3.12. The abi3 floor and `requires-python` move from 3.9 to 3.12; CPython 3.9 (EOL Oct 2025), 3.10, and 3.11 wheels are no longer published. Free-threaded 3.13t / 3.14t wheels are unaffected.
+
 ### Added
 
 - `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
 
+### Changed
+
+- The `stock_list_symbols/in_house` benchmark is excluded from the hard bench-regression gate (it is a network-bound gRPC round-trip whose variance exceeds the threshold by construction); it still runs for information. CPU microbenches remain gated. (#614)
+
 ## [11.0.0] - 2026-05-27
 
 ### Breaking changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ for the FLATFILES coverage matrix.
 
 - **Rust stable** (see `rust-toolchain.toml` - includes rustfmt and clippy)
 - **protoc** (Protocol Buffers compiler) - only needed if modifying `.proto` files
-- **Python 3.9+** - for the Python SDK
+- **Python 3.12+** - for the Python SDK
 - **maturin** - for building the PyO3 Python bindings (`pip install "maturin>=1.9.4,<2.0"`)
 - **Node.js 18+** - for the TypeScript/Node.js SDK
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ No JVM, no subprocess, no IPC serialization.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.88%2B-orange.svg?logo=rust)](https://www.rust-lang.org)
-[![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg?logo=python&logoColor=white)](https://www.python.org)
+[![Python](https://img.shields.io/badge/python-3.12%2B-blue.svg?logo=python&logoColor=white)](https://www.python.org)
 [![Node](https://img.shields.io/badge/node-20%2B-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org)
 [![C++](https://img.shields.io/badge/C%2B%2B-17-00599C.svg?logo=cplusplus&logoColor=white)](https://isocpp.org)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2.svg?logo=discord&logoColor=white)](https://discord.thetadata.us/)

--- a/crates/thetadatadx/benches/baseline/criterion.json
+++ b/crates/thetadatadx/benches/baseline/criterion.json
@@ -3,10 +3,7 @@
         "comment": "Gate 10 (#553) baseline. Calibrated against the GitHub-hosted runner perf profile (PR #566, 2026-05-21). Threshold stays at 25% so a real regression past this baseline trips CI. The loader in `scripts/check_bench_regression.py` ignores `_meta` and the per-entry `_captured_on` field; only `criterion_path` + `p50_ns` are gated."
     },
     "_captured_on": "2026-05-21",
-    "stock_list_symbols/in_house": {
-        "p50_ns": 148653.7,
-        "criterion_path": "stock_list_symbols/in_house"
-    },
+    "_meta_ungated": "stock_list_symbols/in_house is a gRPC round-trip dominated by network / shared-runner I/O variance; it is run for information but excluded from the hard regression gate. See issue #614. CPU microbenches remain gated.",
     "streaming_channels/direct_callback/100k_events": {
         "p50_ns": 807151.3,
         "criterion_path": "streaming_channels_direct_callback/100k_events"

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Minimum supported Python raised to 3.12. The abi3 floor and `requires-python` move from 3.9 to 3.12; CPython 3.9 (EOL Oct 2025), 3.10, and 3.11 wheels are no longer published. Free-threaded 3.13t / 3.14t wheels are unaffected.
+
 ### Added
 
 - `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
 
+### Changed
+
+- The `stock_list_symbols/in_house` benchmark is excluded from the hard bench-regression gate (it is a network-bound gRPC round-trip whose variance exceeds the threshold by construction); it still runs for information. CPU microbenches remain gated. (#614)
+
 ## [11.0.0] - 2026-05-27
 
 ### Breaking changes

--- a/docs-site/docs/getting-started/index.md
+++ b/docs-site/docs/getting-started/index.md
@@ -24,7 +24,7 @@ ThetaDataDx is a Rust SDK for ThetaData's MDDS (historical, gRPC) and FPSS (real
 |-------------|---------|
 | ThetaData account | Email and password from [thetadata.us](https://thetadata.us) |
 | Rust toolchain | Required for the C++ SDK (builds the FFI library); not required for Rust/Python/TypeScript on supported platforms |
-| Python 3.9+ | For the Python SDK; pre-built `abi3` wheels provided |
+| Python 3.12+ | For the Python SDK; pre-built `abi3` wheels provided |
 | Node.js 18+ | For the TypeScript/Node.js SDK |
 | C++17 compiler + CMake 3.16+ | For the C++ SDK |
 

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ pip install thetadatadx[polars]    # polars
 pip install thetadatadx[arrow]     # pyarrow only
 pip install thetadatadx[all]       # all three
 
-# Requires Python 3.9+. Pre-built abi3 wheels — no Rust toolchain required.
+# Requires Python 3.12+. Pre-built abi3 wheels — no Rust toolchain required.
 ```
 ```bash [TypeScript]
 npm install thetadatadx
@@ -57,7 +57,7 @@ make
 
 ## Python abi3 wheels
 
-The Python SDK ships a single `abi3` wheel per OS. One wheel built against Python 3.12 works on Python 3.9 → 3.14 without a per-version recompile, which is why the Rust toolchain is never needed on supported platforms.
+The Python SDK ships a single `abi3` wheel per OS. One wheel built against Python 3.12 works on Python 3.12 → 3.14 without a per-version recompile, which is why the Rust toolchain is never needed on supported platforms.
 
 | Platform | Wheel |
 |----------|-------|

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -44,7 +44,7 @@ make
 ```
 :::
 
-Python wheels are pre-built (`abi3`, Python 3.9+); no Rust toolchain needed on supported platforms. C++ links against the Rust FFI library built once with `cargo build`.
+Python wheels are pre-built (`abi3`, Python 3.12+); no Rust toolchain needed on supported platforms. C++ links against the Rust FFI library built once with `cargo build`.
 
 ## Authenticate
 

--- a/notebooks/live-chain/README.md
+++ b/notebooks/live-chain/README.md
@@ -40,6 +40,6 @@ Then open `http://localhost:8501` in your browser.
 
 ## Requirements
 
-- Python 3.9+
+- Python 3.12+
 - A ThetaData account with an active market data subscription
 - `thetadatadx` compiled for your platform (see main project README)

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -58,7 +58,7 @@ The Python SDK uses [PyO3](https://pyo3.rs/) with [Maturin](https://www.maturin.
 
 ## Validation Matrix
 
-- Python: wheel builds and import smoke are validated on Linux x64, macOS arm64 (Apple Silicon), and Windows x64. The package targets the CPython stable ABI (`abi3`) with a minimum version of Python 3.9, so one wheel per platform covers Python 3.9+.
+- Python: wheel builds and import smoke are validated on Linux x64, macOS arm64 (Apple Silicon), and Windows x64. The package targets the CPython stable ABI (`abi3`) with a minimum version of Python 3.12, so one wheel per platform covers Python 3.12+.
 - TypeScript/Node.js: pre-built napi-rs addons are shipped for Linux x64 (glibc), macOS arm64 (Apple Silicon), and Windows x64 (MSVC), on Node.js 18+.
 - C++: validated with CMake builds on Linux, macOS, and Windows against the generated FFI library.
 
@@ -95,7 +95,7 @@ g = all_greeks(spot=150.0, strike=155.0, rate=0.05,
                div_yield=0.015, tte=45/365, option_price=3.50, right="C")
 ```
 
-Requires Python 3.9+. Binary wheels target the CPython stable ABI, so one wheel works across supported Python 3.9+ interpreters on the same platform. See [sdks/python/README.md](python/README.md) for full documentation.
+Requires Python 3.12+. Binary wheels target the CPython stable ABI, so one wheel works across supported Python 3.12+ interpreters on the same platform. See [sdks/python/README.md](python/README.md) for full documentation.
 
 ## TypeScript / Node.js SDK
 

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -28,8 +28,8 @@ tdbe = { version = "0.13.1", path = "../../crates/tdbe" }
 prost = "=0.14.3"
 
 # PyO3 bindings. We target the stable ABI so one wheel per platform supports
-# every Python version from 3.9 upward.
-pyo3 = { version = "=0.28.3", features = ["abi3-py39", "multiple-pymethods"] }
+# every Python version from 3.12 upward.
+pyo3 = { version = "=0.28.3", features = ["abi3-py312", "multiple-pymethods"] }
 
 # Bridge between pyo3 and tokio so generated `*_async` methods return real
 # awaitables backed by the shared runtime singleton (no second runtime is

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -31,9 +31,9 @@ pip install "maturin>=1.9.4,<2.0"
 maturin develop --release
 ```
 
-Binary wheels use CPython's stable ABI (`abi3`) with a minimum Python version of 3.9, so one wheel per platform supports Python 3.9+.
+Binary wheels use CPython's stable ABI (`abi3`) with a minimum Python version of 3.12, so one wheel per platform supports Python 3.12+.
 
-Separate per-version wheels for PEP 703 free-threaded interpreters (`python3.13t`, `python3.14t`) will be picked up by `pip` automatically once the next PyPI release ships. The wheels carry `gil_used = false` on the extension module, so the GIL stays disabled after `import thetadatadx` and CPU-bound Python threads run truly in parallel with the gRPC dispatcher. After the next release lands, install on a free-threaded interpreter and a `cp313-cp313t-*` or `cp314-cp314t-*` wheel will be picked up; install on a stock interpreter and the `cp39-abi3-*` wheel applies.
+Separate per-version wheels for PEP 703 free-threaded interpreters (`python3.13t`, `python3.14t`) will be picked up by `pip` automatically once the next PyPI release ships. The wheels carry `gil_used = false` on the extension module, so the GIL stays disabled after `import thetadatadx` and CPU-bound Python threads run truly in parallel with the gRPC dispatcher. After the next release lands, install on a free-threaded interpreter and a `cp313-cp313t-*` or `cp314-cp314t-*` wheel will be picked up; install on a stock interpreter and the `cp312-abi3-*` wheel applies.
 
 ## Quick Start
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "thetadatadx"
 dynamic = ["version"]
 description = "No-JVM ThetaData Terminal — native Rust SDK for direct market data access (Python bindings)"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 authors = [{ name = "userFRM" }]
 keywords = ["thetadata", "market-data", "options", "streaming", "grpc"]
@@ -15,6 +15,10 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Financial and Insurance Industry",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading",
     "Programming Language :: Rust",
     "Topic :: Office/Business :: Financial :: Investment",
     "License :: OSI Approved :: Apache Software License",
@@ -32,9 +36,9 @@ Discord = "https://discord.thetadata.us/"
 # merges these into the wheel alongside the compiled `.so` extension
 # emitted from `src/lib.rs`.
 python-source = "python"
-# Stable ABI: one wheel per platform covers every CPython 3.9+ release.
+# Stable ABI: one wheel per platform covers every CPython 3.12+ release.
 #
-# The `abi3-py39` feature is unconditionally enabled here even on
+# The `abi3-py312` feature is unconditionally enabled here even on
 # the free-threaded `3.13t` / `3.14t` build matrix entries — PyO3
 # emits a benign warning at build time for those entries
 # ("free-threaded build ignores abi3"), but the wheel selection is
@@ -45,7 +49,7 @@ python-source = "python"
 # as intended; flipping it on / off per matrix entry would require a
 # maturin overlay file that maintains two source-of-truth feature
 # lists. See the GH Actions log for the documented warning shape.
-features = ["pyo3/abi3-py39"]
+features = ["pyo3/abi3-py312"]
 
 [project.optional-dependencies]
 # Arrow columnar pipeline (feat/arrow-columnar-dataframe):


### PR DESCRIPTION
## Summary

Two CI/packaging cleanups.

**1. Bench-regression gate (#614).** `stock_list_symbols/in_house` is a gRPC round-trip dominated by network / shared-runner I/O variance (swings +27–32% run-to-run) and false-failed the hard 25% gate, blocking unrelated PRs. Removed it from the gated baseline (it still runs, now informational); a `_meta_ungated` note records why. The 9 CPU microbenches (`streaming_channels/*`, `FpssEvent::clone|match/*`) stay gated — that's where real regressions surface.

**2. Python floor → 3.12.** CPython 3.9 is EOL (Oct 2025); 3.10/3.11 dropped too. `requires-python`, the abi3 floor (`pyo3/abi3-py312`), classifiers, the README badge, `python.yml` (floor-wheel interpreter + abi3-smoke matrix floor), and the docs all move to 3.12. Free-threaded 3.13t / 3.14t wheels are unaffected.

## Test plan
- [x] fmt, clippy (`--workspace --all-targets`), `cargo test --workspace`
- [x] banned-vocab, docs-consistency, SDK-surface check
- [x] abi3-py312 binding builds; `maturin build --interpreter python3.12` emits `cp312-abi3` wheel
- [x] bench gate no longer references the ungated bench (9 microbenches remain)

Closes #614