### PR TITLE
fix(typescript): raise typed InvalidParameterError for config and flatfile validation

### DIFF
--- a/sdks/typescript/__tests__/native_typed_errors.test.mjs
+++ b/sdks/typescript/__tests__/native_typed_errors.test.mjs
@@ -18,6 +18,19 @@
 // variant (the prior `unwrap_or(Weekend)` / `chars().next()` truncation
 // corrupted data instead of failing loudly).
 //
+// And they pin the user-input validation parity on the `Config` setters
+// and the FLATFILES enum parsers: an invalid enum / out-of-range value
+// rejected by a hand-written guard before the call reaches the core
+// client must surface as `InvalidParameterError`, the same class the
+// Python binding raises (`ValueError`) for the identical bad input — so
+// a caller's `catch (e) { if (e instanceof InvalidParameterError) }`
+// branch ports across bindings. The `Config` cases are reachable
+// without a connection; the FLATFILES parsers sit on a connected
+// namespace, so that block builds a client from a credentials file and
+// skips when none is available (set `THETADATADX_TEST_CREDS` to point at
+// one), exercising only the synchronous enum parse that runs before any
+// network round-trip.
+//
 // Loads the wrapped surface (`../streaming-session.js`), the package
 // `main`, so the assertions observe exactly what a consumer sees. When
 // the native addon cannot be dlopen'd (no `.node` built) the suite
@@ -25,8 +38,28 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 
 const wrapperImportPath = '../streaming-session.js';
