### PR TITLE
ci(perf-gate): gate decode allocations-per-row on a deterministic metric

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -1,0 +1,60 @@
+name: Perf Gate
+
+# Per-binding performance-regression gate built on a DETERMINISTIC
+# metric: allocations per decoded row. Unlike the wall-clock Criterion
+# gate in `ci.yml`, this gate keys on an allocation count, which is a
+# property of the code rather than of the runner. The identical fixture
+# decodes with the identical number of allocations on a 2-vCPU hosted
+# runner and on a developer workstation, so the gate runs on shared
+# hardware without flaking. The rationale is documented in full in the
+# header of `scripts/check_perf_gate.py`.
+#
+# Kept in its own workflow file (not folded into `ci.yml`) so the gate's
+# bench step and baseline evolve without colliding with other in-flight
+# CI work.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Pin the directory the bench writes its metric report into, decoupled
+  # from the cargo invocation's working directory (Criterion runs benches
+  # with the crate root as cwd). The gate reads from the same path.
+  PERF_GATE_OUT_DIR: ${{ github.workspace }}/target/perf-gate
+
+jobs:
+  decode-allocations:
+    name: Decode allocations-per-row gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      # Same four-step Rust preamble every build job in this repo uses:
+      # stable toolchain, Swatinem cache, protoc.
+      - uses: ./.github/actions/setup-rust-deps
+      - name: Run the decode-allocations bench (counting allocator, no live creds)
+        # The counting global allocator lives only in this bench binary;
+        # the shipped library allocator is unchanged. `__internal` exposes
+        # the wire / decode surface the bench drives. The bench writes
+        # per-row allocation figures to PERF_GATE_OUT_DIR.
+        run: |
+          cargo bench -p thetadatadx --features __internal \
+              --bench bench_decode_allocations --locked -- --noplot
+      - name: Compare against the committed baseline
+        # Relative threshold plus an absolute floor, mirroring
+        # `check_bench_regression.py`. The metric is exact (an integer
+        # count over a fixed row count, no jitter), so the threshold is
+        # tight; the floor keeps the gate meaningful if a baseline ever
+        # approaches zero allocations per row.
+        run: python3 scripts/check_perf_gate.py --threshold 10

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -320,6 +320,18 @@ harness = false
 required-features = ["__internal"]
 
 [[bench]]
+# Records allocations per decoded row for each representative tick type
+# through `thetadatadx::decode::{decode_data_table, parse_*_ticks}` under
+# a counting global allocator, and writes the deterministic per-row
+# figures to `target/perf-gate/decode_allocations.json` for the perf
+# gate. Gated on `__internal` so the wire / decode surface stays off the
+# published API. The counting allocator lives only in this bench binary;
+# the shipped rlib allocator is unchanged.
+name = "bench_decode_allocations"
+harness = false
+required-features = ["__internal"]
+
+[[bench]]
 # Closed-loop measurement of the MDDS transport against a loopback
 # mock server: per-request latency percentiles, aggregate throughput,
 # allocation, and CPU per request across a concurrency x frame-shape

--- a/crates/thetadatadx/benches/baseline/perf_gate.json
+++ b/crates/thetadatadx/benches/baseline/perf_gate.json
@@ -1,0 +1,19 @@
+{
+  "_meta": {
+    "comment": "Per-binding performance-gate baseline (issue #696). Each tracked metric is a DETERMINISTIC allocation count, not a wall-clock time, so it gates identically on a 2-vCPU hosted runner and on a developer workstation. The loader in `scripts/check_perf_gate.py` keys on `metric_file` + `allocs_per_unit`; it ignores the `_meta` and `_captured_on` fields and any key prefixed with `_`. Refresh by re-running the decode-allocations bench on a green main and copying the new per-row figures here in a dedicated PR.",
+    "how_to_refresh": "PERF_GATE_OUT_DIR=$PWD/target/perf-gate cargo bench -p thetadatadx --features __internal --bench bench_decode_allocations -- --noplot, then copy each allocs_per_unit from target/perf-gate/decode_allocations.json into the matching entry below."
+  },
+  "_captured_on": "2026-06-12",
+  "decode_allocations/trade": {
+    "allocs_per_unit": 3.03,
+    "metric_file": "decode_allocations.json"
+  },
+  "decode_allocations/quote": {
+    "allocs_per_unit": 3.025,
+    "metric_file": "decode_allocations.json"
+  },
+  "decode_allocations/ohlc": {
+    "allocs_per_unit": 2.022,
+    "metric_file": "decode_allocations.json"
+  }
+}

