### PR TITLE
fix(config): remove the internal runtime name from the public worker-threads knob; complete cross-binding setter parity

### DIFF
--- a/docs-site/docs/articles/configuration.md
+++ b/docs-site/docs/articles/configuration.md
@@ -37,7 +37,7 @@ In Rust the same fields live on `DirectConfig` struct sub-configs (`config.retry
 | Streaming latency | `flush_mode` (`"batched"` default / `"immediate"`), `fpss_ring_size`, `fpss_timeout_ms`, keepalive fields | Write-path flush behavior and event-buffer capacity. |
 | Flat files | `flatfiles_max_attempts`, `flatfiles_initial_backoff_secs`, `flatfiles_max_backoff_secs`, `flatfiles_jitter` | Retry budget for bulk downloads. |
 | Observability | `metrics_port` | Optional local Prometheus exporter port (off by default). |
-| Runtime | `tokio_worker_threads` | Async-runtime thread count for embedded bindings (0 = auto). |
+| Runtime | `worker_threads` | Async worker-thread count for embedded bindings (0 = auto). |
 
 Every field above is available on all four language surfaces under the naming convention shown earlier; unknown values fail at configuration time, not at first request.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1766,7 +1766,7 @@ pub struct DirectConfig {
                                          // 0 = auto from tier (2^tier)
                                          // n = manual override
     // Threading
-    pub tokio_worker_threads: Option<usize>,
+    pub worker_threads: Option<usize>,
 }
 ```
 

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -1358,20 +1358,19 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_callback(
     })
 }
 
-/// Set the `RuntimeConfig.tokio_worker_threads` knob using the
-/// `(has_value, n)` widened ABI shape that preserves the `Some(0)`
-/// sentinel across the C boundary.
+/// Set the async worker-thread count using the `(has_value, n)`
+/// widened ABI shape that preserves the `Some(0)` sentinel across the C
+/// boundary.
 ///
-/// * `has_value = false` → `None` (tokio default sizing, one worker per
+/// * `has_value = false` → `None` (default sizing, one worker per
 ///   logical CPU). `n` is ignored.
 /// * `has_value = true` → `Some(n)`. Embedders consuming
 ///   [`thetadatadx::RuntimeConfig::build_runtime`] honour the value
-///   verbatim, clamping `0` to `1` to keep tokio from panicking on
-///   `worker_threads(0)`.
+///   verbatim, clamping `0` to `1` so at least one worker is started.
 ///
 /// Returns `0` on success, `-1` if `config` is null.
 #[no_mangle]
-pub unsafe extern "C" fn tdx_config_set_tokio_worker_threads_explicit(
+pub unsafe extern "C" fn tdx_config_set_worker_threads_explicit(
     config: *mut TdxConfig,
     has_value: bool,
     n: usize,
@@ -1390,7 +1389,7 @@ pub unsafe extern "C" fn tdx_config_set_tokio_worker_threads_explicit(
     })
 }
 
-/// Read the current `RuntimeConfig.tokio_worker_threads` setting.
+/// Read the current async worker-thread count.
 /// Widened `(has_value, n)` ABI:
 ///
 /// * `*out_has_value = false` → `None` (auto-size). `*out_n` is left as `0`.
