### PR TITLE
fix(typescript,cpp): reject non-integer and negative request timeouts instead of silently coercing

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/cpp.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/cpp.rs
@@ -47,10 +47,12 @@ pub(super) fn render_cpp_options(params: &[GeneratedParam]) -> String {
         out.push_str("    }\n");
     }
     out.push_str(include_str!("templates/cpp/with_timeout_ms.cpp.tmpl"));
-    // A negative duration means "deadline already in the past" and clamps
-    // to 1 ms (immediate expiration). Without the clamp, the cast to
-    // uint64_t would silently wrap to a multi-century value, the opposite
-    // of the caller's intent.
+    // A negative duration is rejected with `InvalidParameterError` rather
+    // than coerced: the unsigned `timeout_ms` field cannot represent it,
+    // and an `static_cast<uint64_t>` of a negative count would wrap to a
+    // multi-century deadline — the opposite of the caller's intent. This
+    // matches the reject-don't-coerce contract the other bindings hold for
+    // the same out-of-domain deadline.
     out.push_str(include_str!("templates/cpp/with_deadline.cpp.tmpl"));
     out.push_str("};\n");
     out.push_str("\nnamespace detail {\n\n");

--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/templates/cpp/with_deadline.cpp.tmpl
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/templates/cpp/with_deadline.cpp.tmpl
@@ -1,4 +1,8 @@
     EndpointRequestOptions& with_deadline(std::chrono::milliseconds value) {
-        timeout_ms = value.count() < 0 ? 1u : static_cast<uint64_t>(value.count());
+        if (value.count() < 0) {
+            throw InvalidParameterError(
+                "thetadatadx: deadline must be non-negative");
+        }
+        timeout_ms = static_cast<uint64_t>(value.count());
         return *this;
     }

--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/typescript.rs
@@ -100,8 +100,10 @@ fn render_typescript_endpoint_options_struct(endpoint: &GeneratedEndpoint) -> St
         )
         .unwrap();
     }
-    out.push_str("    /// Per-call deadline in milliseconds; on expiry the returned Promise\n");
-    out.push_str("    /// rejects and the underlying request is cancelled.\n");
+    out.push_str("    /// Per-call deadline as a non-negative whole number of milliseconds;\n");
+    out.push_str("    /// on expiry the returned Promise rejects and the underlying request\n");
+    out.push_str("    /// is cancelled. A non-finite, negative, or fractional value is\n");
+    out.push_str("    /// rejected with `InvalidParameterError` rather than coerced.\n");
     out.push_str("    pub timeout_ms: Option<f64>,\n");
     out.push_str("}\n");
     out
@@ -153,6 +155,17 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
     }
 
     out.push_str("        let options = options.unwrap_or_default();\n");
+
+    // Validate the per-call deadline up front, before the request task
+    // is spawned: the option rides in as a JS `number` (f64), and an
+    // `as u64` cast would silently rewrite a non-finite, negative, or
+    // fractional value instead of rejecting it. `validate_timeout_ms`
+    // returns the integer-domain `u64` the other bindings take, or an
+    // `InvalidParameterError`; `?` rejects the Promise synchronously.
+    out.push_str("        let timeout_ms = match options.timeout_ms {\n");
+    out.push_str("            Some(ms) => Some(validate_timeout_ms(ms)?),\n");
+    out.push_str("            None => None,\n");
+    out.push_str("        };\n");
 
     // Clone the `Arc` client handle so the spawned future owns a
     // `'static` borrow source: the request builder borrows the client,
@@ -233,10 +246,12 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
             name = endpoint.name,
         )
         .unwrap();
-        out.push_str("            if let Some(ms) = options.timeout_ms {\n");
-        out.push_str("                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {\n");
+        out.push_str("            if let Some(ms) = timeout_ms {\n");
+        out.push_str("                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {\n");
         out.push_str("                    Ok(inner) => inner,\n");
-        out.push_str("                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),\n");
+        out.push_str(
+            "                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),\n",
+        );
         out.push_str("                }\n");
         out.push_str("            } else {\n");
         out.push_str("                call.await\n");
@@ -292,9 +307,9 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
         .unwrap();
         out.push_str("            }\n");
     }
-    out.push_str("            if let Some(ms) = options.timeout_ms {\n");
+    out.push_str("            if let Some(ms) = timeout_ms {\n");
     out.push_str(
-        "                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));\n",
+        "                request = request.with_deadline(std::time::Duration::from_millis(ms));\n",
     );
     out.push_str("            }\n");
     out.push_str("            request.await\n");

--- a/sdks/cpp/include/endpoint_options.hpp.inc
+++ b/sdks/cpp/include/endpoint_options.hpp.inc
@@ -138,7 +138,11 @@ struct EndpointRequestOptions {
         return *this;
     }
     EndpointRequestOptions& with_deadline(std::chrono::milliseconds value) {
-        timeout_ms = value.count() < 0 ? 1u : static_cast<uint64_t>(value.count());
+        if (value.count() < 0) {
+            throw InvalidParameterError(
+                "thetadatadx: deadline must be non-negative");
+        }
+        timeout_ms = static_cast<uint64_t>(value.count());
         return *this;
     }
 };

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -144,9 +144,6 @@ struct Greeks {
     double lambda;
 };
 
-/* Generated in endpoint_options.hpp.inc. */
-#include "endpoint_options.hpp.inc"
-
 // ══════════════════════════════════════════════════════════════════════════
 // Typed exception hierarchy
 // ══════════════════════════════════════════════════════════════════════════
@@ -289,6 +286,12 @@ class StreamError : public ThetaDataError {
 public:
     using ThetaDataError::ThetaDataError;
 };
+
+// Generated request-options bag. Included after the exception hierarchy
+// so its `with_deadline` setter can throw the complete
+// `InvalidParameterError` type when handed a negative deadline.
+/* Generated in endpoint_options.hpp.inc. */
+#include "endpoint_options.hpp.inc"
 
 // ── RAII typed array wrappers ──
 

--- a/sdks/cpp/tests/error_taxonomy.cpp
+++ b/sdks/cpp/tests/error_taxonomy.cpp
@@ -8,12 +8,14 @@
 // can `catch` on directly. The hierarchy mirrors the Python /
 // TypeScript leaf set so the cross-binding contract stays uniform.
 