--- a/crates/thetadatadx/benches/bench_decode_allocations.rs
+++ b/crates/thetadatadx/benches/bench_decode_allocations.rs
@@ -1,0 +1,267 @@
+//! Allocations-per-decoded-row gate harness (issue #696, metric 1).
+//!
+//! Decodes a fixed fixture of each representative tick type — trade,
+//! quote, OHLC — through the public MDDS decode path and records the
+//! number of heap allocations charged per decoded row. The figure is
+//! written to `target/perf-gate/decode_allocations.json`, which
+//! `scripts/check_perf_gate.py` diffs against the committed baseline.
+//!
+//! Why this gate does not flake on shared CI runners: the metric is an
+//! allocation COUNT, not a wall-clock time. Decoding the identical
+//! fixture performs the identical number of allocations on a 2-vCPU
+//! hosted runner and on a developer workstation — CPU frequency,
+//! scheduler pressure, and memory bandwidth do not change how many
+//! times the decode path calls `alloc`. A purely relative wall-clock
+//! gate against a fixed baseline would, by contrast, trip on the
+//! runner's slower clock alone. The allocation count is the
+//! deterministic invariant the low-allocation decode work earned, so it
+//! is what we pin.
+//!
+//! The counting allocator is installed ONLY in this bench binary (via
+//! the `#[global_allocator]` below). The shipped `thetadatadx` rlib
+//! declares no custom global allocator and is unaffected.
+//!
+//! Run: `cargo bench -p thetadatadx --features __internal \
+//!         --bench bench_decode_allocations -- --noplot`
+
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use thetadatadx::decode::{
+    decode_data_table, parse_ohlc_ticks, parse_quote_ticks, parse_trade_ticks,
+};
+use thetadatadx::wire as proto;
+
+#[path = "perf_gate_support/perf_alloc.rs"]
+mod perf_alloc;
+use perf_alloc::{snapshot, write_metric_file, Sample};
+
+#[path = "common/quote_fixture.rs"]
+mod fixture;
+use fixture::{build_quote_data_table, dv_number, dv_price};
+
+#[global_allocator]
+static ALLOC: perf_alloc::CountingAllocator = perf_alloc::CountingAllocator;
+
+// ─── Fixtures ────────────────────────────────────────────────────────
+//
+// Fixed row count. Large enough that the per-row figure is stable and
+// any constant one-shot allocation (the `Vec` header for the row
+// container, say) amortizes toward zero; the gate keys on the
+// steady-state per-row slope, so the exact constant does not matter as
+// long as it is held fixed across baseline and CI.
+
+const FIXTURE_ROWS: usize = 1000;
+
+fn row_of(values: Vec<proto::DataValue>) -> proto::DataValueList {
+    proto::DataValueList { values }
+}
+
+/// 15-column trade-tick `DataTable` — the canonical MDDS trade schema.
+fn build_trade_data_table(n: usize) -> proto::DataTable {
+    let headers = vec![
+        "ms_of_day".into(),
+        "sequence".into(),
+        "ext_condition1".into(),
+        "ext_condition2".into(),
+        "ext_condition3".into(),
+        "ext_condition4".into(),
+        "condition".into(),
+        "size".into(),
+        "exchange".into(),
+        "price".into(),
+        "condition_flags".into(),
+        "price_flags".into(),
+        "volume_type".into(),
+        "records_back".into(),
+        "date".into(),
+    ];
+    let mut rows = Vec::with_capacity(n);
+    for i in 0..n {
+        rows.push(row_of(vec![
+            dv_number(34_200_000 + i as i64 * 100),
+            dv_number(i as i64 + 1),
+            dv_number(0),
+            dv_number(0),
+            dv_number(0),
+            dv_number(0),
+            dv_number(0),
+            dv_number(100 + (i % 50) as i64),
+            dv_number(4),
+            dv_price(15_025 + (i % 200) as i32, 8),
+            dv_number(0),
+            dv_number(0),
+            dv_number(0),
+            dv_number(0),
+            dv_number(20_240_315),
+        ]));
+    }
+    proto::DataTable {
+        headers,
+        data_table: rows,
+    }
+}
+
+/// 8-column OHLC-tick `DataTable` — the canonical MDDS OHLC schema.
+fn build_ohlc_data_table(n: usize) -> proto::DataTable {
+    let headers = vec![
+        "ms_of_day".into(),
+        "open".into(),
+        "high".into(),
+        "low".into(),
+        "close".into(),
+        "volume".into(),
+        "count".into(),
+        "date".into(),
+    ];
+    let mut rows = Vec::with_capacity(n);
+    for i in 0..n {
+        let base = 15_000 + (i % 300) as i32;
+        rows.push(row_of(vec![
+            dv_number(34_200_000 + i as i64 * 60_000),
+            dv_price(base, 8),
+            dv_price(base + 50, 8),
+            dv_price(base - 30, 8),
+            dv_price(base + 10, 8),
+            dv_number(10_000 + (i * 137 % 5000) as i64),
+            dv_number(100 + (i % 200) as i64),
+            dv_number(20_240_315),
+        ]));
+    }
+    proto::DataTable {
+        headers,
+        data_table: rows,
+    }
+}
+
+fn uncompressed_response(table: &proto::DataTable) -> proto::ResponseData {
+    use prost::Message;
+    let mut raw = Vec::with_capacity(table.encoded_len());
+    table.encode(&mut raw).expect("encode fixture table");
+    proto::ResponseData {
+        compressed_data: raw,
+        compression_description: Some(proto::CompressionDescription {
+            algo: proto::CompressionAlgo::None as i32,
+            level: 0,
+        }),
+        original_size: 0,
+    }
+}
+
+// ─── Measurement ─────────────────────────────────────────────────────
+//
+// Each sample brackets a single full decode of the fixed-row fixture
+// with two counter snapshots and reports `(allocs delta) / rows`. The
+// decode is run once inside the bracket (not `iters` times) because the
+// metric is a per-row allocation count, not a throughput: one decode of
+// N rows yields the exact per-row figure with no averaging needed, and
+// `from_delta` divides by the row count. We still run the decode once
+// before bracketing to retire any first-call lazy initialisation so the
+// bracketed pass measures steady-state decode allocations only.
+
+/// Decode `response` end to end: protobuf table decode followed by the
+/// typed tick parse, exactly as a client receiving this payload would.
+/// Returns the decoded row count so the caller can assert the fixture
+/// drove the expected number of rows.
+fn decode_trade(response: &proto::ResponseData) -> usize {
+    let mut r = response.clone();
+    let table = decode_data_table(&mut r).expect("decode trade table");
+    let ticks = parse_trade_ticks(&table).expect("parse trade ticks");
+    black_box(&ticks);
+    ticks.len()
+}
+
+fn decode_quote(response: &proto::ResponseData) -> usize {
+    let mut r = response.clone();
+    let table = decode_data_table(&mut r).expect("decode quote table");
+    let ticks = parse_quote_ticks(&table).expect("parse quote ticks");
+    black_box(&ticks);
+    ticks.len()
+}
+
+fn decode_ohlc(response: &proto::ResponseData) -> usize {
+    let mut r = response.clone();
+    let table = decode_data_table(&mut r).expect("decode ohlc table");
+    let ticks = parse_ohlc_ticks(&table).expect("parse ohlc ticks");
+    black_box(&ticks);
+    ticks.len()
+}
+
+/// Bracket one decode of the fixture and return the per-row sample.
+fn sample_decode(
+    id: &str,
+    response: &proto::ResponseData,
+    decode: fn(&proto::ResponseData) -> usize,
+) -> Sample {
+    // Warm-up pass outside the bracket: retires any one-shot lazy init
+    // (interned header lookups, etc.) so the measured pass is steady
+    // state.
+    let warm_rows = decode(response);
+    assert_eq!(
+        warm_rows, FIXTURE_ROWS,
+        "{id}: fixture decoded {warm_rows} rows, expected {FIXTURE_ROWS}"
+    );
+
+    let before = snapshot();
+    let rows = decode(response);
+    let after = snapshot();
+    assert_eq!(
+        rows, FIXTURE_ROWS,
+        "{id}: fixture decoded {rows} rows, expected {FIXTURE_ROWS}"
+    );
+
+    Sample::from_delta(id, before, after, rows as u64)
+}
+
+fn bench_decode_allocations(c: &mut Criterion) {
+    let trade = uncompressed_response(&build_trade_data_table(FIXTURE_ROWS));
+    let quote = uncompressed_response(&build_quote_data_table(FIXTURE_ROWS));
+    let ohlc = uncompressed_response(&build_ohlc_data_table(FIXTURE_ROWS));
+
+    let samples = vec![
+        sample_decode("decode_allocations/trade", &trade, decode_trade),
+        sample_decode("decode_allocations/quote", &quote, decode_quote),
+        sample_decode("decode_allocations/ohlc", &ohlc, decode_ohlc),
+    ];
+
+    for s in &samples {
+        eprintln!(
+            "perf-gate decode: {:<28} {:.4} allocs/row  {:.1} bytes/row  ({} rows)",
+            s.id, s.allocs_per_unit, s.bytes_per_unit, s.units
+        );
+    }
+
+    let out = PathBuf::from(
+        std::env::var("PERF_GATE_OUT_DIR").unwrap_or_else(|_| "target/perf-gate".to_string()),
+    )
+    .join("decode_allocations.json");
+    write_metric_file(
+        &out,
+        "Allocations per decoded row for each representative MDDS tick type. \
+         Deterministic: an allocation count is CPU-independent, so it gates safely on shared runners. \
+         allocs_per_unit = heap allocations charged per decoded row over a fixed-row fixture.",
+        &samples,
+    );
+
+    // Also register a no-op timed bench so `cargo bench` reports this
+    // target in its summary line. The metric of record is the JSON
+    // file above; the timing here is incidental and intentionally
+    // unused by the gate.
+    let mut group = c.benchmark_group("decode_allocations");
+    group.bench_function("trade_decode", |b| {
+        b.iter(|| black_box(decode_trade(black_box(&trade))));
+    });
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(2))
+        .sample_size(10);
+    targets = bench_decode_allocations
+}
+criterion_main!(benches);

