### PR TITLE
fix(release): republish tdbe as 0.14.0 and complete the v11.0.0 changelog

### DIFF
--- a/.github/release-notes/v11.0.0.md
+++ b/.github/release-notes/v11.0.0.md
@@ -25,6 +25,7 @@
 - `ChannelError::UpstreamCascade` folded into the existing `ChannelError::ConnectionClosed` variant. The mid-stream classifier `classify_h2_error_mid_stream` is gone; the open-phase classifier `classify_h2_error` covers both phases via a new `classify_h2_error_ref` thin wrapper.
 - TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint` (was `number`) for true `u64` parity with Python / C++ / FFI. Callers passing `Number` should wrap with `BigInt(60)`; negative or above-`u64::MAX` BigInt inputs are rejected at the boundary with a descriptive error rather than silently truncating.
 - `RestError::CsvDecode` and `RestError::MissingColumn` lift into `Error::Transport { kind: Codec, .. }` instead of `Error::Config { internal, .. }`, matching the gRPC-side `ChannelError::Codec` mapping so retry classifiers dispatch uniformly across both transports.
+- Minimum supported Python raised to 3.12. The abi3 floor and `requires-python` move from 3.9 to 3.12; CPython 3.9 (EOL Oct 2025), 3.10, and 3.11 wheels are no longer published. Free-threaded 3.13t / 3.14t wheels are unaffected.
 
 ### Added
 
@@ -56,6 +57,7 @@
 - `FpssClient::connect` rejects a non-power-of-two `ring_size` with `Error::Config` rather than silently rounding to the next power of two; default configs (`131_072`) are unchanged and still valid.
 - FPSS control events surface as typed-per-variant classes across Python, TypeScript, and the C / C++ FFI surface, mirroring the Rust `FpssControl` enum one-for-one. Python dispatch via `match event: case LoginSuccess(permissions=p): ... case Disconnected(reason=r): ...`; TypeScript via the discriminated union's `kind` field; C consumers via `event->kind` into the matching `event-><variant>` payload; C++ uses re-exported `tdx::Fpss<Variant>` aliases. Schema bumped to version 5 (`crates/thetadatadx/fpss_event_schema.toml`).
 - `MddsConfig.override_tier_clamp` (Rust `bool`, default `false`) bypasses the connect-time clamp of `concurrent_requests` to the resolved subscription-tier cap. Rust-only by design (no binding setters); intended for exercising the over-provisioning path against a stubbed authentication response, not production use.
+- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
 
 ### Changed
 
@@ -87,6 +89,7 @@
 - `MddsClient` REST-fallback shims downgrade per-call `start_date` / `end_date` logging from `tracing::debug!` to `tracing::trace!` so routine operator-visible logs no longer echo request date ranges.
 - `interval` millisecond-shorthand normalization realigned to the upstream preset vocabulary. The `"0"` sentinel now resolves to `"tick"` (every event) instead of the prior silent `"100ms"`, and the `1..=10` ms band resolves to `"10ms"` (previously folded into `"100ms"`). Callers that relied on `"0"` meaning `"100ms"` must pass an explicit preset.
 - Dynamic endpoint invocation (`EndpointArgs`, used by the CLI and MCP surfaces) strictly validates the `interval` argument against the upstream preset set (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`) or an all-digit millisecond shorthand. Non-preset strings such as `"1minute"` — previously accepted by the looser alphanumeric check — now surface a typed `EndpointError::InvalidParams` naming the accepted values before any request dispatches.