+
+// Optional credentials file for the FLATFILES enum-parse block. The
+// parsers live on `tdx.flat_files` / `tdx.flatFileToPath`, which require
+// a built client; the enum parse itself is synchronous and runs before
+// any network I/O, so a connected client is enough to exercise it. When
+// no credentials file is present the block skips, keeping the suite
+// runnable offline and on CI.
+const TEST_CREDS_PATH = process.env.THETADATADX_TEST_CREDS ?? '/home/theta-gamma/thetadx/creds.txt';
+
+// Build a client from the credentials file, or return `null` when none
+// is available / the connect fails — the caller skips in that case.
+function tryConnect(mod) {
+  if (!existsSync(TEST_CREDS_PATH)) return null;
+  try {
+    return mod.ThetaDataDxClient.connectFromFile(TEST_CREDS_PATH);
+  } catch {
+    return null;
+  }
+}
 
 async function loadWrapped() {
   try {
@@ -148,5 +181,105 @@ describe('Arrow-IPC logical-enum validation parity (native)', () => {
     const buf = mod.eodTickToArrowIpc([validEodTick('C')]);
     assert.ok(Buffer.isBuffer(buf), 'a valid right must serialise to a Buffer');
     assert.ok(looksLikeArrowIpcStream(buf), 'expected an Arrow IPC stream');
+  });
+});
+
+describe('Config setter input-validation parity (native)', () => {
+  it('setReconnectPolicy with an unknown policy throws InvalidParameterError', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    const cfg = mod.Config.production();
+    assert.throws(
+      () => cfg.setReconnectPolicy('bogus'),
+      (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+      'an unknown reconnect policy must reclassify to InvalidParameterError, matching the Python ValueError',
+    );
+  });
+
+  it('setReconnectPolicy accepts a valid policy', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    const cfg = mod.Config.production();
+    assert.doesNotThrow(
+      () => cfg.setReconnectPolicy('manual'),
+      'a valid reconnect policy must be accepted',
+    );
+  });
+
+  it('setFpssRingSize rejects a non-power-of-two as InvalidParameterError', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    // The setter rejects eagerly with the typed class; the core's
+    // connect-time validation of `fpss.ring_size` is unchanged.
+    const cfg = mod.Config.production();
+    assert.throws(
+      () => cfg.setFpssRingSize(100),
+      (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+      'a non-power-of-two ring size must reclassify to InvalidParameterError',
+    );
+  });
+
+  it('setFpssRingSize accepts a valid power-of-two >= 64', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    const cfg = mod.Config.production();
+    assert.doesNotThrow(
+      () => cfg.setFpssRingSize(65536),
+      'a valid power-of-two ring size must be accepted',
+    );
+  });
+
+  it('setReconnectWaitMs keeps an integer-domain overflow as a plain Error', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    // A value too large for u64 is a representation overflow, not an
+    // invalid parameter: Python raises the built-in OverflowError here,
+    // so TypeScript intentionally leaves it a plain Error rather than
+    // inventing a typed class the parity binding does not raise.
+    const cfg = mod.Config.production();
+    assert.throws(
+      () => cfg.setReconnectWaitMs(2n ** 70n),
+      (err) => err instanceof Error && !(err instanceof mod.InvalidParameterError),
+      'an integer-domain overflow must stay a plain Error, not reclassify',
+    );
+  });
+});
+
+describe('FLATFILES enum-parse input-validation parity (native)', () => {
+  it('flatFiles.request with an unknown sec_type throws InvalidParameterError', async (t) => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+    const tdx = tryConnect(mod);
+    if (!tdx) {
+      t.skip('no credentials available to build a client for the FLATFILES surface');
+      return;
+    }
+
+    assert.throws(
+      () => tdx.flatFiles.request('BOGUS', 'QUOTE', '20260102'),
+      (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+      'an unknown flat-file sec_type must reclassify to InvalidParameterError, matching the Python ValueError',
+    );
+  });
+
+  it('flatFileToPath with an unknown req_type throws InvalidParameterError', async (t) => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+    const tdx = tryConnect(mod);
+    if (!tdx) {
+      t.skip('no credentials available to build a client for the FLATFILES surface');
+      return;
+    }
+
+    assert.throws(
+      () => tdx.flatFileToPath('OPTION', 'BOGUS', '20260102', '/tmp/thetadatadx-test.csv'),
+      (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+      'an unknown flat-file req_type must reclassify to InvalidParameterError',
+    );
   });
 });

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -174,7 +174,7 @@ impl Config {
             "manual" => config::ReconnectPolicy::Manual,
             "auto" => config::ReconnectPolicy::Auto(config::ReconnectAttemptLimits::default()),
             other => {
-                return Err(napi::Error::from_reason(format!(
+                return Err(crate::invalid_parameter_err(format!(
                     "unknown reconnect_policy: {other:?} (expected \"auto\" or \"manual\")"
                 )));
             }
@@ -387,7 +387,7 @@ impl Config {
     #[napi(js_name = "setReconnectJitter")]
     pub fn set_reconnect_jitter(&self, mode: String) -> napi::Result<()> {
         let parsed = config::JitterMode::parse(&mode).ok_or_else(|| {
-            napi::Error::from_reason(format!(
+            crate::invalid_parameter_err(format!(
                 "setReconnectJitter: unknown mode {mode:?}; expected \"full\", \"equal\", \"decorrelated\", or \"none\""
             ))
         })?;
@@ -846,12 +846,12 @@ impl Config {
     #[napi(js_name = "setFpssRingSize")]
     pub fn set_fpss_ring_size(&self, n: u32) -> napi::Result<()> {
         if n == 0 || !n.is_power_of_two() {
-            return Err(napi::Error::from_reason(format!(
+            return Err(crate::invalid_parameter_err(format!(
                 "fpss_ring_size must be a power of two >= 64; got {n}"
             )));
         }
         if n < 64 {
-            return Err(napi::Error::from_reason(format!(
+            return Err(crate::invalid_parameter_err(format!(
                 "fpss_ring_size must be >= 64; got {n}"
             )));
         }
@@ -879,7 +879,7 @@ impl Config {
     #[napi(js_name = "setFpssHostSelection")]
     pub fn set_fpss_host_selection(&self, policy: String) -> napi::Result<()> {
         let parsed = config::HostSelectionPolicy::parse(&policy).ok_or_else(|| {
-            napi::Error::from_reason(format!(
+            crate::invalid_parameter_err(format!(
                 "setFpssHostSelection: unknown policy {policy:?}; expected \"shuffled\" or \"fixed_order\""
             ))
         })?;
@@ -1301,7 +1301,7 @@ impl Config {
     pub fn set_metrics_port(&self, port: Option<u32>) -> napi::Result<()> {
         let resolved = match port {
             Some(v) => Some(u16::try_from(v).map_err(|_| {
-                napi::Error::from_reason(format!(
+                crate::invalid_parameter_err(format!(
                     "setMetricsPort: port must be in 0..=65535; got {v}"
                 ))
             })?),
@@ -1338,7 +1338,7 @@ impl Config {
             "batched" => config::FpssFlushMode::Batched,
             "immediate" => config::FpssFlushMode::Immediate,
             other => {
-                return Err(napi::Error::from_reason(format!(
+                return Err(crate::invalid_parameter_err(format!(
                     "setFlushMode: mode must be \"batched\" or \"immediate\"; got {other:?}"
                 )));
             }

--- a/sdks/typescript/src/flatfile_methods.rs
+++ b/sdks/typescript/src/flatfile_methods.rs
@@ -33,7 +33,7 @@ fn parse_flatfile_sec_type(sec: &str) -> napi::Result<SecType> {
         "OPTION" => Ok(SecType::Option),
         "STOCK" => Ok(SecType::Stock),
         "INDEX" => Ok(SecType::Index),
-        other => Err(napi::Error::from_reason(format!(
+        other => Err(crate::invalid_parameter_err(format!(
             "unknown flat-file sec_type: {other:?} (expected OPTION, STOCK, or INDEX)"
         ))),
     }
@@ -47,7 +47,7 @@ fn parse_flatfile_req_type(req: &str) -> napi::Result<ReqType> {
         "OHLC" => Ok(ReqType::Ohlc),
         "TRADE" => Ok(ReqType::Trade),
         "TRADE_QUOTE" | "TRADEQUOTE" => Ok(ReqType::TradeQuote),
-        other => Err(napi::Error::from_reason(format!(
+        other => Err(crate::invalid_parameter_err(format!(
             "unknown flat-file req_type: {other:?} (expected EOD, QUOTE, OPEN_INTEREST, OHLC, TRADE, TRADE_QUOTE)"
         ))),
     }
@@ -57,7 +57,7 @@ fn parse_flatfile_format(fmt: Option<&str>) -> napi::Result<FlatFileFormat> {
     match fmt.unwrap_or("csv").to_lowercase().as_str() {
         "csv" => Ok(FlatFileFormat::Csv),
         "jsonl" | "json" => Ok(FlatFileFormat::Jsonl),
-        other => Err(napi::Error::from_reason(format!(
+        other => Err(crate::invalid_parameter_err(format!(
             "unknown flat-file format: {other:?} (expected csv or jsonl)"
         ))),
     }

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -52,6 +52,15 @@ pub(crate) fn to_napi_err(e: thetadatadx::Error) -> napi::Error {
     napi::Error::from_reason(format!("{prefix} {e}"))
 }
 
+/// Build an `InvalidParameterError`-typed napi error for user-input
+/// validation that fails before reaching the core client. The JS shim
+/// keys on the `[ClassName]` prefix to re-throw the typed subclass, so
+/// TypeScript callers branch on `instanceof InvalidParameterError`
+/// exactly as Python callers catch the parity `ValueError`.
+pub(crate) fn invalid_parameter_err(message: impl std::fmt::Display) -> napi::Error {
+    napi::Error::from_reason(format!("[InvalidParameterError] {message}"))
+}
+
 /// Run an endpoint round-trip off the runtime's execution thread and
 /// hand the result back as a `napi::Result`.
 ///


### PR DESCRIPTION
User-input validation in the TypeScript binding rejected bad config setter values and unknown FLATFILES enum strings with an untyped napi error, so callers received a plain `Error` where the Python binding raises the typed `ValueError` for the identical bad input. That broke the cross-binding contract that a caller catching invalid-parameter failures branches on the same class in both languages: `Config.setReconnectPolicy('bogus')` surfaced as `InvalidParameterError` in Python but a generic `Error` in TypeScript.

A just-merged change made the JS shim reclassify any napi error whose reason carries a `[ClassName] ...` prefix into the matching typed subclass on instance methods, static factories, and free functions. This change makes the affected validation sites carry that prefix so they reach the caller as `InvalidParameterError`.

A small `invalid_parameter_err` helper next to `to_napi_err` builds the prefixed error in one place rather than sprinkling the literal across call sites. Each converted site keeps its exact message text after the prefix.

Sites converted (Python raises `ValueError` for the same input, which maps to `InvalidParameterError`): the `setReconnectPolicy` / `setReconnectJitter` / `setFpssHostSelection` / `setFlushMode` enum setters, the `setMetricsPort` out-of-range check, the `setFpssRingSize` power-of-two and lower-bound guards, and the three `flat_files` sec-type / req-type / format parsers.

The `setFpssRingSize` guards now reject with the typed class at the setter; the connect-time validation of `fpss.ring_size` in the core is unchanged.

Sites left as a plain `Error` on purpose: the BigInt-to-u64 and sequence wire-range checks reject values outside the integer's representable domain, which the Python binding surfaces as the built-in `OverflowError`, not a `ValueError`. Reclassifying those would invent a typed class the parity binding never raises, so they stay untyped.

Repro against the built addon (`require('./streaming-session.js')`):

```
setReconnectPolicy("bogus")     => instanceof InvalidParameterError: true  | name: InvalidParameterError
setReconnectJitter("bogus")     => instanceof InvalidParameterError: true  | name: InvalidParameterError
setFpssHostSelection("bogus")   => instanceof InvalidParameterError: true  | name: InvalidParameterError
setFlushMode("bogus")           => instanceof InvalidParameterError: true  | name: InvalidParameterError
setMetricsPort(70000)           => instanceof InvalidParameterError: true  | name: InvalidParameterError
setFpssRingSize(100) [not pow2] => instanceof InvalidParameterError: true  | name: InvalidParameterError
setFpssRingSize(32)  [< 64]     => instanceof InvalidParameterError: true  | name: InvalidParameterError
flatFiles.request("BOGUS", ...) => instanceof InvalidParameterError: true  | name: InvalidParameterError
flatFileToPath(.., "BOGUS", ..) => instanceof InvalidParameterError: true  | name: InvalidParameterError
setReconnectWaitMs(2n**70n)     => instanceof InvalidParameterError: false | name: Error   (overflow stays plain, by design)
```

Verification: `cargo fmt --all -- --check` clean, `cargo clippy --manifest-path sdks/typescript/Cargo.toml --all-targets -- -D warnings` clean, `python3 scripts/check_binding_parity.py` clean, `npm run build:debug` builds the addon, `npm test` passes (102 tests, 0 fail). The regression suite gains hermetic `Config` setter cases (typed reject, happy-path accept, and an overflow control that asserts the plain `Error`) plus credentials-guarded FLATFILES enum-parse cases that skip when no client can be built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