--- a/crates/thetadatadx/benches/perf_gate_support/perf_alloc.rs
+++ b/crates/thetadatadx/benches/perf_gate_support/perf_alloc.rs
@@ -1,0 +1,173 @@
+//! Counting global allocator + deterministic-metric JSON writer shared
+//! by the per-binding performance-gate harnesses.
+//!
+//! Wired into a bench binary via
+//! `#[path = "perf_gate_support/perf_alloc.rs"] mod perf_alloc;` plus a
+//! `#[global_allocator] static A: perf_alloc::CountingAllocator = ...;`
+//! line in that binary. The allocator forwards every request to
+//! `std::alloc::System` and tallies the global allocation count in a
+//! `Relaxed` atomic. It exists ONLY in bench/test targets — the shipped
+//! `thetadatadx` rlib never installs a custom `#[global_allocator]`, so
+//! the library's allocator is unchanged.
+//!
+//! The metric this enables — allocations per decoded row — is fully
+//! CPU-independent: the same fixture decoded on a 2-vCPU shared runner
+//! and on a developer workstation produces the identical allocation
+//! count. That is the property that lets the gate run on heterogeneous
+//! CI hardware without flaking, where a wall-clock baseline could not.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// ─── Counting allocator ──────────────────────────────────────────────
+//
+// Tracks total allocation count and total bytes allocated, process-wide.
+// A measurement brackets the region of interest with two `snapshot()`
+// reads and divides the delta by the row count it drove through the
+// decode path — so allocator traffic from Criterion bookkeeping, warmup,
+// or fixture construction outside the bracket never enters the metric.
+
+/// Process-wide allocation counter. Incremented on every successful
+/// `alloc`; never reset by the allocator itself (callers snapshot and
+/// diff instead, so concurrent fixture setup cannot corrupt a bracket).
+pub static ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Process-wide byte counter, kept alongside the count so a metric can
+/// report bytes/row for context even though the gate keys on the count.
+pub static BYTES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
+
+/// System-allocator shim that tallies allocation count + bytes.
+pub struct CountingAllocator;
+
+// SAFETY: every method forwards verbatim to `std::alloc::System`, which
+// itself satisfies the `GlobalAlloc` contract (pointer provenance,
+// layout honoured on dealloc, no over-alignment over-promises). The
+// `Relaxed` atomic adds are pure observational state and cannot violate
+// allocator invariants. Bench/test-only; never linked into the shipped
+// library.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: `GlobalAlloc::alloc` requires `layout.size() > 0` and a
+        // power-of-two `layout.align()`; the alloc shim Rust generates
+        // for any `#[global_allocator]` enforces both before this call.
+        // Forwarding to the `System` impl satisfies it verbatim.
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+            BYTES_ALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `GlobalAlloc::dealloc` requires that `ptr` came from a
+        // prior `alloc` on this allocator with the same `layout` and has
+        // not yet been freed. The shim Rust generates from `Vec`, `Box`,
+        // etc. upholds that pairing; forwarding to `System.dealloc`
+        // satisfies the `System` impl.
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+/// `(alloc_count, bytes_allocated)` read of the global counters.
+#[inline]
+#[must_use]
+pub fn snapshot() -> (u64, u64) {
+    (
+        ALLOC_COUNT.load(Ordering::Relaxed),
+        BYTES_ALLOCATED.load(Ordering::Relaxed),
+    )
+}
+
+/// One deterministic metric sample: a stable id, the allocation count
+/// observed per unit (per decoded row, or per FFI call), the bytes/unit
+/// for context, and the unit count the bracket drove.
+#[derive(Clone)]
+pub struct Sample {
+    pub id: String,
+    pub allocs_per_unit: f64,
+    pub bytes_per_unit: f64,
+    pub units: u64,
+}
+
+impl Sample {
+    /// Build a sample from a bracketed counter delta.
+    ///
+    /// `before` / `after` are `snapshot()` reads taken immediately
+    /// around the measured region; `units` is the number of rows (or
+    /// calls) processed between them. The per-unit figures are exact
+    /// rationals of integer counts — no floating-point measurement
+    /// noise enters, which is what makes the downstream gate
+    /// deterministic.
+    #[must_use]
+    pub fn from_delta(id: &str, before: (u64, u64), after: (u64, u64), units: u64) -> Self {
+        let count_delta = after.0.saturating_sub(before.0);
+        let bytes_delta = after.1.saturating_sub(before.1);
+        let units_f = units.max(1) as f64;
+        Self {
+            id: id.to_string(),
+            allocs_per_unit: count_delta as f64 / units_f,
+            bytes_per_unit: bytes_delta as f64 / units_f,
+            units,
+        }
+    }
+}
+
+/// Escape a string for embedding in a JSON value. The ids we emit are
+/// ASCII bench names, so only the quote and backslash need handling;
+/// kept explicit so the writer carries no serialization dependency
+/// (benches must stay lean and the metric file shape is trivial).
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Write a metric file the gate script consumes.
+///
+/// Shape mirrors the committed baseline (`perf-gate/*.json`): a top
+/// object keyed by sample id, each value carrying `allocs_per_unit`,
+/// `bytes_per_unit`, and `units`. A leading `_meta` object records what
+/// the file measures so a reader needs no external doc. The directory is
+/// created if absent.
+///
+/// # Panics
+///
+/// Panics if the parent directory cannot be created or the file cannot
+/// be written — a bench that cannot emit its metric must fail loudly so
+/// the gate never silently reads a stale file.
+pub fn write_metric_file(path: &Path, meta: &str, samples: &[Sample]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .unwrap_or_else(|e| panic!("create perf-gate metric dir {}: {e}", parent.display()));
+    }
+    let mut body = String::new();
+    body.push_str("{\n");
+    body.push_str(&format!("  \"_meta\": \"{}\",\n", json_escape(meta)));
+    for (idx, sample) in samples.iter().enumerate() {
+        let comma = if idx + 1 < samples.len() { "," } else { "" };
+        body.push_str(&format!(
+            "  \"{id}\": {{ \"allocs_per_unit\": {allocs:.4}, \
+             \"bytes_per_unit\": {bytes:.2}, \"units\": {units} }}{comma}\n",
+            id = json_escape(&sample.id),
+            allocs = sample.allocs_per_unit,
+            bytes = sample.bytes_per_unit,
+            units = sample.units,
+        ));
+    }
+    body.push_str("}\n");
+    std::fs::write(path, body)
+        .unwrap_or_else(|e| panic!("write perf-gate metric file {}: {e}", path.display()));
+    eprintln!(
+        "perf-gate: wrote {} ({} sample(s))",
+        path.display(),
+        samples.len()
+    );
+}