+- The `stock_list_symbols/in_house` benchmark is excluded from the hard bench-regression gate (it is a network-bound gRPC round-trip whose variance exceeds the threshold by construction); it still runs for information. CPU microbenches remain gated. (#614)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking changes
-
-- Minimum supported Python raised to 3.12. The abi3 floor and `requires-python` move from 3.9 to 3.12; CPython 3.9 (EOL Oct 2025), 3.10, and 3.11 wheels are no longer published. Free-threaded 3.13t / 3.14t wheels are unaffected.
-
-### Added
-
-- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
-
-### Changed
-
-- The `stock_list_symbols/in_house` benchmark is excluded from the hard bench-regression gate (it is a network-bound gRPC round-trip whose variance exceeds the threshold by construction); it still runs for information. CPU microbenches remain gated. (#614)
-
-## [11.0.0] - 2026-05-27
+## [11.0.0] - 2026-05-29
 
 ### Breaking changes
 
@@ -46,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ChannelError::UpstreamCascade` folded into the existing `ChannelError::ConnectionClosed` variant. The mid-stream classifier `classify_h2_error_mid_stream` is gone; the open-phase classifier `classify_h2_error` covers both phases via a new `classify_h2_error_ref` thin wrapper.
 - TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint` (was `number`) for true `u64` parity with Python / C++ / FFI. Callers passing `Number` should wrap with `BigInt(60)`; negative or above-`u64::MAX` BigInt inputs are rejected at the boundary with a descriptive error rather than silently truncating.
 - `RestError::CsvDecode` and `RestError::MissingColumn` lift into `Error::Transport { kind: Codec, .. }` instead of `Error::Config { internal, .. }`, matching the gRPC-side `ChannelError::Codec` mapping so retry classifiers dispatch uniformly across both transports.
+- Minimum supported Python raised to 3.12. The abi3 floor and `requires-python` move from 3.9 to 3.12; CPython 3.9 (EOL Oct 2025), 3.10, and 3.11 wheels are no longer published. Free-threaded 3.13t / 3.14t wheels are unaffected.
 
 ### Added
 
@@ -77,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FpssClient::connect` rejects a non-power-of-two `ring_size` with `Error::Config` rather than silently rounding to the next power of two; default configs (`131_072`) are unchanged and still valid.
 - FPSS control events surface as typed-per-variant classes across Python, TypeScript, and the C / C++ FFI surface, mirroring the Rust `FpssControl` enum one-for-one. Python dispatch via `match event: case LoginSuccess(permissions=p): ... case Disconnected(reason=r): ...`; TypeScript via the discriminated union's `kind` field; C consumers via `event->kind` into the matching `event-><variant>` payload; C++ uses re-exported `tdx::Fpss<Variant>` aliases. Schema bumped to version 5 (`crates/thetadatadx/fpss_event_schema.toml`).
 - `MddsConfig.override_tier_clamp` (Rust `bool`, default `false`) bypasses the connect-time clamp of `concurrent_requests` to the resolved subscription-tier cap. Rust-only by design (no binding setters); intended for exercising the over-provisioning path against a stubbed authentication response, not production use.
+- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
 
 ### Changed
 
@@ -108,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MddsClient` REST-fallback shims downgrade per-call `start_date` / `end_date` logging from `tracing::debug!` to `tracing::trace!` so routine operator-visible logs no longer echo request date ranges.
 - `interval` millisecond-shorthand normalization realigned to the upstream preset vocabulary. The `"0"` sentinel now resolves to `"tick"` (every event) instead of the prior silent `"100ms"`, and the `1..=10` ms band resolves to `"10ms"` (previously folded into `"100ms"`). Callers that relied on `"0"` meaning `"100ms"` must pass an explicit preset.
 - Dynamic endpoint invocation (`EndpointArgs`, used by the CLI and MCP surfaces) strictly validates the `interval` argument against the upstream preset set (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`) or an all-digit millisecond shorthand. Non-preset strings such as `"1minute"` — previously accepted by the looser alphanumeric check — now surface a typed `EndpointError::InvalidParams` naming the accepted values before any request dispatches.
+- The `stock_list_symbols/in_house` benchmark is excluded from the hard bench-regression gate (it is a network-bound gRPC round-trip whose variance exceeds the threshold by construction); it still runs for information. CPU microbenches remain gated. (#614)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,7 +3484,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "criterion",
  "proptest",

--- a/crates/tdbe/Cargo.toml
+++ b/crates/tdbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdbe"
-version = "0.13.1"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -67,7 +67,7 @@ __test-helpers = []
 # system allocator pay no compile or link cost.
 mimalloc-allocator = ["dep:mimalloc"]
 [dependencies]
-tdbe = { version = "0.13.1", path = "../tdbe" }
+tdbe = { version = "0.14.0", path = "../tdbe" }
 
 # Protobuf message types for the MDDS wire contract. The in-house
 # gRPC client stack (`src/grpc/`) consumes these directly — no tonic.
@@ -257,7 +257,7 @@ prost-build = "=0.14.3"
 regex = "1.12.3"
 toml = "1.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
-tdbe = { version = "0.13.1", path = "../tdbe" }
+tdbe = { version = "0.14.0", path = "../tdbe" }
 
 # POSIX `pipe2` / `write` / `close` for the asyncio wake-fd bridge used
 # by the Python SDK's `streaming_async()` surface (see

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,19 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking changes
-
-- Minimum supported Python raised to 3.12. The abi3 floor and `requires-python` move from 3.9 to 3.12; CPython 3.9 (EOL Oct 2025), 3.10, and 3.11 wheels are no longer published. Free-threaded 3.13t / 3.14t wheels are unaffected.
-
-### Added
-
-- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
-
-### Changed
-
-- The `stock_list_symbols/in_house` benchmark is excluded from the hard bench-regression gate (it is a network-bound gRPC round-trip whose variance exceeds the threshold by construction); it still runs for information. CPU microbenches remain gated. (#614)
-
-## [11.0.0] - 2026-05-27
+## [11.0.0] - 2026-05-29
 
 ### Breaking changes
 
@@ -46,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ChannelError::UpstreamCascade` folded into the existing `ChannelError::ConnectionClosed` variant. The mid-stream classifier `classify_h2_error_mid_stream` is gone; the open-phase classifier `classify_h2_error` covers both phases via a new `classify_h2_error_ref` thin wrapper.
 - TypeScript `Config.setReconnectStableWindowSecs` accepts `bigint` (was `number`) for true `u64` parity with Python / C++ / FFI. Callers passing `Number` should wrap with `BigInt(60)`; negative or above-`u64::MAX` BigInt inputs are rejected at the boundary with a descriptive error rather than silently truncating.
 - `RestError::CsvDecode` and `RestError::MissingColumn` lift into `Error::Transport { kind: Codec, .. }` instead of `Error::Config { internal, .. }`, matching the gRPC-side `ChannelError::Codec` mapping so retry classifiers dispatch uniformly across both transports.
+- Minimum supported Python raised to 3.12. The abi3 floor and `requires-python` move from 3.9 to 3.12; CPython 3.9 (EOL Oct 2025), 3.10, and 3.11 wheels are no longer published. Free-threaded 3.13t / 3.14t wheels are unaffected.
 
 ### Added
 
@@ -77,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FpssClient::connect` rejects a non-power-of-two `ring_size` with `Error::Config` rather than silently rounding to the next power of two; default configs (`131_072`) are unchanged and still valid.
 - FPSS control events surface as typed-per-variant classes across Python, TypeScript, and the C / C++ FFI surface, mirroring the Rust `FpssControl` enum one-for-one. Python dispatch via `match event: case LoginSuccess(permissions=p): ... case Disconnected(reason=r): ...`; TypeScript via the discriminated union's `kind` field; C consumers via `event->kind` into the matching `event-><variant>` payload; C++ uses re-exported `tdx::Fpss<Variant>` aliases. Schema bumped to version 5 (`crates/thetadatadx/fpss_event_schema.toml`).
 - `MddsConfig.override_tier_clamp` (Rust `bool`, default `false`) bypasses the connect-time clamp of `concurrent_requests` to the resolved subscription-tier cap. Rust-only by design (no binding setters); intended for exercising the over-provisioning path against a stubbed authentication response, not production use.
+- `FpssClient::connect_consumer` returns the client paired with an `FpssEventPoller` whose `run` loop drives the streaming ring on the caller's own thread. No consumer thread is spawned and no intermediate queue is allocated, so an embedded Rust consumer drains the single SDK ring directly with a zero-copy borrow per event. `FpssEventPoller::poll_batch` adds a non-blocking single-batch drain returning a `PollOutcome` for callers that integrate the drive into their own loop. The existing push-callback (`FpssClient::connect`) and pull-iterator (`FpssClient::connect_iter`) delivery modes are unchanged; the I/O reader, reconnect, and re-subscribe paths are shared across all three. Rust-only surface.
 
 ### Changed
 
@@ -108,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MddsClient` REST-fallback shims downgrade per-call `start_date` / `end_date` logging from `tracing::debug!` to `tracing::trace!` so routine operator-visible logs no longer echo request date ranges.
 - `interval` millisecond-shorthand normalization realigned to the upstream preset vocabulary. The `"0"` sentinel now resolves to `"tick"` (every event) instead of the prior silent `"100ms"`, and the `1..=10` ms band resolves to `"10ms"` (previously folded into `"100ms"`). Callers that relied on `"0"` meaning `"100ms"` must pass an explicit preset.
 - Dynamic endpoint invocation (`EndpointArgs`, used by the CLI and MCP surfaces) strictly validates the `interval` argument against the upstream preset set (`tick`, `10ms`, `100ms`, `500ms`, `1s`, `5s`, `10s`, `15s`, `30s`, `1m`, `5m`, `10m`, `15m`, `30m`, `1h`) or an all-digit millisecond shorthand. Non-preset strings such as `"1minute"` — previously accepted by the looser alphanumeric check — now surface a typed `EndpointError::InvalidParams` naming the accepted values before any request dispatches.
+- The `stock_list_symbols/in_house` benchmark is excluded from the hard bench-regression gate (it is a network-bound gRPC round-trip whose variance exceeds the threshold by construction); it still runs for information. CPU microbenches remain gated. (#614)
 
 ### Fixed
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -31,7 +31,7 @@ testing-panic-boundary = []
 
 [dependencies]
 thetadatadx = { path = "../crates/thetadatadx", features = ["arrow"] }
-tdbe = { version = "0.13.1", path = "../crates/tdbe" }
+tdbe = { version = "0.14.0", path = "../crates/tdbe" }
 tokio = { version = "1.52.3", features = ["rt-multi-thread"] }
 arrow-array = "58.1.0"
 arrow-ipc = "58.1.0"

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2422,7 +2422,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tdbe"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -20,7 +20,7 @@ doc = false
 [dependencies]
 # The Rust SDK we're wrapping
 thetadatadx = { path = "../../crates/thetadatadx", features = ["arrow"] }
-tdbe = { version = "0.13.1", path = "../../crates/tdbe" }
+tdbe = { version = "0.14.0", path = "../../crates/tdbe" }
 
 # Direct prost dep for decoding `thetadatadx::proto::ResponseData` bytes in
 # the `decode_response_bytes` hook. The main crate no longer re-exports

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["arrow"] }
-tdbe = { version = "0.13.1", path = "../../crates/tdbe" }
+tdbe = { version = "0.14.0", path = "../../crates/tdbe" }
 
 napi = { version = "3.8.5", features = ["async", "tokio_rt", "serde-json", "napi6", "chrono_date"] }
 arrow-array = "58.1.0"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.13.1", path = "../../crates/tdbe" }
+tdbe = { version = "0.14.0", path = "../../crates/tdbe" }
 clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros"] }
 sonic-rs = "0.5.8"

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx" }
-tdbe = { version = "0.13.1", path = "../../crates/tdbe" }
+tdbe = { version = "0.14.0", path = "../../crates/tdbe" }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 sonic-rs = "0.5.8"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "tdbe"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 [dependencies]
 thetadatadx = { path = "../../crates/thetadatadx", features = ["config-file"] }
 rustls = { version = "0.23.38", features = ["ring"] }
-tdbe = { version = "0.13.1", path = "../../crates/tdbe" }
+tdbe = { version = "0.14.0", path = "../../crates/tdbe" }
 axum = { version = "0.8.9", features = ["ws"] }
 tokio = { version = "1.52.1", features = ["full"] }
 sonic-rs = "0.5.8"


### PR DESCRIPTION
## Summary

Two release blockers found while verifying the v11.0.0 publish path.

**tdbe republish (#616).** The published `tdbe 0.13.1` predates the v11 tick-type and `Price` work, so the tag-driven `cargo publish -p thetadatadx` resolved the registry copy and failed with 31 compile errors (`with_value_and_type`, `OhlcTick.vwap`, the new tick types all missing). Bumped `tdbe` to `0.14.0` — breaking, since `IvTick` grew 64→128 bytes with new required fields and the tick structs are not `#[non_exhaustive]` — across all eight dependents and the five tracked lockfiles.

**Changelog completeness (#617).** The Python 3.12 floor (a breaking interpreter drop), `connect_consumer`, and the bench-gate change were stranded under `[Unreleased]`. Folded into `[11.0.0]` across `CHANGELOG.md`, the docs-site mirror, and `.github/release-notes/v11.0.0.md` so the published release body documents the dropped CPython versions.

## Verification

- `cargo publish --dry-run -p tdbe --locked` packages, verifies, and compiles `0.14.0`.
- `cargo publish --dry-run -p thetadatadx` now fails only on `tdbe ^0.14.0` not-yet-on-registry — the publish-order artifact the release workflow resolves by publishing tdbe before thetadatadx.
- `cargo check` / `cargo clippy --workspace`, `cargo fmt --check`, banned-vocab, and docs-consistency all clean.

Closes #616
Closes #617