### PR TITLE
fix(tools): install the rustls provider at CLI and MCP startup

### DIFF
--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -1781,6 +1781,12 @@ fn render_output(ep: &EndpointMeta, output: EndpointOutput, fmt: &OutputFormat) 
 
 #[tokio::main]
 async fn main() {
+    // Seat ring as the process-default rustls CryptoProvider before any
+    // TLS handshake. The workspace compiles ring as the only provider;
+    // reqwest's rustls path requires the default to be installed
+    // explicitly. Mirrors the server binary's startup.
+    let _ = thetadatadx::__internal_install_ring_crypto_provider();
+
     let matches = build_cli().get_matches();
 
     if let Err(e) = run(matches).await {

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -1233,6 +1233,12 @@ fn parse_args() -> Args {
 
 #[tokio::main]
 async fn main() {
+    // Seat ring as the process-default rustls CryptoProvider before any
+    // TLS handshake. The workspace compiles ring as the only provider;
+    // reqwest's rustls path requires the default to be installed
+    // explicitly. Mirrors the server binary's startup.
+    let _ = thetadatadx::__internal_install_ring_crypto_provider();
+
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(


### PR DESCRIPTION
## Summary

The workspace compiles ring as the only rustls CryptoProvider, and reqwest's rustls path requires the process-default provider to be installed before the first TLS handshake. The server binary seats the provider at the top of `main`; the CLI and MCP binaries did not, so their first authenticated command panicked with `No provider set` before the request left the process.

Two one-line fixes: call the crate's provider-install helper as the first statement of each binary's `main`, mirroring the server binary's startup sequence.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo check -p thetadatadx-cli` + `cargo check --manifest-path tools/mcp/Cargo.toml --locked` clean
- `cargo clippy -p thetadatadx-cli -- -D warnings` clean
- Live smoke: `tdx stock history_eod AAPL 20260101 20260301` with throwaway credentials now completes the TLS handshake and returns the typed `Authentication error (InvalidCredentials)` instead of panicking.

Closes #657