--- a/scripts/check_perf_gate.py
+++ b/scripts/check_perf_gate.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Gate per-binding performance on deterministic allocation counts.
+
+The Rust core already has a Criterion wall-clock regression gate
+(`scripts/check_bench_regression.py`). This companion gate watches a
+metric that a wall-clock gate cannot watch safely on shared CI runners:
+allocations per decoded row.
+
+WHY THIS GATE IS SAFE ON HETEROGENEOUS RUNNERS
+----------------------------------------------
+Every metric this script reads is an allocation COUNT, never a
+wall-clock time. Decoding the identical fixture performs the identical
+number of heap allocations on a 2-vCPU hosted runner and on a developer
+workstation: CPU frequency, scheduler pressure, and memory bandwidth do
+not change how many times the decode path calls `alloc`. The figure is
+therefore a property of the code, not of the machine, so it can be
+pinned to a committed baseline and run anywhere without flaking. A
+wall-clock baseline, by contrast, tracks the runner's clock and would
+trip on slower hardware alone.
+
+The count is produced by the `bench_decode_allocations` harness, which
+installs a counting global allocator ONLY in that bench binary (the
+shipped library allocator is unchanged) and writes the per-row figures
+to `target/perf-gate/decode_allocations.json`. This script diffs that
+file against `crates/thetadatadx/benches/baseline/perf_gate.json`.
+
+GATE SHAPE (mirrors check_bench_regression.py)
+----------------------------------------------
+A tracked metric fails (non-zero exit) when its allocations-per-unit has
+risen above the baseline by more than `--threshold` percent AND by more
+than an absolute floor of `--abs-floor` allocations-per-unit. The two
+conditions are ANDed for the same reason the wall-clock gate ANDs its
+percentage and its nanosecond floor: a purely relative gate is
+meaningless when the baseline approaches zero. A future zero-allocation
+decode path would have a baseline near 0.0; any positive count is an
+infinite percentage over it, so without the floor a single incidental
+allocation would trip the gate. Requiring the absolute rise to clear a
+small floor keeps the gate sensitive to a real regression (re-cloning a
+field per row adds ~1 alloc/row, far above the floor) while refusing to
+fire on a rounding-scale move.
+
+Because the metric is exact (an integer count divided by a fixed unit
+count, with no measurement jitter), the threshold can be tight. The
+default `--threshold` is deliberately small.
+
+Tracked metrics come from the baseline file itself: adding an entry
+opts a metric into the gate, removing it opts out. Keys prefixed with
+`_` (`_meta`, `_captured_on`) are documentation-only and skipped.
+
+Baseline JSON shape::
+
+    {
+        "<metric_id>": {
+            "allocs_per_unit": <float>,
+            "metric_file": "<file under --metrics-dir>"
+        },
+        ...
+    }
+
+Each `metric_file` is a harness-written report keyed by the same
+`<metric_id>`, each value carrying at least `allocs_per_unit`.
+
+Run from the repo root after the bench has written its metric file::
+
+    python3 scripts/check_perf_gate.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+def load_json(path: pathlib.Path, what: str) -> dict:
+    if not path.is_file():
+        sys.stderr.write(
+            f"{what} missing at {path}; "
+            "run the perf-gate bench first (see the workflow / module header)\n"
+        )
+        sys.exit(2)
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"{what} at {path} is not valid JSON: {exc}\n")
+        sys.exit(2)
+
+
+def load_metric(metrics_dir: pathlib.Path, metric_file: str, metric_id: str) -> float | None:
+    """Read `allocs_per_unit` for `metric_id` from a harness report.
+
+    Returns None when the report or the entry is absent so the caller
+    can collect a precise "did the bench run?" diagnostic rather than
+    failing on the first gap.
+    """
+    report_path = metrics_dir / metric_file
+    if not report_path.is_file():
+        return None
+    try:
+        report = json.loads(report_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    entry = report.get(metric_id)
+    if not isinstance(entry, dict):
+        return None
+    value = entry.get("allocs_per_unit")
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Gate decode allocations-per-row against a committed baseline.",
+    )
+    parser.add_argument(
+        "--baseline",
+        default="crates/thetadatadx/benches/baseline/perf_gate.json",
+        type=pathlib.Path,
+        help="committed baseline JSON to diff against",
+    )
+    parser.add_argument(
+        "--metrics-dir",
+        default="target/perf-gate",
+        type=pathlib.Path,
+        help="directory the perf-gate bench wrote its metric report(s) into",
+    )
+    parser.add_argument(
+        "--threshold",
+        default=10.0,
+        type=float,
+        help="fail on an allocations-per-unit rise exceeding this percentage",
+    )
+    parser.add_argument(
+        "--abs-floor",
+        default=0.25,
+        type=float,
+        help=(
+            "minimum absolute allocations-per-unit rise required alongside "
+            "the percentage threshold; filters rounding-scale moves and "
+            "makes the gate meaningful when a baseline approaches zero"
+        ),
+    )
+    args = parser.parse_args()
+
+    baseline = load_json(args.baseline, "baseline file")
+    failures: list[tuple[str, float, float, float]] = []
+    missing: list[str] = []
+    checked = 0
+
+    for metric_id, entry in sorted(baseline.items()):
+        # Underscore-prefixed keys are documentation-only (`_meta`,
+        # `_captured_on`) — skip them so the loader can host
+        # human-readable context alongside the gated samples.
+        if metric_id.startswith("_"):
+            continue
+        metric_file = entry.get("metric_file")
+        baseline_value = entry.get("allocs_per_unit")
+        if not isinstance(metric_file, str) or not isinstance(
+            baseline_value, (int, float)
+        ):
+            sys.stderr.write(
+                f"malformed baseline entry for {metric_id!r}; "
+                "expected `metric_file` (str) + `allocs_per_unit` (number)\n"
+            )
+            return 2
+
+        current = load_metric(args.metrics_dir, metric_file, metric_id)
+        if current is None:
+            missing.append(metric_id)
+            continue
+
+        checked += 1
+        abs_delta = current - float(baseline_value)
+        # Guard the division: a zero baseline yields an infinite
+        # percentage for any positive count, which the absolute floor
+        # is there to arbitrate.
+        if baseline_value != 0:
+            delta_pct = abs_delta / float(baseline_value) * 100.0
+        else:
+            delta_pct = float("inf") if abs_delta > 0 else 0.0
+        over_pct = delta_pct > args.threshold
+        regressed = over_pct and abs_delta > args.abs_floor
+        # `NOISE` marks a metric that cleared the percentage gate but not
+        # the absolute floor — a rounding-scale move we refuse to treat
+        # as real.
+        status = "REGRESSION" if regressed else ("NOISE" if over_pct else "OK")
+        print(
+            f"{status:<11} {metric_id:<44} "
+            f"baseline {baseline_value:>8.4f}  "
+            f"current {current:>8.4f} allocs/unit  "
+            f"delta {delta_pct:+.2f}%"
+        )
+        if regressed:
+            failures.append((metric_id, float(baseline_value), current, delta_pct))
+
+    if missing:
+        sys.stderr.write(
+            "missing perf-gate metric data for the following tracked "
+            "metrics (did the bench run and write to --metrics-dir?):\n"
+        )
+        for metric_id in missing:
+            sys.stderr.write(f"  - {metric_id}\n")
+        return 2
+
+    if checked == 0:
+        sys.stderr.write(
+            "no tracked metrics were checked; the baseline lists none "
+            "(or all are documentation-only). Add at least one metric entry.\n"
+        )
+        return 2
+
+    if failures:
+        sys.stderr.write(
+            f"\n{len(failures)} metric(s) rose beyond the "
+            f"{args.threshold:.1f}% threshold:\n"
+        )
+        for metric_id, base, cur, delta in failures:
+            sys.stderr.write(
+                f"  - {metric_id}: {base:.4f} -> {cur:.4f} allocs/unit  ({delta:+.2f}%)\n"
+            )
+        sys.stderr.write(
+            "Refresh the baseline only after auditing the rise: confirm the "
+            "extra allocations are intended, re-run the bench on a green "
+            "main, copy the new figures into the baseline JSON, and commit "
+            "that change in its own PR.\n"
+        )
+        return 1
+
+    print(f"\nAll {checked} tracked metric(s) within threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds a per-binding performance-regression gate keyed on a deterministic metric: allocations per decoded row. The Rust core already has a wall-clock Criterion gate; this adds the one perf signal that can be gated safely on heterogeneous CI runners without flaking.

Closes #696.

## Why this gate does not flake on shared runners

Every figure the gate reads is an allocation count, never a wall-clock time. Decoding the identical fixture performs the identical number of heap allocations on a 2-vCPU hosted runner and on a developer workstation, because CPU frequency, scheduler pressure, and memory bandwidth do not change how many times the decode path calls the allocator. The count is a property of the code, not of the machine, so it can be pinned to a committed baseline and run anywhere. A wall-clock baseline against a fixed reference would instead track the runner's clock and trip on slower hardware alone. The full rationale lives in the header of `scripts/check_perf_gate.py`.

## Metrics gated, baselines, thresholds

The gate tracks allocations per decoded row for each representative tick type, measured over a fixed 1000-row fixture through the public decode path (`decode_data_table` then `parse_*_ticks`). Committed baselines: trade 3.03, quote 3.025, OHLC 2.022 allocations per row. The gate fails when a metric rises above its baseline by more than the relative threshold (default 10 percent) AND by more than an absolute floor (default 0.25 allocations per row). The two conditions are ANDed for the same reason the wall-clock gate ANDs its percentage and its nanosecond floor: a purely relative gate is meaningless when a baseline approaches zero, so the absolute floor keeps the gate sensitive to a real regression while refusing to fire on a rounding-scale move.

## Proof the gate catches a regression

Injecting one forced per-row heap allocation into the decode path (a `row_date` allocation, reverted before commit) moved every metric up by exactly one allocation per row and the gate failed as designed:

```
REGRESSION  decode_allocations/ohlc    baseline   2.0220  current   3.0220 allocs/unit  delta +49.46%
REGRESSION  decode_allocations/quote   baseline   3.0250  current   4.0250 allocs/unit  delta +33.06%
REGRESSION  decode_allocations/trade   baseline   3.0300  current   4.0300 allocs/unit  delta +33.00%
```

That command exited 1. On a clean tree the same gate reports every metric at +0.00 percent and exits 0. The per-row figures are byte-identical across repeated runs, confirming the metric carries no measurement jitter.

## Allocator containment

The counting global allocator is installed only in the `bench_decode_allocations` bench binary. The shipped library declares no custom global allocator and is unchanged; the gate touches nothing on the hot path that a user runs.

## Scope

The issue framed three candidate metrics. After building and empirically measuring all three, this PR ships only the decode-allocations gate, which is the clean, high-value, fully deterministic one. The interpreter-lock-release ratio was prototyped against the live binding: the measurement separates a held lock (about 50 percent foreground progress) from a released lock (about 100 percent) cleanly, but a clean signal requires a sustained blocking operation. Offline, that means either a long fixed connect timeout (too slow, and no setter to shorten it) or the live authentication path (a network dependency the issue explicitly warns against), while the fast offline binding-call alternative does not discriminate on a stock interpreter build. Rather than ship a gate that flakes on network or fails to catch regressions, that metric is deferred; the no-lock-hold discipline stays covered by the existing static audit and the free-threaded throughput gate. The FFI per-call overhead metric was dropped as marginal. A single high-value deterministic gate is the deliverable.

## Local gate

All green before push: `cargo fmt --all -- --check`; `cargo clippy --workspace -- -D warnings` (plus the bench under its feature); the workspace test suite; `python3 scripts/check_banned_vocab.py`; and the new gate end-to-end, proven to pass on a clean tree and fail on an injected regression.
