### PR TITLE
fix(typescript): preserve typed errors on static entrypoints and reject invalid logical enums

### DIFF
--- a/crates/thetadatadx/build_support_bin/ticks/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/typescript.rs
@@ -88,10 +88,26 @@ fn render_ts_tick_arrow_ipc(type_name: &str, def: &TickTypeDef) -> Option<String
         "pub fn {fn_name}(rows: Vec<{type_name}>) -> napi::Result<napi::bindgen_prelude::Buffer> {{"
     )
     .unwrap();
+    // Logical-enum columns (`right` / `calendar_status`) reject invalid
+    // input with `return Err(..)`; when the type carries one the
+    // reconstruct closure is fallible and its results are collected into a
+    // `napi::Result<Vec<..>>` and `?`-propagated. Types without such a
+    // column keep the infallible `.map(..).collect()` so a build that adds
+    // no validation pays no wrapping.
+    let fallible = ts_arrow_reconstruct_is_fallible(def);
     writeln!(out, "    let owned: Vec<tick::{type_name}> = rows").unwrap();
     out.push_str("        .into_iter()\n");
-    out.push_str("        .map(|r| {\n");
-    writeln!(out, "            tick::{type_name} {{").unwrap();
+    if fallible {
+        writeln!(
+            out,
+            "        .map(|r| -> napi::Result<tick::{type_name}> {{"
+        )
+        .unwrap();
+        writeln!(out, "            Ok(tick::{type_name} {{").unwrap();
+    } else {
+        out.push_str("        .map(|r| {\n");
+        writeln!(out, "            tick::{type_name} {{").unwrap();
+    }
     for column in &def.columns {
         let field = rust_field_ident(&column.field);
         let expr = ts_arrow_reconstruct_expr(&column.r#type, &field);
@@ -103,16 +119,28 @@ fn render_ts_tick_arrow_ipc(type_name: &str, def: &TickTypeDef) -> Option<String
     if def.contract_id {
         // Inverse of the factory's `has_contract_id().then_some(..)`: the
         // absent JS `undefined`/`null` round-trips back to the struct's
-        // documented zero / NUL fill.
+        // documented zero / NUL fill. `right` validates its inbound string
+        // the same way the standalone `right` column does, rejecting any
+        // value outside `"C"` / `"P"` (absent / empty → NUL).
         out.push_str("                expiration: r.expiration.unwrap_or(0),\n");
         out.push_str("                strike: r.strike.unwrap_or(0.0),\n");
         out.push_str(
-            "                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\\0'),\n",
+            "                right: match r.right.as_deref() { Some(\"C\") => 'C', Some(\"P\") => 'P', None | Some(\"\") => '\\0', Some(other) => return Err(napi::Error::from_reason(format!(\"[InvalidParameterError] right must be \\\"C\\\" or \\\"P\\\", got {other:?}\"))) },\n",
         );
     }
-    out.push_str("            }\n");
-    out.push_str("        })\n");
-    out.push_str("        .collect();\n");
+    if fallible {
+        out.push_str("            })\n");
+        out.push_str("        })\n");
+        writeln!(
+            out,
+            "        .collect::<napi::Result<Vec<tick::{type_name}>>>()?;"
+        )
+        .unwrap();
+    } else {
+        out.push_str("            }\n");
+        out.push_str("        })\n");
+        out.push_str("        .collect();\n");
+    }
     out.push_str(
         "    let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())\n",
     );
@@ -138,23 +166,50 @@ fn render_ts_tick_arrow_ipc(type_name: &str, def: &TickTypeDef) -> Option<String
 
 /// Reconstruct one columnar field of `tick::T` from the JS object binding
 /// `r`. Inverse of the forward factory's per-type projection.
+///
+/// Logical-enum columns (`right`, `calendar_status`) validate the inbound
+/// string against the accepted vocabulary and `return Err(..)` on anything
+/// outside it, so an invalid value is rejected rather than silently coerced
+/// to a neighbouring variant — the same accepted set and message wording the
+/// Python `pyclass_to_tick_expr` reverse projection enforces, keeping the two
+/// bindings' rejection behaviour identical. The `napi::Error` carries the
+/// `[InvalidParameterError]` prefix so the wrapped free function re-throws it
+/// as the typed `InvalidParameterError` subclass. Because these arms emit
+/// `return Err(..)`, the surrounding reconstruct runs inside a fallible
+/// closure (see [`render_ts_tick_arrow_ipc`]).
 fn ts_arrow_reconstruct_expr(column_type: &str, field: &str) -> String {
     match column_type {
         // i64 columns cross from JS as `BigInt`; `get_i64` yields the value.
         "i64" | "eod_num64" => format!("{{ let (v, _) = r.{field}.get_i64(); v }}"),
-        // The logical right char arrives as a one-character string.
+        // The logical right char arrives as a one-character string; only
+        // `"C"` / `"P"` (and empty → NUL) are accepted, matching Python.
         "right" => format!(
-            "r.{field}.chars().next().unwrap_or('\\0')"
+            "match r.{field}.as_str() {{ \"C\" => 'C', \"P\" => 'P', \"\" => '\\0', other => return Err(napi::Error::from_reason(format!(\"[InvalidParameterError] right must be \\\"C\\\" or \\\"P\\\", got {{other:?}}\"))) }}"
         ),
         // The calendar day type arrives as the vendor vocabulary string;
-        // round-trip it back through the enum (unknown text → Weekend, the
-        // closed-day default, never a phantom open session).
+        // round-trip it back through the enum, rejecting anything outside the
+        // documented vocabulary rather than mis-classifying schema drift.
         "calendar_status" => format!(
-            "tdbe::types::enums::CalendarStatus::from_wire_text(&r.{field}).unwrap_or(tdbe::types::enums::CalendarStatus::Weekend)"
+            "match tdbe::types::enums::CalendarStatus::from_wire_text(&r.{field}) {{ Some(status) => status, None => return Err(napi::Error::from_reason(format!(\"[InvalidParameterError] status must be one of open, early_close, full_close, weekend; got {{:?}}\", r.{field}))) }}"
         ),
         // Plain Copy primitives (i32 / f64 / bool) deref straight through.
         _ => format!("r.{field}"),
     }
+}
+
+/// `true` when a tick type's Arrow-IPC reconstruction validates at least one
+/// inbound string and so emits `return Err(..)`: either a logical-enum column
+/// (`right` / `calendar_status`) or the appended contract-identity `right`
+/// (present whenever `def.contract_id`). Such a reconstruct must run inside a
+/// fallible closure; types without any validated field keep the infallible
+/// `.map(..).collect()` form so a build that adds no validation pays no
+/// wrapping.
+fn ts_arrow_reconstruct_is_fallible(def: &TickTypeDef) -> bool {
+    def.contract_id
+        || def
+            .columns
+            .iter()
+            .any(|column| matches!(column.r#type.as_str(), "right" | "calendar_status"))
 }
 
 /// PascalCase tick type name → snake_case fn-name stem (`EodTick` →

--- a/sdks/typescript/__tests__/native_typed_errors.test.mjs
+++ b/sdks/typescript/__tests__/native_typed_errors.test.mjs
@@ -1,0 +1,152 @@
+// Native regression tests for the typed-error contract on every call
+// shape, exercised against the real built addon (not a synthetic stub).
+//
+// The typed-error contract requires both halves to hold for a typed
+// error to reach the caller: the Rust method tags its error reason with
+// a `[ClassName] ...` prefix, AND the JS entrypoint is wrapped so the
+// shim's `rethrowTyped` runs. Instance methods were wrapped already;
+// these tests pin the previously-unwrapped shapes:
+//
+//   * static / factory methods (`ThetaDataDxClient.connectFromFile`,
+//     `Contract.option`) — wrapped on the constructor object itself;
+//   * exported free functions (`calendarDayToArrowIpc`,
+//     `eodTickToArrowIpc`) — wrapped directly on the native binding.
+//
+// They also pin the Arrow-IPC enum-validation parity with Python: an
+// invalid logical `status` / `right` must be REJECTED as
+// `InvalidParameterError`, never silently coerced to a neighbouring
+// variant (the prior `unwrap_or(Weekend)` / `chars().next()` truncation
+// corrupted data instead of failing loudly).
+//
+// Loads the wrapped surface (`../streaming-session.js`), the package
+// `main`, so the assertions observe exactly what a consumer sees. When
+// the native addon cannot be dlopen'd (no `.node` built) the suite
+// skips, matching the offline-tolerance of the sibling test files.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const wrapperImportPath = '../streaming-session.js';
+
+async function loadWrapped() {
+  try {
+    const imported = await import(wrapperImportPath);
+    return imported.default ?? imported;
+  } catch (err) {
+    if (err.code === 'ERR_DLOPEN_FAILED' || err.code === 'MODULE_NOT_FOUND') {
+      return null;
+    }
+    throw err;
+  }
+}
+
+// Arrow IPC streams open with the 0xFFFFFFFF continuation marker.
+function looksLikeArrowIpcStream(buf) {
+  return buf.length >= 8 && buf[0] === 0xff && buf[1] === 0xff && buf[2] === 0xff && buf[3] === 0xff;
+}
+
+// A valid single-row CalendarDay (used for the happy-path control and
+// as the base the invalid-status case mutates).
+function validCalendarDay(status) {
+  return {
+    date: 20260102,
+    isOpen: true,
+    openTime: 34200000,
+    closeTime: 57600000,
+    status,
+  };
+}
+
+// A valid single-row EodTick (used for the happy-path control and as
+// the base the invalid-right case mutates).
+function validEodTick(right) {
+  return {
+    createdMsOfDay: 0,
+    lastTradeMsOfDay: 0,
+    open: 1,
+    high: 1,
+    low: 1,
+    close: 1,
+    volume: 1n,
+    count: 1n,
+    bidSize: 0,
+    bidExchange: 0,
+    bid: 0,
+    bidCondition: 0,
+    askSize: 0,
+    askExchange: 0,
+    ask: 0,
+    askCondition: 0,
+    date: 20260115,
+    expiration: 20260117,
+    strike: 550,
+    right,
+  };
+}
+
+describe('typed errors on static / factory entrypoints (native)', () => {
+  it('ThetaDataDxClient.connectFromFile on a missing path throws ThetaDataError', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    assert.throws(
+      () => mod.ThetaDataDxClient.connectFromFile('/definitely/missing-creds.txt'),
+      (err) => err instanceof mod.ThetaDataError,
+      'a static factory failure must reclassify to the typed hierarchy, not a plain Error',
+    );
+  });
+
+  it('Contract.option with a bad expiration throws InvalidParameterError', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    assert.throws(
+      () => mod.Contract.option('SPY', { expiration: 'bad', strike: '550', right: 'C' }),
+      (err) =>
+        err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+      'an invalid option leg must reclassify to InvalidParameterError',
+    );
+  });
+});
+
+describe('Arrow-IPC logical-enum validation parity (native)', () => {
+  it('calendarDayToArrowIpc rejects an invalid status as InvalidParameterError', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    assert.throws(
+      () => mod.calendarDayToArrowIpc([validCalendarDay('bogus')]),
+      (err) => err instanceof mod.InvalidParameterError,
+      'an out-of-vocabulary status must be rejected, not coerced to Weekend',
+    );
+  });
+
+  it('calendarDayToArrowIpc accepts a valid status and returns an Arrow IPC Buffer', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    const buf = mod.calendarDayToArrowIpc([validCalendarDay('full_close')]);
+    assert.ok(Buffer.isBuffer(buf), 'a valid status must serialise to a Buffer');
+    assert.ok(looksLikeArrowIpcStream(buf), 'expected an Arrow IPC stream');
+  });
+
+  it('eodTickToArrowIpc rejects an invalid right as InvalidParameterError', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    assert.throws(
+      () => mod.eodTickToArrowIpc([validEodTick('XYZ')]),
+      (err) => err instanceof mod.InvalidParameterError,
+      'an out-of-vocabulary right must be rejected, not truncated to its first char',
+    );
+  });
+
+  it('eodTickToArrowIpc accepts a valid right and returns an Arrow IPC Buffer', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    const buf = mod.eodTickToArrowIpc([validEodTick('C')]);
+    assert.ok(Buffer.isBuffer(buf), 'a valid right must serialise to a Buffer');
+    assert.ok(looksLikeArrowIpcStream(buf), 'expected an Arrow IPC stream');
+  });
+});

