### PR TITLE
fix(python): correct PyO3 stub return types stubtest cannot verify

### DIFF
--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -12,6 +12,18 @@ typed mirror would be high-maintenance noise.
 
 Mypy / pyright pick this up via the ``py.typed`` marker (PEP 561)
 shipped alongside this file.
+
+Return types on PyO3-exported callables are NOT verified by the
+stubtest gate: a compiled extension presents an opaque ``builtin``
+descriptor whose annotations stubtest cannot read, so it never
+compares the declared return against the concrete runtime object
+(e.g. it cannot tell ``tuple[float, float]`` from ``float``). The
+return annotation on every function and method below is therefore
+hand-maintained against the live runtime and must be kept correct
+by hand when the binding changes — the gate will not flag a wrong
+one. The ``tests/test_typed_surface.py`` guard re-checks the
+non-trivial offline-constructible returns at runtime to catch
+drift the gate cannot.
 """
 
 from __future__ import annotations
@@ -953,6 +965,11 @@ def all_greeks(
 ) -> AllGreeks: ...
 
 
+# Returns a ``(iv, iv_error)`` pair: the implied volatility from the
+# bisection solver and the residual `(model_price - option_price) /
+# option_price` at that vol. The runtime hands back a 2-tuple, not a
+# bare float — stubtest cannot see the difference, so this annotation
+# is the only thing keeping callers correct.
 def implied_volatility(
     spot: float,
     strike: float,
@@ -961,27 +978,53 @@ def implied_volatility(
     tte: float,
     option_price: float,
     right: str,
-) -> float: ...
+) -> tuple[float, float]: ...
 
 
 @final
 class AllGreeks:
-    """Greeks bundle returned by ``all_greeks(...)``."""
+    """All 23 Black-Scholes Greeks plus IV returned by ``all_greeks(...)``.
 
