### PR TITLE
feat(server): ship prebuilt thetadatadx-server binaries with first-run credentials prompt

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,0 +1,177 @@
+name: Release Server Binaries
+
+# Builds the `thetadatadx-server` binary for each supported platform on that
+# platform's own native runner (no cross-compilation from a single host) and
+# ships it as a self-contained archive. When a GitHub Release is published the
+# archives are attached to that release; a manual `workflow_dispatch` run
+# uploads them as workflow artifacts instead, so binaries can be produced for
+# testing without cutting a tag.
+#
+# Signing is deferred: the binaries ship unsigned with per-OS launch
+# instructions in the bundled README. The packaging step is the single point
+# where a code-signing + notarization step can later be inserted (before the
+# archive is created) without restructuring the matrix or the upload paths.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-server-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.archive }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    permissions:
+      # Needed only on the `release: published` path, where the job uploads the
+      # archive to the release with `gh release upload`. Harmless on
+      # `workflow_dispatch`, where the archive is an artifact instead.
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Windows x64 — MSVC toolchain, `.exe` inside a zip.
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: thetadatadx-server-windows-x86_64.zip
+          # macOS arm64 (Apple silicon) — the native target of the runner.
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            archive: thetadatadx-server-macos-arm64.tar.gz
+          # macOS x64 (Intel) — cross-target on the same Apple-silicon runner
+          # via `rustup target add`; both Apple targets share macos-latest.
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            archive: thetadatadx-server-macos-x86_64.tar.gz
+          # Linux x64 — static musl so the binary has no system-library
+          # dependency and runs on any glibc/musl distribution.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            archive: thetadatadx-server-linux-x86_64.tar.gz
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # The server crate declares its own `[workspace]`, so its build
+          # output lands under `tools/server/target`. Key the cache on the
+          # target triple so each matrix leg keeps a separate cache.
+          workspaces: tools/server
+          key: ${{ matrix.target }}
+
+      # `thetadatadx` builds its gRPC client from `proto/mdds.proto` via
+      # prost-build, which needs the protobuf compiler on every runner.
+      - uses: ./.github/actions/install-protoc
+
+      # musl is not a host target on ubuntu-latest. `musl-tools` provides the
+      # `musl-gcc` wrapper that ring / zstd's C build invokes when targeting
+      # `x86_64-unknown-linux-musl`.
+      - name: Install musl toolchain (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Add Rust target
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build release binary
+        shell: bash
+        # The musl C builds (ring, zstd) need an explicit compiler; cargo reads
+        # the target-scoped CC. glibc/MSVC/Darwin legs ignore it.
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+        run: cargo build --release --locked --manifest-path tools/server/Cargo.toml --target ${{ matrix.target }}
+
+      # Stage the binary plus a short run-instructions README into a clean
+      # directory, then compress it. A signing + notarization step belongs
+      # here, after staging and before the archive is created.
+      - name: Package archive
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          bindir="tools/server/target/${{ matrix.target }}/release"
+          stage="$(mktemp -d)/thetadatadx-server"
+          mkdir -p "$stage"
+
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp "$bindir/thetadatadx-server.exe" "$stage/"
+          else
+            cp "$bindir/thetadatadx-server" "$stage/"
+          fi
+
+          cat > "$stage/README.txt" <<'EOF'
+          thetadatadx-server
+          ==================
+
+          A local HTTP REST (port 25503) and WebSocket (port 25520) server that
+          speaks the v3 route surface. It connects to the upstream data servers
+          directly; no Java terminal is required.
+
+          These binaries are not code-signed yet, so each operating system asks
+          for a one-time confirmation the first time you run them.
+
+          Windows
+            1. Unzip this archive.
+            2. Double-click thetadatadx-server.exe. If a "Windows protected your
+               PC" SmartScreen dialog appears, click "More info", then
+               "Run anyway".
+
+          macOS
+            1. Unpack this archive.
+            2. Right-click (or Control-click) thetadatadx-server and choose
+               "Open", then confirm "Open" in the dialog. If macOS still blocks
+               it, open System Settings > Privacy & Security and click
+               "Open Anyway" next to the thetadatadx-server entry.
+
+          Linux
+            1. Unpack this archive.
+            2. Make the binary executable, then run it:
+                 chmod +x thetadatadx-server
+                 ./thetadatadx-server
+
+          On the first launch the server prompts for the email and password of
+          your ThetaData login and saves them to a local creds.txt file so the
+          prompt does not repeat. Pass --creds <path> to use a different file.
+          EOF
+
+          out="$(pwd)/${{ matrix.archive }}"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            # `7z` ships on GitHub Windows runners and produces a standard zip.
+            ( cd "$(dirname "$stage")" && 7z a -tzip "$out" "$(basename "$stage")" >/dev/null )
+          else
+            tar -czf "$out" -C "$(dirname "$stage")" "$(basename "$stage")"
+          fi
+          echo "path=$out" >> "$GITHUB_OUTPUT"
+
+      # Published release: attach the archive to that release.
+      - name: Upload to release
+        if: github.event_name == 'release'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" "${{ steps.package.outputs.path }}" --clobber
+
+      # Manual dispatch: publish the archive as a workflow artifact for testing.
+      - name: Upload artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.archive }}
+          path: ${{ steps.package.outputs.path }}