+#include <chrono>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "thetadx.h"
 #include "thetadx.hpp"
 
 TEST_CASE("ThetaDataError is the root of the SDK exception hierarchy",
@@ -64,6 +66,40 @@ TEST_CASE("throw_for_code routes the invalid-parameter discriminant to InvalidPa
     } catch (const tdx::ThetaDataError&) {
         // expected — generic config fault
     }
+}
+
+TEST_CASE("with_deadline rejects a negative deadline as InvalidParameterError",
+          "[errors][offline]") {
+    // A negative duration cannot be represented by the unsigned
+    // `timeout_ms` field. `with_deadline` rejects it with
+    // `InvalidParameterError` rather than coercing it: a
+    // `static_cast<uint64_t>` of a negative count would wrap to a
+    // multi-century deadline, the opposite of the caller's intent. This
+    // matches the reject-don't-coerce contract the TypeScript binding
+    // holds for the same out-of-domain `timeoutMs`, so a deadline a caller
+    // could not have meant fails loudly across both surfaces.
+    tdx::EndpointRequestOptions options;
+    try {
+        options.with_deadline(std::chrono::milliseconds(-5));
+        FAIL("with_deadline must reject a negative deadline");
+    } catch (const tdx::InvalidParameterError&) {
+        // expected — distinguishable by catch type from a generic fault
+    } catch (const tdx::ThetaDataError& e) {
+        FAIL("expected InvalidParameterError, got generic ThetaDataError: " << e.what());
+    }
+
+    // A non-negative deadline is accepted and recorded as whole
+    // milliseconds; the setter returns the bag by reference for chaining.
+    tdx::EndpointRequestOptions ok;
+    REQUIRE_NOTHROW(ok.with_deadline(std::chrono::milliseconds(5000)));
+    REQUIRE(ok.timeout_ms.has_value());
+    REQUIRE(ok.timeout_ms.value() == 5000u);
+
+    // The boundary value zero is a valid (immediate) deadline, not a
+    // rejected one.
+    tdx::EndpointRequestOptions zero;
+    REQUIRE_NOTHROW(zero.with_deadline(std::chrono::milliseconds(0)));
+    REQUIRE(zero.timeout_ms.value() == 0u);
 }
 
 TEST_CASE("RateLimitError carries the server retry_after as a typed value",
@@ -149,4 +185,53 @@ TEST_CASE("forced Unauthenticated from a real RPC surfaces as AuthenticationErro
     } catch (const tdx::ThetaDataError& e) {
         FAIL("expected AuthenticationError, got generic ThetaDataError: " << e.what());
     }
+}
+
+TEST_CASE("config enum setters reject an out-of-domain value with InvalidParameterError",
+          "[errors][config][offline]") {
+    // A bad enum int on a config setter is a rejected client parameter,
+    // not an environmental config fault — every setter must surface
+    // `InvalidParameterError` (narrowing `ThetaDataError`) so the C++
+    // catch type matches the Python `ValueError` / TypeScript
+    // `InvalidParameterError` for the same input. A valid value must not
+    // throw.
+    auto cfg = tdx::Config::production();
+
+    REQUIRE_NOTHROW(cfg.set_flush_mode(1));
+    REQUIRE_THROWS_AS(cfg.set_flush_mode(9), tdx::InvalidParameterError);
+    REQUIRE_THROWS_AS(cfg.set_flush_mode(9), tdx::ThetaDataError);
+
+    REQUIRE_NOTHROW(cfg.set_reconnect_jitter(2));
+    REQUIRE_THROWS_AS(cfg.set_reconnect_jitter(9), tdx::InvalidParameterError);
+
+    REQUIRE_NOTHROW(cfg.set_fpss_host_selection(1));
+    REQUIRE_THROWS_AS(cfg.set_fpss_host_selection(5), tdx::InvalidParameterError);
+}
+
+TEST_CASE("sequence converters reject out-of-wire-range inputs with InvalidParameterError",
+          "[errors][util][offline]") {
+    // The wire domain is the i32 cycle. A representable integer outside
+    // that domain is a rejected value, not a silent reinterpret — it
+    // must throw `InvalidParameterError`, matching the Python
+    // `ValueError` / TypeScript `InvalidParameterError`. In-range inputs
+    // round-trip without throwing.
+    REQUIRE_NOTHROW(tdx::util::sequence_signed_to_unsigned(0));
+    REQUIRE(tdx::util::sequence_signed_to_unsigned(-1) ==
+            tdx::util::sequence_signed_to_unsigned(-1));
+
+    // i32::MAX + 1 and i32::MIN - 1 are outside the signed wire range.
+    REQUIRE_THROWS_AS(tdx::util::sequence_signed_to_unsigned(2147483648LL),
+                      tdx::InvalidParameterError);
+    REQUIRE_THROWS_AS(tdx::util::sequence_signed_to_unsigned(-2147483649LL),
+                      tdx::InvalidParameterError);
+
+    // 2^32 is the first value past the unsigned wire range; the audit
+    // repro that returned 0 before now rejects.
+    REQUIRE_THROWS_AS(tdx::util::sequence_unsigned_to_signed(4294967296ULL),
+                      tdx::InvalidParameterError);
+    REQUIRE_THROWS_AS(tdx::util::sequence_unsigned_to_signed(4294967296ULL),
+                      tdx::ThetaDataError);
+
+    // The largest valid unsigned wire value still converts.
+    REQUIRE_NOTHROW(tdx::util::sequence_unsigned_to_signed(4294967295ULL));
 }

--- a/sdks/typescript/__tests__/native_typed_errors.test.mjs
+++ b/sdks/typescript/__tests__/native_typed_errors.test.mjs
@@ -250,6 +250,46 @@ describe('Config setter input-validation parity (native)', () => {
   });
 });
 