--- a/sdks/typescript/src/_generated/tick_classes.rs
+++ b/sdks/typescript/src/_generated/tick_classes.rs
@@ -1204,16 +1204,16 @@ fn trade_ticks_to_class_vec(ticks: &[tick::TradeTick]) -> Vec<TradeTick> {
 pub fn calendar_day_to_arrow_ipc(rows: Vec<CalendarDay>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::CalendarDay> = rows
         .into_iter()
-        .map(|r| {
-            tick::CalendarDay {
+        .map(|r| -> napi::Result<tick::CalendarDay> {
+            Ok(tick::CalendarDay {
                 date: r.date,
                 is_open: r.is_open,
                 open_time: r.open_time,
                 close_time: r.close_time,
-                status: tdbe::types::enums::CalendarStatus::from_wire_text(&r.status).unwrap_or(tdbe::types::enums::CalendarStatus::Weekend),
-            }
+                status: match tdbe::types::enums::CalendarStatus::from_wire_text(&r.status) { Some(status) => status, None => return Err(napi::Error::from_reason(format!("[InvalidParameterError] status must be one of open, early_close, full_close, weekend; got {:?}", r.status))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::CalendarDay>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1242,8 +1242,8 @@ pub fn calendar_day_to_arrow_ipc(rows: Vec<CalendarDay>) -> napi::Result<napi::b
 pub fn eod_tick_to_arrow_ipc(rows: Vec<EodTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::EodTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::EodTick {
+        .map(|r| -> napi::Result<tick::EodTick> {
+            Ok(tick::EodTick {
                 created_ms_of_day: r.created_ms_of_day,
                 last_trade_ms_of_day: r.last_trade_ms_of_day,
                 open: r.open,
@@ -1263,10 +1263,10 @@ pub fn eod_tick_to_arrow_ipc(rows: Vec<EodTick>) -> napi::Result<napi::bindgen_p
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::EodTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1295,8 +1295,8 @@ pub fn eod_tick_to_arrow_ipc(rows: Vec<EodTick>) -> napi::Result<napi::bindgen_p
 pub fn greeks_all_tick_to_arrow_ipc(rows: Vec<GreeksAllTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::GreeksAllTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::GreeksAllTick {
+        .map(|r| -> napi::Result<tick::GreeksAllTick> {
+            Ok(tick::GreeksAllTick {
                 ms_of_day: r.ms_of_day,
                 bid: r.bid,
                 ask: r.ask,
@@ -1327,10 +1327,10 @@ pub fn greeks_all_tick_to_arrow_ipc(rows: Vec<GreeksAllTick>) -> napi::Result<na
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::GreeksAllTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1359,8 +1359,8 @@ pub fn greeks_all_tick_to_arrow_ipc(rows: Vec<GreeksAllTick>) -> napi::Result<na
 pub fn greeks_eod_tick_to_arrow_ipc(rows: Vec<GreeksEodTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::GreeksEodTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::GreeksEodTick {
+        .map(|r| -> napi::Result<tick::GreeksEodTick> {
+            Ok(tick::GreeksEodTick {
                 ms_of_day: r.ms_of_day,
                 open: r.open,
                 high: r.high,
@@ -1403,10 +1403,10 @@ pub fn greeks_eod_tick_to_arrow_ipc(rows: Vec<GreeksEodTick>) -> napi::Result<na
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::GreeksEodTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1435,8 +1435,8 @@ pub fn greeks_eod_tick_to_arrow_ipc(rows: Vec<GreeksEodTick>) -> napi::Result<na
 pub fn greeks_first_order_tick_to_arrow_ipc(rows: Vec<GreeksFirstOrderTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::GreeksFirstOrderTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::GreeksFirstOrderTick {
+        .map(|r| -> napi::Result<tick::GreeksFirstOrderTick> {
+            Ok(tick::GreeksFirstOrderTick {
                 ms_of_day: r.ms_of_day,
                 bid: r.bid,
                 ask: r.ask,
@@ -1453,10 +1453,10 @@ pub fn greeks_first_order_tick_to_arrow_ipc(rows: Vec<GreeksFirstOrderTick>) -> 
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::GreeksFirstOrderTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1485,8 +1485,8 @@ pub fn greeks_first_order_tick_to_arrow_ipc(rows: Vec<GreeksFirstOrderTick>) -> 
 pub fn greeks_second_order_tick_to_arrow_ipc(rows: Vec<GreeksSecondOrderTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::GreeksSecondOrderTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::GreeksSecondOrderTick {
+        .map(|r| -> napi::Result<tick::GreeksSecondOrderTick> {
+            Ok(tick::GreeksSecondOrderTick {
                 ms_of_day: r.ms_of_day,
                 bid: r.bid,
                 ask: r.ask,
@@ -1502,10 +1502,10 @@ pub fn greeks_second_order_tick_to_arrow_ipc(rows: Vec<GreeksSecondOrderTick>) -
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::GreeksSecondOrderTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1534,8 +1534,8 @@ pub fn greeks_second_order_tick_to_arrow_ipc(rows: Vec<GreeksSecondOrderTick>) -
 pub fn greeks_third_order_tick_to_arrow_ipc(rows: Vec<GreeksThirdOrderTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::GreeksThirdOrderTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::GreeksThirdOrderTick {
+        .map(|r| -> napi::Result<tick::GreeksThirdOrderTick> {
+            Ok(tick::GreeksThirdOrderTick {
                 ms_of_day: r.ms_of_day,
                 bid: r.bid,
                 ask: r.ask,
@@ -1550,10 +1550,10 @@ pub fn greeks_third_order_tick_to_arrow_ipc(rows: Vec<GreeksThirdOrderTick>) -> 
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::GreeksThirdOrderTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1661,8 +1661,8 @@ pub fn interest_rate_tick_to_arrow_ipc(rows: Vec<InterestRateTick>) -> napi::Res
 pub fn iv_tick_to_arrow_ipc(rows: Vec<IvTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::IvTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::IvTick {
+        .map(|r| -> napi::Result<tick::IvTick> {
+            Ok(tick::IvTick {
                 ms_of_day: r.ms_of_day,
                 bid: r.bid,
                 bid_implied_volatility: r.bid_implied_volatility,
@@ -1676,10 +1676,10 @@ pub fn iv_tick_to_arrow_ipc(rows: Vec<IvTick>) -> napi::Result<napi::bindgen_pre
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::IvTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1708,8 +1708,8 @@ pub fn iv_tick_to_arrow_ipc(rows: Vec<IvTick>) -> napi::Result<napi::bindgen_pre
 pub fn market_value_tick_to_arrow_ipc(rows: Vec<MarketValueTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::MarketValueTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::MarketValueTick {
+        .map(|r| -> napi::Result<tick::MarketValueTick> {
+            Ok(tick::MarketValueTick {
                 ms_of_day: r.ms_of_day,
                 market_bid: r.market_bid,
                 market_ask: r.market_ask,
@@ -1717,10 +1717,10 @@ pub fn market_value_tick_to_arrow_ipc(rows: Vec<MarketValueTick>) -> napi::Resul
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::MarketValueTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1749,8 +1749,8 @@ pub fn market_value_tick_to_arrow_ipc(rows: Vec<MarketValueTick>) -> napi::Resul
 pub fn ohlc_tick_to_arrow_ipc(rows: Vec<OhlcTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::OhlcTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::OhlcTick {
+        .map(|r| -> napi::Result<tick::OhlcTick> {
+            Ok(tick::OhlcTick {
                 ms_of_day: r.ms_of_day,
                 open: r.open,
                 high: r.high,
@@ -1762,10 +1762,10 @@ pub fn ohlc_tick_to_arrow_ipc(rows: Vec<OhlcTick>) -> napi::Result<napi::bindgen
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::OhlcTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1794,17 +1794,17 @@ pub fn ohlc_tick_to_arrow_ipc(rows: Vec<OhlcTick>) -> napi::Result<napi::bindgen
 pub fn open_interest_tick_to_arrow_ipc(rows: Vec<OpenInterestTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::OpenInterestTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::OpenInterestTick {
+        .map(|r| -> napi::Result<tick::OpenInterestTick> {
+            Ok(tick::OpenInterestTick {
                 ms_of_day: r.ms_of_day,
                 open_interest: r.open_interest,
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::OpenInterestTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1869,8 +1869,8 @@ pub fn price_tick_to_arrow_ipc(rows: Vec<PriceTick>) -> napi::Result<napi::bindg
 pub fn quote_tick_to_arrow_ipc(rows: Vec<QuoteTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::QuoteTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::QuoteTick {
+        .map(|r| -> napi::Result<tick::QuoteTick> {
+            Ok(tick::QuoteTick {
                 ms_of_day: r.ms_of_day,
                 bid_size: r.bid_size,
                 bid_exchange: r.bid_exchange,
@@ -1884,10 +1884,10 @@ pub fn quote_tick_to_arrow_ipc(rows: Vec<QuoteTick>) -> napi::Result<napi::bindg
                 midpoint: r.midpoint,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::QuoteTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1916,8 +1916,8 @@ pub fn quote_tick_to_arrow_ipc(rows: Vec<QuoteTick>) -> napi::Result<napi::bindg
 pub fn trade_greeks_all_tick_to_arrow_ipc(rows: Vec<TradeGreeksAllTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::TradeGreeksAllTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::TradeGreeksAllTick {
+        .map(|r| -> napi::Result<tick::TradeGreeksAllTick> {
+            Ok(tick::TradeGreeksAllTick {
                 ms_of_day: r.ms_of_day,
                 sequence: r.sequence,
                 ext_condition1: r.ext_condition1,
@@ -1955,10 +1955,10 @@ pub fn trade_greeks_all_tick_to_arrow_ipc(rows: Vec<TradeGreeksAllTick>) -> napi
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::TradeGreeksAllTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -1987,8 +1987,8 @@ pub fn trade_greeks_all_tick_to_arrow_ipc(rows: Vec<TradeGreeksAllTick>) -> napi
 pub fn trade_greeks_first_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksFirstOrderTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::TradeGreeksFirstOrderTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::TradeGreeksFirstOrderTick {
+        .map(|r| -> napi::Result<tick::TradeGreeksFirstOrderTick> {
+            Ok(tick::TradeGreeksFirstOrderTick {
                 ms_of_day: r.ms_of_day,
                 sequence: r.sequence,
                 ext_condition1: r.ext_condition1,
@@ -2012,10 +2012,10 @@ pub fn trade_greeks_first_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksFirstOrde
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::TradeGreeksFirstOrderTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -2044,8 +2044,8 @@ pub fn trade_greeks_first_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksFirstOrde
 pub fn trade_greeks_implied_volatility_tick_to_arrow_ipc(rows: Vec<TradeGreeksImpliedVolatilityTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::TradeGreeksImpliedVolatilityTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::TradeGreeksImpliedVolatilityTick {
+        .map(|r| -> napi::Result<tick::TradeGreeksImpliedVolatilityTick> {
+            Ok(tick::TradeGreeksImpliedVolatilityTick {
                 ms_of_day: r.ms_of_day,
                 sequence: r.sequence,
                 ext_condition1: r.ext_condition1,
@@ -2063,10 +2063,10 @@ pub fn trade_greeks_implied_volatility_tick_to_arrow_ipc(rows: Vec<TradeGreeksIm
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::TradeGreeksImpliedVolatilityTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -2095,8 +2095,8 @@ pub fn trade_greeks_implied_volatility_tick_to_arrow_ipc(rows: Vec<TradeGreeksIm
 pub fn trade_greeks_second_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksSecondOrderTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::TradeGreeksSecondOrderTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::TradeGreeksSecondOrderTick {
+        .map(|r| -> napi::Result<tick::TradeGreeksSecondOrderTick> {
+            Ok(tick::TradeGreeksSecondOrderTick {
                 ms_of_day: r.ms_of_day,
                 sequence: r.sequence,
                 ext_condition1: r.ext_condition1,
@@ -2119,10 +2119,10 @@ pub fn trade_greeks_second_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksSecondOr
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::TradeGreeksSecondOrderTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -2151,8 +2151,8 @@ pub fn trade_greeks_second_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksSecondOr
 pub fn trade_greeks_third_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksThirdOrderTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::TradeGreeksThirdOrderTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::TradeGreeksThirdOrderTick {
+        .map(|r| -> napi::Result<tick::TradeGreeksThirdOrderTick> {
+            Ok(tick::TradeGreeksThirdOrderTick {
                 ms_of_day: r.ms_of_day,
                 sequence: r.sequence,
                 ext_condition1: r.ext_condition1,
@@ -2174,10 +2174,10 @@ pub fn trade_greeks_third_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksThirdOrde
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::TradeGreeksThirdOrderTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -2206,8 +2206,8 @@ pub fn trade_greeks_third_order_tick_to_arrow_ipc(rows: Vec<TradeGreeksThirdOrde
 pub fn trade_quote_tick_to_arrow_ipc(rows: Vec<TradeQuoteTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::TradeQuoteTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::TradeQuoteTick {
+        .map(|r| -> napi::Result<tick::TradeQuoteTick> {
+            Ok(tick::TradeQuoteTick {
                 ms_of_day: r.ms_of_day,
                 sequence: r.sequence,
                 ext_condition1: r.ext_condition1,
@@ -2234,10 +2234,10 @@ pub fn trade_quote_tick_to_arrow_ipc(rows: Vec<TradeQuoteTick>) -> napi::Result<
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::TradeQuoteTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();
@@ -2266,8 +2266,8 @@ pub fn trade_quote_tick_to_arrow_ipc(rows: Vec<TradeQuoteTick>) -> napi::Result<
 pub fn trade_tick_to_arrow_ipc(rows: Vec<TradeTick>) -> napi::Result<napi::bindgen_prelude::Buffer> {
     let owned: Vec<tick::TradeTick> = rows
         .into_iter()
-        .map(|r| {
-            tick::TradeTick {
+        .map(|r| -> napi::Result<tick::TradeTick> {
+            Ok(tick::TradeTick {
                 ms_of_day: r.ms_of_day,
                 sequence: r.sequence,
                 ext_condition1: r.ext_condition1,
@@ -2285,10 +2285,10 @@ pub fn trade_tick_to_arrow_ipc(rows: Vec<TradeTick>) -> napi::Result<napi::bindg
                 date: r.date,
                 expiration: r.expiration.unwrap_or(0),
                 strike: r.strike.unwrap_or(0.0),
-                right: r.right.as_deref().and_then(|s| s.chars().next()).unwrap_or('\0'),
-            }
+                right: match r.right.as_deref() { Some("C") => 'C', Some("P") => 'P', None | Some("") => '\0', Some(other) => return Err(napi::Error::from_reason(format!("[InvalidParameterError] right must be \"C\" or \"P\", got {other:?}"))) },
+            })
         })
-        .collect();
+        .collect::<napi::Result<Vec<tick::TradeTick>>>()?;
     let batch = thetadatadx::frames::TicksArrowExt::to_arrow(owned.as_slice())
         .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
     let mut buf: Vec<u8> = Vec::new();

--- a/sdks/typescript/src/fluent.rs
+++ b/sdks/typescript/src/fluent.rs
@@ -169,7 +169,7 @@ impl ContractRef {
             },
         )
         .map(Self::from_inner)
-        .map_err(|e| napi::Error::from_reason(e.to_string()))
+        .map_err(crate::to_napi_err)
     }
 
     /// Per-contract Quote subscription.

--- a/sdks/typescript/streaming-session.js
+++ b/sdks/typescript/streaming-session.js
@@ -275,9 +275,156 @@ if (
 }
 
 
+// Re-cast typed errors on every native entrypoint — instance method,
+// static factory, or free function. The Rust binding tags every
+// `thetadatadx::Error` with a `[ClassName] ...` prefix on the napi
+// `reason`; this interceptor parses it and re-throws the matching
+// subclass so the caller can branch on `instanceof`. Errors without
+// the prefix (napi argument coercion, etc.) surface unchanged. The
+// single helper keeps the sync-throw and async-rejection handling
+// identical across every call shape — there is no second copy of the
+// try/`rethrowTyped` logic to drift.
+function installTypedErrorInterceptor(original, boundThis) {
+  return function typedErrorBoundary(...args) {
+    let result;
+    try {
+      result = original.apply(boundThis !== undefined ? boundThis : this, args);
+    } catch (err) {
+      rethrowTyped(err);
+    }
+    // napi-rs async methods return a Promise; intercept the
+    // rejection without altering the resolved value.
+    if (result && typeof result.then === 'function') {
+      return result.then(
+        (value) => value,
+        (err) => rethrowTyped(err),
+      );
+    }
+    return result;
+  };
+}
+
+// Intrinsic own props every function carries; never wrappable members.
+const FUNCTION_INTRINSICS = new Set(['prototype', 'length', 'name', 'constructor']);
+
+// `true` when `value` is a native class constructor rather than a free
+// function. napi-rs emits both as plain (writable-`prototype`)
+// functions, so the ES2015 `prototype` non-writability test does not
+// apply; a class is distinguished structurally — it carries instance
+// members on its prototype and/or static methods on itself, whereas a
+// free function's prototype holds only `constructor` and it has no own
+// statics.
+function isNativeClass(value) {
+  if (typeof value !== 'function') return false;
+  const proto = value.prototype;
+  if (proto && Object.getOwnPropertyNames(proto).some((n) => n !== 'constructor')) {
+    return true;
+  }
+  return Object.getOwnPropertyNames(value).some(
+    (n) => !FUNCTION_INTRINSICS.has(n) && typeof value[n] === 'function',
+  );
+}
+
+// Re-cast typed errors thrown by a class's instance methods. Instance
+// methods live on `klass.prototype` and napi-rs emits them as writable
+// data properties, so they are patched in place. Static / factory
+// methods cannot be patched this way — napi-rs seals them as
+// non-writable, non-configurable own props of the constructor — so
+// those are re-exposed through a subclass below.
+function wrapInstanceMethods(klass) {
+  if (!klass || !klass.prototype) return;
+  for (const name of Object.getOwnPropertyNames(klass.prototype)) {
+    if (name === 'constructor') continue;
+    const desc = Object.getOwnPropertyDescriptor(klass.prototype, name);
+    if (!desc || typeof desc.value !== 'function') continue;
+    klass.prototype[name] = installTypedErrorInterceptor(desc.value);
+  }
+}
+
+// Re-expose a native class through a thin subclass whose static methods
+// carry the typed-error interceptor. napi-rs seals factory statics
+// (`ThetaDataDxClient.connectFromFile`, `Contract.option`, ...) as
+// non-writable, non-configurable own props, so they cannot be patched
+// in place; a subclass owns fresh static slots that shadow them while
+// inheriting everything else. Each wrapped static invokes the native
+// static with `this` bound to the native class, so the value it returns
+// is a genuine native instance — `result instanceof NativeClass` stays
+// true. `Symbol.hasInstance` defers to the native class so
+// `x instanceof Exported` continues to recognise those native instances
+// even though their prototype chain points at the native class, not the
+// subclass. Returns the native class unchanged when it has no statics
+// (nothing to re-expose), so non-factory classes keep their identity.
+function wrapClassStatics(klass) {
+  const staticNames = Object.getOwnPropertyNames(klass).filter(
+    (n) => !FUNCTION_INTRINSICS.has(n) && typeof klass[n] === 'function',
+  );
+  if (staticNames.length === 0) return klass;
+
+  const Exported = class extends klass {};
+  for (const name of staticNames) {
+    const nativeStatic = klass[name];
+    Object.defineProperty(Exported, name, {
+      value: installTypedErrorInterceptor(nativeStatic, klass),
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+  // Native factory statics return native-class instances, never
+  // subclass instances; keep `instanceof Exported` recognising them.
+  Object.defineProperty(Exported, Symbol.hasInstance, {
+    value: (inst) => inst instanceof klass,
+    configurable: true,
+  });
+  // Preserve the readable class name (`extends` would otherwise leave
+  // the anonymous-class name empty).
+  Object.defineProperty(Exported, 'name', {
+    value: klass.name,
+    configurable: true,
+  });
+  return Exported;
+}
+
+// Every exported native class: patch its instance methods in place,
+// then re-expose it (static-wrapped). Discovered structurally so a
+// newly added native class is covered with no edit here. Aliased
+// exports (`Contract` shares `ContractRef`'s constructor) are
+// processed once per distinct native constructor — keyed by identity —
+// so instance methods are not double-wrapped and every alias receives
+// the same re-exposed subclass.
+const exportedClasses = {};
+const wrappedByNativeClass = new Map();
+for (const name of Object.getOwnPropertyNames(native)) {
+  const value = native[name];
+  if (!isNativeClass(value)) continue;
+  let wrapped = wrappedByNativeClass.get(value);
+  if (wrapped === undefined) {
+    wrapInstanceMethods(value);
+    wrapped = wrapClassStatics(value);
+    wrappedByNativeClass.set(value, wrapped);
+  }
+  exportedClasses[name] = wrapped;
+}
+
+// Free functions (e.g. `calendarDayToArrowIpc`, `eodTickToArrowIpc`)
+// are exported directly on the native binding, not on a class. Wrap
+// every own function-valued export that is not a class so a
+// `[ClassName] ...` error raised inside a free function reclassifies
+// the same way it does on a method — one rule: any native export
+// reclassifies typed errors.
+const exportedFreeFns = {};
+for (const name of Object.getOwnPropertyNames(native)) {
+  const value = native[name];
+  if (typeof value !== 'function' || isNativeClass(value)) continue;
+  exportedFreeFns[name] = installTypedErrorInterceptor(value);
+}
+
 // Re-export the entire native surface plus the StreamingSession class.
 // `Object.assign` rather than spread so non-enumerable properties on
-// the napi binding survive.
+// the napi binding survive. The static-wrapped classes
+// (`exportedClasses`) and reclassifying free functions
+// (`exportedFreeFns`) shadow their raw native counterparts so every
+// public entrypoint reaches the typed-error hierarchy.
 //
 // `Contract` aliases `ContractRef` — napi-rs exposes the fluent
 // contract type under the `ContractRef` symbol because `Contract`
@@ -285,48 +432,11 @@ if (
 // surface documented in the quickstart is `Contract.stock("AAPL")` /
 // `Contract.option(...)`, so the alias makes the JS export agree with
 // the docs without a second pyclass.
-// Patch every method on the native binding's exported classes so
-// rejections / throws get re-cast through the typed error hierarchy.
-// The shim parses the `[ClassName] ...` prefix the Rust shim emits;
-// errors without the prefix surface unchanged.
-function wrapMethodsWithTypedErrors(klass) {
-  if (!klass || !klass.prototype) return;
-  for (const name of Object.getOwnPropertyNames(klass.prototype)) {
-    if (name === 'constructor') continue;
-    const desc = Object.getOwnPropertyDescriptor(klass.prototype, name);
-    if (!desc || typeof desc.value !== 'function') continue;
-    const original = desc.value;
-    klass.prototype[name] = function patchedNapiMethod(...args) {
-      let result;
-      try {
-        result = original.apply(this, args);
-      } catch (err) {
-        rethrowTyped(err);
-      }
-      // napi-rs async methods return a Promise; intercept the
-      // rejection without altering the resolved value.
-      if (result && typeof result.then === 'function') {
-        return result.then(
-          (value) => value,
-          (err) => rethrowTyped(err),
-        );
-      }
-      return result;
-    };
-  }
-}
-
-for (const klassName of [
-  'ThetaDataDxClient',
-  'FlatFileRowList',
-]) {
-  const klass = native[klassName];
-  if (klass) wrapMethodsWithTypedErrors(klass);
-}
-
-module.exports = Object.assign({}, native, {
+module.exports = Object.assign({}, native, exportedClasses, exportedFreeFns, {
   StreamingSession,
-  Contract: native.ContractRef,
+  // The documented `Contract` name resolves to the same static-wrapped
+  // export as `ContractRef`, so `Contract.option(...)` reclassifies too.
+  Contract: exportedClasses.ContractRef ?? native.ContractRef,
   ThetaDataError,
   AuthenticationError,
   InvalidCredentialsError,


### PR DESCRIPTION
A quant calling the same function in Python and TypeScript must get the same rejection and the same typed error. Three cross-binding-parity gaps broke that for the napi-rs binding; this restores it, with native regression tests proving each path against the built addon.

The typed-error contract needs two halves to hold for a typed error to reach the caller: the Rust method tags its reason with a `[ClassName] ...` prefix, and the JS entrypoint is wrapped so the shim's `rethrowTyped` reclassifies it. Only instance methods satisfied both. Static factory methods (`ThetaDataDxClient.connectFromFile`, `Contract.option`) and the exported Arrow-IPC free functions threw a plain `Error`, so `catch (e) { if (e instanceof tdx.InvalidParameterError) ... }` — which works in Python — silently fell through in TypeScript.

The static gap is structural: napi-rs seals factory statics as non-writable, non-configurable own properties of the constructor, so they cannot be patched in place the way prototype methods can. The shim now re-exposes every native class through a thin subclass that owns interceptor-wrapped static slots shadowing the sealed ones, while `Symbol.hasInstance` defers to the native class so `result instanceof Exported` keeps recognising the native instances those factories return. Exported free functions are wrapped directly on the re-export. Both classes and free functions are discovered structurally, so one rule holds — any native export reclassifies typed errors — and a newly added export is covered with no further edit. `ContractRef::option` additionally now maps its error through `to_napi_err`, the only fallible fluent factory that previously emitted an unprefixed reason.

The second gap is data corruption. The TypeScript Arrow-IPC reconstruction silently coerced invalid logical enums: a calendar `status` outside the documented vocabulary became `Weekend`, and a `right` outside `"C"`/`"P"` was truncated to its first character. Python rejects both with a typed error. The fix is in the tick codegen, not the generated file: `right` and `calendar_status` now reconstruct through a validating `match` that returns an `[InvalidParameterError]`-prefixed error on any out-of-vocabulary value, mirroring the Python reverse projection's accepted set and message wording exactly. Tick types carrying a validated column reconstruct inside a fallible closure collected into a `napi::Result`; types without one keep the infallible form, so no build pays for wrapping it does not need. The checked-in generated surface was regenerated and the drift check passes.

Repro evidence against the freshly built debug addon (before: repros 1-2 threw a plain `Error`, repros 3-4 succeeded by corrupting the value; after):

```
connectFromFile('/definitely/missing-creds.txt') -> THROW ThetaDataError (instanceof ThetaDataError = true)
Contract.option('SPY', {expiration:'bad',strike:'550',right:'C'}) -> THROW InvalidParameterError (instanceof InvalidParameterError = true)
calendarDayToArrowIpc([{...,status:'bogus'}]) -> THROW InvalidParameterError  (was: success, status rewritten to Weekend)
eodTickToArrowIpc([{...,right:'XYZ'}]) -> THROW InvalidParameterError  (was: success, right truncated to 'X')
calendarDayToArrowIpc([{...,status:'full_close'}]) -> Buffer (len 1480)
eodTickToArrowIpc([{...,right:'C'}]) -> Buffer (len 4936)
```

Verification: `cargo fmt --all -- --check`, `cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check` (drift), `python3 scripts/check_binding_parity.py`, `cargo clippy --all-targets -- -D warnings` on the napi crate, and `npm test` (95 tests, including the 6 new native regression tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)