--- a/docs-site/docs/server/index.md
+++ b/docs-site/docs/server/index.md
@@ -7,13 +7,33 @@ description: Run the local HTTP REST and WebSocket server speaking the v3 route 
 
 `thetadatadx-server` runs the full data surface as a **local HTTP REST + WebSocket server** on the v3 route scheme. Scripts and tools that already speak the v3 routes point at it unchanged — same ports, same paths, same response envelope.
 
-## Install and run
+## Download and run
+
+Prebuilt binaries are attached to each [GitHub Release](https://github.com/userFRM/ThetaDataDx/releases). No Rust toolchain and no Java terminal are required — download the archive for your platform, unpack it, and run the binary.
+
+The binaries are not code-signed yet, so each operating system asks for a one-time confirmation the first time you launch one.
+
+### Windows
+
+1. Download `thetadatadx-server-windows-x86_64.zip` and unzip it.
+2. Double-click `thetadatadx-server.exe`. If a "Windows protected your PC" SmartScreen dialog appears, click **More info**, then **Run anyway**.
+
+### macOS
+
+1. Download `thetadatadx-server-macos-arm64.tar.gz` (Apple silicon) or `thetadatadx-server-macos-x86_64.tar.gz` (Intel) and unpack it.
+2. Right-click (or Control-click) `thetadatadx-server` and choose **Open**, then confirm **Open** in the dialog. If macOS still blocks it, open **System Settings > Privacy & Security** and click **Open Anyway** next to the `thetadatadx-server` entry.
+
+### Linux
+
+1. Download `thetadatadx-server-linux-x86_64.tar.gz` and unpack it. The Linux binary is statically linked, so it runs on any distribution with no extra system libraries.
+2. Make it executable and run it:
 
 ```bash
-cargo install thetadatadx-server --git https://github.com/userFRM/ThetaDataDx
-
-thetadatadx-server --creds creds.txt
+chmod +x thetadatadx-server
+./thetadatadx-server
 ```
+
+On the first launch the server prompts for the email and password of your ThetaData login, then saves them to a local `creds.txt` file so the prompt does not repeat. Pass `--creds <path>` to use a different file, or supply `--email` / `--password` directly.
 
 This starts:
 
@@ -27,6 +47,16 @@ curl 'http://127.0.0.1:25503/v3/stock/history/eod?symbol=AAPL&start_date=2025-03
 ```
 
 Every [reference page](/reference/)'s HTTP tab is a ready-made request against this server.
+
+## Build from source (advanced)
+
+If you have a Rust toolchain and prefer to build the binary yourself, install it from the repository and run it the same way:
+
+```bash
+cargo install thetadatadx-server --git https://github.com/userFRM/ThetaDataDx
+
+thetadatadx-server --creds creds.txt
+```
 
 ## Flags
 

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -1737,6 +1737,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2258,7 @@ dependencies = [
  "axum",
  "clap",
  "rand",
+ "rpassword",
  "rustls",
  "serde",
  "serde_urlencoded",
@@ -2923,6 +2945,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -65,6 +65,12 @@ rand = "0.9"
 # after `Credentials` internally moved it into its own `Zeroizing`.
 zeroize = "1.8.2"
 
+# Hidden (non-echoing) password read for the first-run credentials prompt.
+# The returned `String` is moved straight into `Zeroizing` so the typed
+# password is scrubbed from the heap on drop, matching the existing
+# `--password` flag path.
+rpassword = "7.5.4"
+
 # Match the main workspace's strict bar. This crate declares its own
 # `[workspace]` table (line 15) so it's an independent workspace — it
 # can't inherit via `[lints] workspace = true` from the parent repo.

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -316,10 +316,8 @@ fn endpoint_error_response(ep: &EndpointMeta, error: EndpointError) -> Response 
             );
             // Prefer the server-advertised cooldown when the upstream
             // attached one; fall back to the static default otherwise.
-            let retry_secs = retry_after
-                .map_or(UPSTREAM_EXHAUSTED_RETRY_AFTER_SECS, |d| {
-                    d.as_secs().max(1)
-                });
+            let retry_secs =
+                retry_after.map_or(UPSTREAM_EXHAUSTED_RETRY_AFTER_SECS, |d| d.as_secs().max(1));
             if let Ok(value) = axum::http::HeaderValue::from_str(&retry_secs.to_string()) {
                 resp.headers_mut()
                     .insert(axum::http::header::RETRY_AFTER, value);

--- a/tools/server/src/main.rs
+++ b/tools/server/src/main.rs
@@ -29,7 +29,9 @@ mod state;
 mod validation;
 mod ws;
 
+use std::io::{IsTerminal, Write};
 use std::net::SocketAddr;
+use std::path::Path;
 
 use clap::Parser;
 use tower_http::cors::CorsLayer;
@@ -189,16 +191,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 drop(password); // explicit for readers; `Zeroizing` scrubs on drop
                 c
             }
-            None => {
-                let c = Credentials::from_file(&args.creds)?;
-                tracing::info!(creds_file = %args.creds, "loaded credentials from file");
-                c
-            }
+            None => load_or_prompt_credentials(&args.creds)?,
         }
     } else {
-        let c = Credentials::from_file(&args.creds)?;
-        tracing::info!(creds_file = %args.creds, "loaded credentials from file");
-        c
+        load_or_prompt_credentials(&args.creds)?
     };
 
     // Step 2: Load config -- prefer --config file, then --fpss-region.
@@ -320,6 +316,106 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     tracing::info!("thetadatadx-server stopped");
+    Ok(())
+}
+
+/// Resolve credentials when neither `--email` nor `--password` was passed.
+///
+/// Resolution order:
+/// 1. If the credentials file at `creds_path` exists, load it (the long-
+///    standing `--creds` behaviour: email on line 1, password on line 2).
+/// 2. If the file is absent and stdin is an interactive terminal, prompt
+///    for email and password on first run, then persist them to
+///    `creds_path` in the same two-line format so the prompt does not
+///    repeat on the next launch.
+/// 3. If the file is absent and stdin is **not** a terminal (CI, a piped
+///    invocation, a service manager), fall through to `Credentials::from_file`
+///    so the process fails fast with the existing missing-file error instead
+///    of blocking forever on a read that will never receive input.
+fn load_or_prompt_credentials(creds_path: &str) -> Result<Credentials, Box<dyn std::error::Error>> {
+    if Path::new(creds_path).exists() {
+        let c = Credentials::from_file(creds_path)?;
+        tracing::info!(creds_file = %creds_path, "loaded credentials from file");
+        return Ok(c);
+    }
+
+    if !std::io::stdin().is_terminal() {
+        // Non-interactive and no file: preserve the historical behaviour of
+        // erroring on missing credentials rather than hanging on stdin.
+        let c = Credentials::from_file(creds_path)?;
+        tracing::info!(creds_file = %creds_path, "loaded credentials from file");
+        return Ok(c);
+    }
+
+    let (email, password) = prompt_credentials(creds_path)?;
+    persist_credentials(creds_path, &email, password.as_str())?;
+    tracing::info!(creds_file = %creds_path, "saved credentials entered at the first-run prompt");
+    let c = Credentials::new(email, password.as_str().to_string());
+    drop(password); // explicit for readers; `Zeroizing` scrubs on drop
+    Ok(c)
+}
+
+/// Prompt the operator for an email and password on first run.
+///
+/// The email is read from stdin in the clear; the password is read with
+/// echo suppressed via `rpassword` and handed back inside `Zeroizing` so the
+/// typed bytes are wiped from the heap on drop, matching the `--password`
+/// flag path. The password is never logged or echoed.
+fn prompt_credentials(
+    creds_path: &str,
+) -> Result<(String, Zeroizing<String>), Box<dyn std::error::Error>> {
+    // Prompts go to stderr, mirroring the startup banner, so stdout stays
+    // free for anything a wrapper script might capture.
+    eprintln!();
+    eprintln!("No credentials file found at \"{creds_path}\".");
+    eprintln!("Enter your ThetaData login to continue; it will be saved to that file.");
+
+    eprint!("Email: ");
+    std::io::stderr().flush()?;
+    let mut email = String::new();
+    std::io::stdin().read_line(&mut email)?;
+    let email = email.trim().to_string();
+    if email.is_empty() {
+        return Err("email must not be empty".into());
+    }
+
+    // `rpassword` reads without echoing the typed characters. Move the
+    // returned `String` straight into `Zeroizing` so the plaintext is
+    // scrubbed when this value drops.
+    let password = Zeroizing::new(rpassword::prompt_password("Password: ")?);
+    if password.trim().is_empty() {
+        return Err("password must not be empty".into());
+    }
+
+    Ok((email, password))
+}
+
+/// Persist first-run credentials to `creds_path` in the two-line format
+/// `Credentials::from_file` expects (email on line 1, password on line 2).
+///
+/// On Unix the file is created with `0600` (owner read/write only) so the
+/// saved secret is not world-readable; on other platforms the default
+/// permissions apply.
+fn persist_credentials(
+    creds_path: &str,
+    email: &str,
+    password: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs::OpenOptions;
+
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(creds_path)?;
+    // Trailing newline keeps the file shape identical to a hand-written
+    // creds.txt and round-trips through `Credentials::from_file`, which
+    // trims each line.
+    write!(file, "{email}\n{password}\n")?;
+    file.flush()?;
     Ok(())
 }
 


### PR DESCRIPTION
Ships `thetadatadx-server` as a prebuilt native binary per platform so non-technical users can download and run it without a Rust toolchain or Java. Closes #689.

## Release workflow

`.github/workflows/release-server.yml` builds the server on each platform's own native runner — no cross-host compilation — and packages a self-contained archive per target. It triggers on `release: published` and on `workflow_dispatch`. Targets: `x86_64-pc-windows-msvc` (zip with the `.exe`), `aarch64-apple-darwin` and `x86_64-apple-darwin` (the x64 target is added with `rustup target add` on the Apple-silicon runner), and `x86_64-unknown-linux-musl` (with `musl-tools`) so the Linux binary is statically linked with no system-library dependency. Each archive bundles the binary plus a short README with the per-OS launch steps. A published release attaches the archives with `gh release upload`; a manual dispatch publishes them as workflow artifacts so binaries can be produced for testing without cutting a tag. The workflow mirrors the existing FFI build job's conventions (action versions, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`, the shared `install-protoc` action, `--locked`).