+describe('Sequence-util wire-range input-validation parity (native)', () => {
+  it('sequenceUnsignedToSigned rejects an above-wire-range value as InvalidParameterError', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    // 2^32 fits the BigInt parameter but is outside the unsigned wire
+    // range (0 ..= 2^32 - 1). It is a rejected value, not a silent
+    // reinterpret, so through the wrapped surface it reclassifies to
+    // InvalidParameterError — matching the Python ValueError / C++
+    // InvalidParameterError for the same input. Before the fix this
+    // returned 0.
+    assert.throws(
+      () => mod.Util.sequenceUnsignedToSigned(4294967296n),
+      (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+      'an above-wire-range sequence value must reclassify to InvalidParameterError',
+    );
+  });
+
+  it('sequenceSignedToUnsigned rejects an out-of-i32-range value as InvalidParameterError', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    assert.throws(
+      () => mod.Util.sequenceSignedToUnsigned(2147483648n),
+      (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+      'an out-of-i32-range sequence value must reclassify to InvalidParameterError',
+    );
+  });
+
+  it('sequence converters round-trip in-wire-range values', async () => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+
+    for (const signed of [-2147483648n, -1n, 0n, 1n, 2147483647n]) {
+      const unsigned = mod.Util.sequenceSignedToUnsigned(signed);
+      assert.equal(mod.Util.sequenceUnsignedToSigned(unsigned), signed);
+    }
+  });
+});
+
 describe('FLATFILES enum-parse input-validation parity (native)', () => {
   it('flatFiles.request with an unknown sec_type throws InvalidParameterError', async (t) => {
     const mod = await loadWrapped();
@@ -281,5 +321,88 @@ describe('FLATFILES enum-parse input-validation parity (native)', () => {
       (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
       'an unknown flat-file req_type must reclassify to InvalidParameterError',
     );
+  });
+});
+
+describe('timeoutMs input-validation parity (native)', () => {
+  // `timeoutMs` rides in the per-endpoint options object as a JS `number`
+  // (an IEEE-754 double). The integer-typed bindings (Python / C++ / C
+  // ABI) take a `u64`, which cannot represent a non-finite, negative, or
+  // fractional deadline; this binding rejects the same inputs rather than
+  // coercing them. A bare `as u64` cast would silently rewrite `NaN` and a
+  // negative value to `0` (an instant deadline), `Infinity` to `u64::MAX`
+  // (a multi-century deadline), and a fractional value to its truncation —
+  // each the opposite of the caller's intent. The reject must surface as
+  // `InvalidParameterError`, the same class the Python binding raises
+  // (`ValueError`) for the identical bad input, so a caller's
+  // `catch (e instanceof InvalidParameterError)` branch ports across
+  // bindings. Validation runs synchronously before the request task is
+  // spawned, so the Promise rejects regardless of network state.
+  //
+  // Both endpoint shapes are covered: a builder-backed endpoint
+  // (`stockSnapshotQuote`) and a string-list endpoint (`stockListSymbols`),
+  // since each consumes the deadline at a separate generated cast site.
+  const badValues = [
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['-Infinity', Number.NEGATIVE_INFINITY],
+    ['a negative value', -1],
+    ['a fractional value', 1.9],
+  ];
+
+  for (const [label, value] of badValues) {
+    it(`stockSnapshotQuote rejects ${label} timeoutMs as InvalidParameterError`, async (t) => {
+      const mod = await loadWrapped();
+      if (!mod) return;
+      const tdx = tryConnect(mod);
+      if (!tdx) {
+        t.skip('no credentials available to build a client for the endpoint surface');
+        return;
+      }
+
+      await assert.rejects(
+        () => tdx.stockSnapshotQuote('AAPL', { timeoutMs: value }),
+        (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+        `a ${label} timeoutMs must reject as InvalidParameterError, not coerce`,
+      );
+    });
+  }
+
+  it('stockListSymbols rejects a negative timeoutMs on the string-list path', async (t) => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+    const tdx = tryConnect(mod);
+    if (!tdx) {
+      t.skip('no credentials available to build a client for the endpoint surface');
+      return;
+    }
+
+    await assert.rejects(
+      () => tdx.stockListSymbols({ timeoutMs: -1 }),
+      (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
+      'a negative timeoutMs must reject on the string-list path too',
+    );
+  });
+
+  it('stockSnapshotQuote accepts a valid whole-millisecond timeoutMs', async (t) => {
+    const mod = await loadWrapped();
+    if (!mod) return;
+    const tdx = tryConnect(mod);
+    if (!tdx) {
+      t.skip('no credentials available to build a client for the endpoint surface');
+      return;
+    }
+
+    // A valid integer deadline must pass validation and reach the core
+    // client. The round-trip may surface a data/network error, but it must
+    // never be an InvalidParameterError from the deadline guard.
+    try {
+      await tdx.stockSnapshotQuote('AAPL', { timeoutMs: 5000 });
+    } catch (err) {
+      assert.ok(
+        !(err instanceof mod.InvalidParameterError),
+        `a valid integer timeoutMs must not be rejected by validation: ${err.message}`,
+      );
+    }
   });
 });

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -1608,8 +1608,10 @@ export declare function calendarDayToArrowIpc(rows: Array<CalendarDay>): Buffer
  */
 export interface CalendarOnDateOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -1622,8 +1624,10 @@ export interface CalendarOnDateOptions {
  */
 export interface CalendarOpenTodayOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -1636,8 +1640,10 @@ export interface CalendarOpenTodayOptions {
  */
 export interface CalendarYearOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -1946,8 +1952,10 @@ export declare function greeksThirdOrderTickToArrowIpc(rows: Array<GreeksThirdOr
  */
 export interface IndexAtTimePriceOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -1960,8 +1968,10 @@ export interface IndexAtTimePriceOptions {
  */
 export interface IndexHistoryEodOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -1980,8 +1990,10 @@ export interface IndexHistoryOhlcOptions {
   /** End time filter */
   endTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2004,8 +2016,10 @@ export interface IndexHistoryPriceOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2018,8 +2032,10 @@ export interface IndexHistoryPriceOptions {
  */
 export interface IndexListDatesOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2032,8 +2048,10 @@ export interface IndexListDatesOptions {
  */
 export interface IndexListSymbolsOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2072,8 +2090,10 @@ export interface IndexSnapshotMarketValueOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2088,8 +2108,10 @@ export interface IndexSnapshotOhlcOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2104,8 +2126,10 @@ export interface IndexSnapshotPriceOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2118,8 +2142,10 @@ export interface IndexSnapshotPriceOptions {
  */
 export interface InterestRateHistoryEodOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2303,8 +2329,10 @@ export interface OptionAtTimeQuoteOptions {
   /** Strike range filter */
   strikeRange?: number
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2325,8 +2353,10 @@ export interface OptionAtTimeTradeOptions {
   /** Strike range filter */
   strikeRange?: number
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2355,8 +2385,10 @@ export interface OptionHistoryEodOptions {
   /** Strike range filter */
   strikeRange?: number
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2393,8 +2425,10 @@ export interface OptionHistoryGreeksAllOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2425,8 +2459,10 @@ export interface OptionHistoryGreeksEodOptions {
   /** Strike range filter */
   strikeRange?: number
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2463,8 +2499,10 @@ export interface OptionHistoryGreeksFirstOrderOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2501,8 +2539,10 @@ export interface OptionHistoryGreeksImpliedVolatilityOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2539,8 +2579,10 @@ export interface OptionHistoryGreeksSecondOrderOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2577,8 +2619,10 @@ export interface OptionHistoryGreeksThirdOrderOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2607,8 +2651,10 @@ export interface OptionHistoryOhlcOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2633,8 +2679,10 @@ export interface OptionHistoryOpenInterestOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2665,8 +2713,10 @@ export interface OptionHistoryQuoteOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2703,8 +2753,10 @@ export interface OptionHistoryTradeGreeksAllOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2741,8 +2793,10 @@ export interface OptionHistoryTradeGreeksFirstOrderOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2779,8 +2833,10 @@ export interface OptionHistoryTradeGreeksImpliedVolatilityOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2817,8 +2873,10 @@ export interface OptionHistoryTradeGreeksSecondOrderOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2855,8 +2913,10 @@ export interface OptionHistoryTradeGreeksThirdOrderOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2885,8 +2945,10 @@ export interface OptionHistoryTradeOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2917,8 +2979,10 @@ export interface OptionHistoryTradeQuoteOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2957,8 +3021,10 @@ export interface OptionListContractsOptions {
   /** Maximum days to expiration */
   maxDte?: number
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2971,8 +3037,10 @@ export interface OptionListContractsOptions {
  */
 export interface OptionListDatesOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2985,8 +3053,10 @@ export interface OptionListDatesOptions {
  */
 export interface OptionListExpirationsOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -2999,8 +3069,10 @@ export interface OptionListExpirationsOptions {
  */
 export interface OptionListStrikesOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3013,8 +3085,10 @@ export interface OptionListStrikesOptions {
  */
 export interface OptionListSymbolsOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3049,8 +3123,10 @@ export interface OptionSnapshotGreeksAllOptions {
   /** When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair. */
   useMarketValue?: boolean
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3085,8 +3161,10 @@ export interface OptionSnapshotGreeksFirstOrderOptions {
   /** When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair. */
   useMarketValue?: boolean
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3121,8 +3199,10 @@ export interface OptionSnapshotGreeksImpliedVolatilityOptions {
   /** When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair. */
   useMarketValue?: boolean
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3157,8 +3237,10 @@ export interface OptionSnapshotGreeksSecondOrderOptions {
   /** When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair. */
   useMarketValue?: boolean
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3193,8 +3275,10 @@ export interface OptionSnapshotGreeksThirdOrderOptions {
   /** When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair. */
   useMarketValue?: boolean
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3217,8 +3301,10 @@ export interface OptionSnapshotMarketValueOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3241,8 +3327,10 @@ export interface OptionSnapshotOhlcOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3265,8 +3353,10 @@ export interface OptionSnapshotOpenInterestOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3289,8 +3379,10 @@ export interface OptionSnapshotQuoteOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3311,8 +3403,10 @@ export interface OptionSnapshotTradeOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3486,8 +3580,10 @@ export interface StockAtTimeQuoteOptions {
   /** Venue/exchange filter. Accepted values: `nqb`, `utp_cta`. */
   venue?: string
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3502,8 +3598,10 @@ export interface StockAtTimeTradeOptions {
   /** Venue/exchange filter. Accepted values: `nqb`, `utp_cta`. */
   venue?: string
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3516,8 +3614,10 @@ export interface StockAtTimeTradeOptions {
  */
 export interface StockHistoryEodOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3542,8 +3642,10 @@ export interface StockHistoryOhlcOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3564,8 +3666,10 @@ export interface StockHistoryOhlcRangeOptions {
   /** Venue/exchange filter. Accepted values: `nqb`, `utp_cta`. */
   venue?: string
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3590,8 +3694,10 @@ export interface StockHistoryQuoteOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3614,8 +3720,10 @@ export interface StockHistoryTradeOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3640,8 +3748,10 @@ export interface StockHistoryTradeQuoteOptions {
   /** End date YYYYMMDD */
   endDate?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3654,8 +3764,10 @@ export interface StockHistoryTradeQuoteOptions {
  */
 export interface StockListDatesOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3668,8 +3780,10 @@ export interface StockListDatesOptions {
  */
 export interface StockListSymbolsOptions {
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3686,8 +3800,10 @@ export interface StockSnapshotMarketValueOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3704,8 +3820,10 @@ export interface StockSnapshotOhlcOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3722,8 +3840,10 @@ export interface StockSnapshotQuoteOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }
@@ -3740,8 +3860,10 @@ export interface StockSnapshotTradeOptions {
   /** Minimum time filter */
   minTime?: string | Date
   /**
-   * Per-call deadline in milliseconds; on expiry the returned Promise
-   * rejects and the underlying request is cancelled.
+   * Per-call deadline as a non-negative whole number of milliseconds;
+   * on expiry the returned Promise rejects and the underlying request
+   * is cancelled. A non-finite, negative, or fractional value is
+   * rejected with `InvalidParameterError` rather than coerced.
    */
   timeoutMs?: number
 }

--- a/sdks/typescript/src/_generated/historical_methods.rs
+++ b/sdks/typescript/src/_generated/historical_methods.rs
@@ -7,8 +7,10 @@
 #[napi(object)]
 #[derive(Default)]
 pub struct StockListSymbolsOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -19,8 +21,10 @@ pub struct StockListSymbolsOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct StockListDatesOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -35,8 +39,10 @@ pub struct StockSnapshotOHLCOptions {
     pub venue: Option<String>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -51,8 +57,10 @@ pub struct StockSnapshotTradeOptions {
     pub venue: Option<String>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -67,8 +75,10 @@ pub struct StockSnapshotQuoteOptions {
     pub venue: Option<String>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -83,8 +93,10 @@ pub struct StockSnapshotMarketValueOptions {
     pub venue: Option<String>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -95,8 +107,10 @@ pub struct StockSnapshotMarketValueOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct StockHistoryEODOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -119,8 +133,10 @@ pub struct StockHistoryOHLCOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -141,8 +157,10 @@ pub struct StockHistoryTradeOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -165,8 +183,10 @@ pub struct StockHistoryQuoteOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -189,8 +209,10 @@ pub struct StockHistoryTradeQuoteOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -203,8 +225,10 @@ pub struct StockHistoryTradeQuoteOptions {
 pub struct StockAtTimeTradeOptions {
     /// Venue/exchange filter. Accepted values: `nqb`, `utp_cta`.
     pub venue: Option<String>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -217,8 +241,10 @@ pub struct StockAtTimeTradeOptions {
 pub struct StockAtTimeQuoteOptions {
     /// Venue/exchange filter. Accepted values: `nqb`, `utp_cta`.
     pub venue: Option<String>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -229,8 +255,10 @@ pub struct StockAtTimeQuoteOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct OptionListSymbolsOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -241,8 +269,10 @@ pub struct OptionListSymbolsOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct OptionListDatesOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -253,8 +283,10 @@ pub struct OptionListDatesOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct OptionListExpirationsOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -265,8 +297,10 @@ pub struct OptionListExpirationsOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct OptionListStrikesOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -279,8 +313,10 @@ pub struct OptionListStrikesOptions {
 pub struct OptionListContractsOptions {
     /// Maximum days to expiration
     pub max_dte: Option<i32>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -301,8 +337,10 @@ pub struct OptionSnapshotOHLCOptions {
     pub strike_range: Option<i32>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -321,8 +359,10 @@ pub struct OptionSnapshotTradeOptions {
     pub strike_range: Option<i32>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -343,8 +383,10 @@ pub struct OptionSnapshotQuoteOptions {
     pub strike_range: Option<i32>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -365,8 +407,10 @@ pub struct OptionSnapshotOpenInterestOptions {
     pub strike_range: Option<i32>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -387,8 +431,10 @@ pub struct OptionSnapshotMarketValueOptions {
     pub strike_range: Option<i32>,
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -421,8 +467,10 @@ pub struct OptionSnapshotGreeksImpliedVolatilityOptions {
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair.
     pub use_market_value: Option<bool>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -455,8 +503,10 @@ pub struct OptionSnapshotGreeksAllOptions {
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair.
     pub use_market_value: Option<bool>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -489,8 +539,10 @@ pub struct OptionSnapshotGreeksFirstOrderOptions {
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair.
     pub use_market_value: Option<bool>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -523,8 +575,10 @@ pub struct OptionSnapshotGreeksSecondOrderOptions {
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair.
     pub use_market_value: Option<bool>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -557,8 +611,10 @@ pub struct OptionSnapshotGreeksThirdOrderOptions {
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// When true, calculate Greeks against the option market value (mid-price) instead of the NBBO bid/ask pair.
     pub use_market_value: Option<bool>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -577,8 +633,10 @@ pub struct OptionHistoryEODOptions {
     pub max_dte: Option<i32>,
     /// Strike range filter
     pub strike_range: Option<i32>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -605,8 +663,10 @@ pub struct OptionHistoryOHLCOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -633,8 +693,10 @@ pub struct OptionHistoryTradeOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -663,8 +725,10 @@ pub struct OptionHistoryQuoteOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -693,8 +757,10 @@ pub struct OptionHistoryTradeQuoteOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -717,8 +783,10 @@ pub struct OptionHistoryOpenInterestOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -747,8 +815,10 @@ pub struct OptionHistoryGreeksEODOptions {
     pub max_dte: Option<i32>,
     /// Strike range filter
     pub strike_range: Option<i32>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -783,8 +853,10 @@ pub struct OptionHistoryGreeksAllOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -819,8 +891,10 @@ pub struct OptionHistoryTradeGreeksAllOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -855,8 +929,10 @@ pub struct OptionHistoryGreeksFirstOrderOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -891,8 +967,10 @@ pub struct OptionHistoryTradeGreeksFirstOrderOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -927,8 +1005,10 @@ pub struct OptionHistoryGreeksSecondOrderOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -963,8 +1043,10 @@ pub struct OptionHistoryTradeGreeksSecondOrderOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -999,8 +1081,10 @@ pub struct OptionHistoryGreeksThirdOrderOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1035,8 +1119,10 @@ pub struct OptionHistoryTradeGreeksThirdOrderOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1071,8 +1157,10 @@ pub struct OptionHistoryGreeksImpliedVolatilityOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1107,8 +1195,10 @@ pub struct OptionHistoryTradeGreeksImpliedVolatilityOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1127,8 +1217,10 @@ pub struct OptionAtTimeTradeOptions {
     pub max_dte: Option<i32>,
     /// Strike range filter
     pub strike_range: Option<i32>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1147,8 +1239,10 @@ pub struct OptionAtTimeQuoteOptions {
     pub max_dte: Option<i32>,
     /// Strike range filter
     pub strike_range: Option<i32>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1159,8 +1253,10 @@ pub struct OptionAtTimeQuoteOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct IndexListSymbolsOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1171,8 +1267,10 @@ pub struct IndexListSymbolsOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct IndexListDatesOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1185,8 +1283,10 @@ pub struct IndexListDatesOptions {
 pub struct IndexSnapshotOHLCOptions {
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1199,8 +1299,10 @@ pub struct IndexSnapshotOHLCOptions {
 pub struct IndexSnapshotPriceOptions {
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1213,8 +1315,10 @@ pub struct IndexSnapshotPriceOptions {
 pub struct IndexSnapshotMarketValueOptions {
     /// Minimum time filter
     pub min_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1225,8 +1329,10 @@ pub struct IndexSnapshotMarketValueOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct IndexHistoryEODOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1243,8 +1349,10 @@ pub struct IndexHistoryOHLCOptions {
     pub start_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End time filter
     pub end_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1265,8 +1373,10 @@ pub struct IndexHistoryPriceOptions {
     pub start_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// End date YYYYMMDD
     pub end_date: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1277,8 +1387,10 @@ pub struct IndexHistoryPriceOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct IndexAtTimePriceOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1289,8 +1401,10 @@ pub struct IndexAtTimePriceOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct CalendarOpenTodayOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1301,8 +1415,10 @@ pub struct CalendarOpenTodayOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct CalendarOnDateOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1313,8 +1429,10 @@ pub struct CalendarOnDateOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct CalendarYearOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1325,8 +1443,10 @@ pub struct CalendarYearOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct InterestRateHistoryEODOptions {
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1345,8 +1465,10 @@ pub struct StockHistoryOHLCRangeOptions {
     pub end_time: Option<Either<String, chrono::DateTime<chrono::Utc>>>,
     /// Venue/exchange filter. Accepted values: `nqb`, `utp_cta`.
     pub venue: Option<String>,
-    /// Per-call deadline in milliseconds; on expiry the returned Promise
-    /// rejects and the underlying request is cancelled.
+    /// Per-call deadline as a non-negative whole number of milliseconds;
+    /// on expiry the returned Promise rejects and the underlying request
+    /// is cancelled. A non-finite, negative, or fractional value is
+    /// rejected with `InvalidParameterError` rather than coerced.
     pub timeout_ms: Option<f64>,
 }
 
@@ -1361,13 +1483,17 @@ impl ThetaDataDxClient {
         options: Option<StockListSymbolsOptions>,
     ) -> napi::Result<Vec<String>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         spawn_endpoint_task(async move {
             let call = tdx.stock_list_symbols();
-            if let Some(ms) = options.timeout_ms {
-                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {
+            if let Some(ms) = timeout_ms {
+                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {
                     Ok(inner) => inner,
-                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),
+                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),
                 }
             } else {
                 call.await
@@ -1387,13 +1513,17 @@ impl ThetaDataDxClient {
         options: Option<StockListDatesOptions>,
     ) -> napi::Result<Vec<String>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         spawn_endpoint_task(async move {
             let call = tdx.stock_list_dates(&request_type, &symbol);
-            if let Some(ms) = options.timeout_ms {
-                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {
+            if let Some(ms) = timeout_ms {
+                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {
                     Ok(inner) => inner,
-                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),
+                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),
                 }
             } else {
                 call.await
@@ -1418,6 +1548,10 @@ impl ThetaDataDxClient {
         options: Option<StockSnapshotOHLCOptions>,
     ) -> napi::Result<Vec<OhlcTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
@@ -1431,8 +1565,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1455,6 +1589,10 @@ impl ThetaDataDxClient {
         options: Option<StockSnapshotTradeOptions>,
     ) -> napi::Result<Vec<TradeTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
@@ -1468,8 +1606,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1492,6 +1630,10 @@ impl ThetaDataDxClient {
         options: Option<StockSnapshotQuoteOptions>,
     ) -> napi::Result<Vec<QuoteTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
@@ -1505,8 +1647,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1529,6 +1671,10 @@ impl ThetaDataDxClient {
         options: Option<StockSnapshotMarketValueOptions>,
     ) -> napi::Result<Vec<MarketValueTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let symbols = normalize_symbols(symbols);
         let venue = options.venue;
@@ -1542,8 +1688,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1563,13 +1709,17 @@ impl ThetaDataDxClient {
         options: Option<StockHistoryEODOptions>,
     ) -> napi::Result<Vec<EodTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
             let mut request = tdx.stock_history_eod(&symbol, start_date.as_str(), end_date.as_str());
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1596,6 +1746,10 @@ impl ThetaDataDxClient {
         options: Option<StockHistoryOHLCOptions>,
     ) -> napi::Result<Vec<OhlcTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let date = normalize_date(date);
         let interval = options.interval;
@@ -1624,8 +1778,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1650,6 +1804,10 @@ impl ThetaDataDxClient {
         options: Option<StockHistoryTradeOptions>,
     ) -> napi::Result<Vec<TradeTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
@@ -1674,8 +1832,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1703,6 +1861,10 @@ impl ThetaDataDxClient {
         options: Option<StockHistoryQuoteOptions>,
     ) -> napi::Result<Vec<QuoteTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let date = normalize_date(date);
         let interval = options.interval;
@@ -1731,8 +1893,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1758,6 +1920,10 @@ impl ThetaDataDxClient {
         options: Option<StockHistoryTradeQuoteOptions>,
     ) -> napi::Result<Vec<TradeQuoteTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let date = normalize_date(date);
         let start_time = normalize_optional_time(options.start_time);
@@ -1786,8 +1952,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1817,6 +1983,10 @@ impl ThetaDataDxClient {
         options: Option<StockAtTimeTradeOptions>,
     ) -> napi::Result<Vec<TradeTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -1827,8 +1997,8 @@ impl ThetaDataDxClient {
             if let Some(value) = venue {
                 request = request.venue(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1858,6 +2028,10 @@ impl ThetaDataDxClient {
         options: Option<StockAtTimeQuoteOptions>,
     ) -> napi::Result<Vec<QuoteTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -1868,8 +2042,8 @@ impl ThetaDataDxClient {
             if let Some(value) = venue {
                 request = request.venue(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -1886,13 +2060,17 @@ impl ThetaDataDxClient {
         options: Option<OptionListSymbolsOptions>,
     ) -> napi::Result<Vec<String>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         spawn_endpoint_task(async move {
             let call = tdx.option_list_symbols();
-            if let Some(ms) = options.timeout_ms {
-                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {
+            if let Some(ms) = timeout_ms {
+                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {
                     Ok(inner) => inner,
-                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),
+                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),
                 }
             } else {
                 call.await
@@ -1918,14 +2096,18 @@ impl ThetaDataDxClient {
         options: Option<OptionListDatesOptions>,
     ) -> napi::Result<Vec<String>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         spawn_endpoint_task(async move {
             let call = tdx.option_list_dates(&request_type, &symbol, expiration.as_str());
-            if let Some(ms) = options.timeout_ms {
-                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {
+            if let Some(ms) = timeout_ms {
+                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {
                     Ok(inner) => inner,
-                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),
+                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),
                 }
             } else {
                 call.await
@@ -1945,13 +2127,17 @@ impl ThetaDataDxClient {
         options: Option<OptionListExpirationsOptions>,
     ) -> napi::Result<Vec<String>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         spawn_endpoint_task(async move {
             let call = tdx.option_list_expirations(&symbol);
-            if let Some(ms) = options.timeout_ms {
-                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {
+            if let Some(ms) = timeout_ms {
+                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {
                     Ok(inner) => inner,
-                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),
+                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),
                 }
             } else {
                 call.await
@@ -1972,14 +2158,18 @@ impl ThetaDataDxClient {
         options: Option<OptionListStrikesOptions>,
     ) -> napi::Result<Vec<String>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         spawn_endpoint_task(async move {
             let call = tdx.option_list_strikes(&symbol, expiration.as_str());
-            if let Some(ms) = options.timeout_ms {
-                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {
+            if let Some(ms) = timeout_ms {
+                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {
                     Ok(inner) => inner,
-                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),
+                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),
                 }
             } else {
                 call.await
@@ -2004,6 +2194,10 @@ impl ThetaDataDxClient {
         options: Option<OptionListContractsOptions>,
     ) -> napi::Result<Vec<OptionContract>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let date = normalize_date(date);
         let max_dte = options.max_dte;
@@ -2012,8 +2206,8 @@ impl ThetaDataDxClient {
             if let Some(value) = max_dte {
                 request = request.max_dte(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2037,6 +2231,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotOHLCOptions>,
     ) -> napi::Result<Vec<OhlcTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2061,8 +2259,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2087,6 +2285,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotTradeOptions>,
     ) -> napi::Result<Vec<TradeTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2107,8 +2309,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2133,6 +2335,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotQuoteOptions>,
     ) -> napi::Result<Vec<QuoteTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2157,8 +2363,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2184,6 +2390,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotOpenInterestOptions>,
     ) -> napi::Result<Vec<OpenInterestTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2208,8 +2418,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2232,6 +2442,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotMarketValueOptions>,
     ) -> napi::Result<Vec<MarketValueTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2256,8 +2470,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2286,6 +2500,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotGreeksImpliedVolatilityOptions>,
     ) -> napi::Result<Vec<IvTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2334,8 +2552,8 @@ impl ThetaDataDxClient {
             if let Some(value) = use_market_value {
                 request = request.use_market_value(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2364,6 +2582,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotGreeksAllOptions>,
     ) -> napi::Result<Vec<GreeksAllTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2412,8 +2634,8 @@ impl ThetaDataDxClient {
             if let Some(value) = use_market_value {
                 request = request.use_market_value(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2442,6 +2664,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotGreeksFirstOrderOptions>,
     ) -> napi::Result<Vec<GreeksFirstOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2490,8 +2716,8 @@ impl ThetaDataDxClient {
             if let Some(value) = use_market_value {
                 request = request.use_market_value(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2520,6 +2746,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotGreeksSecondOrderOptions>,
     ) -> napi::Result<Vec<GreeksSecondOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2568,8 +2798,8 @@ impl ThetaDataDxClient {
             if let Some(value) = use_market_value {
                 request = request.use_market_value(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2598,6 +2828,10 @@ impl ThetaDataDxClient {
         options: Option<OptionSnapshotGreeksThirdOrderOptions>,
     ) -> napi::Result<Vec<GreeksThirdOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let strike = options.strike;
@@ -2646,8 +2880,8 @@ impl ThetaDataDxClient {
             if let Some(value) = use_market_value {
                 request = request.use_market_value(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2675,6 +2909,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryEODOptions>,
     ) -> napi::Result<Vec<EodTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
@@ -2697,8 +2935,8 @@ impl ThetaDataDxClient {
             if let Some(value) = strike_range {
                 request = request.strike_range(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2727,6 +2965,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryOHLCOptions>,
     ) -> napi::Result<Vec<OhlcTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -2764,8 +3006,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2794,6 +3036,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryTradeOptions>,
     ) -> napi::Result<Vec<TradeTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -2831,8 +3077,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2861,6 +3107,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryQuoteOptions>,
     ) -> napi::Result<Vec<QuoteTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -2902,8 +3152,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -2933,6 +3183,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryTradeQuoteOptions>,
     ) -> napi::Result<Vec<TradeQuoteTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -2974,8 +3228,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3001,6 +3255,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryOpenInterestOptions>,
     ) -> napi::Result<Vec<OpenInterestTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3030,8 +3288,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3061,6 +3319,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryGreeksEODOptions>,
     ) -> napi::Result<Vec<GreeksEodTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
@@ -3103,8 +3365,8 @@ impl ThetaDataDxClient {
             if let Some(value) = strike_range {
                 request = request.strike_range(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3136,6 +3398,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryGreeksAllOptions>,
     ) -> napi::Result<Vec<GreeksAllTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3189,8 +3455,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3221,6 +3487,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryTradeGreeksAllOptions>,
     ) -> napi::Result<Vec<TradeGreeksAllTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3274,8 +3544,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3307,6 +3577,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryGreeksFirstOrderOptions>,
     ) -> napi::Result<Vec<GreeksFirstOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3360,8 +3634,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3392,6 +3666,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryTradeGreeksFirstOrderOptions>,
     ) -> napi::Result<Vec<TradeGreeksFirstOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3445,8 +3723,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3478,6 +3756,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryGreeksSecondOrderOptions>,
     ) -> napi::Result<Vec<GreeksSecondOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3531,8 +3813,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3563,6 +3845,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryTradeGreeksSecondOrderOptions>,
     ) -> napi::Result<Vec<TradeGreeksSecondOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3616,8 +3902,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3649,6 +3935,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryGreeksThirdOrderOptions>,
     ) -> napi::Result<Vec<GreeksThirdOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3702,8 +3992,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3734,6 +4024,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryTradeGreeksThirdOrderOptions>,
     ) -> napi::Result<Vec<TradeGreeksThirdOrderTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3787,8 +4081,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3819,6 +4113,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryGreeksImpliedVolatilityOptions>,
     ) -> napi::Result<Vec<IvTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3872,8 +4170,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3903,6 +4201,10 @@ impl ThetaDataDxClient {
         options: Option<OptionHistoryTradeGreeksImpliedVolatilityOptions>,
     ) -> napi::Result<Vec<TradeGreeksImpliedVolatilityTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let date = normalize_date(date);
@@ -3956,8 +4258,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -3986,6 +4288,10 @@ impl ThetaDataDxClient {
         options: Option<OptionAtTimeTradeOptions>,
     ) -> napi::Result<Vec<TradeTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
@@ -4009,8 +4315,8 @@ impl ThetaDataDxClient {
             if let Some(value) = strike_range {
                 request = request.strike_range(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4037,6 +4343,10 @@ impl ThetaDataDxClient {
         options: Option<OptionAtTimeQuoteOptions>,
     ) -> napi::Result<Vec<QuoteTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let expiration = normalize_date(expiration);
         let start_date = normalize_date(start_date);
@@ -4060,8 +4370,8 @@ impl ThetaDataDxClient {
             if let Some(value) = strike_range {
                 request = request.strike_range(value);
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4078,13 +4388,17 @@ impl ThetaDataDxClient {
         options: Option<IndexListSymbolsOptions>,
     ) -> napi::Result<Vec<String>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         spawn_endpoint_task(async move {
             let call = tdx.index_list_symbols();
-            if let Some(ms) = options.timeout_ms {
-                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {
+            if let Some(ms) = timeout_ms {
+                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {
                     Ok(inner) => inner,
-                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),
+                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),
                 }
             } else {
                 call.await
@@ -4103,13 +4417,17 @@ impl ThetaDataDxClient {
         options: Option<IndexListDatesOptions>,
     ) -> napi::Result<Vec<String>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         spawn_endpoint_task(async move {
             let call = tdx.index_list_dates(&symbol);
-            if let Some(ms) = options.timeout_ms {
-                match tokio::time::timeout(std::time::Duration::from_millis(ms as u64), call).await {
+            if let Some(ms) = timeout_ms {
+                match tokio::time::timeout(std::time::Duration::from_millis(ms), call).await {
                     Ok(inner) => inner,
-                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms as u64 }),
+                    Err(_) => Err(thetadatadx::Error::Timeout { duration_ms: ms }),
                 }
             } else {
                 call.await
@@ -4129,6 +4447,10 @@ impl ThetaDataDxClient {
         options: Option<IndexSnapshotOHLCOptions>,
     ) -> napi::Result<Vec<OhlcTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
@@ -4138,8 +4460,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4158,6 +4480,10 @@ impl ThetaDataDxClient {
         options: Option<IndexSnapshotPriceOptions>,
     ) -> napi::Result<Vec<PriceTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
@@ -4167,8 +4493,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4187,6 +4513,10 @@ impl ThetaDataDxClient {
         options: Option<IndexSnapshotMarketValueOptions>,
     ) -> napi::Result<Vec<MarketValueTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let symbols = normalize_symbols(symbols);
         let min_time = normalize_optional_time(options.min_time);
@@ -4196,8 +4526,8 @@ impl ThetaDataDxClient {
             if let Some(value) = min_time {
                 request = request.min_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4217,13 +4547,17 @@ impl ThetaDataDxClient {
         options: Option<IndexHistoryEODOptions>,
     ) -> napi::Result<Vec<EodTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
             let mut request = tdx.index_history_eod(&symbol, start_date.as_str(), end_date.as_str());
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4250,6 +4584,10 @@ impl ThetaDataDxClient {
         options: Option<IndexHistoryOHLCOptions>,
     ) -> napi::Result<Vec<OhlcTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -4267,8 +4605,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_time {
                 request = request.end_time(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4295,6 +4633,10 @@ impl ThetaDataDxClient {
         options: Option<IndexHistoryPriceOptions>,
     ) -> napi::Result<Vec<PriceTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let date = normalize_date(date);
         let interval = options.interval;
@@ -4319,8 +4661,8 @@ impl ThetaDataDxClient {
             if let Some(value) = end_date {
                 request = request.end_date(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4342,14 +4684,18 @@ impl ThetaDataDxClient {
         options: Option<IndexAtTimePriceOptions>,
     ) -> napi::Result<Vec<IndexPriceAtTimeTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let time_of_day = normalize_time(time_of_day);
         let ticks = spawn_endpoint_task(async move {
             let mut request = tdx.index_at_time_price(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4368,11 +4714,15 @@ impl ThetaDataDxClient {
         options: Option<CalendarOpenTodayOptions>,
     ) -> napi::Result<Vec<CalendarDay>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let ticks = spawn_endpoint_task(async move {
             let mut request = tdx.calendar_open_today();
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4393,12 +4743,16 @@ impl ThetaDataDxClient {
         options: Option<CalendarOnDateOptions>,
     ) -> napi::Result<Vec<CalendarDay>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let date = normalize_date(date);
         let ticks = spawn_endpoint_task(async move {
             let mut request = tdx.calendar_on_date(date.as_str());
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4419,11 +4773,15 @@ impl ThetaDataDxClient {
         options: Option<CalendarYearOptions>,
     ) -> napi::Result<Vec<CalendarDay>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let ticks = spawn_endpoint_task(async move {
             let mut request = tdx.calendar_year(&year);
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4447,13 +4805,17 @@ impl ThetaDataDxClient {
         options: Option<InterestRateHistoryEODOptions>,
     ) -> napi::Result<Vec<InterestRateTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
         let ticks = spawn_endpoint_task(async move {
             let mut request = tdx.interest_rate_history_eod(&symbol, start_date.as_str(), end_date.as_str());
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })
@@ -4477,6 +4839,10 @@ impl ThetaDataDxClient {
         options: Option<StockHistoryOHLCRangeOptions>,
     ) -> napi::Result<Vec<OhlcTick>> {
         let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
         let tdx = self.tdx.clone();
         let start_date = normalize_date(start_date);
         let end_date = normalize_date(end_date);
@@ -4498,8 +4864,8 @@ impl ThetaDataDxClient {
             if let Some(value) = venue {
                 request = request.venue(value.as_str());
             }
-            if let Some(ms) = options.timeout_ms {
-                request = request.with_deadline(std::time::Duration::from_millis(ms as u64));
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
             }
             request.await
         })

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -61,6 +61,44 @@ pub(crate) fn invalid_parameter_err(message: impl std::fmt::Display) -> napi::Er
     napi::Error::from_reason(format!("[InvalidParameterError] {message}"))
 }
 
+/// Validate a JavaScript `timeoutMs` deadline and convert it to the
+/// integer millisecond domain the Python, C++, and C ABI bindings take.
+///
+/// `timeoutMs` rides in the options object as a JS `number` (an IEEE-754
+/// double). The integer-typed bindings cannot represent a fractional,
+/// negative, or non-finite deadline, so this binding rejects the same
+/// inputs rather than coercing them: an `as u64` cast would silently
+/// rewrite `NaN` and a negative value to `0` (an instant deadline),
+/// `Infinity` to `u64::MAX` (a multi-century deadline), and a fractional
+/// value to its truncation — each the opposite of a caller's intent. A
+/// rejected value surfaces as `InvalidParameterError`, the typed class
+/// the Python binding raises (`ValueError`) for the identical input, so
+/// a caller's `catch (e instanceof InvalidParameterError)` branch ports
+/// across bindings.
+pub(crate) fn validate_timeout_ms(timeout_ms: f64) -> napi::Result<u64> {
+    if !timeout_ms.is_finite() {
+        return Err(invalid_parameter_err(format!(
+            "timeoutMs must be a non-negative integer number of milliseconds; got {timeout_ms}"
+        )));
+    }
+    if timeout_ms < 0.0 {
+        return Err(invalid_parameter_err(format!(
+            "timeoutMs must be non-negative; got {timeout_ms}"
+        )));
+    }
+    if timeout_ms.fract() != 0.0 {
+        return Err(invalid_parameter_err(format!(
+            "timeoutMs must be a whole number of milliseconds; got {timeout_ms}"
+        )));
+    }
+    if timeout_ms > u64::MAX as f64 {
+        return Err(invalid_parameter_err(format!(
+            "timeoutMs exceeds the representable millisecond range; got {timeout_ms}"
+        )));
+    }
+    Ok(timeout_ms as u64)
+}
+
 /// Run an endpoint round-trip off the runtime's execution thread and
 /// hand the result back as a `napi::Result`.
 ///


### PR DESCRIPTION
The per-call request deadline must live in the integer millisecond domain on every binding. The TypeScript `timeoutMs` option arrived as a JS `number` (an IEEE-754 double) and was converted with an `as u64` cast, which silently rewrites any value the integer-typed Python, C++, and C ABI bindings would reject: `NaN` and a negative value collapse to `0` (an instant deadline), `Infinity` becomes `u64::MAX` (a multi-century deadline), and a fractional value truncates. A caller could not have meant any of these, so the cast corrupted intent instead of failing.

## TypeScript

`timeoutMs` is validated before use and a non-finite, negative, or fractional value is rejected as `InvalidParameterError` — the typed class the Python binding raises (`ValueError`) for the identical input, so a `catch (e instanceof InvalidParameterError)` branch ports across bindings. The option keeps its documented `number` type (no surface change); only out-of-domain values are rejected, and a valid whole-millisecond deadline is unaffected. Validation runs before the request task is spawned, so the Promise rejects synchronously. Both generated consumption sites (builder-backed and string-list endpoints) route through one shared validator, so per-endpoint cost stays at zero.

## C++

`with_deadline` had the mirror defect: it clamped a negative duration to 1ms rather than rejecting it. It now throws `tdx::InvalidParameterError`, matching the same reject-don't-coerce contract. The generated options bag is included after the exception hierarchy so the complete `InvalidParameterError` type is in scope at the throw site.

## Python / C ABI

Both already take an unsigned integer for this field and need no change.

## Before / after (TypeScript, built addon)

Before, each invalid input was silently accepted with a corrupted deadline. After:

```
timeoutMs=NaN       -> InvalidParameterError: timeoutMs must be a non-negative integer number of milliseconds; got NaN
timeoutMs=Infinity  -> InvalidParameterError: timeoutMs must be a non-negative integer number of milliseconds; got inf
timeoutMs=-Infinity -> InvalidParameterError: timeoutMs must be a non-negative integer number of milliseconds; got -inf
timeoutMs=-1        -> InvalidParameterError: timeoutMs must be non-negative; got -1
timeoutMs=1.9       -> InvalidParameterError: timeoutMs must be a whole number of milliseconds; got 1.9
timeoutMs=5000      -> call returned 1 row (valid integer accepted, reached the core)
```

The string-list path (`stockListSymbols`) rejects the same inputs. C++ `with_deadline(milliseconds(-5))` now throws `InvalidParameterError`; `milliseconds(0)` and `milliseconds(5000)` are accepted.

## Tests

Regression tests added for both bindings: a `timeoutMs` rejection block in the TypeScript native suite (each bad value on a builder-backed and a string-list endpoint, plus a valid-input control) and a `with_deadline` negative-rejection case in the C++ error-taxonomy suite (including the zero and positive boundaries).

## Gates

`cargo fmt --check` and `cargo clippy -D warnings` on the generator and napi crates, the generated-files drift check, `check_binding_parity.py`, the full TypeScript suite (109 pass), and the C++ offline suite all pass. Generated wrapper surfaces were produced only by the generator, never hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)