### PR TITLE
chore(release): v11.0.1

### DIFF
--- a/.github/release-notes/v11.0.1.md
+++ b/.github/release-notes/v11.0.1.md
@@ -1,6 +1,6 @@
-## ThetaDataDx 11.1.0
+## ThetaDataDx 11.0.1
 
-An idle-CPU fix for the historical-channel decode pipeline on the v11 line. No API changes; the companion `tdbe` crate stays at `0.14.0`.
+A patch on the v11 line: an idle-CPU fix for the historical-channel decode pipeline. No API changes; the companion `tdbe` crate stays at `0.14.0`.
 
 ### Fixed
 

--- a/.github/release-notes/v11.1.0.md
+++ b/.github/release-notes/v11.1.0.md
@@ -1,0 +1,7 @@
+## ThetaDataDx 11.1.0
+
+An idle-CPU fix for the historical-channel decode pipeline on the v11 line. No API changes; the companion `tdbe` crate stays at `0.14.0`.
+
+### Fixed
+
+- The historical-channel decode pipeline's stage-1 wait strategy now parks on a 30 µs microsleep floor once its spin and yield phases elapse, instead of ending in a bare `std::hint::spin_loop` hint. That hint is a CPU pause, not a scheduler yield, so an idle decoder thread stayed `RUNNABLE` and re-polled continuously, pinning each idle stage-1 thread at roughly 100% CPU. Idle decoder CPU now drops to about 0% with no measurable change to active-path decode latency. ([#619](https://github.com/userFRM/ThetaDataDx/issues/619))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.1.0] - 2026-05-29
+## [11.0.1] - 2026-05-29
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.1.0] - 2026-05-29
+
 ### Fixed
 
 - The historical-channel decode pipeline's stage-1 wait strategy now parks on a 30 µs microsleep floor once its spin and yield phases elapse, instead of ending in a bare `std::hint::spin_loop` hint. That hint is a CPU pause, not a scheduler yield, so an idle decoder thread stayed `RUNNABLE` and re-polled continuously, pinning each idle stage-1 thread at roughly 100% CPU. Idle decoder CPU now drops to about 0% with no measurable change to active-path decode latency. ([#619](https://github.com/userFRM/ThetaDataDx/issues/619))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "11.0.0"
+version = "11.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "11.1.0"
+version = "11.0.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.1.0] - 2026-05-29
+## [11.0.1] - 2026-05-29
 
 ### Fixed
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.1.0] - 2026-05-29
+
 ### Fixed
 
 - The historical-channel decode pipeline's stage-1 wait strategy now parks on a 30 µs microsleep floor once its spin and yield phases elapse, instead of ending in a bare `std::hint::spin_loop` hint. That hint is a CPU pause, not a scheduler yield, so an idle decoder thread stayed `RUNNABLE` and re-polled continuously, pinning each idle stage-1 thread at roughly 100% CPU. Idle decoder CPU now drops to about 0% with no measurable change to active-path decode latency. ([#619](https://github.com/userFRM/ThetaDataDx/issues/619))

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "11.0.0"
+version = "11.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "11.1.0"
+version = "11.0.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 # (`Cargo.toml`, `crates/*/Cargo.toml`, `tools/*/Cargo.toml`) and the
 # TypeScript `package.json` files. Keep all of them in lockstep when
 # cutting an 11.0.x release — see `CHANGELOG.md` for the canonical version.
-project(thetadatadx-cpp VERSION 11.0.0 LANGUAGES CXX)
+project(thetadatadx-cpp VERSION 11.0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "11.0.0"
+version = "11.1.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "11.1.0"
+version = "11.0.1"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "11.1.0"
+version = "11.0.1"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "11.0.0"
+version = "11.1.0"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm64')
         const bindingPackageVersion = require('thetadatadx-android-arm64/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm-eabi')
         const bindingPackageVersion = require('thetadatadx-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-gnu')
         const bindingPackageVersion = require('thetadatadx-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-ia32-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-arm64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('thetadatadx-darwin-universal')
       const bindingPackageVersion = require('thetadatadx-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-x64')
         const bindingPackageVersion = require('thetadatadx-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-arm64')
         const bindingPackageVersion = require('thetadatadx-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-x64')
         const bindingPackageVersion = require('thetadatadx-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-arm64')
         const bindingPackageVersion = require('thetadatadx-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-musleabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-gnueabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-ppc64-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-s390x-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm64')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-x64')
         const bindingPackageVersion = require('thetadatadx-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '11.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 11.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '11.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 11.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Native ThetaData SDK for Node.js — powered by Rust via napi-rs",
   "license": "Apache-2.0",
   "repository": {
@@ -30,9 +30,9 @@
     "@napi-rs/cli": "^3.6.2"
   },
   "optionalDependencies": {
-    "thetadatadx-linux-x64-gnu": "11.0.0",
-    "thetadatadx-darwin-arm64": "11.0.0",
-    "thetadatadx-win32-x64-msvc": "11.0.0"
+    "thetadatadx-linux-x64-gnu": "11.0.1",
+    "thetadatadx-darwin-arm64": "11.0.1",
+    "thetadatadx-win32-x64-msvc": "11.0.1"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "11.1.0"
+version = "11.0.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "11.0.0"
+version = "11.1.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "11.1.0"
+version = "11.0.1"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "11.0.0"
+version = "11.1.0"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "11.1.0"
+version = "11.0.1"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "11.0.0"
+version = "11.1.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "11.1.0"
+version = "11.0.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
## Summary

Patch release on the v11 line. Ships the historical-channel decode-pipeline idle-CPU fix from #619 (landed in #620): idle stage-1 decoder threads now park on a 30 µs microsleep floor instead of busy-spinning a core at ~100%.

- Bumps `thetadatadx`, `thetadatadx-py`, `thetadatadx-napi`, `thetadatadx-cli`, `thetadatadx-server`, `thetadatadx-mcp`, and `thetadatadx-ffi` **11.0.0 → 11.0.1**.
- Refreshes the five tracked `Cargo.lock` files.
- Promotes the `[Unreleased]` changelog entry to `[11.0.1]` (CHANGELOG + docs-site mirror) and adds `.github/release-notes/v11.0.1.md`.
- The companion `tdbe` crate is unchanged and stays at **0.14.0** (already on crates.io; the publish step skips it).

**Patch, not minor:** #619 is a backwards-compatible bug fix with no public API change (`DecoderWaitStrategy` is `pub(crate)`).

## Verification

`cargo fmt --check`, `cargo check --workspace --locked`, banned-vocab, and docs-consistency all clean. The code fix passed full CI in #620.