+    Field order mirrors ``tdbe::greeks::GreeksResult`` (the Rust
+    single-source-of-truth the binding wraps): the model value and IV
+    pair first, then first-, second-, and third-order Greeks, then the
+    ``d1`` / ``d2`` auxiliaries. Every attribute is a plain ``float``.
+    """
+
+    # Model price + implied-volatility pair.
+    value: float
+    iv: float
+    iv_error: float
+    # First-order Greeks.
     delta: float
     gamma: float
     theta: float
     vega: float
     rho: float
-    epsilon: float
-    speed: float
-    charm: float
-    color: float
+    # Second-order Greeks.
     vanna: float
-    veta: float
+    charm: float
     vomma: float
+    veta: float
+    vera: float
+    # Third-order Greeks.
+    speed: float
+    zomma: float
+    color: float
     ultima: float
-    implied_volatility: float
+    # Auxiliary quantities.
+    d1: float
+    d2: float
+    dual_delta: float
+    dual_gamma: float
+    epsilon: float
+    # NOTE: the runtime also exposes ``lambda`` (the option elasticity,
+    # `delta * spot / value`). It is reachable only as
+    # ``getattr(result, "lambda")`` because ``lambda`` is a reserved
+    # Python keyword and cannot be written as a stub attribute or in
+    # ordinary attribute-access syntax. It is intentionally absent from
+    # the typed body for that reason; the field carries an ``f64`` at
+    # runtime like every other Greek here.
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/sdks/python/tests/test_typed_surface.py
+++ b/sdks/python/tests/test_typed_surface.py
@@ -270,3 +270,92 @@ def test_trade_tick_flag_accessors_decode_condition_words():
     assert quiet.price_condition_set_last is False
     assert quiet.is_incremental_volume is False
     assert quiet.is_seller is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Offline-analytics return shapes (stub drift guard)
+#
+# stubtest reads the compiled extension's free functions and frozen
+# pyclasses as opaque ``builtin`` descriptors, so a wrong return
+# annotation in the ``.pyi`` (e.g. ``-> float`` on a function that
+# actually returns a 2-tuple, or a short field list on a frozen result
+# class) sails through the gate. These cases call the real runtime and
+# assert the concrete shape the stub now declares, so future drift on
+# exactly these symbols is caught here instead of slipping silently.
+# Inputs are in-the-money so the IV solver converges deterministically.
+# ──────────────────────────────────────────────────────────────────────
+
+
+_GREEKS_ARGS = dict(
+    spot=100.0,
+    strike=100.0,
+    rate=0.05,
+    div_yield=0.0,
+    tte=0.5,
+    option_price=7.0,
+    right="C",
+)
+
+
+def test_implied_volatility_returns_iv_and_error_tuple():
+    result = thetadatadx.implied_volatility(**_GREEKS_ARGS)
+    # The stub declares ``tuple[float, float]`` — the runtime hands back
+    # ``(iv, iv_error)``, not the bare ``iv`` float an older stub claimed.
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    iv, iv_error = result
+    assert isinstance(iv, float)
+    assert isinstance(iv_error, float)
+    assert iv > 0.0  # in-the-money call solves to a positive vol
+
+
+# Every field the ``AllGreeks`` stub declares, in declaration order, plus
+# the keyword-reserved ``lambda`` the stub documents but cannot annotate.
+_ALL_GREEKS_STUB_FIELDS = (
+    "value",
+    "iv",
+    "iv_error",
+    "delta",
+    "gamma",
+    "theta",
+    "vega",
+    "rho",
+    "vanna",
+    "charm",
+    "vomma",
+    "veta",
+    "vera",
+    "speed",
+    "zomma",
+    "color",
+    "ultima",
+    "d1",
+    "d2",
+    "dual_delta",
+    "dual_gamma",
+    "epsilon",
+)
+
+
+def test_all_greeks_exposes_every_stubbed_field_as_float():
+    greeks = thetadatadx.all_greeks(**_GREEKS_ARGS)
+    assert type(greeks).__name__ == "AllGreeks"
+    for field in _ALL_GREEKS_STUB_FIELDS:
+        value = getattr(greeks, field)
+        assert isinstance(value, float), f"AllGreeks.{field} is not a float"
+    # The keyword-reserved elasticity column is documented in the stub as
+    # reachable only via ``getattr`` and is a float like the rest.
+    assert isinstance(getattr(greeks, "lambda"), float)
+
+
+def test_all_greeks_runtime_fields_match_the_stub_exactly():
+    """No runtime field is missing from the stub and the stub invents no
+    field the runtime lacks (covering the ``lambda`` keyword escape)."""
+    greeks = thetadatadx.all_greeks(**_GREEKS_ARGS)
+    runtime_fields = {
+        name
+        for name in dir(greeks)
+        if not name.startswith("_") and not callable(getattr(greeks, name))
+    }
+    stubbed_fields = set(_ALL_GREEKS_STUB_FIELDS) | {"lambda"}
+    assert runtime_fields == stubbed_fields


### PR DESCRIPTION
The committed `sdks/python/python/thetadatadx/__init__.pyi` declared return types for two PyO3-exported analytics symbols that disagreed with the live runtime, and the stubtest gate could not catch it: a compiled extension presents PyO3 callables as opaque `builtin` descriptors whose return annotations stubtest cannot read, so it never compares the declared return against the concrete object (it cannot tell `tuple[float, float]` from `float`). The runtime is the ground truth here, and the runtime is unchanged — this is a stub/annotation correctness fix only.

`implied_volatility(...)` was stubbed `-> float` but the native function returns `PyResult<(f64, f64)>`, i.e. a `(iv, iv_error)` 2-tuple; introspecting the built wheel confirms `type(...)` is `tuple` of length 2. The stub now declares `tuple[float, float]`.

`AllGreeks` was stubbed with 14 attributes including a phantom `implied_volatility` field that does not exist at runtime, while omitting ten real ones. The frozen pyclass exposes 23 `f64` getters in the `tdbe::greeks::GreeksResult` order: `value`, `iv`, `iv_error`, `delta`, `gamma`, `theta`, `vega`, `rho`, `vanna`, `charm`, `vomma`, `veta`, `vera`, `speed`, `zomma`, `color`, `ultima`, `d1`, `d2`, `dual_delta`, `dual_gamma`, `epsilon`, `lambda`. The stub now carries all of them. The `lambda` elasticity column is reachable only as `getattr(result, "lambda")` because it is a hard Python keyword that cannot be written as a stub attribute, so it is documented in place rather than annotated.

These two symbols are emitted by the SDK codegen into `sdks/python/src/_generated/utility_functions.rs`, but the `.pyi` itself is hand-maintained — no generator writes it (the generator only emits the `_generated/*.rs` Rust sources). So the fix lands in the hand-maintained stub, not in a generator.

I audited the rest of the hand-maintained stub for the same class of return-type drift: every explicitly-stubbed free function and pyclass method whose return stubtest cannot verify. The only `PyResult<(...)>` tuple-returning function in the entire Python SDK is `implied_volatility`; every other `PyResult<()>` is a `None`-returning mutator that is stubbed correctly. The non-trivial returns that are constructible offline (`Contract`, `Subscription`, `SecType`, `Credentials`, `Config`, `AllGreeks`) were checked against the live runtime and agree with the stub; the client accessor returns that need a live connection were cross-checked against the authoritative Rust signatures (`Vec<PySubscription>` to `List[Subscription]`, `Option<u64>` to `Optional[int]`, `Option<String>` to `Optional[str]`, `StreamingSession`, `FlatFilesNamespace`) and agree. The 100+ generator-emitted builders and typed list wrappers correctly fall through the module-level `__getattr__` to `Any`. No further drift was found beyond the two symbols in the issue.

A note in the stub header now records that PyO3 callable return types are not gate-verified and must be kept correct by hand against the runtime. A small guard in `tests/test_typed_surface.py` calls both corrected symbols and asserts the runtime shape matches the stub: `implied_volatility` returns a two-element `tuple[float, float]`, and `AllGreeks` exposes every stubbed field as a `float` with its runtime field set matching the stub exactly (including the `lambda` keyword escape). Future drift on these specific symbols now fails the Python suite even though the gate stays silent.

Gates, all green after the edits: `cargo fmt --all -- --check`; `cargo clippy --workspace -- -D warnings`; `cargo test --workspace`; `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check` (zero drift); `python3 scripts/check_binding_parity.py` and `--selftest`; the exact CI stubtest invocation `python -m mypy.stubtest thetadatadx --allowlist sdks/python/stubtest_allowlist.txt --ignore-missing-stub --ignore-disjoint-bases --ignore-positional-only`; and the full Python suite (397 passed, 19 skipped network-only, including 3 new guard tests).

Closes #701