@@ -1398,7 +1397,7 @@ pub unsafe extern "C" fn tdx_config_set_tokio_worker_threads_explicit(
 ///
 /// Returns `0` on success, `-1` if any pointer is null.
 #[no_mangle]
-pub unsafe extern "C" fn tdx_config_get_tokio_worker_threads(
+pub unsafe extern "C" fn tdx_config_get_worker_threads(
     config: *const TdxConfig,
     out_has_value: *mut bool,
     out_n: *mut usize,
@@ -2343,14 +2342,14 @@ mod reconnect_setter_tests {
 
 #[cfg(test)]
 mod runtime_setter_tests {
-    //! Offline tests for the `RuntimeConfig.tokio_worker_threads`
-    //! setter/getter pair on the FFI surface — cross-binding parity
-    //! with Python / TypeScript / C++. The `(has_value, n)` shape
-    //! preserves `Some(0)` across the C boundary the same way the
-    //! decode-pipeline setters do.
+    //! Offline tests for the async `worker_threads` setter/getter pair
+    //! on the FFI surface — cross-binding parity with Python /
+    //! TypeScript / C++. The `(has_value, n)` shape preserves `Some(0)`
+    //! across the C boundary the same way the decode-pipeline setters
+    //! do.
 
     #[test]
-    fn tokio_worker_threads_explicit_round_trips_via_getter() {
+    fn worker_threads_explicit_round_trips_via_getter() {
         let cfg = super::tdx_config_production();
         // SAFETY: handle just returned by tdx_config_production.
         unsafe {
@@ -2358,19 +2357,19 @@ mod runtime_setter_tests {
             let mut got_has = true;
             let mut got_n: usize = 99;
             assert_eq!(
-                super::tdx_config_get_tokio_worker_threads(cfg, &mut got_has, &mut got_n),
+                super::tdx_config_get_worker_threads(cfg, &mut got_has, &mut got_n),
                 0
             );
-            assert!(!got_has, "default tokio_worker_threads must be None");
+            assert!(!got_has, "default worker_threads must be None");
             assert_eq!(got_n, 0);
 
             // Explicit values round-trip including the Some(0) sentinel.
             for n in [0usize, 1, 2, 4, 8, 16, 32, 64] {
-                let rc = super::tdx_config_set_tokio_worker_threads_explicit(cfg, true, n);
+                let rc = super::tdx_config_set_worker_threads_explicit(cfg, true, n);
                 assert_eq!(rc, 0);
                 assert_eq!((*cfg).inner.runtime.tokio_worker_threads, Some(n));
                 assert_eq!(
-                    super::tdx_config_get_tokio_worker_threads(cfg, &mut got_has, &mut got_n),
+                    super::tdx_config_get_worker_threads(cfg, &mut got_has, &mut got_n),
                     0
                 );
                 assert!(got_has);
@@ -2378,7 +2377,7 @@ mod runtime_setter_tests {
             }
 
             // Reset to None.
-            let rc = super::tdx_config_set_tokio_worker_threads_explicit(cfg, false, 999);
+            let rc = super::tdx_config_set_worker_threads_explicit(cfg, false, 999);
             assert_eq!(rc, 0);
             assert_eq!((*cfg).inner.runtime.tokio_worker_threads, None);
             super::tdx_config_free(cfg);
@@ -2386,21 +2385,16 @@ mod runtime_setter_tests {
     }
 
     #[test]
-    fn tokio_worker_threads_null_handle_returns_minus_one() {
+    fn worker_threads_null_handle_returns_minus_one() {
         // SAFETY: passing null to tdx_config_* is the documented FFI
         // contract — getter returns sentinel, setter no-ops.
         unsafe {
-            let rc =
-                super::tdx_config_set_tokio_worker_threads_explicit(std::ptr::null_mut(), true, 4);
+            let rc = super::tdx_config_set_worker_threads_explicit(std::ptr::null_mut(), true, 4);
             assert_eq!(rc, -1);
             let mut got_has = false;
             let mut got_n: usize = 0;
             assert_eq!(
-                super::tdx_config_get_tokio_worker_threads(
-                    std::ptr::null(),
-                    &mut got_has,
-                    &mut got_n,
-                ),
+                super::tdx_config_get_worker_threads(std::ptr::null(), &mut got_has, &mut got_n,),
                 -1
             );
         }

--- a/scripts/check_banned_vocab.py
+++ b/scripts/check_banned_vocab.py
@@ -104,6 +104,22 @@ BANNED = [
     # in user-facing surfaces (doc comments, public READMEs, marketing).
     # Protocol/vendor names (FPSS, MDDS) are ALLOW-listed — these banned
     # items are Rust impl-detail names.
+    #
+    # NOTE on identifier-embedded leaks: the patterns below match as
+    # whole tokens (`\bword\b`). An underscore is a regex word
+    # character, so a banned token buried inside a snake_case /
+    # camelCase PUBLIC identifier (`set_tokio_worker_threads`,
+    # `TokioWorkerThreadsSetting`) is intentionally NOT caught here — a
+    # substring scan over every source file would false-positive on the
+    # engine's and bindings' legitimate INTERNAL use of the same tokens
+    # (`tokio::runtime`, `crossbeam::channel`, `parking_lot::Mutex`,
+    # `Runtime::block_on`). That leak class is caught structurally,
+    # without false positives, by `check_binding_parity.py`
+    # (`_check_public_surface_vocab`), which inspects only the declared
+    # PUBLIC client identifiers the parity collectors harvest. The two
+    # guards are complementary: this scrubber owns standalone / phrase
+    # vocabulary across all prose; the parity guard owns
+    # identifier-embedded tokens on the public API surface.
     "MDDS gRPC",
     "FPSS TCP",
     "FIT nibble",
@@ -174,6 +190,15 @@ EXEMPT_PATHS = {
     "CHANGELOG.md",
     "docs-site/docs/changelog.md",
     "scripts/check_banned_vocab.py",
+    # The cross-binding parity gate is the SECOND vocabulary policy
+    # file: its `BANNED_SURFACE_TOKENS` list enumerates the same
+    # impl-detail token names, and its selftest fixtures spell them out
+    # to prove the public-surface guard fires. A file whose job is to
+    # name the banned tokens cannot be scrubbed for containing them —
+    # identical rationale to the `check_banned_vocab.py` self-exemption
+    # above. Its companion test file follows for the same reason.
+    "scripts/check_binding_parity.py",
+    "scripts/test_check_binding_parity.py",
     "scripts/__pycache__",
     ".github/release-notes",
     # The `tdbe` crate is an independent library with its own release cycle.

--- a/scripts/check_binding_parity.py
+++ b/scripts/check_binding_parity.py
@@ -461,6 +461,13 @@ def _collect_rust_pub_fields(config_dir: pathlib.Path) -> dict[str, set[str]]:
 # The table below records the rust-field → binding-suffix renames.
 # Fields not listed are 1:1.
 RUST_FIELD_RENAMES: dict[tuple[str, str], str] = {
+    # The async worker-thread count is stored internally on
+    # `RuntimeConfig.tokio_worker_threads`, but the public client setter
+    # is named `worker_threads` on every binding (the implementation
+    # runtime name never reaches the user surface). The parity row is
+    # keyed by the public concept; this mapping bridges the internal
+    # storage field to that row for the reverse-direction orphan check.
+    ("RuntimeConfig", "tokio_worker_threads"): "worker_threads",
     ("ReconnectConfig", "stable_window"): "stable_window_secs",
     ("ReconnectAttemptLimits", "stable_window"): "stable_window_secs",
     ("ReconnectAttemptLimits", "max_elapsed"): "max_elapsed_secs",

--- a/scripts/check_binding_parity.py
+++ b/scripts/check_binding_parity.py
@@ -66,6 +66,62 @@ FFI_SRC = REPO_ROOT / "ffi" / "src"
 CONFIG_DIR = REPO_ROOT / "crates" / "thetadatadx" / "src" / "config"
 
 
+# ─── Public-surface vocabulary guard ────────────────────────────────
+#
+# OUR Rust implementation-detail names that must never appear inside a
+# PUBLIC client identifier (class / method / field / setter / getter /
+# exported type). The bindings legitimately USE the async runtime, the
+# lock-free ring, and the lock primitives internally — those uses live
+# in implementation code and are out of scope here. This guard fires
+# only on the identifiers the parity collectors already harvest, i.e.
+# the names a user types. It catches the leak class structurally (a
+# banned token embedded in a snake_case / camelCase identifier) where
+# the text scrubber's `\bword\b` rule cannot, without false-positives
+# on internal code.
+#
+# ALLOW-LIST — kept deliberately aligned with `check_banned_vocab.py`:
+# `mdds` and `fpss` are ThetaData's PROPRIETARY PROTOCOL names (the
+# vendor this SDK wraps). They are NOT impl-detail leaks; the public
+# surface stays aligned with the vendor's vocabulary. They are NOT
+# listed below and MUST NOT be flagged. Only OUR own implementation
+# details (the async runtime, the disruptor-style ring, the lock
+# primitives, the I/O-bridge calls) are leaks.
+#
+# Lowercased; matched as a substring against the lowercased identifier
+# (so `Tokio`, `tokio`, `TOKIO`, and an embedded `_tokio_` all hit).
+BANNED_SURFACE_TOKENS: tuple[str, ...] = (
+    "tokio",
+    "disruptor",
+    "crossbeam",
+    "parking_lot",
+    "parkinglot",
+    "block_on",
+    "blockon",
+    "allow_threads",
+    "allowthreads",
+    "os_pipe",
+    "ospipe",
+)
+
+
+def _surface_token_hit(identifier: str) -> str | None:
+    """Return the banned implementation-detail token embedded in
+    `identifier`, or ``None`` if the identifier is clean.
+
+    The match is case-insensitive and substring-based so a token buried
+    inside a snake_case or camelCase name (`set_tokio_worker_threads`,
+    `TokioWorkerThreadsSetting`) is caught — exactly the blind spot in
+    the text scrubber's word-boundary rule. Vendor protocol names
+    (`mdds`, `fpss`) are intentionally absent from the token list, so a
+    `MddsClient` / `setFpssRingSize` identifier is never flagged.
+    """
+    lowered = identifier.lower()
+    for token in BANNED_SURFACE_TOKENS:
+        if token in lowered:
+            return token
+    return None
+
+
 # ─── Class-level discovery (legacy / non-dotted rows) ───────────────
 
 
@@ -372,6 +428,174 @@ def _setter_present(canonical: str, setters: set[str]) -> bool:
         if f"{canonical}{suffix}" in setters:
             return True
     return False
+
+
+# ─── Client-facing setter-set parity ────────────────────────────────
+
+
+# Per-binding spelling differences that are pure transport / language
+# idiom, not a semantic divergence. Folding them away lets the four
+# setter sets be compared for exact equality:
+#
+#   * `_explicit` — the widened `(has_value, n)` ABI variant a binding
+#     emits for an `Option<usize>` field (`worker_threads_explicit` on
+#     the C ABI / C++ / napi vs the bare `worker_threads` on Python).
+#     Same knob, transport-only suffix.
+#   * `flat_files` → `flatfiles` — napi auto-camelCases `setFlatFiles*`
+#     to a multi-word `FlatFiles`, which lifts back to BOTH
+#     `flat_files_*` and `flatfiles_*`; the cross-binding canonical
+#     form is the single-token `flatfiles_*`.
+def _normalize_setter(name: str) -> str:
+    """Collapse a per-binding setter spelling to its cross-binding
+    canonical form so the four setter sets compare for equality.
+    """
+    for suffix in FFI_EXPLICIT_SUFFIXES:
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+    name = name.replace("flat_files", "flatfiles")
+    return name
+
+
+# Client-facing setters that legitimately exist on only some bindings.
+# Each entry maps the canonical (normalized) setter name to a written
+# reason. This is the documented per-language-idiom carve-out the gate
+# tolerates — every entry is a reviewed decision, not a silencer.
+SETTER_PARITY_EXEMPT: dict[str, str] = {
+    "mdds_host": (
+        "advanced MDDS endpoint override, Python-only by design "
+        "(structural tests point the historical channel at a refused "
+        "endpoint); mdds is a vendor protocol name, kept verbatim"
+    ),
+    "mdds_port": (
+        "advanced MDDS endpoint override, Python-only by design "
+        "(companion to mdds_host); mdds is a vendor protocol name, "
+        "kept verbatim"
+    ),
+}
+
+
+def _check_setter_set_parity(
+    py_setters: set[str],
+    ts_setters: set[str],
+    cpp_setters: set[str],
+    ffi_setters: set[str],
+    exempt: dict[str, str] | None = None,
+) -> list[str]:
+    """Assert the client-facing setter SET matches across Python /
+    TypeScript / C++ / the C ABI after normalization.
+
+    The per-row dotted check (`_check_dotted_rows`) verifies each
+    declared knob resolves on the bindings it claims; this set-level
+    check is the complementary direction — it catches a knob that
+    landed on some bindings but silently never made it into the parity
+    matrix on the others (the `derive_ohlcvc`-missing-on-TS defect
+    class). Genuine per-language idioms are folded by
+    `_normalize_setter`; anything still divergent must be listed in
+    `exempt` (defaults to `SETTER_PARITY_EXEMPT`) with a reason or it
+    fails the gate. The `exempt` parameter is injectable so the
+    selftest can exercise the logic with synthetic carve-out lists.
+    """
+    if exempt is None:
+        exempt = SETTER_PARITY_EXEMPT
+    norm = {
+        "python": {_normalize_setter(s) for s in py_setters},
+        "typescript": {_normalize_setter(s) for s in ts_setters},
+        "cpp": {_normalize_setter(s) for s in cpp_setters},
+        "ffi": {_normalize_setter(s) for s in ffi_setters},
+    }
+    universe: set[str] = set().union(*norm.values())
+    errors: list[str] = []
+    for setter in sorted(universe - set(exempt)):
+        present_on = [lang for lang, names in norm.items() if setter in names]
+        if len(present_on) != len(norm):
+            missing = [lang for lang in norm if lang not in present_on]
+            errors.append(
+                f"  setter `{setter}`: present on {sorted(present_on)}, "
+                f"missing on {sorted(missing)}. Bind it on every binding, "
+                f"or add it to SETTER_PARITY_EXEMPT with a per-language-"
+                f"idiom reason."
+            )
+    # A stale exemption — the knob is now uniformly bound on every
+    # binding, so the carve-out is obsolete — is itself a drift; surface
+    # it so the list never rots. (A knob that is simply absent from the
+    # universe is not flagged: the exemption may guard a binding the
+    # current scan does not see.)
+    for setter, reason in exempt.items():
+        present_on = [lang for lang, names in norm.items() if setter in names]
+        if present_on and len(present_on) == len(norm):
+            errors.append(
+                f"  setter `{setter}`: listed in SETTER_PARITY_EXEMPT "
+                f"({reason!r}) but is now uniformly bound on every "
+                f"binding. Drop the stale exemption."
+            )
+    return errors
+
+
+# ─── Public-surface identifier collection (vocab guard) ─────────────
+
+
+def _check_public_surface_vocab(
+    py_classes: set[str],
+    ts_classes: set[str],
+    cpp_classes: set[str],
+    py_setters: set[str],
+    ts_setters: set[str],
+    cpp_setters: set[str],
+    ffi_setters: set[str],
+    py_methods: dict[str, set[str]],
+    ts_methods: dict[str, set[str]],
+    cpp_methods: dict[str, set[str]],
+) -> list[str]:
+    """Assert no PUBLIC client identifier embeds a banned architecture
+    token.
+
+    Scans the identifier sets the parity collectors already harvest —
+    classes, config setters, and per-class methods on every binding —
+    for an internal-architecture token (`tokio`, `mdds`, `disruptor`,
+    ...) buried inside the name. This is the structural counterpart to
+    the text scrubber: it sees only declared public API names, so it
+    never false-positives on the bindings' legitimate internal use of
+    the runtime / ring / lock primitives, and it catches a banned token
+    embedded in a snake_case / camelCase identifier that the scrubber's
+    `\\bword\\b` rule misses.
+    """
+    errors: list[str] = []
+
+    def _check(identifier: str, where: str) -> None:
+        token = _surface_token_hit(identifier)
+        if token is not None:
+            errors.append(
+                f"  {where}: public identifier `{identifier}` embeds "
+                f"banned architecture token `{token}`. Rename to a "
+                f"neutral client-facing name (the user concept, not the "
+                f"implementation)."
+            )
+
+    for cls in sorted(py_classes):
+        _check(cls, "python class")
+    for cls in sorted(ts_classes):
+        _check(cls, "typescript class")
+    for cls in sorted(cpp_classes):
+        _check(cls, "cpp class")
+    for setter in sorted(py_setters):
+        _check(setter, "python setter")
+    for setter in sorted(ts_setters):
+        _check(setter, "typescript setter")
+    for setter in sorted(cpp_setters):
+        _check(setter, "cpp setter")
+    for setter in sorted(ffi_setters):
+        _check(setter, "ffi setter")
+    for cls, methods in sorted(py_methods.items()):
+        for method in sorted(methods):
+            _check(method, f"python method {cls}.")
+    for cls, methods in sorted(ts_methods.items()):
+        for method in sorted(methods):
+            _check(method, f"typescript method {cls}.")
+    for cls, methods in sorted(cpp_methods.items()):
+        for method in sorted(methods):
+            _check(method, f"cpp method {cls}.")
+    return errors
 
 
 # ─── Rust field discovery (reverse-direction orphan check) ──────────
@@ -1091,6 +1315,35 @@ def main(argv: list[str] | None = None) -> int:
     # Value-field TYPE parity ([[value_field]] rows).
     value_field_errors = _check_value_field_rows(value_field_rows)
 
+    # Public-surface vocabulary: no public client identifier may embed
+    # one of OUR implementation-detail tokens (tokio / disruptor /
+    # crossbeam / parking_lot / block_on / allow_threads / os_pipe).
+    # Vendor protocol names (mdds / fpss) are allow-listed. This is the
+    # structural counterpart to the text scrubber — it sees only public
+    # API names, so it never false-positives on internal runtime use.
+    surface_vocab_errors = _check_public_surface_vocab(
+        py_classes,
+        ts_classes,
+        cpp_classes,
+        py_setters,
+        ts_setters,
+        cpp_setters,
+        ffi_setters,
+        py_class_methods,
+        ts_class_methods,
+        cpp_class_methods,
+    )
+
+    # Client-facing setter-SET equality across Python / TS / C++ / the
+    # C ABI after normalization (`_explicit` widened-ABI suffix and the
+    # `flat_files`↔`flatfiles` camelCase split folded away). Catches a
+    # knob bound on some bindings but silently absent from the matrix on
+    # the others. Genuine per-language idioms are exempted in
+    # `SETTER_PARITY_EXEMPT` with a written reason.
+    setter_set_errors = _check_setter_set_parity(
+        py_setters, ts_setters, cpp_setters, ffi_setters
+    )
+
     # Catch-all: every Python pyclass must be either tracked
     # explicitly or via the implicit pattern (mechanical parity).
     untracked: set[str] = {
@@ -1149,6 +1402,26 @@ def main(argv: list[str] | None = None) -> int:
         )
         for e in value_field_errors:
             print(f"  {e}")
+        print()
+
+    if surface_vocab_errors:
+        had_errors = True
+        print(
+            f"check_binding_parity: {len(surface_vocab_errors)} public "
+            f"identifier(s) embed an implementation-detail token:"
+        )
+        for e in surface_vocab_errors:
+            print(e)
+        print()
+
+    if setter_set_errors:
+        had_errors = True
+        print(
+            f"check_binding_parity: {len(setter_set_errors)} client-facing "
+            f"setter(s) diverge across bindings (set-level parity):"
+        )
+        for e in setter_set_errors:
+            print(e)
         print()
 
     if untracked:
@@ -1679,6 +1952,207 @@ def _run_selftest() -> int:
     _case("value_field positive — Rust + C++ types match the declared", _case_value_field_positive_matches)
     _case("value_field negative — Rust strike type drift trips", _case_value_field_rust_type_mismatch_trips)
     _case("value_field negative — C++ right-as-int trips", _case_value_field_cpp_type_mismatch_trips)
+
+    # ── Public-surface vocabulary guard selftests ──────────────────
+
+    def _case_surface_vocab_flags_tokio_identifier() -> None:
+        """An impl-detail token embedded in a public identifier trips,
+        even though `\\btokio\\b` would not match it.
+        """
+        errors = _check_public_surface_vocab(
+            {"Config"},
+            set(),
+            set(),
+            {"tokio_worker_threads"},
+            set(),
+            set(),
+            set(),
+            {},
+            {},
+            {},
+        )
+        assert any("tokio" in e for e in errors), (
+            f"embedded tokio token must trip the guard; got {errors!r}"
+        )
+
+    def _case_surface_vocab_flags_camelcase_export() -> None:
+        """A camelCase export type embedding the token trips."""
+        errors = _check_public_surface_vocab(
+            set(),
+            {"TokioWorkerThreadsSetting"},
+            set(),
+            set(),
+            set(),
+            set(),
+            set(),
+            {},
+            {},
+            {},
+        )
+        assert any("tokio" in e for e in errors), (
+            f"camelCase Tokio export must trip; got {errors!r}"
+        )
+
+    def _case_surface_vocab_flags_other_impl_tokens() -> None:
+        """The other OUR-impl tokens (crossbeam / parking_lot /
+        disruptor / block_on / allow_threads / os_pipe) all trip when
+        embedded in a public identifier, in both snake_case and
+        camelCase spellings (the camelCase form collapses the
+        underscore, so `parkingLotGuard` hits the `parkinglot` variant).
+        """
+        for ident in [
+            "set_crossbeam_depth",
+            "parkingLotGuard",
+            "parking_lot_guard",
+            "disruptorRingSize",
+            "blockOnConnect",
+            "block_on_connect",
+            "allowThreadsFlag",
+            "allow_threads_flag",
+            "osPipeFd",
+        ]:
+            errors = _check_public_surface_vocab(
+                set(), set(), set(), {ident}, set(), set(), set(), {}, {}, {}
+            )
+            assert any(ident in e for e in errors), (
+                f"{ident!r} must trip the surface-vocab guard; got {errors!r}"
+            )
+
+    def _case_surface_vocab_allows_vendor_protocol_names() -> None:
+        """Vendor protocol names (mdds / fpss) are allow-listed and must
+        NEVER trip — `MddsClient`, `mdds_host`, `setFpssRingSize`,
+        `fpss_ring_size` are all clean.
+        """
+        errors = _check_public_surface_vocab(
+            {"MddsClient", "FpssClient", "FpssEvent"},
+            set(),
+            set(),
+            {"mdds_host", "mdds_port", "fpss_ring_size", "fpss_host_selection"},
+            {"fpss_ring_size"},
+            set(),
+            set(),
+            {"FpssClient": {"subscribe"}},
+            {},
+            {},
+        )
+        assert errors == [], (
+            f"vendor protocol names must be allow-listed; got {errors!r}"
+        )
+
+    def _case_surface_vocab_allows_neutral_names() -> None:
+        """The renamed neutral knob (`worker_threads`) is clean."""
+        errors = _check_public_surface_vocab(
+            {"Config", "WorkerThreadsSetting"},
+            set(),
+            set(),
+            {"worker_threads"},
+            {"worker_threads_explicit"},
+            {"worker_threads_explicit"},
+            {"worker_threads_explicit"},
+            {},
+            {},
+            {},
+        )
+        assert errors == [], (
+            f"neutral worker_threads names must be clean; got {errors!r}"
+        )
+
+    _case("surface-vocab — embedded tokio token trips", _case_surface_vocab_flags_tokio_identifier)
+    _case("surface-vocab — camelCase Tokio export trips", _case_surface_vocab_flags_camelcase_export)
+    _case("surface-vocab — other impl tokens trip", _case_surface_vocab_flags_other_impl_tokens)
+    _case("surface-vocab — vendor protocol names allow-listed", _case_surface_vocab_allows_vendor_protocol_names)
+    _case("surface-vocab — neutral names clean", _case_surface_vocab_allows_neutral_names)
+
+    # ── Setter normalizer + set-parity selftests ───────────────────
+
+    def _case_normalizer_folds_explicit_and_flatfiles() -> None:
+        """`_normalize_setter` folds the `_explicit` widened-ABI suffix
+        and the `flat_files`→`flatfiles` camelCase split.
+        """
+        assert _normalize_setter("worker_threads_explicit") == "worker_threads"
+        assert _normalize_setter("worker_threads") == "worker_threads"
+        assert _normalize_setter("flat_files_max_attempts") == "flatfiles_max_attempts"
+        assert _normalize_setter("flatfiles_max_attempts") == "flatfiles_max_attempts"
+        assert _normalize_setter("fpss_host_shuffle_seed_explicit") == "fpss_host_shuffle_seed"
+
+    def _case_setter_set_parity_positive_after_normalize() -> None:
+        """The four sets, spelled in their per-binding idioms, compare
+        equal after normalization — the gate is silent.
+        """
+        py = {"worker_threads", "flatfiles_jitter", "derive_ohlcvc"}
+        ts = {"worker_threads_explicit", "flat_files_jitter", "flatfiles_jitter", "derive_ohlcvc"}
+        cpp = {"worker_threads_explicit", "flatfiles_jitter", "derive_ohlcvc"}
+        ffi = {"worker_threads_explicit", "flatfiles_jitter", "derive_ohlcvc"}
+        errors = _check_setter_set_parity(py, ts, cpp, ffi, exempt={})
+        assert errors == [], (
+            f"normalized-equal sets must be silent; got {errors!r}"
+        )
+
+    def _case_setter_set_parity_missing_on_one_binding_trips() -> None:
+        """A knob bound on three bindings but absent from TS trips — the
+        `derive_ohlcvc`-missing-on-TS defect class.
+        """
+        py = {"derive_ohlcvc"}
+        ts: set[str] = set()
+        cpp = {"derive_ohlcvc"}
+        ffi = {"derive_ohlcvc"}
+        errors = _check_setter_set_parity(py, ts, cpp, ffi, exempt={})
+        assert any("derive_ohlcvc" in e and "typescript" in e for e in errors), (
+            f"missing-on-TS knob must trip the set-parity gate; got {errors!r}"
+        )
+
+    def _case_setter_set_parity_honours_exemption() -> None:
+        """A Python-only knob listed in the exemption map does NOT trip
+        — the documented per-language-idiom carve-out.
+        """
+        py = {"mdds_host", "shared"}
+        ts = {"shared"}
+        cpp = {"shared"}
+        ffi = {"shared"}
+        errors = _check_setter_set_parity(
+            py, ts, cpp, ffi, exempt={"mdds_host": "Python-only advanced override"}
+        )
+        assert errors == [], (
+            f"exempted Python-only knob must not trip; got {errors!r}"
+        )
+
+    def _case_setter_set_parity_stale_exemption_trips() -> None:
+        """An exempted knob that is now uniformly bound on every binding
+        is a stale carve-out and trips so the list never rots.
+        """
+        allfour = {"mdds_host"}
+        errors = _check_setter_set_parity(
+            allfour,
+            allfour,
+            allfour,
+            allfour,
+            exempt={"mdds_host": "Python-only advanced override"},
+        )
+        assert any("mdds_host" in e and "stale" in e for e in errors), (
+            f"uniformly-bound exemption must surface as stale; got {errors!r}"
+        )
+
+    def _case_setter_set_parity_shipped_exemption_is_live() -> None:
+        """The shipped `SETTER_PARITY_EXEMPT` carve-outs must be live
+        against the real binding sources — `mdds_host` / `mdds_port`
+        present on Python alone, so neither flags as stale and the live
+        gate stays silent on them.
+        """
+        py = _collect_python_setters(PY_SRC)
+        ts = _collect_typescript_setters(TS_SRC)
+        cpp = _collect_cpp_setters(CPP_HPP, CPP_H)
+        ffi = _collect_ffi_setters(FFI_SRC)
+        errors = _check_setter_set_parity(py, ts, cpp, ffi)
+        assert errors == [], (
+            f"live setter-set parity must be clean; got {errors!r}"
+        )
+
+    _case("normalizer — folds _explicit + flat_files", _case_normalizer_folds_explicit_and_flatfiles)
+    _case("setter-set — normalized-equal sets are silent", _case_setter_set_parity_positive_after_normalize)
+    _case("setter-set — missing-on-TS knob trips", _case_setter_set_parity_missing_on_one_binding_trips)
+    _case("setter-set — Python-only exemption honoured", _case_setter_set_parity_honours_exemption)
+    _case("setter-set — stale exemption trips", _case_setter_set_parity_stale_exemption_trips)
+    _case("setter-set — shipped exemptions live against real sources", _case_setter_set_parity_shipped_exemption_is_live)
 
     print(f"check_binding_parity --selftest: {n_pass} passed, {n_fail} failed")
     return 0 if n_fail == 0 else 1

--- a/scripts/test_check_binding_parity.py
+++ b/scripts/test_check_binding_parity.py
@@ -41,10 +41,13 @@ import check_binding_parity as cbp  # noqa: E402
 
 
 _fails: list[str] = []
+_total = 0
 
 
 def _check(label: str, fn) -> None:
     """Run a test closure under a label; record failures."""
+    global _total
+    _total += 1
     try:
         fn()
     except AssertionError as e:
@@ -256,23 +259,23 @@ def test_orphan_rust_field_trips(tmpdir: pathlib.Path) -> None:
 
 
 def test_explicit_widened_abi_accepted() -> None:
-    """FFI emits `tdx_config_set_tokio_worker_threads_explicit` for the
+    """FFI emits `tdx_config_set_worker_threads_explicit` for the
     widened `(has_value, n)` ABI shape; the parity row uses the bare
-    `tokio_worker_threads` name. The gate must accept the `_explicit`
+    public `worker_threads` name. The gate must accept the `_explicit`
     suffix as equivalent.
     """
     rows = [
         {
-            "name": "RuntimeConfig.tokio_worker_threads",
+            "name": "RuntimeConfig.worker_threads",
             "python": True,
             "typescript": True,
             "cpp": True,
         }
     ]
-    ffi_setters = {"tokio_worker_threads_explicit", "tokio_worker_threads"}
-    py_setters = {"tokio_worker_threads"}
-    ts_setters = {"tokio_worker_threads"}
-    cpp_setters = {"tokio_worker_threads"}
+    ffi_setters = {"worker_threads_explicit", "worker_threads"}
+    py_setters = {"worker_threads"}
+    ts_setters = {"worker_threads"}
+    cpp_setters = {"worker_threads"}
     errors = cbp._check_dotted_rows(
         rows, py_setters, ts_setters, cpp_setters, ffi_setters
     )
@@ -323,6 +326,95 @@ def test_unknown_struct_dotted_row_is_skipped() -> None:
     assert errors == [], f"unknown struct dotted row must skip; got {errors!r}"
 
 
+# ─── Public-surface vocabulary guard ────────────────────────────────
+
+
+def test_surface_vocab_flags_embedded_impl_token() -> None:
+    """A public identifier embedding one of OUR impl tokens (tokio)
+    trips the guard, even though `\\btokio\\b` would not match it.
+    """
+    errors = cbp._check_public_surface_vocab(
+        {"Config"}, set(), set(),
+        {"tokio_worker_threads"}, set(), set(), set(),
+        {}, {}, {},
+    )
+    assert any("tokio" in e for e in errors), (
+        f"embedded tokio identifier must trip; got {errors!r}"
+    )
+
+
+def test_surface_vocab_allows_vendor_protocol_names() -> None:
+    """Vendor protocol names (mdds / fpss) are allow-listed; the
+    `MddsClient` class and `mdds_host` / `fpss_ring_size` setters must
+    NOT trip.
+    """
+    errors = cbp._check_public_surface_vocab(
+        {"MddsClient", "FpssClient"}, set(), set(),
+        {"mdds_host", "mdds_port", "fpss_ring_size"}, set(), set(), set(),
+        {}, {}, {},
+    )
+    assert errors == [], f"vendor protocol names must be clean; got {errors!r}"
+
+
+def test_surface_vocab_allows_neutral_worker_threads() -> None:
+    """The renamed neutral knob is clean on every binding spelling."""
+    errors = cbp._check_public_surface_vocab(
+        {"WorkerThreadsSetting"}, set(), set(),
+        {"worker_threads"}, {"worker_threads_explicit"},
+        {"worker_threads_explicit"}, {"worker_threads_explicit"},
+        {}, {}, {},
+    )
+    assert errors == [], f"neutral worker_threads must be clean; got {errors!r}"
+
+
+# ─── Client-facing setter-SET parity ────────────────────────────────
+
+
+def test_setter_set_parity_normalizes_and_matches() -> None:
+    """Per-binding idioms (`_explicit`, `flat_files`↔`flatfiles`) fold
+    away; equal sets are silent.
+    """
+    py = {"worker_threads", "flatfiles_jitter"}
+    ts = {"worker_threads_explicit", "flat_files_jitter", "flatfiles_jitter"}
+    cpp = {"worker_threads_explicit", "flatfiles_jitter"}
+    ffi = {"worker_threads_explicit", "flatfiles_jitter"}
+    errors = cbp._check_setter_set_parity(py, ts, cpp, ffi, exempt={})
+    assert errors == [], f"normalized-equal sets must be silent; got {errors!r}"
+
+
+def test_setter_set_parity_missing_on_ts_trips() -> None:
+    """A knob bound on Python/C++/FFI but absent from TS trips — the
+    `derive_ohlcvc`-missing-on-TS defect class.
+    """
+    errors = cbp._check_setter_set_parity(
+        {"derive_ohlcvc"}, set(), {"derive_ohlcvc"}, {"derive_ohlcvc"}, exempt={}
+    )
+    assert any("derive_ohlcvc" in e and "typescript" in e for e in errors), (
+        f"missing-on-TS knob must trip; got {errors!r}"
+    )
+
+
+def test_setter_set_parity_exemption_honoured() -> None:
+    """A Python-only knob in the exemption map does NOT trip."""
+    errors = cbp._check_setter_set_parity(
+        {"mdds_host", "shared"}, {"shared"}, {"shared"}, {"shared"},
+        exempt={"mdds_host": "Python-only advanced override"},
+    )
+    assert errors == [], f"exempted Python-only knob must not trip; got {errors!r}"
+
+
+def test_setter_set_parity_live_sources_clean() -> None:
+    """The shipped exemptions are live against the real binding
+    sources: the full setter-set parity gate is clean.
+    """
+    py = cbp._collect_python_setters(cbp.PY_SRC)
+    ts = cbp._collect_typescript_setters(cbp.TS_SRC)
+    cpp = cbp._collect_cpp_setters(cbp.CPP_HPP, cbp.CPP_H)
+    ffi = cbp._collect_ffi_setters(cbp.FFI_SRC)
+    errors = cbp._check_setter_set_parity(py, ts, cpp, ffi)
+    assert errors == [], f"live setter-set parity must be clean; got {errors!r}"
+
+
 # ─── Driver ────────────────────────────────────────────────────────
 
 
@@ -343,13 +435,20 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         _check("setter override resolves alternate name", lambda: test_setter_override_resolves_alternate_name(pathlib.Path(tmp)))
     _check("unknown struct dotted row is skipped", test_unknown_struct_dotted_row_is_skipped)
+    _check("surface-vocab flags embedded impl token", test_surface_vocab_flags_embedded_impl_token)
+    _check("surface-vocab allows vendor protocol names", test_surface_vocab_allows_vendor_protocol_names)
+    _check("surface-vocab allows neutral worker_threads", test_surface_vocab_allows_neutral_worker_threads)
+    _check("setter-set normalizes and matches", test_setter_set_parity_normalizes_and_matches)
+    _check("setter-set missing-on-TS trips", test_setter_set_parity_missing_on_ts_trips)
+    _check("setter-set exemption honoured", test_setter_set_parity_exemption_honoured)
+    _check("setter-set live sources clean", test_setter_set_parity_live_sources_clean)
 
     if _fails:
         print(f"test_check_binding_parity: {len(_fails)} failure(s)")
         for line in _fails:
             print(f"  {line}")
         return 1
-    print("test_check_binding_parity: all 12 cases passed")
+    print(f"test_check_binding_parity: all {_total} cases passed")
     return 0
 
 

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -1251,30 +1251,29 @@ void tdx_config_set_flatfiles_jitter(TdxConfig* config, bool jitter);
 int32_t tdx_config_get_flatfiles_jitter(const TdxConfig* config, bool* out_jitter);
 
 /**
- * Set the RuntimeConfig.tokio_worker_threads knob for embedded
- * runtimes built via RuntimeConfig::build_runtime.
+ * Set the async worker-thread count for embedded runtimes.
  *
  *   has_value=false: encodes the auto-size sentinel (`None`); `n`
- *     is ignored. Defers to tokio's default sizing.
- *   has_value=true: encodes `Some(n)`. RuntimeConfig::build_runtime
- *     clamps `n=0` to `1`, but the explicit `Some(0)` is preserved
- *     across the C boundary matching the widened Option shape so
- *     Python / TS / C++ bindings agree.
+ *     is ignored. Defers to the default sizing.
+ *   has_value=true: encodes `Some(n)`. The builder clamps `n=0` to
+ *     `1`, but the explicit `Some(0)` is preserved across the C
+ *     boundary matching the widened Option shape so Python / TS / C++
+ *     bindings agree.
  *
  * Returns 0 on success, -1 if `config` is NULL.
  */
-int32_t tdx_config_set_tokio_worker_threads_explicit(TdxConfig* config, bool has_value, size_t n);
+int32_t tdx_config_set_worker_threads_explicit(TdxConfig* config, bool has_value, size_t n);
 
 /**
- * Read the current RuntimeConfig.tokio_worker_threads setting. Same
- * widened (has_value, n) shape:
+ * Read the current async worker-thread count. Same widened
+ * (has_value, n) shape:
  *
  *   *out_has_value=false: config holds `None` (auto-size). *out_n=0.
  *   *out_has_value=true:  config holds `Some(*out_n)`.
  *
  * Returns 0 on success, -1 if any pointer is null.
  */
-int32_t tdx_config_get_tokio_worker_threads(const TdxConfig* config, bool* out_has_value, size_t* out_n);
+int32_t tdx_config_get_worker_threads(const TdxConfig* config, bool* out_has_value, size_t* out_n);
 
 /* ── RetryPolicy field setters/getters ── */
 

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -841,17 +841,17 @@ public:
     }
 
 
-    /** Set the RuntimeConfig.tokio_worker_threads knob using the
-     *  (has_value, n) shape that preserves Some(0) across the C
-     *  boundary. has_value=false defers to tokio's default sizing. */
-    int32_t set_tokio_worker_threads_explicit(bool has_value, size_t n) {
-        return tdx_config_set_tokio_worker_threads_explicit(handle_.get(), has_value, n);
+    /** Set the async worker-thread count using the (has_value, n) shape
+     *  that preserves Some(0) across the C boundary. has_value=false
+     *  defers to the default sizing. */
+    int32_t set_worker_threads_explicit(bool has_value, size_t n) {
+        return tdx_config_set_worker_threads_explicit(handle_.get(), has_value, n);
     }
 
-    /** Read tokio_worker_threads back. *out_has_value=false encodes
-     *  the None (auto-size) sentinel. */
-    int32_t get_tokio_worker_threads(bool* out_has_value, size_t* out_n) const {
-        return tdx_config_get_tokio_worker_threads(handle_.get(), out_has_value, out_n);
+    /** Read worker_threads back. *out_has_value=false encodes the None
+     *  (auto-size) sentinel. */
+    int32_t get_worker_threads(bool* out_has_value, size_t* out_n) const {
+        return tdx_config_get_worker_threads(handle_.get(), out_has_value, out_n);
     }
 
     // ── RetryPolicy field setters/getters ──

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -345,15 +345,19 @@ cpp = true
 
 # ─── RuntimeConfig cross-binding setters ───────────────────────────────
 #
-# Async-runtime sub-config knobs honoured by embedded bindings that own
-# their tokio runtime (FFI / Python / napi). The
-# `tokio_worker_threads` field uses the widened `(has_value, n)` ABI
-# shape on the C surface so the `Some(0)` sentinel survives the C
-# boundary. `RuntimeConfig::build_runtime` interprets the field for
-# callers building their own runtime.
+# Async worker-thread sub-config knob honoured by embedded bindings
+# that own their runtime (FFI / Python / napi). The public setter is
+# `worker_threads` on every binding (Python `Config.worker_threads`,
+# TypeScript `Config.setWorkerThreadsExplicit` / `workerThreads`, C++
+# `set_worker_threads_explicit`, FFI
+# `tdx_config_set_worker_threads_explicit`). The row name carries the
+# public concept; the internal storage field maps to it through the
+# rename table in `check_binding_parity.py`. The widened
+# `(has_value, n)` ABI shape on the C surface lets the `Some(0)`
+# sentinel survive the C boundary.
 
 [[class]]
-name = "RuntimeConfig.tokio_worker_threads"
+name = "RuntimeConfig.worker_threads"
 python = true
 typescript = true
 cpp = true

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -640,14 +640,14 @@ python = true
 typescript = true
 cpp = true
 
-# `FpssConfig.derive_ohlcvc` is exposed on the C ABI
-# (`tdx_config_set_derive_ohlcvc`) + Python (`Config.derive_ohlcvc`)
-# + C++ (`set_derive_ohlcvc`) but not on TypeScript. The row
-# captures the partial-binding state.
+# `FpssConfig.derive_ohlcvc` is exposed on every binding: the C ABI
+# (`tdx_config_set_derive_ohlcvc`), Python (`Config.derive_ohlcvc`),
+# C++ (`set_derive_ohlcvc`), and TypeScript (`Config.setDeriveOhlcvc`
+# / `deriveOhlcvc`).
 [[class]]
 name = "FpssConfig.derive_ohlcvc"
 python = true
-typescript = false
+typescript = true
 cpp = true
 
 # ─── AuthConfig / MetricsConfig cross-binding setters ──────────────────

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -465,22 +465,26 @@ cpp = true          # `tdx::IndexPriceAtTimeTick` alias over `TdxIndexPriceAtTim
 # tightening) is the umbrella issue under which the cross-binding
 # sweep for these fields would be planned.
 #
-# Two `MddsConfig` test-only setters (`mdds_host` / `mdds_port`) are
+# Two `MddsConfig` advanced overrides (`mdds_host` / `mdds_port`) are
 # exposed on Python alone for structural-test usage (point the
 # historical channel at a refused endpoint to prove the streaming
-# surface never opens it). The dotted rows below capture the
-# partial-binding state via the `setter = "..."` override on Python.
+# surface never opens it). MDDS is a vendor protocol name, kept
+# verbatim; these knobs are Python-only by design — they are NOT
+# forced onto the other bindings, and the setter-set parity check
+# exempts them with a written reason. The dotted rows below capture
+# the partial-binding state via the `setter = "..."` override on
+# Python.
 
 [[class]]
 name = "MddsConfig.host"
-python = true       # `Config.mdds_host` test-only setter
+python = true       # `Config.mdds_host` advanced override (Python-only)
 typescript = false
 cpp = false
 setter = "mdds_host"
 
 [[class]]
 name = "MddsConfig.port"
-python = true       # `Config.mdds_port` test-only setter
+python = true       # `Config.mdds_port` advanced override (Python-only)
 typescript = false
 cpp = false
 setter = "mdds_port"

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -108,11 +108,10 @@ class Config:
     # Write-only: reading the configured callable back is not
     # supported (`reconnect_policy` reports "custom").
     reconnect_callback: Optional[Callable[[int, int], Optional[int]]]
-    # Tokio worker-thread count for embedded runtimes built via
-    # `RuntimeConfig::build_runtime`. `None` defers to tokio's default
-    # sizing; `int` (including `0`, which clamps to `1` inside the
-    # builder) pins worker count.
-    tokio_worker_threads: Optional[int]
+    # Async worker-thread count for embedded runtimes. `None` defers to
+    # the default sizing; `int` (including `0`, which clamps to `1`)
+    # pins worker count.
+    worker_threads: Optional[int]
     # RetryPolicy fields — per-field access on `DirectConfig.retry`.
     # Defaults: `initial=250ms`, `max=30s`, `attempts=20`,
     # `max_elapsed_secs=300` (0 disables the wall-clock envelope),

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -760,27 +760,25 @@ impl Config {
         guard.flatfiles.jitter
     }
 
-    /// Set the tokio worker thread count for embedded bindings that own
+    /// Set the async worker-thread count for embedded bindings that own
     /// their runtime (Python / FFI / napi). ``None`` (the default)
-    /// defers to tokio's default sizing (one worker per logical CPU);
+    /// defers to the default sizing (one worker per logical CPU);
     /// ``Some(n)`` pins the worker pool to ``n``. ``Some(0)`` is
-    /// preserved across the binding boundary and clamps to ``1`` inside
-    /// :func:`RuntimeConfig.build_runtime` so the runtime always has at
-    /// least one worker.
+    /// preserved across the binding boundary and clamps to ``1`` so the
+    /// runtime always has at least one worker.
     ///
     /// Note that the runtime backing ``ThetaDataDxClient`` is built
     /// process-once at module init; mutating this value after import
-    /// affects only freshly-constructed runtimes such as those built
-    /// via the FFI ``tdx_config_get_tokio_worker_threads`` helper.
+    /// affects only freshly-constructed runtimes.
     #[setter]
-    fn set_tokio_worker_threads(&self, n: Option<usize>) {
+    fn set_worker_threads(&self, n: Option<usize>) {
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         guard.runtime.tokio_worker_threads = n;
     }
 
-    /// Current ``tokio_worker_threads`` setting (``None`` = auto).
+    /// Current ``worker_threads`` setting (``None`` = auto).
     #[getter]
-    fn get_tokio_worker_threads(&self) -> Option<usize> {
+    fn get_worker_threads(&self) -> Option<usize> {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         guard.runtime.tokio_worker_threads
     }

--- a/sdks/python/tests/test_config_reconnect.py
+++ b/sdks/python/tests/test_config_reconnect.py
@@ -217,30 +217,30 @@ def test_reconnect_wait_ms_rejects_above_u64() -> None:
         cfg.reconnect_wait_rate_limited_ms = 1 << 65
 
 
-# ─── RuntimeConfig.tokio_worker_threads ────────────────────────────
+# ─── RuntimeConfig.worker_threads ──────────────────────────────────
 
 
-def test_tokio_worker_threads_default_is_none() -> None:
-    """Default is ``None`` (tokio default sizing, one worker per
-    logical CPU).
+def test_worker_threads_default_is_none() -> None:
+    """Default is ``None`` (default sizing, one worker per logical
+    CPU).
     """
     mod = _import_module()
     cfg = mod.Config.production()
-    assert cfg.tokio_worker_threads is None
+    assert cfg.worker_threads is None
 
 
-def test_tokio_worker_threads_round_trips_some_zero() -> None:
+def test_worker_threads_round_trips_some_zero() -> None:
     """``Some(0)`` is preserved verbatim across the binding boundary;
-    ``RuntimeConfig::build_runtime`` clamps it to ``1`` only inside
-    the runtime builder, never at the setter.
+    the runtime builder clamps it to ``1`` only inside the builder,
+    never at the setter.
     """
     mod = _import_module()
     cfg = mod.Config.production()
     for n in [0, 1, 2, 4, 8, 16, 64]:
-        cfg.tokio_worker_threads = n
-        assert cfg.tokio_worker_threads == n
-    cfg.tokio_worker_threads = None
-    assert cfg.tokio_worker_threads is None
+        cfg.worker_threads = n
+        assert cfg.worker_threads == n
+    cfg.worker_threads = None
+    assert cfg.worker_threads is None
 
 
 # ─── RetryPolicy field setters/getters ─────────────────────────────

--- a/sdks/typescript/__tests__/config_reconnect.test.mjs
+++ b/sdks/typescript/__tests__/config_reconnect.test.mjs
@@ -155,10 +155,10 @@ describe('Config.setReconnectWaitMs / setReconnectWaitRateLimitedMs', () => {
   });
 });
 
-describe('Config.setTokioWorkerThreadsExplicit', () => {
-  it('default tokio_worker_threads is the None (auto) sentinel', () => {
+describe('Config.setWorkerThreadsExplicit', () => {
+  it('default workerThreads is the None (auto) sentinel', () => {
     const cfg = Config.production();
-    const got = cfg.tokioWorkerThreads;
+    const got = cfg.workerThreads;
     assert.equal(got.hasValue, false, 'default must be None');
     assert.equal(got.n, 0);
   });
@@ -166,14 +166,14 @@ describe('Config.setTokioWorkerThreadsExplicit', () => {
   it('round-trip preserves Some(0) and explicit pinned counts', () => {
     const cfg = Config.production();
     for (const n of [0, 1, 2, 4, 8, 16, 64]) {
-      cfg.setTokioWorkerThreadsExplicit(true, n);
-      const got = cfg.tokioWorkerThreads;
+      cfg.setWorkerThreadsExplicit(true, n);
+      const got = cfg.workerThreads;
       assert.equal(got.hasValue, true);
       assert.equal(got.n, n);
     }
     // Reset to None.
-    cfg.setTokioWorkerThreadsExplicit(false, 999);
-    const got = cfg.tokioWorkerThreads;
+    cfg.setWorkerThreadsExplicit(false, 999);
+    const got = cfg.workerThreads;
     assert.equal(got.hasValue, false);
     assert.equal(got.n, 0);
   });

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -409,6 +409,14 @@ export declare class Config {
    * `"immediate"`).
    */
   get flushMode(): string
+  /**
+   * Set whether to derive OHLCVC bars locally from trade events.
+   * When `false`, only server-sent OHLCVC frames are emitted,
+   * reducing per-trade throughput overhead. Default `true`.
+   */
+  setDeriveOhlcvc(enabled: boolean): void
+  /** Current OHLCVC derivation setting. */
+  get deriveOhlcvc(): boolean
 }
 
 /**

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -288,19 +288,18 @@ export declare class Config {
   /** Current `flatfiles.jitter` value (default `true`). */
   get flatFilesJitter(): boolean
   /**
-   * Set the `RuntimeConfig.tokio_worker_threads` knob for embedded
-   * runtimes built via `RuntimeConfig::build_runtime`. `hasValue=false`
-   * defers to tokio's default sizing; `hasValue=true` pins worker
-   * count to `n` (with `n=0` preserved as the `Some(0)` sentinel,
-   * matching the widened-`Option` setter shape across the binding
-   * matrix).
+   * Set the async worker-thread count for embedded runtimes.
+   * `hasValue=false` defers to the default sizing; `hasValue=true`
+   * pins worker count to `n` (with `n=0` preserved as the `Some(0)`
+   * sentinel, matching the widened-`Option` setter shape across the
+   * binding matrix).
    */
-  setTokioWorkerThreadsExplicit(hasValue: boolean, n: number): void
+  setWorkerThreadsExplicit(hasValue: boolean, n: number): void
   /**
-   * Current `tokio_worker_threads` setting as `{ hasValue, n }`.
+   * Current `workerThreads` setting as `{ hasValue, n }`.
    * `hasValue=false` encodes the `None` (auto) sentinel.
    */
-  get tokioWorkerThreads(): TokioWorkerThreadsSetting
+  get workerThreads(): WorkerThreadsSetting
   /**
    * Set the initial backoff delay (ms) for the historical-channel retry policy.
    * Default `250n`. Subsequent retries double from here, capped at
@@ -3739,19 +3738,6 @@ export interface StockSnapshotTradeOptions {
   timeoutMs?: number
 }
 
-/**
- * `(has_value, n)` shape mirroring the FFI
- * `tdx_config_get_tokio_worker_threads` out-params and the Python
- * `Option<usize>` return — `has_value=false` encodes the `None`
- * sentinel, `has_value=true` carries the explicit worker count
- * (with `n=0` preserved verbatim, matching the widened-`Option`
- * cross-binding contract).
- */
-export interface TokioWorkerThreadsSetting {
-  hasValue: boolean
-  n: number
-}
-
 /** FPSS Trade tick. Mirrors `FpssData::Trade`. */
 export interface Trade {
   contract: Contract
@@ -4065,6 +4051,18 @@ export declare const enum Venue {
 export declare const enum Version {
   Latest = 'latest',
   V1 = '1'
+}
+
+/**
+ * `(has_value, n)` shape mirroring the C-ABI `worker_threads`
+ * out-params and the Python `Option<usize>` return — `has_value=false`
+ * encodes the `None` sentinel, `has_value=true` carries the explicit
+ * worker count (with `n=0` preserved verbatim, matching the
+ * widened-`Option` cross-binding contract).
+ */
+export interface WorkerThreadsSetting {
+  hasValue: boolean
+  n: number
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -1365,4 +1365,27 @@ impl Config {
             _ => "unknown",
         })
     }
+
+    /// Set whether to derive OHLCVC bars locally from trade events.
+    /// When `false`, only server-sent OHLCVC frames are emitted,
+    /// reducing per-trade throughput overhead. Default `true`.
+    #[napi(js_name = "setDeriveOhlcvc")]
+    pub fn set_derive_ohlcvc(&self, enabled: bool) -> napi::Result<()> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.fpss.derive_ohlcvc = enabled;
+        Ok(())
+    }
+
+    /// Current OHLCVC derivation setting.
+    #[napi(getter, js_name = "deriveOhlcvc")]
+    pub fn derive_ohlcvc(&self) -> napi::Result<bool> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.fpss.derive_ohlcvc)
+    }
 }

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -3,15 +3,14 @@ use std::sync::{Arc, Mutex};
 
 use thetadatadx::config;
 
-/// `(has_value, n)` shape mirroring the FFI
-/// `tdx_config_get_tokio_worker_threads` out-params and the Python
-/// `Option<usize>` return — `has_value=false` encodes the `None`
-/// sentinel, `has_value=true` carries the explicit worker count
-/// (with `n=0` preserved verbatim, matching the widened-`Option`
-/// cross-binding contract).
+/// `(has_value, n)` shape mirroring the C-ABI `worker_threads`
+/// out-params and the Python `Option<usize>` return — `has_value=false`
+/// encodes the `None` sentinel, `has_value=true` carries the explicit
+/// worker count (with `n=0` preserved verbatim, matching the
+/// widened-`Option` cross-binding contract).
 #[napi(object)]
 #[derive(Clone, Copy)]
-pub struct TokioWorkerThreadsSetting {
+pub struct WorkerThreadsSetting {
     pub has_value: bool,
     pub n: u32,
 }
@@ -994,14 +993,13 @@ impl Config {
         Ok(guard.flatfiles.jitter)
     }
 
-    /// Set the `RuntimeConfig.tokio_worker_threads` knob for embedded
-    /// runtimes built via `RuntimeConfig::build_runtime`. `hasValue=false`
-    /// defers to tokio's default sizing; `hasValue=true` pins worker
-    /// count to `n` (with `n=0` preserved as the `Some(0)` sentinel,
-    /// matching the widened-`Option` setter shape across the binding
-    /// matrix).
-    #[napi(js_name = "setTokioWorkerThreadsExplicit")]
-    pub fn set_tokio_worker_threads_explicit(&self, has_value: bool, n: u32) -> napi::Result<()> {
+    /// Set the async worker-thread count for embedded runtimes.
+    /// `hasValue=false` defers to the default sizing; `hasValue=true`
+    /// pins worker count to `n` (with `n=0` preserved as the `Some(0)`
+    /// sentinel, matching the widened-`Option` setter shape across the
+    /// binding matrix).
+    #[napi(js_name = "setWorkerThreadsExplicit")]
+    pub fn set_worker_threads_explicit(&self, has_value: bool, n: u32) -> napi::Result<()> {
         let mut guard = self
             .inner
             .lock()
@@ -1010,20 +1008,20 @@ impl Config {
         Ok(())
     }
 
-    /// Current `tokio_worker_threads` setting as `{ hasValue, n }`.
+    /// Current `workerThreads` setting as `{ hasValue, n }`.
     /// `hasValue=false` encodes the `None` (auto) sentinel.
-    #[napi(getter, js_name = "tokioWorkerThreads")]
-    pub fn tokio_worker_threads(&self) -> napi::Result<TokioWorkerThreadsSetting> {
+    #[napi(getter, js_name = "workerThreads")]
+    pub fn worker_threads(&self) -> napi::Result<WorkerThreadsSetting> {
         let guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
         Ok(match guard.runtime.tokio_worker_threads {
-            Some(n) => TokioWorkerThreadsSetting {
+            Some(n) => WorkerThreadsSetting {
                 has_value: true,
                 n: u32::try_from(n).unwrap_or(u32::MAX),
             },
-            None => TokioWorkerThreadsSetting {
+            None => WorkerThreadsSetting {
                 has_value: false,
                 n: 0,
             },

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -449,10 +449,10 @@ include!("_generated/streaming_methods.rs");
 
 // SDK configuration class. Adds `Config` napi class with
 // `production()` / `dev()` / `stage()` factories plus the full setter
-// surface for MDDS pool sizing, retry policy, reconnect policy, and
-// flat-file backoff.
+// surface for historical pool sizing, retry policy, reconnect policy,
+// and flat-file backoff.
 mod config_class;
-pub use config_class::{Config, TokioWorkerThreadsSetting};
+pub use config_class::{Config, WorkerThreadsSetting};
 
 // Hand-written FLATFILES bindings — dynamic schema, see module docs.
 mod flatfile_methods;


### PR DESCRIPTION
Removes our internal Rust runtime name from the public configuration API and completes the cross-binding parity guard so this class of leak cannot recur.

The async worker-thread-count knob was named after the runtime crate that backs it — an implementation detail that has no business in the client surface. It is renamed to `worker_threads` (Python setter/getter, TypeScript `workerThreads` / `WorkerThreadsSetting`, C++ `worker_threads`, and the C ABI `tdx_config_*_worker_threads`), identically across all four bindings. The internal `Config` storage field is unchanged. This is breaking and rides the next major.

ThetaData's own protocol names (`mdds`, `fpss`, `MddsClient`, `FpssClient`, and the rest) are vendor vocabulary and are kept verbatim — the SDK stays aligned with the vendor, and any migration is the vendor's call. They are allow-listed.

A full sweep of the public surface for our implementation-detail crate names (runtime, lock-primitive, ring-buffer, and FFI-bridge tokens) found exactly one leaked knob — the one above. Nothing else.

To prevent recurrence, a new structural guard in `check_binding_parity.py` asserts that no public identifier the parity collectors harvest embeds one of our implementation-detail tokens. It uses substring matching, so it catches a token embedded inside a snake_case or camelCase identifier — the exact blind spot in the whole-word text scrubber that let this through. The allow-list is shared with the text scrubber, so the vendor protocol names are never flagged.

The setter-parity check is also completed: the normalizer now folds the C-ABI `_explicit` suffix and the `flat_files` / `flatfiles` spelling, and a new assertion requires the client-facing setter set to be identical across all four bindings. That surfaced one real gap — `derive_ohlcvc` was missing on the TypeScript binding — now added. The Python-only `mdds_host` / `mdds_port` advanced overrides are exempted with a written reason.

Closes #694.
