### PR TITLE
fix(errors): unify the typed error vocabulary and structured detail across bindings

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -51,10 +51,11 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Mirror the documented deferral in deny.toml: RUSTSEC-2026-0176
-          # (PyList/PyTuple `nth` out-of-bounds read) is fixed in pyo3 0.29,
-          # but pyo3-async-runtimes and pyo3-arrow still cap at `pyo3 ^0.28`,
-          # so 0.29 cannot resolve yet. Exposure is nil — the workspace never
-          # calls the affected methods. Remove with the deny.toml entry when
-          # the bump lands. Tracked in #684.
-          ignore: RUSTSEC-2026-0176
+          # Mirror the documented deferrals in deny.toml: RUSTSEC-2026-0176
+          # (PyList/PyTuple `nth` out-of-bounds read) and RUSTSEC-2026-0177
+          # (missing `Sync` bound on `PyCFunction::new_closure`) are both fixed
+          # in pyo3 0.29, but pyo3-async-runtimes and pyo3-arrow still cap at
+          # `pyo3 ^0.28`, so 0.29 cannot resolve yet. Exposure is nil — the
+          # workspace calls neither affected API. Remove with the deny.toml
+          # entries when the bump lands. Tracked in #684.
+          ignore: RUSTSEC-2026-0176,RUSTSEC-2026-0177

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -51,11 +51,3 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Mirror the documented deferrals in deny.toml: RUSTSEC-2026-0176
-          # (PyList/PyTuple `nth` out-of-bounds read) and RUSTSEC-2026-0177
-          # (missing `Sync` bound on `PyCFunction::new_closure`) are both fixed
-          # in pyo3 0.29, but pyo3-async-runtimes and pyo3-arrow still cap at
-          # `pyo3 ^0.28`, so 0.29 cannot resolve yet. Exposure is nil — the
-          # workspace calls neither affected API. Remove with the deny.toml
-          # entries when the bump lands. Tracked in #684.
-          ignore: RUSTSEC-2026-0176,RUSTSEC-2026-0177

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -51,3 +51,10 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Mirror the documented deferral in deny.toml: RUSTSEC-2026-0176
+          # (PyList/PyTuple `nth` out-of-bounds read) is fixed in pyo3 0.29,
+          # but pyo3-async-runtimes and pyo3-arrow still cap at `pyo3 ^0.28`,
+          # so 0.29 cannot resolve yet. Exposure is nil — the workspace never
+          # calls the affected methods. Remove with the deny.toml entry when
+          # the bump lands. Tracked in #684.
+          ignore: RUSTSEC-2026-0176

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -2502,18 +2502,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2521,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2533,13 +2533,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2487,63 +2487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
-dependencies = [
- "libc",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
-dependencies = [
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,12 +3307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
 name = "tdbe"
 version = "0.14.0"
 dependencies = [
@@ -3419,7 +3356,6 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "pyo3",
  "rand",
  "regex",
  "reqwest",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -234,7 +234,7 @@ toml = "1.1.2"
 # PyO3 with `auto-initialize` so the `streaming_throughput` bench can
 # acquire the GIL without an explicit `Py_Initialize`. dev-only — never
 # enters the published crate graph.
-pyo3 = { version = "=0.28.3", features = ["auto-initialize"] }
+pyo3 = { version = "=0.29.0", features = ["auto-initialize"] }
 
 # Signal-driven sampling profiler used by the concurrent-burst bench
 # to emit a flamegraph SVG when `THETADATADX_FLAMEGRAPH=1` is set.

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -231,10 +231,6 @@ proptest = "1.5"
 # Test-only: load captured-response fixtures and their sidecar .meta.toml
 # files for the decoder-regression suite.
 toml = "1.1.2"
-# PyO3 with `auto-initialize` so the `streaming_throughput` bench can
-# acquire the GIL without an explicit `Py_Initialize`. dev-only — never
-# enters the published crate graph.
-pyo3 = { version = "=0.29.0", features = ["auto-initialize"] }
 
 # Signal-driven sampling profiler used by the concurrent-burst bench
 # to emit a flamegraph SVG when `THETADATADX_FLAMEGRAPH=1` is set.

--- a/crates/thetadatadx/benches/streaming_throughput.rs
+++ b/crates/thetadatadx/benches/streaming_throughput.rs
@@ -27,25 +27,18 @@
 //!   allocation) — this matches the live decode path where the
 //!   contract is interned in the FPSS contract cache and every event
 //!   takes a refcount on the same pointer.
-//! - Python variants pre-acquire the deque / Queue object once per
-//!   sample and stash it as `Py<PyAny>` on the consumer closure. The
-//!   timed region acquires the GIL per event (matches the recommended
-//!   Python integration pattern from `sdks/python/README.md`).
 //!
 //! Run: `cargo bench --bench streaming_throughput -- --noplot`
 
 use std::ffi::c_void;
 use std::hint::black_box;
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use disruptor::{build_single_producer, BusySpin, Producer, Sequence};
-use pyo3::exceptions::PyValueError;
-use pyo3::prelude::*;
-use pyo3::types::PyDict;
 use tdbe::types::price::Price;
 use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::fpss::{FpssData, FpssEvent};
@@ -257,224 +250,6 @@ fn run_ffi_simulated(contract: Arc<Contract>) -> (u64, Duration) {
     result
 }
 
-// ─── Variant 5: PyO3 + collections.deque.append(tuple) ────────────────
-
-fn run_pyo3_deque_append(contract: Arc<Contract>) -> (u64, Duration) {
-    // Acquire the deque object once per sample. Two `Py<PyAny>`
-    // handles: one held by the bench thread (for length read-out
-    // after the run), one moved into the consumer closure.
-    let (deque, deque_consumer) = Python::attach(|py| -> PyResult<(Py<PyAny>, Py<PyAny>)> {
-        let collections = py.import("collections")?;
-        let deque_cls = collections.getattr("deque")?;
-        let kwargs = PyDict::new(py);
-        kwargs.set_item("maxlen", EVENTS_PER_ITER + 16)?;
-        let dq = deque_cls.call((), Some(&kwargs))?.unbind();
-        let dq_clone = dq.clone_ref(py);
-        Ok((dq, dq_clone))
-    })
-    .expect("pyo3 deque construction failed");
-
-    let (producer, delivered) = build_pipeline(move |evt: &FpssEvent| {
-        Python::attach(|py| {
-            // Mirror the recommended Python integration pattern: build
-            // a small tuple (5 fields) and append it to the deque.
-            // Tuple construction is the dominant cost on the Python
-            // side because it allocates a PyObject per event.
-            if let FpssEvent::Data(FpssData::Trade {
-                ms_of_day,
-                price,
-                size,
-                received_at_ns,
-                ..
-            }) = evt
-            {
-                if let Ok(tup) = (*ms_of_day, *price, *size, *received_at_ns).into_pyobject(py) {
-                    let _ = deque_consumer.bind(py).call_method1("append", (tup,));
-                }
-            }
-        });
-    });
-    let result = drive_publish(producer, delivered, contract);
-    let len = Python::attach(|py| deque.bind(py).len().expect("deque len"));
-    black_box(len);
-    result
-}
-
-// ─── Variant 6: PyO3 + queue.Queue.put_nowait(tuple) ──────────────────
-
-fn run_pyo3_queue_put_nowait(contract: Arc<Contract>) -> (u64, Duration) {
-    let (q, q_consumer) = Python::attach(|py| -> PyResult<(Py<PyAny>, Py<PyAny>)> {
-        let queue_mod = py.import("queue")?;
-        let queue_cls = queue_mod.getattr("Queue")?;
-        // maxsize=0 -> unbounded. Matches the typical "drain on
-        // worker thread" pattern for Python integrators.
-        let q = queue_cls.call((0i32,), None)?.unbind();
-        let q_clone = q.clone_ref(py);
-        Ok((q, q_clone))
-    })
-    .expect("pyo3 Queue construction failed");
-
-    let (producer, delivered) = build_pipeline(move |evt: &FpssEvent| {
-        Python::attach(|py| {
-            if let FpssEvent::Data(FpssData::Trade {
-                ms_of_day,
-                price,
-                size,
-                received_at_ns,
-                ..
-            }) = evt
-            {
-                if let Ok(tup) = (*ms_of_day, *price, *size, *received_at_ns).into_pyobject(py) {
-                    let _ = q_consumer.bind(py).call_method1("put_nowait", (tup,));
-                }
-            }
-        });
-    });
-    let result = drive_publish(producer, delivered, contract);
-    let qsize = Python::attach(|py| {
-        q.bind(py)
-            .call_method0("qsize")
-            .and_then(|v| v.extract::<usize>())
-            .unwrap_or(0)
-    });
-    black_box(qsize);
-    result
-}
-
-// ─── Variant 7: PyO3 zero-copy lazy-getter pyclass + deque.append ─────
-//
-// Mirrors the Python SDK's `FpssEvent` zero-copy wrapper. A
-// `#[pyclass(frozen, freelist = 256)]` is reused across events via
-// PyO3's per-class freelist (no heap alloc per event). The class
-// holds a raw `*const FpssEvent` borrowed from the consumer closure
-// scope plus a per-instance `AtomicBool` lifetime guard. Field access
-// through the lazy getters is what the Python user pays — the
-// 5-field tuple build of variant 5 is gone.
-//
-// The bench callback only touches one field (`price`) on the
-// event, matching the typical "filter by price band" pattern; the
-// throughput floor is the cost of crossing the binding once
-// regardless of how many fields the user reads.
-
-#[pyclass(frozen, freelist = 256, name = "BenchFpssEvent")]
-struct BenchPyEvent {
-    /// Raw pointer to a `FpssEvent` borrowed from the Disruptor consumer
-    /// closure scope. Valid only while `valid` is true; flipped to false
-    /// after the synchronous user callback returns.
-    inner: *const FpssEvent,
-    /// Lifetime guard. `Acquire` on every getter, `Release` after the
-    /// callback returns. A retained handle (e.g., the user pushed the
-    /// event into a list) raises `ValueError` on subsequent field access
-    /// rather than reading freed memory.
-    valid: AtomicBool,
-}
-
-// SAFETY: `BenchPyEvent` is constructed and dropped on the same
-// (Disruptor consumer) thread; the Python interpreter may move the
-// PyObject across threads, but every field access goes through the
-// `valid: AtomicBool` gate so a stale pointer can never be
-// dereferenced after the closure returns. The underlying `FpssEvent`
-// is `Send + Sync` (`Arc<Contract>` + scalars). The bench mirrors the
-// SDK's contract here exactly.
-unsafe impl Send for BenchPyEvent {}
-// SAFETY: same argument as the `Send` impl above — every field access
-// is gated by an `Acquire` load on `valid`, so a thread that observes a
-// live `BenchPyEvent` reads a non-stale `FpssEvent` reference. The
-// `FpssEvent` graph itself is `Sync`.
-unsafe impl Sync for BenchPyEvent {}
-
-impl BenchPyEvent {
-    #[inline]
-    fn evt(&self) -> PyResult<&FpssEvent> {
-        if !self.valid.load(Ordering::Acquire) {
-            return Err(PyValueError::new_err(
-                "BenchFpssEvent accessed outside callback scope",
-            ));
-        }
-        // SAFETY: `valid` is true, which the consumer closure guarantees
-        // until it sets `valid = false` on closure exit. The pointer
-        // therefore points at a `FpssEvent` borrowed from a stack-pinned
-        // closure scope that strictly outlives the synchronous getter
-        // call.
-        Ok(unsafe { &*self.inner })
-    }
-}
-
-#[pymethods]
-impl BenchPyEvent {
-    #[getter]
-    fn price(&self) -> PyResult<Option<f64>> {
-        match self.evt()? {
-            FpssEvent::Data(FpssData::Trade { price, .. }) => Ok(Some(*price)),
-            _ => Ok(None),
-        }
-    }
-    #[getter]
-    fn size(&self) -> PyResult<Option<i32>> {
-        match self.evt()? {
-            FpssEvent::Data(FpssData::Trade { size, .. }) => Ok(Some(*size)),
-            _ => Ok(None),
-        }
-    }
-    #[getter]
-    fn ms_of_day(&self) -> PyResult<Option<i32>> {
-        match self.evt()? {
-            FpssEvent::Data(FpssData::Trade { ms_of_day, .. }) => Ok(Some(*ms_of_day)),
-            _ => Ok(None),
-        }
-    }
-}
-
-fn run_pyo3_zerocopy_class_deque_append(contract: Arc<Contract>) -> (u64, Duration) {
-    let (deque, deque_consumer) = Python::attach(|py| -> PyResult<(Py<PyAny>, Py<PyAny>)> {
-        let collections = py.import("collections")?;
-        let deque_cls = collections.getattr("deque")?;
-        let kwargs = PyDict::new(py);
-        kwargs.set_item("maxlen", EVENTS_PER_ITER + 16)?;
-        let dq = deque_cls.call((), Some(&kwargs))?.unbind();
-        let dq_clone = dq.clone_ref(py);
-        Ok((dq, dq_clone))
-    })
-    .expect("pyo3 deque construction failed");
-
-    let (producer, delivered) = build_pipeline(move |evt: &FpssEvent| {
-        Python::attach(|py| {
-            // SAFETY: `evt` is borrowed from the consumer closure
-            // scope and lives for the synchronous duration of this
-            // `Python::attach` block — the lifetime guard below
-            // invalidates the wrapper immediately on scope exit, so
-            // the user code (here `deque.append(py_evt)`) cannot read
-            // the pointer after we leave.
-            let py_evt = match Py::new(
-                py,
-                BenchPyEvent {
-                    inner: evt as *const FpssEvent,
-                    valid: AtomicBool::new(true),
-                },
-            ) {
-                Ok(p) => p,
-                Err(e) => {
-                    e.write_unraisable(py, None);
-                    return;
-                }
-            };
-            // The realistic Python integrator pattern: hand the event
-            // to `deque.append`. The deque retains the wrapper, but
-            // any later field access raises `ValueError` since we
-            // invalidate below.
-            let bound = py_evt.bind(py).clone();
-            let _ = deque_consumer.bind(py).call_method1("append", (bound,));
-            // Invalidate so the retained wrapper safe-fails on later
-            // access. Matches the SDK contract exactly.
-            py_evt.borrow(py).valid.store(false, Ordering::Release);
-        });
-    });
-    let result = drive_publish(producer, delivered, contract);
-    let len = Python::attach(|py| deque.bind(py).len().expect("deque len"));
-    black_box(len);
-    result
-}
-
 // ─── Criterion driver ──────────────────────────────────────────────────
 
 /// Run `runner` exactly `iters` times, summing the in-loop wall clock
@@ -524,29 +299,10 @@ fn bench_ffi_simulated(c: &mut Criterion) {
     bench_variant(c, "ffi_simulated", run_ffi_simulated);
 }
 
-fn bench_pyo3_deque_append(c: &mut Criterion) {
-    bench_variant(c, "pyo3_deque_append", run_pyo3_deque_append);
-}
-
-fn bench_pyo3_queue_put_nowait(c: &mut Criterion) {
-    bench_variant(c, "pyo3_queue_put_nowait", run_pyo3_queue_put_nowait);
-}
-
-fn bench_pyo3_zerocopy_class_deque_append(c: &mut Criterion) {
-    bench_variant(
-        c,
-        "pyo3_zerocopy_class_deque_append",
-        run_pyo3_zerocopy_class_deque_append,
-    );
-}
-
 criterion_group!(
     streaming_throughput,
     bench_rust_noop,
     bench_rust_vec_push,
     bench_ffi_simulated,
-    bench_pyo3_deque_append,
-    bench_pyo3_queue_put_nowait,
-    bench_pyo3_zerocopy_class_deque_append,
 );
 criterion_main!(streaming_throughput);

--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/ffi.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/ffi.rs
@@ -209,7 +209,13 @@ fn render_ffi_with_options_endpoint(endpoint: &GeneratedEndpoint) -> String {
     out.push_str("                empty\n");
     out.push_str("            }\n");
     out.push_str("            Err(error) => {\n");
-    out.push_str("                set_error(&error.to_string());\n");
+    // Convert the endpoint error into the core `Error` (preserving the
+    // gRPC variant + its `retry_after` hint for server failures and
+    // classifying bad params as invalid-parameter) and route through
+    // `set_error_from` so the typed discriminant and the back-off hint
+    // reach the C ABI; the C++ wrapper reads both to pick the right
+    // exception leaf and seat `retry_after`.
+    out.push_str("                set_error_from(&thetadatadx::Error::from(error));\n");
     out.push_str("                empty\n");
     out.push_str("            }\n");
     out.push_str("        }\n");

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -197,6 +197,28 @@ pub enum ConfigErrorKind {
     Internal(String),
 }
 
+impl ConfigErrorKind {
+    /// True when this kind reflects a rejected user-supplied parameter
+    /// (a bad value, an out-of-range number, a missing required field)
+    /// rather than an environmental fault (config-file I/O, TOML parse)
+    /// or an internal invariant violation.
+    ///
+    /// The bindings route the user-input kinds to a dedicated
+    /// invalid-parameter error class so a caller can distinguish a
+    /// malformed-but-rejected argument from an unrelated configuration
+    /// failure by class, while `Io` / `TomlParse` / `Internal` stay on
+    /// the root error class.
+    #[must_use]
+    pub fn is_invalid_parameter(&self) -> bool {
+        matches!(
+            self,
+            ConfigErrorKind::OutOfRange { .. }
+                | ConfigErrorKind::MissingField(_)
+                | ConfigErrorKind::InvalidValue { .. }
+        )
+    }
+}
+
 /// Canonical gRPC status codes.
 ///
 /// Numeric discriminants match the gRPC wire codes one-for-one (see
@@ -593,6 +615,26 @@ impl Error {
         let message = kind.to_string();
         Self::Decompress { kind, message }
     }
+
+    // ─── Structured accessors ───────────────────────────────────────────
+
+    /// Server-supplied minimum backoff before the next retry, when the
+    /// upstream attached a `google.rpc.RetryInfo` detail to a
+    /// rate-limit status.
+    ///
+    /// Returns `Some(duration)` only for a [`Error::Grpc`] carrying the
+    /// hint; every other variant (and a rate-limit status without the
+    /// detail) returns `None`. The language bindings surface this as a
+    /// typed field on their rate-limit error class so a caller can read
+    /// the back-off interval as a value instead of parsing it out of the
+    /// message text.
+    #[must_use]
+    pub fn retry_after(&self) -> Option<std::time::Duration> {
+        match self {
+            Error::Grpc { retry_after, .. } => *retry_after,
+            _ => None,
+        }
+    }
 }
 
 impl From<tdbe::error::Error> for Error {
@@ -866,6 +908,53 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn retry_after_exposes_grpc_hint() {
+        let with_hint = Error::Grpc {
+            kind: GrpcStatusKind::ResourceExhausted,
+            message: "429".into(),
+            retry_after: Some(std::time::Duration::from_millis(1500)),
+        };
+        assert_eq!(
+            with_hint.retry_after(),
+            Some(std::time::Duration::from_millis(1500))
+        );
+
+        let no_hint = Error::Grpc {
+            kind: GrpcStatusKind::ResourceExhausted,
+            message: "429".into(),
+            retry_after: None,
+        };
+        assert_eq!(no_hint.retry_after(), None);
+
+        // Non-gRPC variants never carry a retry hint.
+        assert_eq!(Error::NoData.retry_after(), None);
+        assert_eq!(Error::Timeout { duration_ms: 500 }.retry_after(), None);
+    }
+
+    #[test]
+    fn config_kind_invalid_parameter_partition() {
+        // User-input rejections are invalid-parameter kinds.
+        assert!(ConfigErrorKind::OutOfRange {
+            field: "fpss.timeout_ms".into(),
+            value: 0,
+            min: 100,
+            max: 60_000,
+        }
+        .is_invalid_parameter());
+        assert!(ConfigErrorKind::MissingField("auth.email".into()).is_invalid_parameter());
+        assert!(ConfigErrorKind::InvalidValue {
+            field: "mdds.uri".into(),
+            message: "not a URI".into(),
+        }
+        .is_invalid_parameter());
+
+        // Environmental / internal faults are not.
+        assert!(!ConfigErrorKind::Io("file not found".into()).is_invalid_parameter());
+        assert!(!ConfigErrorKind::TomlParse("expected `]`".into()).is_invalid_parameter());
+        assert!(!ConfigErrorKind::Internal("semaphore closed".into()).is_invalid_parameter());
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -38,9 +38,20 @@ no-default-features = false
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# No advisories ignored. If a RUSTSEC fires, fix the dependency — or
-# document the exception here with a concrete `# Reason:` comment.
-ignore = []
+# Fix a RUSTSEC by upgrading the dependency. The single exception below is
+# documented with a concrete `# Reason:` and a tracking issue; it is the
+# only case where the patched upstream release does not yet exist.
+ignore = [
+    # Reason: RUSTSEC-2026-0176 (out-of-bounds read in the optimized
+    # `nth`/`nth_back` paths for `PyList`/`PyTuple` iterators) is fixed in
+    # pyo3 0.29, but the async bridge (`pyo3-async-runtimes` 0.28.0) and the
+    # Arrow boundary (`pyo3-arrow` 0.18.0) both require `pyo3 ^0.28`, so 0.29
+    # cannot resolve until they publish compat builds. The workspace never
+    # calls the vulnerable methods — the only `.nth()` is `std::env::Args::nth`
+    # in `bench_latency`, not a Python sequence iterator — so exposure is nil.
+    # Tracked in #684; delete this entry when the pyo3 0.29 bump lands.
+    "RUSTSEC-2026-0176",
+]
 
 [licenses]
 # Workspace crates (tdbe, thetadatadx, FFI shim, SDK shims, tools) are

--- a/deny.toml
+++ b/deny.toml
@@ -38,19 +38,26 @@ no-default-features = false
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# Fix a RUSTSEC by upgrading the dependency. The single exception below is
-# documented with a concrete `# Reason:` and a tracking issue; it is the
-# only case where the patched upstream release does not yet exist.
+# Fix a RUSTSEC by upgrading the dependency. The two exceptions below are
+# documented with a concrete `# Reason:` and a tracking issue; they are the
+# only cases where the patched upstream release does not yet exist.
 ignore = [
-    # Reason: RUSTSEC-2026-0176 (out-of-bounds read in the optimized
-    # `nth`/`nth_back` paths for `PyList`/`PyTuple` iterators) is fixed in
-    # pyo3 0.29, but the async bridge (`pyo3-async-runtimes` 0.28.0) and the
-    # Arrow boundary (`pyo3-arrow` 0.18.0) both require `pyo3 ^0.28`, so 0.29
-    # cannot resolve until they publish compat builds. The workspace never
-    # calls the vulnerable methods — the only `.nth()` is `std::env::Args::nth`
-    # in `bench_latency`, not a Python sequence iterator — so exposure is nil.
-    # Tracked in #684; delete this entry when the pyo3 0.29 bump lands.
+    # Both entries clear when pyo3 0.29 becomes reachable. pyo3 0.29 fixes
+    # both advisories, but the async bridge (`pyo3-async-runtimes` 0.28.0) and
+    # the Arrow boundary (`pyo3-arrow` 0.18.0) still require `pyo3 ^0.28`, so
+    # the upgrade cannot resolve until they publish compat builds. Tracked in
+    # #684; delete both entries when the bump lands.
+    #
+    # Reason: RUSTSEC-2026-0176 — out-of-bounds read in the optimized
+    # `nth`/`nth_back` paths for `PyList`/`PyTuple` iterators. The workspace
+    # never calls them — the only `.nth()` is `std::env::Args::nth` in
+    # `bench_latency`, not a Python sequence iterator — so exposure is nil.
     "RUSTSEC-2026-0176",
+    # Reason: RUSTSEC-2026-0177 — missing `Sync` bound on
+    # `PyCFunction::new_closure` closures. The workspace never constructs a
+    # `PyCFunction::new_closure`, so the unsound cross-thread share is
+    # unreachable from our code — exposure is nil.
+    "RUSTSEC-2026-0177",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -38,27 +38,9 @@ no-default-features = false
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# Fix a RUSTSEC by upgrading the dependency. The two exceptions below are
-# documented with a concrete `# Reason:` and a tracking issue; they are the
-# only cases where the patched upstream release does not yet exist.
-ignore = [
-    # Both entries clear when pyo3 0.29 becomes reachable. pyo3 0.29 fixes
-    # both advisories, but the async bridge (`pyo3-async-runtimes` 0.28.0) and
-    # the Arrow boundary (`pyo3-arrow` 0.18.0) still require `pyo3 ^0.28`, so
-    # the upgrade cannot resolve until they publish compat builds. Tracked in
-    # #684; delete both entries when the bump lands.
-    #
-    # Reason: RUSTSEC-2026-0176 — out-of-bounds read in the optimized
-    # `nth`/`nth_back` paths for `PyList`/`PyTuple` iterators. The workspace
-    # never calls them — the only `.nth()` is `std::env::Args::nth` in
-    # `bench_latency`, not a Python sequence iterator — so exposure is nil.
-    "RUSTSEC-2026-0176",
-    # Reason: RUSTSEC-2026-0177 — missing `Sync` bound on
-    # `PyCFunction::new_closure` closures. The workspace never constructs a
-    # `PyCFunction::new_closure`, so the unsound cross-thread share is
-    # unreachable from our code — exposure is nil.
-    "RUSTSEC-2026-0177",
-]
+# No advisories ignored. If a RUSTSEC fires, fix the dependency — or
+# document the exception here with a concrete `# Reason:` comment.
+ignore = []
 
 [licenses]
 # Workspace crates (tdbe, thetadatadx, FFI shim, SDK shims, tools) are

--- a/ffi/src/endpoint_with_options.rs
+++ b/ffi/src/endpoint_with_options.rs
@@ -34,7 +34,7 @@ pub unsafe extern "C" fn tdx_stock_list_symbols_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn tdx_stock_list_dates_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn tdx_stock_snapshot_ohlc_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn tdx_stock_snapshot_trade_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn tdx_stock_snapshot_quote_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn tdx_stock_snapshot_market_value_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -343,7 +343,7 @@ pub unsafe extern "C" fn tdx_stock_history_eod_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -398,7 +398,7 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -453,7 +453,7 @@ pub unsafe extern "C" fn tdx_stock_history_trade_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -508,7 +508,7 @@ pub unsafe extern "C" fn tdx_stock_history_quote_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -563,7 +563,7 @@ pub unsafe extern "C" fn tdx_stock_history_trade_quote_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -632,7 +632,7 @@ pub unsafe extern "C" fn tdx_stock_at_time_trade_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -701,7 +701,7 @@ pub unsafe extern "C" fn tdx_stock_at_time_quote_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -742,7 +742,7 @@ pub unsafe extern "C" fn tdx_option_list_symbols_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -804,7 +804,7 @@ pub unsafe extern "C" fn tdx_option_list_dates_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -852,7 +852,7 @@ pub unsafe extern "C" fn tdx_option_list_expirations_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -907,7 +907,7 @@ pub unsafe extern "C" fn tdx_option_list_strikes_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -969,7 +969,7 @@ pub unsafe extern "C" fn tdx_option_list_contracts_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1024,7 +1024,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_ohlc_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1079,7 +1079,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_trade_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1134,7 +1134,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_quote_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1189,7 +1189,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_open_interest_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1244,7 +1244,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_market_value_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1299,7 +1299,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_implied_volatility_with_opti
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1354,7 +1354,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_all_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1409,7 +1409,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_first_order_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1464,7 +1464,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_second_order_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1519,7 +1519,7 @@ pub unsafe extern "C" fn tdx_option_snapshot_greeks_third_order_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1588,7 +1588,7 @@ pub unsafe extern "C" fn tdx_option_history_eod_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1650,7 +1650,7 @@ pub unsafe extern "C" fn tdx_option_history_ohlc_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1712,7 +1712,7 @@ pub unsafe extern "C" fn tdx_option_history_trade_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1774,7 +1774,7 @@ pub unsafe extern "C" fn tdx_option_history_quote_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1836,7 +1836,7 @@ pub unsafe extern "C" fn tdx_option_history_trade_quote_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1898,7 +1898,7 @@ pub unsafe extern "C" fn tdx_option_history_open_interest_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -1967,7 +1967,7 @@ pub unsafe extern "C" fn tdx_option_history_greeks_eod_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2029,7 +2029,7 @@ pub unsafe extern "C" fn tdx_option_history_greeks_all_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2091,7 +2091,7 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_all_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2153,7 +2153,7 @@ pub unsafe extern "C" fn tdx_option_history_greeks_first_order_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2215,7 +2215,7 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_first_order_with_option
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2277,7 +2277,7 @@ pub unsafe extern "C" fn tdx_option_history_greeks_second_order_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2339,7 +2339,7 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_second_order_with_optio
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2401,7 +2401,7 @@ pub unsafe extern "C" fn tdx_option_history_greeks_third_order_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2463,7 +2463,7 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_third_order_with_option
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2525,7 +2525,7 @@ pub unsafe extern "C" fn tdx_option_history_greeks_implied_volatility_with_optio
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2587,7 +2587,7 @@ pub unsafe extern "C" fn tdx_option_history_trade_greeks_implied_volatility_with
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2663,7 +2663,7 @@ pub unsafe extern "C" fn tdx_option_at_time_trade_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2739,7 +2739,7 @@ pub unsafe extern "C" fn tdx_option_at_time_quote_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2780,7 +2780,7 @@ pub unsafe extern "C" fn tdx_index_list_symbols_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2828,7 +2828,7 @@ pub unsafe extern "C" fn tdx_index_list_dates_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2876,7 +2876,7 @@ pub unsafe extern "C" fn tdx_index_snapshot_ohlc_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2924,7 +2924,7 @@ pub unsafe extern "C" fn tdx_index_snapshot_price_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -2972,7 +2972,7 @@ pub unsafe extern "C" fn tdx_index_snapshot_market_value_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3034,7 +3034,7 @@ pub unsafe extern "C" fn tdx_index_history_eod_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3096,7 +3096,7 @@ pub unsafe extern "C" fn tdx_index_history_ohlc_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3151,7 +3151,7 @@ pub unsafe extern "C" fn tdx_index_history_price_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3220,7 +3220,7 @@ pub unsafe extern "C" fn tdx_index_at_time_price_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3261,7 +3261,7 @@ pub unsafe extern "C" fn tdx_calendar_open_today_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3309,7 +3309,7 @@ pub unsafe extern "C" fn tdx_calendar_on_date_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3357,7 +3357,7 @@ pub unsafe extern "C" fn tdx_calendar_year_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3419,7 +3419,7 @@ pub unsafe extern "C" fn tdx_interest_rate_history_eod_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }
@@ -3481,7 +3481,7 @@ pub unsafe extern "C" fn tdx_stock_history_ohlc_range_with_options(
                 empty
             }
             Err(error) => {
-                set_error(&error.to_string());
+                set_error_from(&thetadatadx::Error::from(error));
                 empty
             }
         }

--- a/ffi/src/endpoints.rs
+++ b/ffi/src/endpoints.rs
@@ -9,7 +9,7 @@
 use std::os::raw::c_char;
 use std::ptr;
 
-use crate::error::set_error;
+use crate::error::{set_error, set_error_from};
 use crate::runtime;
 use crate::types::{
     insert_bool_arg, insert_float_arg, insert_int_arg, insert_optional_str_arg,

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -16,7 +16,16 @@ use std::ptr;
 thread_local! {
     static LAST_ERROR: std::cell::RefCell<Option<CString>> = const { std::cell::RefCell::new(None) };
     static LAST_ERROR_CODE: std::cell::Cell<i32> = const { std::cell::Cell::new(TDX_ERR_NONE) };
+    /// Server-supplied rate-limit back-off in milliseconds, or `-1` when
+    /// the last error carries no `RetryInfo` hint. Read via
+    /// [`tdx_last_error_retry_after_ms`] so the C++ `RateLimitError`
+    /// surfaces the back-off as a typed value.
+    static LAST_ERROR_RETRY_AFTER_MS: std::cell::Cell<i64> = const { std::cell::Cell::new(-1) };
 }
+
+/// Sentinel returned by [`tdx_last_error_retry_after_ms`] when the last
+/// error carries no rate-limit back-off hint.
+pub const TDX_RETRY_AFTER_NONE: i64 = -1;
 
 /// Typed error-code discriminants surfaced via [`tdx_last_error_code`].
 ///
@@ -40,12 +49,20 @@ pub const TDX_ERR_NETWORK: i32 = 9;
 pub const TDX_ERR_SCHEMA_MISMATCH: i32 = 10;
 pub const TDX_ERR_STREAM: i32 = 11;
 pub const TDX_ERR_CONFIG: i32 = 12;
+/// A client-side parameter was rejected by input validation (a bad
+/// value, an out-of-range number, a missing required field). Distinct
+/// from [`TDX_ERR_CONFIG`], which stays reserved for environmental
+/// configuration faults (config-file I/O, TOML parse, internal
+/// invariant) so a rejected argument is distinguishable by code from an
+/// unrelated configuration failure.
+pub const TDX_ERR_INVALID_PARAMETER: i32 = 13;
 
 pub(crate) fn set_error(msg: &str) {
     LAST_ERROR.with(|e| {
         *e.borrow_mut() = CString::new(msg).ok();
     });
     LAST_ERROR_CODE.with(|c| c.set(TDX_ERR_OTHER));
+    clear_retry_after();
 }
 
 /// Set the error string and pin the typed discriminant explicitly. Used by
@@ -57,15 +74,30 @@ pub(crate) fn set_error_with_code(msg: &str, code: i32) {
         *e.borrow_mut() = CString::new(msg).ok();
     });
     LAST_ERROR_CODE.with(|c| c.set(code));
+    clear_retry_after();
 }
 
 /// Set both the formatted error string AND the typed discriminant
 /// from a [`thetadatadx::Error`]. The string keeps the previous
 /// surface; the code is what the C++ / TypeScript bindings dispatch
-/// on to pick the right exception class.
+/// on to pick the right exception class. A rate-limit back-off hint, if
+/// the error carries one, is stashed for [`tdx_last_error_retry_after_ms`].
 pub(crate) fn set_error_from(err: &thetadatadx::Error) {
     set_error_string_only(&err.to_string());
     LAST_ERROR_CODE.with(|c| c.set(error_code_for(err)));
+    let retry_after_ms = err
+        .retry_after()
+        .and_then(|d| i64::try_from(d.as_millis()).ok())
+        .unwrap_or(TDX_RETRY_AFTER_NONE);
+    LAST_ERROR_RETRY_AFTER_MS.with(|c| c.set(retry_after_ms));
+}
+
+/// Reset the rate-limit back-off slot to "no hint". Called by every
+/// error setter that does not carry a `RetryInfo` detail so a stale hint
+/// from a prior rate-limit error is never misattributed to an unrelated
+/// failure.
+fn clear_retry_after() {
+    LAST_ERROR_RETRY_AFTER_MS.with(|c| c.set(TDX_RETRY_AFTER_NONE));
 }
 
 /// Set the error string without touching the typed code. Used by the
@@ -104,7 +136,17 @@ pub(crate) fn error_code_for(err: &thetadatadx::Error) -> i32 {
         Error::Timeout { .. } => TDX_ERR_DEADLINE_EXCEEDED,
         Error::Transport { .. } | Error::Tls(_) | Error::Io(_) | Error::Http(_) => TDX_ERR_NETWORK,
         Error::Decode { .. } | Error::Decompress { .. } => TDX_ERR_SCHEMA_MISMATCH,
-        Error::Config { .. } => TDX_ERR_CONFIG,
+        // Split user-input validation failures out from environmental
+        // config faults so the C++ / C ABI surface a dedicated
+        // invalid-parameter class while file-I/O / TOML / internal
+        // faults stay on the generic config code.
+        Error::Config { kind, .. } => {
+            if kind.is_invalid_parameter() {
+                TDX_ERR_INVALID_PARAMETER
+            } else {
+                TDX_ERR_CONFIG
+            }
+        }
         Error::Fpss { kind, .. } => match kind {
             FpssErrorKind::TooManyRequests => TDX_ERR_RATE_LIMIT,
             FpssErrorKind::Timeout => TDX_ERR_DEADLINE_EXCEEDED,
@@ -127,6 +169,22 @@ pub(crate) fn error_code_for(err: &thetadatadx::Error) -> i32 {
 pub extern "C" fn tdx_last_error_code() -> i32 {
     ffi_boundary!(TDX_ERR_OTHER, {
         LAST_ERROR_CODE.with(std::cell::Cell::get)
+    })
+}
+
+/// Retrieve the server-supplied rate-limit back-off of the last FFI
+/// error on this thread, in milliseconds, or [`TDX_RETRY_AFTER_NONE`]
+/// (`-1`) when the error carries no `RetryInfo` hint.
+///
+/// Set only for a rate-limit error whose upstream status attached a
+/// `google.rpc.RetryInfo` detail; every other error (and a rate-limit
+/// error without the detail) reads `-1`. The C++ `RateLimitError`
+/// exposes this as a typed `retry_after()` value so a caller can honour
+/// the back-off without parsing the message text.
+#[no_mangle]
+pub extern "C" fn tdx_last_error_retry_after_ms() -> i64 {
+    ffi_boundary!(TDX_RETRY_AFTER_NONE, {
+        LAST_ERROR_RETRY_AFTER_MS.with(std::cell::Cell::get)
     })
 }
 
@@ -162,6 +220,7 @@ pub extern "C" fn tdx_clear_error() {
             *e.borrow_mut() = None;
         });
         LAST_ERROR_CODE.with(|c| c.set(TDX_ERR_NONE));
+        LAST_ERROR_RETRY_AFTER_MS.with(|c| c.set(TDX_RETRY_AFTER_NONE));
     })
 }
 
@@ -359,10 +418,65 @@ mod tests {
             error_code_for(&thetadatadx::Error::decode_codec("cell type mismatch")),
             TDX_ERR_SCHEMA_MISMATCH
         );
+    }
+
+    #[test]
+    fn config_validation_routes_to_invalid_parameter_others_to_config() {
+        // User-input validation failures get the dedicated discriminant.
         assert_eq!(
             error_code_for(&thetadatadx::Error::config_invalid("ffi", "bad")),
+            TDX_ERR_INVALID_PARAMETER
+        );
+        assert_eq!(
+            error_code_for(&thetadatadx::Error::config_out_of_range("ffi", 0, 1, 9)),
+            TDX_ERR_INVALID_PARAMETER
+        );
+        assert_eq!(
+            error_code_for(&thetadatadx::Error::config_missing("ffi")),
+            TDX_ERR_INVALID_PARAMETER
+        );
+        // Environmental config faults stay on the generic config code.
+        assert_eq!(
+            error_code_for(&thetadatadx::Error::config_io("file not found")),
             TDX_ERR_CONFIG
         );
+        assert_eq!(
+            error_code_for(&thetadatadx::Error::config_toml("expected `]`")),
+            TDX_ERR_CONFIG
+        );
+    }
+
+    #[test]
+    fn set_error_from_stashes_retry_after_hint() {
+        // A rate-limit error with a RetryInfo hint populates the
+        // retry-after slot in milliseconds; reading it back returns the
+        // hint, and clearing resets it to the "no hint" sentinel.
+        tdx_clear_error();
+        set_error_from(&thetadatadx::Error::Grpc {
+            kind: GrpcStatusKind::ResourceExhausted,
+            message: "429".into(),
+            retry_after: Some(std::time::Duration::from_millis(1500)),
+        });
+        assert_eq!(tdx_last_error_code(), TDX_ERR_RATE_LIMIT);
+        assert_eq!(tdx_last_error_retry_after_ms(), 1500);
+
+        // A rate-limit error without a hint reads the sentinel.
+        set_error_from(&grpc(GrpcStatusKind::ResourceExhausted));
+        assert_eq!(tdx_last_error_retry_after_ms(), TDX_RETRY_AFTER_NONE);
+
+        // A plain `set_error` clears any prior hint so it is never
+        // misattributed to an unrelated failure.
+        set_error_from(&thetadatadx::Error::Grpc {
+            kind: GrpcStatusKind::ResourceExhausted,
+            message: "429".into(),
+            retry_after: Some(std::time::Duration::from_millis(2000)),
+        });
+        assert_eq!(tdx_last_error_retry_after_ms(), 2000);
+        set_error("unrelated failure");
+        assert_eq!(tdx_last_error_retry_after_ms(), TDX_RETRY_AFTER_NONE);
+
+        tdx_clear_error();
+        assert_eq!(tdx_last_error_retry_after_ms(), TDX_RETRY_AFTER_NONE);
     }
 
     #[test]

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -750,6 +750,13 @@ void tdx_clear_error(void);
  *  `tdx_clear_error()`. */
 int32_t tdx_last_error_code(void);
 
+/** Server-supplied rate-limit back-off of the last FFI error on this
+ *  thread, in milliseconds, or `-1` when the error carries no
+ *  `RetryInfo` hint. Set only for a rate-limit error whose upstream
+ *  status attached the hint; every other error reads `-1`. The C++
+ *  `RateLimitError::retry_after()` surfaces this as a typed value. */
+int64_t tdx_last_error_retry_after_ms(void);
+
 /* Error-code discriminants returned by `tdx_last_error_code()`.
  * Kept in sync with the `TDX_ERR_*` constants in `ffi/src/error.rs`. */
 #define TDX_ERR_NONE 0
@@ -765,6 +772,7 @@ int32_t tdx_last_error_code(void);
 #define TDX_ERR_SCHEMA_MISMATCH 10
 #define TDX_ERR_STREAM 11
 #define TDX_ERR_CONFIG 12
+#define TDX_ERR_INVALID_PARAMETER 13
 
 /* ── Credentials ── */
 

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -147,8 +147,12 @@ struct Greeks {
 // generic `catch (const std::runtime_error&)` continue to observe
 // the failure unchanged; callers that want structured handling can
 // `catch (const SubscriptionError&)` for a tier / permission error
-// or `catch (const RateLimitError&)` for a 429-shaped response,
-// matching the Python and TypeScript leaf sets one-for-one.
+// or `catch (const RateLimitError&)` for a 429-shaped response. The
+// canonical leaf names (`NotFoundError`, `DeadlineExceededError`,
+// `UnavailableError`, `InvalidParameterError`, ...) are identical to
+// the Python and TypeScript leaf sets, so a handler ports across
+// bindings by name. Python additionally ships two back-compat aliases
+// (`NoDataFoundError` / `TimeoutError`) that have no C++ equivalent.
 //
 // The dispatcher [`detail::throw_for_grpc_kind`] reads
 // `tdx_last_error_code()` (typed discriminant set inside the FFI
@@ -207,9 +211,25 @@ public:
 };
 
 /// Rate limit / quota (gRPC `ResourceExhausted`, HTTP 429).
+///
+/// Carries the server-supplied minimum back-off in seconds when the
+/// upstream attached a `google.rpc.RetryInfo` detail, so a caller can
+/// honour the cooldown as a value (`retry_after()`) instead of parsing
+/// the message text. `retry_after()` is `std::nullopt` when no hint was
+/// supplied.
 class RateLimitError : public ThetaDataError {
 public:
     using ThetaDataError::ThetaDataError;
+
+    RateLimitError(const std::string& message, std::optional<double> retry_after_seconds)
+        : ThetaDataError(message), retry_after_(retry_after_seconds) {}
+
+    /// Server-supplied minimum back-off in seconds, or `std::nullopt`
+    /// when the upstream attached no `RetryInfo` hint.
+    std::optional<double> retry_after() const { return retry_after_; }
+
+private:
+    std::optional<double> retry_after_;
 };
 
 /// Empty result / unknown contract (gRPC `NotFound`,
@@ -245,6 +265,16 @@ public:
     using ThetaDataError::ThetaDataError;
 };
 