## First-run credentials prompt

`tools/server/src/main.rs` now prompts for email and password on first run when no creds file exists and neither `--email`/`--password` nor a readable `--creds` file was supplied, then persists them to the creds-file path so the prompt does not repeat. The existing `--creds` flag and its two-line file format are unchanged. The password is read without echoing via `rpassword` and kept in `Zeroizing` so the bytes are scrubbed from the heap on drop; it is never logged or printed, and on Unix the persisted file is created `0600`. The prompt fires only on an interactive TTY via `stdin().is_terminal()`; in CI or a piped invocation the previous behaviour is preserved — a missing creds file errors immediately rather than hanging on a read that will never receive input.

## Docs

`docs-site/docs/server/index.md` (hand-written markdown served at `/server/`) gains a Download and run section above the build-from-source content, covering per-OS download plus the one-time confirmation each system asks for an unsigned binary — SmartScreen "More info" then "Run anyway" on Windows, right-click then Open or Privacy & Security "Open Anyway" on macOS, `chmod +x` then run on Linux — and that the server prompts for email and password on first launch. The cargo-install instructions move under a Build from source (advanced) note.

## Signing

The binaries ship unsigned for now, which is why the docs and the bundled README spell out the per-OS launch confirmation. The packaging step in the workflow is the single insertion point where a code-signing and notarization step can be added later, between staging and archive creation, without restructuring the matrix or the upload paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)