+/// A client-side parameter was rejected by input validation (a bad
+/// value, an out-of-range number, a missing required field). Distinct
+/// from the root `ThetaDataError` so a malformed-but-rejected argument
+/// is distinguishable by catch type from an unrelated configuration
+/// fault (config-file I/O, TOML parse), which stays on the root class.
+class InvalidParameterError : public ThetaDataError {
+public:
+    using ThetaDataError::ThetaDataError;
+};
+
 /// FPSS streaming protocol / state-machine failure.
 class StreamError : public ThetaDataError {
 public:
@@ -259,6 +289,16 @@ namespace detail {
 /// discriminant `code` (one of the `TDX_ERR_*` constants in
 /// `thetadx.h`). Used by every wrapper that already has the formatted
 /// message in hand and wants the right leaf class without re-parsing.
+/// Read the thread-local rate-limit back-off hint and convert it to
+/// seconds, or `std::nullopt` when the FFI slot carries no hint (`-1`).
+inline std::optional<double> last_ffi_retry_after_seconds() {
+    const int64_t ms = tdx_last_error_retry_after_ms();
+    if (ms < 0) {
+        return std::nullopt;
+    }
+    return static_cast<double>(ms) / 1000.0;
+}
+
 [[noreturn]] inline void throw_for_code(int32_t code, const std::string& message) {
     switch (code) {
         case TDX_ERR_AUTHENTICATION:
@@ -268,7 +308,9 @@ namespace detail {
         case TDX_ERR_SUBSCRIPTION:
             throw SubscriptionError("thetadatadx: " + message);
         case TDX_ERR_RATE_LIMIT:
-            throw RateLimitError("thetadatadx: " + message);
+            // Carry the server back-off hint (if any) so the caller can
+            // read `RateLimitError::retry_after()` as a value.
+            throw RateLimitError("thetadatadx: " + message, last_ffi_retry_after_seconds());
         case TDX_ERR_NOT_FOUND:
             throw NotFoundError("thetadatadx: " + message);
         case TDX_ERR_DEADLINE_EXCEEDED:
@@ -279,6 +321,8 @@ namespace detail {
             throw NetworkError("thetadatadx: " + message);
         case TDX_ERR_SCHEMA_MISMATCH:
             throw SchemaMismatchError("thetadatadx: " + message);
+        case TDX_ERR_INVALID_PARAMETER:
+            throw InvalidParameterError("thetadatadx: " + message);
         case TDX_ERR_STREAM:
             throw StreamError("thetadatadx: " + message);
         case TDX_ERR_OTHER:

--- a/sdks/cpp/tests/error_taxonomy.cpp
+++ b/sdks/cpp/tests/error_taxonomy.cpp
@@ -34,9 +34,53 @@ TEST_CASE("ThetaDataError is the root of the SDK exception hierarchy",
     STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::UnavailableError>);
     STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::NetworkError>);
     STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::SchemaMismatchError>);
+    STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::InvalidParameterError>);
     STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::StreamError>);
     // InvalidCredentialsError narrows AuthenticationError.
     STATIC_REQUIRE(std::is_base_of_v<tdx::AuthenticationError, tdx::InvalidCredentialsError>);
+}
+
+TEST_CASE("throw_for_code routes the invalid-parameter discriminant to InvalidParameterError",
+          "[errors][offline]") {
+    // A rejected client parameter (`TDX_ERR_INVALID_PARAMETER`) must
+    // surface as `InvalidParameterError`, distinguishable by catch type
+    // from the generic `ThetaDataError` that the environmental config
+    // code (`TDX_ERR_CONFIG`) still produces.
+    try {
+        tdx::detail::throw_for_code(TDX_ERR_INVALID_PARAMETER, "bad date");
+        FAIL("throw_for_code must throw");
+    } catch (const tdx::InvalidParameterError&) {
+        // expected
+    } catch (const tdx::ThetaDataError& e) {
+        FAIL("expected InvalidParameterError, got generic ThetaDataError: " << e.what());
+    }
+
+    // The generic config code stays on the root class.
+    try {
+        tdx::detail::throw_for_code(TDX_ERR_CONFIG, "toml parse");
+        FAIL("throw_for_code must throw");
+    } catch (const tdx::InvalidParameterError& e) {
+        FAIL("TDX_ERR_CONFIG must not surface as InvalidParameterError: " << e.what());
+    } catch (const tdx::ThetaDataError&) {
+        // expected — generic config fault
+    }
+}
+
+TEST_CASE("RateLimitError carries the server retry_after as a typed value",
+          "[errors][offline]") {
+    // A `RateLimitError` constructed with a back-off hint exposes it as
+    // seconds; one constructed without a hint reports `std::nullopt`.
+    tdx::RateLimitError with_hint("thetadatadx: 429", 1.5);
+    REQUIRE(with_hint.retry_after().has_value());
+    REQUIRE(with_hint.retry_after().value() == 1.5);
+
+    tdx::RateLimitError without_hint("thetadatadx: 429", std::nullopt);
+    REQUIRE_FALSE(without_hint.retry_after().has_value());
+
+    // The legacy single-arg constructor still compiles and defaults the
+    // hint to absent.
+    tdx::RateLimitError legacy("thetadatadx: 429");
+    REQUIRE_FALSE(legacy.retry_after().has_value());
 }
 
 TEST_CASE("classify_grpc_kind routes every canonical gRPC status to the right leaf",

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -73,17 +73,21 @@ python = true
 typescript = true
 cpp = true
 
+# `NoDataFoundError` / `TimeoutError` are Python-only back-compat
+# aliases of the canonical `NotFoundError` / `DeadlineExceededError`
+# (registered as the same type object under both names). TypeScript and
+# C++ ship only the canonical names, so the alias rows stay Python-only.
 [[class]]
 name = "NoDataFoundError"
 python = true
-typescript = false
-cpp = false         # C++ folds NoData into the generic `Error` class with `.kind == NoData`
+typescript = false  # canonical `NotFoundError` only; no TS alias
+cpp = false         # canonical `NotFoundError` only; no C++ alias
 
 [[class]]
 name = "TimeoutError"
 python = true
-typescript = false
-cpp = false         # C++ folds Timeout into the generic `Error` class with `.kind == Timeout`
+typescript = false  # canonical `DeadlineExceededError` only; no TS alias
+cpp = false         # canonical `DeadlineExceededError` only; no C++ alias
 
 [[class]]
 name = "Subscription"
@@ -111,60 +115,90 @@ cpp = true
 
 # ── Typed exception hierarchy.
 #
-# C++ exposes one class per leaf, matching the Python tree.
-# TypeScript surfaces every error variant via a single discriminated
-# `Error` class with `.kind` (see `index.d.ts` line ~1127); the
-# narrowing pattern is `if (e.kind === "InvalidCredentials")`. That
-# is intentional — JS error classes don't compose with `instanceof`
-# across native module boundaries — so each row below records the TS
-# column as `false` rather than misrepresenting the surface.
+# The canonical leaf class names (`NotFoundError`,
+# `DeadlineExceededError`, `UnavailableError`, `InvalidParameterError`,
+# ...) are identical across Python, TypeScript, and C++, so a handler
+# ports across bindings by class name.
+#
+# C++ exposes one class per leaf in `thetadx.hpp`, matching the Python
+# tree. TypeScript also exposes one runtime class per leaf, but they
+# live in the package entry point `streaming-session.{js,d.ts}` (the
+# napi shim re-casts every `[ClassName] ...`-prefixed rejection into the
+# matching subclass). The parity checker reads the napi-generated
+# `index.d.ts`, which does not declare these JS-side classes, so each
+# row records the TypeScript column as `false` — the classes exist on
+# the public TS surface, they are simply not in the file the gate scans.
 
 [[class]]
 name = "ThetaDataError"
 python = true
-typescript = false
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
 
 [[class]]
 name = "AuthenticationError"
 python = true
-typescript = false
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
 
 [[class]]
 name = "InvalidCredentialsError"
 python = true
-typescript = false
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
 
 [[class]]
 name = "SubscriptionError"
 python = true
-typescript = false
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
 
 [[class]]
 name = "RateLimitError"
 python = true
-typescript = false
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+cpp = true
+
+[[class]]
+name = "InvalidParameterError"
+python = true
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
 
 [[class]]
 name = "NetworkError"
 python = true
-typescript = false
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+cpp = true
+
+[[class]]
+name = "UnavailableError"
+python = true
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+cpp = true
+
+[[class]]
+name = "DeadlineExceededError"
+python = true
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+cpp = true
+
+[[class]]
+name = "NotFoundError"
+python = true
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
 
 [[class]]
 name = "SchemaMismatchError"
 python = true
-typescript = false
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
 
 [[class]]
 name = "StreamError"
 python = true
-typescript = false
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
 
 # ─── FlatFilesConfig cross-binding setters ─────────────────────────────

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -842,11 +842,91 @@ class InvalidCredentialsError(AuthenticationError): ...
 
 
 @final
-class NetworkError(ThetaDataError): ...
+class SubscriptionError(ThetaDataError):
+    """Tier / plan does not cover the request (gRPC ``PermissionDenied``)."""
+
+    ...
 
 
 @final
-class NoDataFoundError(ThetaDataError): ...
+class RateLimitError(ThetaDataError):
+    """Rate limit / quota exhausted (gRPC ``ResourceExhausted``, HTTP 429).
+
+    ``retry_after`` is the server-supplied minimum back-off in seconds
+    when the upstream attached a ``google.rpc.RetryInfo`` detail, or
+    ``None`` when no hint was supplied. The attribute is always present
+    so callers can read it unconditionally.
+    """
+
+    retry_after: Optional[float]
+
+
+@final
+class InvalidParameterError(ThetaDataError):
+    """A client-side parameter was rejected by input validation.
+
+    Distinct from the root :class:`ThetaDataError` so a malformed-but-
+    rejected argument (bad value, out-of-range number, missing required
+    field) is distinguishable by class from an unrelated configuration
+    fault (config-file I/O, TOML parse), which stays on the root class.
+    """
+
+    ...
+
+
+@final
+class SchemaMismatchError(ThetaDataError):
+    """Decoder schema mismatch — usually a server proto bump."""
+
+    ...
+
+
+@final
+class NetworkError(ThetaDataError):
+    """Transport-layer failure (TCP / TLS / IO) other than ``Unavailable``."""
+
+    ...
+
+
+@final
+class UnavailableError(ThetaDataError):
+    """Upstream unavailable (gRPC ``Unavailable``, often retryable)."""
+
+    ...
+
+
+@final
+class DeadlineExceededError(ThetaDataError):
+    """Per-request deadline elapsed (``timeout_ms`` / gRPC ``DeadlineExceeded``)."""
+
+    ...
+
+
+@final
+class NotFoundError(ThetaDataError):
+    """Empty result / unknown contract (gRPC ``NotFound``)."""
+
+    ...
+
+
+@final
+class StreamError(ThetaDataError):
+    """FPSS streaming protocol / state-machine failure."""
+
+    ...
+
+
+# ── Back-compatibility aliases ────────────────────────────────────────
+#
+# `NoDataFoundError` and `TimeoutError` are registered as assignment
+# aliases of their canonical replacements (`NotFoundError` /
+# `DeadlineExceededError`) — the same class object under both names — so
+# existing `except thetadatadx.NoDataFoundError` / `except
+# thetadatadx.TimeoutError` clauses keep catching the dispatched
+# canonical class. New code should use the canonical names. Typed here
+# as the canonical class so `except` narrowing matches runtime identity.
+NoDataFoundError: Type[NotFoundError]
+TimeoutError: Type[DeadlineExceededError]
 
 
 @final

--- a/sdks/python/src/errors.rs
+++ b/sdks/python/src/errors.rs
@@ -24,9 +24,22 @@
 //! Rust SDK layer is picked up here via the `non_exhaustive` catch-all so
 //! the build never breaks on upstream additions.
 //!
-//! The `NoDataFoundError` class name matches the upstream vendor's Python
-//! SDK (Apache-2.0) by design — users porting from `thetadata` to
-//! `thetadatadx` keep the same `except` clause.
+//! # Canonical leaf vocabulary
+//!
+//! The canonical leaf class names are identical across every binding
+//! (Python, TypeScript, C++, and the C ABI discriminants): a `NotFound`
+//! status raises `NotFoundError`, an expired deadline raises
+//! `DeadlineExceededError`, and an `Unavailable` status raises
+//! `UnavailableError`. Porting an `except` clause from one binding to
+//! another keeps the same class name.
+//!
+//! `NoDataFoundError` and `TimeoutError` remain as documented
+//! back-compatibility aliases: each is registered as the same type
+//! object as its canonical replacement (`NotFoundError` /
+//! `DeadlineExceededError`), so existing
+//! `except thetadatadx.NoDataFoundError` / `except thetadatadx.TimeoutError`
+//! clauses keep catching the same conditions. New code should reach for
+//! the canonical names.
 
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
@@ -49,35 +62,68 @@ create_exception!(thetadatadx, InvalidCredentialsError, AuthenticationError);
 create_exception!(thetadatadx, SubscriptionError, ThetaDataError);
 
 // Rate limiting: gRPC `ResourceExhausted` / `TooManyRequests` / HTTP 429.
+// Carries a `retry_after` attribute (float seconds, or `None`) read from
+// the upstream `google.rpc.RetryInfo` detail when the server attached
+// one, so callers can honour a server-instructed back-off as a value.
 create_exception!(thetadatadx, RateLimitError, ThetaDataError);
+
+// Client-side input validation rejected a parameter (a bad value, an
+// out-of-range number, a missing required field). Distinct from the root
+// `ThetaDataError` so a malformed-but-rejected argument is distinguishable
+// by class from an unrelated configuration fault (config-file I/O, TOML
+// parse, internal invariant) which stays on the root class.
+create_exception!(thetadatadx, InvalidParameterError, ThetaDataError);
 
 // Decoder schema mismatch — surfaces `Error::Decode` + `DecodeError`
 // variants. Triggering cause is usually a proto bump on the server before
 // the SDK is refreshed.
 create_exception!(thetadatadx, SchemaMismatchError, ThetaDataError);
 
-// Transport — TCP / gRPC / TLS failures.
+// Transport — TCP / TLS / IO failures other than an explicit
+// `Unavailable` status (which routes to `UnavailableError`).
 create_exception!(thetadatadx, NetworkError, ThetaDataError);
 
-// Per-request deadline (`with_deadline(d)` / `timeout_ms` kwarg).
-// Intentionally NOT inheriting from the stdlib builtins.TimeoutError — the
-// v8.0.1 behavior mapped to `PyTimeoutError` but that conflates user-
-// imposed deadlines with OS-level socket timeouts. Callers who want the
-// stdlib behaviour can `except (thetadatadx.TimeoutError, TimeoutError)`.
-// The local name deliberately shadows the stdlib name inside the
-// `thetadatadx` namespace, matching the vendor SDK convention.
-create_exception!(thetadatadx, TimeoutError, ThetaDataError);
+// Upstream unavailable — gRPC `Unavailable`. Split out from
+// `NetworkError` so the canonical leaf set matches the other bindings:
+// an `Unavailable` status raises `UnavailableError` in Python,
+// TypeScript, and C++ alike.
+create_exception!(thetadatadx, UnavailableError, ThetaDataError);
 
-// Empty result — gRPC `NotFound`. Class name matches the upstream vendor
-// SDK's `NoDataFoundError` so users porting from `thetadata` to
-// `thetadatadx` keep the same `except` clause.
-create_exception!(thetadatadx, NoDataFoundError, ThetaDataError);
+// Per-request deadline (`with_deadline(d)` / `timeout_ms` kwarg) and
+// upstream `DeadlineExceeded`. Intentionally NOT inheriting from the
+// stdlib `builtins.TimeoutError` — a user-imposed deadline is not an
+// OS-level socket timeout. Callers who want the stdlib behaviour can
+// `except (thetadatadx.DeadlineExceededError, TimeoutError)`.
+create_exception!(thetadatadx, DeadlineExceededError, ThetaDataError);
+
+// Empty result — gRPC `NotFound`. The canonical name matches the other
+// bindings (`NotFoundError` in TypeScript / C++ / the C ABI codes).
+create_exception!(thetadatadx, NotFoundError, ThetaDataError);
 
 // FPSS streaming protocol / state-machine failures.
 create_exception!(thetadatadx, StreamError, ThetaDataError);
 
+// ── Back-compatibility aliases ────────────────────────────────────────
+//
+// `NoDataFoundError` and `TimeoutError` predate the cross-binding
+// vocabulary unification. They are registered in [`register_exceptions`]
+// as true assignment aliases of their canonical replacements
+// (`NotFoundError` / `DeadlineExceededError`) — the same type object is
+// added to the module under both names, so
+// `thetadatadx.NoDataFoundError is thetadatadx.NotFoundError` holds and an
+// existing `except thetadatadx.NoDataFoundError` clause keeps catching
+// the conditions the dispatch raises. No separate subclass is created:
+// an alias must share identity with its target to preserve the `except`
+// semantics. New code should use the canonical names.
+
 /// Register every exception class on the module. Called from
 /// `thetadatadx_py` at module init time.
+///
+/// `NoDataFoundError` / `TimeoutError` are registered as assignment
+/// aliases: the canonical `NotFoundError` / `DeadlineExceededError` type
+/// objects are added under both names so the alias shares identity with
+/// its target and an existing `except` clause on the legacy name keeps
+/// catching the dispatched canonical class.
 pub fn register_exceptions(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("ThetaDataError", py.get_type::<ThetaDataError>())?;
     m.add("AuthenticationError", py.get_type::<AuthenticationError>())?;
@@ -86,13 +132,53 @@ pub fn register_exceptions(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<
         py.get_type::<InvalidCredentialsError>(),
     )?;
     m.add("SubscriptionError", py.get_type::<SubscriptionError>())?;
-    m.add("RateLimitError", py.get_type::<RateLimitError>())?;
+    let rate_limit_type = py.get_type::<RateLimitError>();
+    // Seat a class-level `retry_after` default so the attribute is
+    // present (as `None`) on every `RateLimitError` even before the
+    // dispatch sets a per-instance value from a server `RetryInfo` hint.
+    rate_limit_type.setattr("retry_after", py.None())?;
+    m.add("RateLimitError", rate_limit_type)?;
+    m.add(
+        "InvalidParameterError",
+        py.get_type::<InvalidParameterError>(),
+    )?;
     m.add("SchemaMismatchError", py.get_type::<SchemaMismatchError>())?;
     m.add("NetworkError", py.get_type::<NetworkError>())?;
-    m.add("TimeoutError", py.get_type::<TimeoutError>())?;
-    m.add("NoDataFoundError", py.get_type::<NoDataFoundError>())?;
+    m.add("UnavailableError", py.get_type::<UnavailableError>())?;
+    m.add(
+        "DeadlineExceededError",
+        py.get_type::<DeadlineExceededError>(),
+    )?;
+    m.add("NotFoundError", py.get_type::<NotFoundError>())?;
     m.add("StreamError", py.get_type::<StreamError>())?;
+    // Back-compatibility aliases: same type object under the legacy name.
+    m.add("NoDataFoundError", py.get_type::<NotFoundError>())?;
+    m.add("TimeoutError", py.get_type::<DeadlineExceededError>())?;
     Ok(())
+}
+
+/// Build a `RateLimitError` whose `retry_after` attribute carries the
+/// server-supplied back-off (float seconds) when the upstream attached a
+/// `google.rpc.RetryInfo` detail, or `None` otherwise.
+///
+/// The attribute is always present so callers can read
+/// `err.retry_after` unconditionally; it is `None` when no hint was
+/// supplied. `Python::attach` acquires the interpreter lock only to seat
+/// the attribute and is a no-op when the caller already holds it.
+fn rate_limit_err(e: &thetadatadx::Error) -> PyErr {
+    let retry_after_secs = e.retry_after().map(|d| d.as_secs_f64());
+    let err = RateLimitError::new_err(e.to_string());
+    Python::attach(|py| {
+        // Surfacing the back-off is best-effort metadata. Setting an
+        // attribute on a pyo3 exception instance does not fail in
+        // practice; if it ever did, the typed class is still correct, so
+        // the result is intentionally discarded rather than masking the
+        // rate-limit error with a setattr failure. `setattr` returns the
+        // error by value without touching the interpreter error state,
+        // so discarding it leaves no error set.
+        let _ = err.value(py).setattr("retry_after", retry_after_secs);
+    });
+    err
 }
 
 /// Map a `thetadatadx::Error` into the closest Python exception class.
@@ -108,32 +194,41 @@ pub fn to_py_err(e: thetadatadx::Error) -> PyErr {
         thetadatadx::Error::Auth { kind, .. } => match kind {
             AuthErrorKind::InvalidCredentials => InvalidCredentialsError::new_err(e.to_string()),
             AuthErrorKind::NetworkError => NetworkError::new_err(e.to_string()),
-            AuthErrorKind::Timeout => TimeoutError::new_err(e.to_string()),
+            AuthErrorKind::Timeout => DeadlineExceededError::new_err(e.to_string()),
             AuthErrorKind::ServerError => AuthenticationError::new_err(e.to_string()),
             // Future `AuthErrorKind` variants land on the parent family.
             _ => AuthenticationError::new_err(e.to_string()),
         },
         thetadatadx::Error::Grpc { kind, .. } => match kind {
             GrpcStatusKind::PermissionDenied => SubscriptionError::new_err(e.to_string()),
-            GrpcStatusKind::ResourceExhausted => RateLimitError::new_err(e.to_string()),
-            GrpcStatusKind::NotFound => NoDataFoundError::new_err(e.to_string()),
-            GrpcStatusKind::DeadlineExceeded => TimeoutError::new_err(e.to_string()),
+            GrpcStatusKind::ResourceExhausted => rate_limit_err(&e),
+            GrpcStatusKind::NotFound => NotFoundError::new_err(e.to_string()),
+            GrpcStatusKind::DeadlineExceeded => DeadlineExceededError::new_err(e.to_string()),
             GrpcStatusKind::Unauthenticated => AuthenticationError::new_err(e.to_string()),
-            GrpcStatusKind::Unavailable => NetworkError::new_err(e.to_string()),
+            GrpcStatusKind::Unavailable => UnavailableError::new_err(e.to_string()),
             _ => ThetaDataError::new_err(e.to_string()),
         },
-        thetadatadx::Error::NoData => NoDataFoundError::new_err(e.to_string()),
-        thetadatadx::Error::Timeout { .. } => TimeoutError::new_err(e.to_string()),
+        thetadatadx::Error::NoData => NotFoundError::new_err(e.to_string()),
+        thetadatadx::Error::Timeout { .. } => DeadlineExceededError::new_err(e.to_string()),
         thetadatadx::Error::Transport { .. } => NetworkError::new_err(e.to_string()),
         thetadatadx::Error::Tls(_) => NetworkError::new_err(e.to_string()),
         thetadatadx::Error::Io(_) => NetworkError::new_err(e.to_string()),
         thetadatadx::Error::Http(_) => NetworkError::new_err(e.to_string()),
         thetadatadx::Error::Decode { .. } => SchemaMismatchError::new_err(e.to_string()),
         thetadatadx::Error::Decompress { .. } => SchemaMismatchError::new_err(e.to_string()),
-        thetadatadx::Error::Config { .. } => ThetaDataError::new_err(e.to_string()),
+        // User-input validation failures route to the dedicated
+        // invalid-parameter class; environmental config faults
+        // (`Io` / `TomlParse` / `Internal`) stay on the root class.
+        thetadatadx::Error::Config { kind, .. } => {
+            if kind.is_invalid_parameter() {
+                InvalidParameterError::new_err(e.to_string())
+            } else {
+                ThetaDataError::new_err(e.to_string())
+            }
+        }
         thetadatadx::Error::Fpss { kind, .. } => match kind {
-            FpssErrorKind::TooManyRequests => RateLimitError::new_err(e.to_string()),
-            FpssErrorKind::Timeout => TimeoutError::new_err(e.to_string()),
+            FpssErrorKind::TooManyRequests => rate_limit_err(&e),
+            FpssErrorKind::Timeout => DeadlineExceededError::new_err(e.to_string()),
             FpssErrorKind::ConnectionRefused | FpssErrorKind::Disconnected => {
                 NetworkError::new_err(e.to_string())
             }
@@ -197,14 +292,14 @@ mod tests {
     }
 
     #[test]
-    fn auth_timeout_maps_to_timeout_error() {
+    fn auth_timeout_maps_to_deadline_exceeded_error() {
         Python::initialize();
         Python::attach(|py| {
             let err = to_py_err(thetadatadx::Error::Auth {
                 kind: AuthErrorKind::Timeout,
                 message: "auth timed out".into(),
             });
-            assert_exception_class(py, &err, "TimeoutError");
+            assert_exception_class(py, &err, "DeadlineExceededError");
         });
     }
 
@@ -235,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn grpc_not_found_maps_to_no_data_found() {
+    fn grpc_not_found_maps_to_not_found() {
         Python::initialize();
         Python::attach(|py| {
             let err = to_py_err(thetadatadx::Error::Grpc {
@@ -243,25 +338,73 @@ mod tests {
                 message: "no rows".into(),
                 retry_after: None,
             });
-            assert_exception_class(py, &err, "NoDataFoundError");
+            assert_exception_class(py, &err, "NotFoundError");
         });
     }
 
     #[test]
-    fn nodata_error_maps_to_no_data_found() {
+    fn grpc_unavailable_maps_to_unavailable() {
+        Python::initialize();
+        Python::attach(|py| {
+            let err = to_py_err(thetadatadx::Error::Grpc {
+                kind: GrpcStatusKind::Unavailable,
+                message: "backend down".into(),
+                retry_after: None,
+            });
+            assert_exception_class(py, &err, "UnavailableError");
+        });
+    }
+
+    #[test]
+    fn nodata_error_maps_to_not_found() {
         Python::initialize();
         Python::attach(|py| {
             let err = to_py_err(thetadatadx::Error::NoData);
-            assert_exception_class(py, &err, "NoDataFoundError");
+            assert_exception_class(py, &err, "NotFoundError");
         });
     }
 
     #[test]
-    fn timeout_variant_maps_to_timeout_error() {
+    fn timeout_variant_maps_to_deadline_exceeded_error() {
         Python::initialize();
         Python::attach(|py| {
             let err = to_py_err(thetadatadx::Error::Timeout { duration_ms: 500 });
-            assert_exception_class(py, &err, "TimeoutError");
+            assert_exception_class(py, &err, "DeadlineExceededError");
+        });
+    }
+
+    #[test]
+    fn rate_limit_carries_retry_after_attribute() {
+        Python::initialize();
+        Python::attach(|py| {
+            // With a RetryInfo hint: the attribute is the float seconds.
+            let err = to_py_err(thetadatadx::Error::Grpc {
+                kind: GrpcStatusKind::ResourceExhausted,
+                message: "429".into(),
+                retry_after: Some(std::time::Duration::from_millis(1500)),
+            });
+            assert_exception_class(py, &err, "RateLimitError");
+            let value = err.value(py);
+            let secs: Option<f64> = value
+                .getattr("retry_after")
+                .expect("retry_after attribute is present")
+                .extract()
+                .expect("retry_after is float | None");
+            assert_eq!(secs, Some(1.5));
+
+            // Without a hint: the attribute is present and None.
+            let err_none = to_py_err(thetadatadx::Error::Grpc {
+                kind: GrpcStatusKind::ResourceExhausted,
+                message: "429".into(),
+                retry_after: None,
+            });
+            let secs_none: Option<f64> = err_none
+                .value(py)
+                .getattr("retry_after")
+                .expect("retry_after attribute is present")
+                .extract()
+                .expect("retry_after is float | None");
+            assert_eq!(secs_none, None);
         });
     }
 
@@ -299,14 +442,42 @@ mod tests {
     }
 
     #[test]
-    fn config_error_maps_to_root_class() {
+    fn config_validation_failure_maps_to_invalid_parameter() {
+        // A rejected user parameter (bad value, out-of-range, missing
+        // field) routes to the dedicated invalid-parameter class.
         Python::initialize();
         Python::attach(|py| {
-            let err = to_py_err(thetadatadx::Error::config_invalid(
+            let invalid_value = to_py_err(thetadatadx::Error::config_invalid(
                 "mdds.uri",
                 "invalid URI",
             ));
-            assert_exception_class(py, &err, "ThetaDataError");
+            assert_exception_class(py, &invalid_value, "InvalidParameterError");
+
+            let out_of_range = to_py_err(thetadatadx::Error::config_out_of_range(
+                "fpss.timeout_ms",
+                0,
+                100,
+                60_000,
+            ));
+            assert_exception_class(py, &out_of_range, "InvalidParameterError");
+
+            let missing = to_py_err(thetadatadx::Error::config_missing("auth.email"));
+            assert_exception_class(py, &missing, "InvalidParameterError");
+        });
+    }
+
+    #[test]
+    fn config_environmental_fault_maps_to_root_class() {
+        // A non-input config fault (file I/O, TOML parse, internal
+        // invariant) is not a user-parameter error and stays on the
+        // root class.
+        Python::initialize();
+        Python::attach(|py| {
+            let io = to_py_err(thetadatadx::Error::config_io("file not found"));
+            assert_exception_class(py, &io, "ThetaDataError");
+
+            let toml = to_py_err(thetadatadx::Error::config_toml("expected `]`"));
+            assert_exception_class(py, &toml, "ThetaDataError");
         });
     }
 
@@ -327,10 +498,18 @@ mod tests {
                 ),
                 ("SubscriptionError", py.get_type::<SubscriptionError>()),
                 ("RateLimitError", py.get_type::<RateLimitError>()),
+                (
+                    "InvalidParameterError",
+                    py.get_type::<InvalidParameterError>(),
+                ),
                 ("SchemaMismatchError", py.get_type::<SchemaMismatchError>()),
                 ("NetworkError", py.get_type::<NetworkError>()),
-                ("TimeoutError", py.get_type::<TimeoutError>()),
-                ("NoDataFoundError", py.get_type::<NoDataFoundError>()),
+                ("UnavailableError", py.get_type::<UnavailableError>()),
+                (
+                    "DeadlineExceededError",
+                    py.get_type::<DeadlineExceededError>(),
+                ),
+                ("NotFoundError", py.get_type::<NotFoundError>()),
                 ("StreamError", py.get_type::<StreamError>()),
             ] {
                 let is_sub = cls_ty
@@ -359,6 +538,34 @@ mod tests {
                 is_sub,
                 "InvalidCredentialsError must inherit from AuthenticationError"
             );
+        });
+    }
+
+    #[test]
+    fn legacy_names_are_aliases_of_canonical_classes() {
+        // `register_exceptions` adds the canonical type object under the
+        // legacy name too, so the alias shares identity with its target.
+        // An existing `except thetadatadx.NoDataFoundError` clause then
+        // catches the dispatched `NotFoundError`.
+        Python::initialize();
+        Python::attach(|py| {
+            let module = PyModule::new(py, "thetadatadx_alias_probe")
+                .expect("module construction succeeds with GIL held");
+            register_exceptions(py, &module).expect("registration succeeds");
+
+            for (legacy, canonical) in [
+                ("NoDataFoundError", "NotFoundError"),
+                ("TimeoutError", "DeadlineExceededError"),
+            ] {
+                let legacy_obj = module.getattr(legacy).expect("legacy name is registered");
+                let canonical_obj = module
+                    .getattr(canonical)
+                    .expect("canonical name is registered");
+                assert!(
+                    legacy_obj.is(&canonical_obj),
+                    "{legacy} must be the same object as {canonical}"
+                );
+            }
         });
     }
 }

--- a/sdks/python/tests/test_error_parity.py
+++ b/sdks/python/tests/test_error_parity.py
@@ -1,0 +1,87 @@
+"""Cross-binding error-class parity — Python surface (issue #681).
+
+Pins the canonical typed-exception vocabulary so it stays identical to
+the TypeScript / C++ / C ABI leaf sets: a `NotFound` status raises
+`NotFoundError`, an expired deadline raises `DeadlineExceededError`, and
+an `Unavailable` status raises `UnavailableError`. The two legacy names
+(`NoDataFoundError` / `TimeoutError`) must remain as assignment aliases
+of their canonical replacements so existing `except` clauses keep
+working. `RateLimitError` must carry a `retry_after` attribute, and a
+rejected client parameter must surface as `InvalidParameterError`, not
+the root `ThetaDataError`.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def tdx():
+    try:
+        return importlib.import_module("thetadatadx")
+    except ImportError:
+        pytest.skip("native module thetadatadx not built")
+
+
+# Every canonical leaf class plus the root, in the cross-binding
+# vocabulary. These names must match the TypeScript / C++ / C ABI sets.
+CANONICAL_CLASSES = [
+    "ThetaDataError",
+    "AuthenticationError",
+    "InvalidCredentialsError",
+    "SubscriptionError",
+    "RateLimitError",
+    "InvalidParameterError",
+    "SchemaMismatchError",
+    "NetworkError",
+    "UnavailableError",
+    "DeadlineExceededError",
+    "NotFoundError",
+    "StreamError",
+]
+
+
+@pytest.mark.parametrize("name", CANONICAL_CLASSES)
+def test_canonical_class_exists_and_roots_at_theta_data_error(tdx, name: str) -> None:
+    cls = getattr(tdx, name, None)
+    assert isinstance(cls, type), f"thetadatadx.{name} must be an exception class"
+    assert issubclass(
+        cls, tdx.ThetaDataError
+    ), f"{name} must derive from ThetaDataError"
+
+
+def test_invalid_credentials_narrows_authentication_error(tdx) -> None:
+    assert issubclass(tdx.InvalidCredentialsError, tdx.AuthenticationError)
+
+
+def test_legacy_names_are_assignment_aliases(tdx) -> None:
+    # The legacy names must be the *same object* as their canonical
+    # replacement so `except thetadatadx.NoDataFoundError` keeps catching
+    # the dispatched `NotFoundError`.
+    assert tdx.NoDataFoundError is tdx.NotFoundError
+    assert tdx.TimeoutError is tdx.DeadlineExceededError
+
+
+def test_legacy_except_clause_catches_canonical(tdx) -> None:
+    # Raising the canonical class is caught by an `except` on the alias.
+    with pytest.raises(tdx.NoDataFoundError):
+        raise tdx.NotFoundError("no rows")
+    with pytest.raises(tdx.TimeoutError):
+        raise tdx.DeadlineExceededError("deadline")
+
+
+def test_rate_limit_carries_retry_after_attribute(tdx) -> None:
+    # The attribute is present (default None) on the class, so callers
+    # can read `err.retry_after` unconditionally.
+    assert hasattr(tdx.RateLimitError, "retry_after")
+    inst = tdx.RateLimitError("429")
+    assert inst.retry_after is None
+
+
+def test_invalid_parameter_is_distinct_from_root(tdx) -> None:
+    # A dedicated subclass under the root, not the root itself.
+    assert tdx.InvalidParameterError is not tdx.ThetaDataError
+    assert issubclass(tdx.InvalidParameterError, tdx.ThetaDataError)

--- a/sdks/python/tests/test_fresh_install_smoke.py
+++ b/sdks/python/tests/test_fresh_install_smoke.py
@@ -58,11 +58,16 @@ PUBLIC_CLASSES = [
     "InvalidCredentialsError",
     "SubscriptionError",
     "RateLimitError",
+    "InvalidParameterError",
     "SchemaMismatchError",
     "NetworkError",
-    "TimeoutError",
-    "NoDataFoundError",
+    "UnavailableError",
+    "DeadlineExceededError",
+    "NotFoundError",
     "StreamError",
+    # Back-compatibility aliases of the canonical classes above.
+    "NoDataFoundError",
+    "TimeoutError",
 ]
 
 PUBLIC_FUNCTIONS = [

--- a/sdks/typescript/__tests__/typed-errors.test.mjs
+++ b/sdks/typescript/__tests__/typed-errors.test.mjs
@@ -34,6 +34,7 @@ describe('typed error hierarchy', () => {
       'InvalidCredentialsError',
       'SubscriptionError',
       'RateLimitError',
+      'InvalidParameterError',
       'NotFoundError',
       'DeadlineExceededError',
       'UnavailableError',
@@ -133,5 +134,62 @@ describe('typed error hierarchy', () => {
       () => stub.throwIt('something raw and untyped'),
       (err) => err instanceof Error && !(err instanceof mod.ThetaDataError),
     );
+  });
+
+  it('exposes retryAfter on RateLimitError and a default of null', async () => {
+    let mod;
+    try {
+      const imported = await import(wrapperImportPath);
+      mod = imported.default ?? imported;
+    } catch (err) {
+      if (err.code === 'ERR_DLOPEN_FAILED') return;
+      throw err;
+    }
+
+    // Default: a RateLimitError constructed without a hint carries a
+    // null retryAfter so callers can read it unconditionally.
+    const bare = new mod.RateLimitError('429');
+    assert.equal(bare.retryAfter, null);
+
+    // The shim widens the prefix to `[RateLimitError retry_after_ms=N]`
+    // when the server attached a RetryInfo hint; the interceptor parses
+    // the hint off and seats it as `retryAfter` in seconds. Mirror the
+    // shim's parse here (the real `rethrowTyped` is module-private).
+    const PREFIX_RE = /^\[([A-Za-z]+Error)(?:\s+retry_after_ms=(\d+))?\]\s*(.*)$/s;
+    const parse = (message) => {
+      const match = PREFIX_RE.exec(message);
+      const [, className, retryAfterMs, payload] = match;
+      const Cls = mod[className];
+      const typed = new Cls(payload);
+      if (retryAfterMs !== undefined && typed instanceof mod.RateLimitError) {
+        typed.retryAfter = Number(retryAfterMs) / 1000;
+      }
+      return typed;
+    };
+
+    const withHint = parse('[RateLimitError retry_after_ms=1500] back off');
+    assert.ok(withHint instanceof mod.RateLimitError);
+    assert.equal(withHint.retryAfter, 1.5);
+    assert.equal(withHint.message, 'back off');
+
+    const withoutHint = parse('[RateLimitError] back off');
+    assert.ok(withoutHint instanceof mod.RateLimitError);
+    assert.equal(withoutHint.retryAfter, null);
+  });
+
+  it('maps a rejected parameter to InvalidParameterError', async () => {
+    let mod;
+    try {
+      const imported = await import(wrapperImportPath);
+      mod = imported.default ?? imported;
+    } catch (err) {
+      if (err.code === 'ERR_DLOPEN_FAILED') return;
+      throw err;
+    }
+
+    assert.equal(typeof mod.InvalidParameterError, 'function');
+    const inst = new mod.InvalidParameterError('bad date');
+    assert.ok(inst instanceof mod.ThetaDataError);
+    assert.equal(inst.name, 'InvalidParameterError');
   });
 });

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -33,16 +33,28 @@ pub(crate) fn runtime() -> &'static tokio::runtime::Runtime {
 /// base `ThetaDataError` so callers writing `catch (e instanceof
 /// tdx.ThetaDataError)` continue to observe every failure.
 ///
-/// Mirrors the Python `to_py_err` leaf set one-for-one so the
-/// cross-binding error contract stays uniform.
+/// The canonical leaf set (`NotFoundError`, `DeadlineExceededError`,
+/// `UnavailableError`, `InvalidParameterError`, ...) is identical to the
+/// Python, C++, and C ABI leaf sets, so an `except`/`catch` clause ports
+/// across bindings by name. Python additionally ships two back-compat
+/// aliases (`NoDataFoundError` / `TimeoutError`) that do not exist here.
+///
+/// When the error is a rate limit carrying a server `retry_after` hint,
+/// the prefix is widened to `"[RateLimitError retry_after_ms=N] ..."` so
+/// the JS shim can surface the back-off as a typed `retryAfter` property
+/// (seconds) on the thrown `RateLimitError`.
 pub(crate) fn to_napi_err(e: thetadatadx::Error) -> napi::Error {
     let class = leaf_class_for(&e);
-    napi::Error::from_reason(format!("[{class}] {e}"))
+    let prefix = match e.retry_after() {
+        Some(d) => format!("[{class} retry_after_ms={}]", d.as_millis()),
+        None => format!("[{class}]"),
+    };
+    napi::Error::from_reason(format!("{prefix} {e}"))
 }
 
 /// Pick the typed leaf class name for a `thetadatadx::Error`. The
-/// JS shim parses this prefix off the error reason. Mirrors the
-/// Python `to_py_err` dispatch table.
+/// JS shim parses this prefix off the error reason. The canonical leaf
+/// names match the Python `to_py_err` dispatch one-for-one.
 fn leaf_class_for(e: &thetadatadx::Error) -> &'static str {
     use thetadatadx::error::{AuthErrorKind, FpssErrorKind, GrpcStatusKind};
     match e {
@@ -70,7 +82,16 @@ fn leaf_class_for(e: &thetadatadx::Error) -> &'static str {
         thetadatadx::Error::Decode { .. } | thetadatadx::Error::Decompress { .. } => {
             "SchemaMismatchError"
         }
-        thetadatadx::Error::Config { .. } => "ThetaDataError",
+        // User-input validation failures route to the dedicated
+        // invalid-parameter class; environmental config faults stay on
+        // the root class.
+        thetadatadx::Error::Config { kind, .. } => {
+            if kind.is_invalid_parameter() {
+                "InvalidParameterError"
+            } else {
+                "ThetaDataError"
+            }
+        }
         thetadatadx::Error::Fpss { kind, .. } => match kind {
             FpssErrorKind::TooManyRequests => "RateLimitError",
             FpssErrorKind::Timeout => "DeadlineExceededError",

--- a/sdks/typescript/streaming-session.d.ts
+++ b/sdks/typescript/streaming-session.d.ts
@@ -28,17 +28,28 @@ export type Contract = ContractRef;
 // ── Typed error hierarchy ─────────────────────────────────────────────
 //
 // Every `thetadatadx::Error` surfaced through the napi boundary is
-// re-cast on the JS side as one of the leaves below. The hierarchy
-// mirrors the Python `to_py_err` leaf set one-for-one so the
-// cross-binding error contract stays uniform — port a Python
-// `except thetadatadx.SubscriptionError` clause to TS by writing
-// `catch (e) { if (e instanceof tdx.SubscriptionError) { ... } }`.
+// re-cast on the JS side as one of the leaves below. The canonical leaf
+// set (`NotFoundError`, `DeadlineExceededError`, `UnavailableError`,
+// `InvalidParameterError`, ...) is identical to the Python, C++, and C
+// ABI leaf sets, so a `catch` clause ports across bindings by class name
+// — port a Python `except thetadatadx.SubscriptionError` clause to TS by
+// writing `catch (e) { if (e instanceof tdx.SubscriptionError) { ... } }`.
+// Python additionally ships two back-compat aliases
+// (`NoDataFoundError` / `TimeoutError`) that have no equivalent here.
 
 export class ThetaDataError extends Error {}
 export class AuthenticationError extends ThetaDataError {}
 export class InvalidCredentialsError extends AuthenticationError {}
 export class SubscriptionError extends ThetaDataError {}
-export class RateLimitError extends ThetaDataError {}
+export class RateLimitError extends ThetaDataError {
+  /**
+   * Server-supplied minimum back-off in seconds, parsed from the
+   * upstream `google.rpc.RetryInfo` hint, or `null` when none was
+   * supplied. Always present so callers can read it unconditionally.
+   */
+  retryAfter: number | null;
+}
+export class InvalidParameterError extends ThetaDataError {}
 export class NotFoundError extends ThetaDataError {}
 export class DeadlineExceededError extends ThetaDataError {}
 export class UnavailableError extends ThetaDataError {}

--- a/sdks/typescript/streaming-session.js
+++ b/sdks/typescript/streaming-session.js
@@ -33,7 +33,16 @@ const native = require('./index.js');
 // callers can write `catch (e) { if (e instanceof tdx.SubscriptionError)
 // { ... } }` rather than substring-matching the message.
 //
-// The hierarchy mirrors the Python `to_py_err` leaf set one-for-one.
+// The canonical leaf set (`NotFoundError`, `DeadlineExceededError`,
+// `UnavailableError`, `InvalidParameterError`, ...) is identical to the
+// Python, C++, and C ABI leaf sets, so a `catch` clause ports across
+// bindings by class name. Python additionally ships two back-compat
+// aliases (`NoDataFoundError` / `TimeoutError`) that do not exist here.
+//
+// A rate limit carrying a server back-off hint widens the prefix to
+// `[RateLimitError retry_after_ms=N] ...`; the interceptor parses the
+// hint off and seats it as a `retryAfter` (seconds) property on the
+// thrown `RateLimitError`.
 
 class ThetaDataError extends Error {
   constructor(message) {
@@ -63,6 +72,16 @@ class RateLimitError extends ThetaDataError {
   constructor(message) {
     super(message);
     this.name = 'RateLimitError';
+    // Server-supplied minimum back-off in seconds, parsed from the
+    // upstream `google.rpc.RetryInfo` hint, or `null` when none was
+    // supplied. Always present so callers can read it unconditionally.
+    this.retryAfter = null;
+  }
+}
+class InvalidParameterError extends ThetaDataError {
+  constructor(message) {
+    super(message);
+    this.name = 'InvalidParameterError';
   }
 }
 class NotFoundError extends ThetaDataError {
@@ -108,6 +127,7 @@ const CLASS_BY_NAME = {
   InvalidCredentialsError,
   SubscriptionError,
   RateLimitError,
+  InvalidParameterError,
   NotFoundError,
   DeadlineExceededError,
   UnavailableError,
@@ -116,7 +136,11 @@ const CLASS_BY_NAME = {
   StreamError,
 };
 
-const PREFIX_RE = /^\[([A-Za-z]+Error)\]\s*(.*)$/s;
+// `[ClassName] message` or `[ClassName retry_after_ms=N] message`. The
+// optional `retry_after_ms` group carries the rate-limit back-off hint
+// the Rust shim widens the prefix with; it is parsed off and surfaced
+// as `retryAfter` (seconds) on the thrown `RateLimitError`.
+const PREFIX_RE = /^\[([A-Za-z]+Error)(?:\s+retry_after_ms=(\d+))?\]\s*(.*)$/s;
 
 /**
  * Re-cast a napi-thrown `Error` as the matching typed subclass when
@@ -134,12 +158,17 @@ function rethrowTyped(err) {
   if (!match) {
     throw err;
   }
-  const [, className, payload] = match;
+  const [, className, retryAfterMs, payload] = match;
   const Cls = CLASS_BY_NAME[className];
   if (!Cls) {
     throw err;
   }
   const typed = new Cls(payload);
+  // Seat the rate-limit back-off (ms → seconds) when the prefix carried
+  // a `retry_after_ms` hint, so callers can read `err.retryAfter`.
+  if (retryAfterMs !== undefined && typed instanceof RateLimitError) {
+    typed.retryAfter = Number(retryAfterMs) / 1000;
+  }
   // Preserve the stack from the napi-thrown Error so the typed
   // re-throw still carries the original call site.
   typed.stack = err.stack;
@@ -303,6 +332,7 @@ module.exports = Object.assign({}, native, {
   InvalidCredentialsError,
   SubscriptionError,
   RateLimitError,
+  InvalidParameterError,
   NotFoundError,
   DeadlineExceededError,
   UnavailableError,


### PR DESCRIPTION
This closes the three Medium findings of the cross-binding behavioral parity sweep: the typed error vocabulary diverged between Python and the other bindings, structured rate-limit back-off survived only in Rust, and a rejected client parameter was indistinguishable by class from an unrelated configuration fault. The canonical leaf set is now identical across Python, TypeScript, C++, and the C ABI discriminant codes. The dispatch tables, class registries, and the C ABI code set are changed together because they share one routing seam — splitting them would leave intermediate states that reference classes before they exist.

M.1 — error-class vocabulary unification (breaking in Python). Python adopts the majority leaf names: a NotFound status now raises NotFoundError, an expired deadline raises DeadlineExceededError, and an Unavailable status raises a dedicated UnavailableError split out of NetworkError. NoDataFoundError and TimeoutError remain as documented back-compatibility aliases registered as the same type object as their canonical replacement, so an existing `except thetadatadx.NoDataFoundError` / `except thetadatadx.TimeoutError` clause keeps catching the dispatched canonical class. The stale TypeScript and C++ source comments claiming a one-for-one mirror are corrected to state the canonical leaf set is identical while noting Python's two extra aliases.

M.2 — structured retry_after (additive). The core Error gains a `retry_after()` accessor returning the server-supplied RetryInfo back-off. Python exposes `RateLimitError.retry_after` as float seconds (or None), TypeScript exposes `RateLimitError.retryAfter` as seconds (or null) parsed from a widened error prefix, and C++ exposes `RateLimitError::retry_after()` as optional seconds read from a new `tdx_last_error_retry_after_ms` C ABI accessor. The generated historical endpoint shims now route failures through the typed error conversion so the discriminant and the back-off hint reach the C ABI rather than being flattened to a plain string.

M.3 — distinct invalid-parameter class (additive). `ConfigErrorKind` gains an `is_invalid_parameter()` predicate separating rejected user input (bad value, out-of-range, missing field) from environmental faults (file I/O, TOML parse, internal invariant). The validation kinds route to a new `InvalidParameterError` in Python, TypeScript, and C++, and to a new `TDX_ERR_INVALID_PARAMETER` C ABI code; the environmental faults stay on the root class.

Canonical error-class table after this change, identical across all four bindings (Python adds the two parenthesised back-compat aliases): ThetaDataError, AuthenticationError, InvalidCredentialsError, SubscriptionError, RateLimitError (carries retry_after / retryAfter / retry_after()), InvalidParameterError, SchemaMismatchError, NetworkError, UnavailableError, DeadlineExceededError (alias TimeoutError in Python), NotFoundError (alias NoDataFoundError in Python), StreamError.

Local gates all green: `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` (1070 passed / 0 failed), `check_binding_parity.py` + `--selftest` (19 passed), `check_banned_vocab.py`. Python: maturin develop + pytest (364 passed, 23 skipped live) + `mypy.stubtest` (no issues, no allowlist additions). TypeScript: napi build + `node --test` (67 passed). C++: cmake configure + build + ctest (32 passed; live tests skip without creds).

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)