### PR TITLE
fix(cpp,ffi): reject invalid config and sequence inputs with typed InvalidParameterError across bindings

### DIFF
--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -137,9 +137,12 @@ pub unsafe extern "C" fn tdx_config_free(config: *mut TdxConfig) {
 /// - `mode = 0`: Batched (default) -- flush only on PING every 100ms
 /// - `mode = 1`: Immediate -- flush after every frame write (lowest latency)
 ///
-/// Returns `0` on success. Returns `-1` and sets `tdx_last_error` /
-/// `tdx_last_error_code = TDX_ERR_CONFIG` when `mode` is outside the
-/// documented `{0, 1}` set or when `config` is null.
+/// Returns `0` on success. Returns `-1` and sets `tdx_last_error` when
+/// `mode` is outside the documented `{0, 1}` set or when `config` is
+/// null. A rejected `mode` value carries
+/// `tdx_last_error_code = TDX_ERR_INVALID_PARAMETER` (the same typed
+/// class the Python / TypeScript bindings raise for a bad enum value);
+/// a null `config` carries `TDX_ERR_CONFIG`.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_config_set_flush_mode(config: *mut TdxConfig, mode: i32) -> i32 {
     ffi_boundary!(-1, {
@@ -158,7 +161,7 @@ pub unsafe extern "C" fn tdx_config_set_flush_mode(config: *mut TdxConfig, mode:
                     &format!(
                         "tdx_config_set_flush_mode: invalid mode {other}; expected 0 (Batched) or 1 (Immediate)"
                     ),
-                    crate::error::TDX_ERR_CONFIG,
+                    crate::error::TDX_ERR_INVALID_PARAMETER,
                 );
                 return -1;
             }
@@ -181,14 +184,47 @@ pub unsafe extern "C" fn tdx_config_set_flush_mode(config: *mut TdxConfig, mode:
 ///   `tdx_config_set_reconnect_max_rate_limited_attempts`,
 ///   `tdx_config_set_reconnect_stable_window_secs`).
 /// - `policy = 1`: Manual -- no auto-reconnect, user calls reconnect explicitly
+///
+/// Returns `0` on success. Returns `-1` and sets `tdx_last_error` /
+/// `tdx_last_error_code = TDX_ERR_INVALID_PARAMETER` when `policy` is
+/// outside the documented `{0, 1}` set, so an unknown policy is rejected
+/// with the same typed class the Python / TypeScript bindings raise
+/// rather than being silently coerced to `Auto`. A null `config` is
+/// rejected with `TDX_ERR_CONFIG`.
 #[no_mangle]
-pub unsafe extern "C" fn tdx_config_set_reconnect_policy(config: *mut TdxConfig, policy: i32) {
-    ffi_boundary!((), {
-        let config = require_config_mut!(config);
-        config.inner.reconnect.policy = match policy {
+pub unsafe extern "C" fn tdx_config_set_reconnect_policy(
+    config: *mut TdxConfig,
+    policy: i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            crate::error::set_error_with_code(
+                "tdx_config_set_reconnect_policy: config handle is null",
+                crate::error::TDX_ERR_CONFIG,
+            );
+            return -1;
+        }
+        let value = match policy {
+            0 => thetadatadx::ReconnectPolicy::Auto(thetadatadx::ReconnectAttemptLimits::default()),
             1 => thetadatadx::ReconnectPolicy::Manual,
-            _ => thetadatadx::ReconnectPolicy::Auto(thetadatadx::ReconnectAttemptLimits::default()),
+            other => {
+                crate::error::set_error_with_code(
+                    &format!(
+                        "tdx_config_set_reconnect_policy: invalid policy {other}; expected 0 (Auto) or 1 (Manual)"
+                    ),
+                    crate::error::TDX_ERR_INVALID_PARAMETER,
+                );
+                return -1;
+            }
         };
+        // SAFETY: caller passes a pointer returned by `tdx_direct_config_new`
+        // that has not been freed; null was rejected above; `&mut *` produces a
+        // unique reference valid for the call duration because the caller owns
+        // the Box and the FFI contract forbids concurrent calls on the same
+        // handle.
+        let config = unsafe { &mut *config };
+        config.inner.reconnect.policy = value;
+        0
     })
 }
 
@@ -616,7 +652,9 @@ pub unsafe extern "C" fn tdx_config_get_reconnect_wait_server_restart_ms(
 ///
 /// Returns `0` on success. Returns `-1` and sets `tdx_last_error` when
 /// `mode` is outside the documented `{0, 1, 2, 3}` set or `config` is
-/// null.
+/// null. A rejected `mode` value carries
+/// `tdx_last_error_code = TDX_ERR_INVALID_PARAMETER` so an out-of-domain
+/// enum int surfaces the same typed class across every binding.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_config_set_reconnect_jitter(config: *mut TdxConfig, mode: i32) -> i32 {
     ffi_boundary!(-1, {
@@ -630,9 +668,12 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_jitter(config: *mut TdxConfig,
             2 => thetadatadx::JitterMode::Decorrelated,
             3 => thetadatadx::JitterMode::None,
             other => {
-                set_error(&format!(
-                    "tdx_config_set_reconnect_jitter: invalid mode {other}; expected 0 (Full), 1 (Equal), 2 (Decorrelated), or 3 (None)"
-                ));
+                crate::error::set_error_with_code(
+                    &format!(
+                        "tdx_config_set_reconnect_jitter: invalid mode {other}; expected 0 (Full), 1 (Equal), 2 (Decorrelated), or 3 (None)"
+                    ),
+                    crate::error::TDX_ERR_INVALID_PARAMETER,
+                );
                 return -1;
             }
         };
@@ -1084,7 +1125,9 @@ pub unsafe extern "C" fn tdx_config_get_fpss_ring_size(
 ///
 /// Returns `0` on success. Returns `-1` and sets `tdx_last_error`
 /// when `policy` is outside the documented `{0, 1}` set or `config`
-/// is null.
+/// is null. A rejected `policy` value carries
+/// `tdx_last_error_code = TDX_ERR_INVALID_PARAMETER` so an out-of-domain
+/// enum int surfaces the same typed class across every binding.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_config_set_fpss_host_selection(
     config: *mut TdxConfig,
@@ -1099,9 +1142,12 @@ pub unsafe extern "C" fn tdx_config_set_fpss_host_selection(
             0 => thetadatadx::HostSelectionPolicy::Shuffled,
             1 => thetadatadx::HostSelectionPolicy::FixedOrder,
             other => {
-                set_error(&format!(
-                    "tdx_config_set_fpss_host_selection: invalid policy {other}; expected 0 (Shuffled) or 1 (FixedOrder)"
-                ));
+                crate::error::set_error_with_code(
+                    &format!(
+                        "tdx_config_set_fpss_host_selection: invalid policy {other}; expected 0 (Shuffled) or 1 (FixedOrder)"
+                    ),
+                    crate::error::TDX_ERR_INVALID_PARAMETER,
+                );
                 return -1;
             }
         };
@@ -2132,19 +2178,28 @@ mod reconnect_setter_tests {
     }
 
     #[test]
-    fn reconnect_policy_unknown_selector_falls_through_to_auto() {
-        // The C ABI accepts an int selector; values other than 0/1
-        // resolve to the documented default (`Auto`). Pin the
-        // behaviour so the FFI cannot drift away from the documented
-        // contract without trapping the test.
+    fn reconnect_policy_unknown_selector_rejected_with_typed_code() {
+        // An int selector outside `{0, 1}` is rejected with the typed
+        // invalid-parameter class rather than silently coerced to
+        // `Auto` — the cross-binding contract the Python ValueError /
+        // TypeScript InvalidParameterError already honour. The setter
+        // returns `-1`, sets the typed code, and leaves the prior
+        // policy untouched.
         let cfg = super::tdx_config_production();
         // SAFETY: handle just returned by tdx_config_production.
         unsafe {
-            super::tdx_config_set_reconnect_policy(cfg, 1);
-            super::tdx_config_set_reconnect_policy(cfg, 7);
+            assert_eq!(super::tdx_config_set_reconnect_policy(cfg, 1), 0);
+            crate::error::tdx_clear_error();
+            assert_eq!(super::tdx_config_set_reconnect_policy(cfg, 7), -1);
+            assert_eq!(
+                crate::error::tdx_last_error_code(),
+                crate::error::TDX_ERR_INVALID_PARAMETER
+            );
+            // The rejected call leaves the previously-set Manual policy
+            // in place rather than overwriting it with a coerced Auto.
             assert!(matches!(
                 (*cfg).inner.reconnect.policy,
-                thetadatadx::ReconnectPolicy::Auto(_)
+                thetadatadx::ReconnectPolicy::Manual
             ));
             super::tdx_config_free(cfg);
         }
@@ -2905,6 +2960,61 @@ mod resilience_knob_tests {
     }
 
     #[test]
+    fn reconnect_policy_round_trips_and_rejects_invalid() {
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            let mut policy: i32 = -1;
+            assert_eq!(super::tdx_config_get_reconnect_policy(cfg, &mut policy), 0);
+            assert_eq!(policy, 0, "production default policy is Auto");
+            for p in [1, 0] {
+                assert_eq!(super::tdx_config_set_reconnect_policy(cfg, p), 0);
+                assert_eq!(super::tdx_config_get_reconnect_policy(cfg, &mut policy), 0);
+                assert_eq!(policy, p);
+            }
+            // An unknown selector is rejected with the typed
+            // invalid-parameter class rather than silently coerced to
+            // Auto — the cross-binding contract the Python ValueError /
+            // TypeScript InvalidParameterError already honour.
+            assert_eq!(
+                super::tdx_config_set_reconnect_policy(cfg, 7),
+                -1,
+                "unknown policy rejected, not coerced"
+            );
+            assert_eq!(
+                crate::error::tdx_last_error_code(),
+                crate::error::TDX_ERR_INVALID_PARAMETER
+            );
+            assert_eq!(super::tdx_config_set_reconnect_policy(cfg, -5), -1);
+            assert_eq!(
+                crate::error::tdx_last_error_code(),
+                crate::error::TDX_ERR_INVALID_PARAMETER
+            );
+            assert_eq!(super::tdx_config_get_reconnect_policy(cfg, &mut policy), 0);
+            assert_eq!(policy, 0, "rejected policy leaves the config unchanged");
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn flush_mode_round_trips_and_rejects_invalid_with_typed_code() {
+        let cfg = super::tdx_config_production();
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            assert_eq!(super::tdx_config_set_flush_mode(cfg, 0), 0);
+            assert_eq!(super::tdx_config_set_flush_mode(cfg, 1), 0);
+            // A rejected enum value surfaces the typed invalid-parameter
+            // class, not the generic config code.
+            assert_eq!(super::tdx_config_set_flush_mode(cfg, 9), -1);
+            assert_eq!(
+                crate::error::tdx_last_error_code(),
+                crate::error::TDX_ERR_INVALID_PARAMETER
+            );
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
     fn reconnect_cadence_and_replay_round_trip() {
         let cfg = super::tdx_config_production();
         // SAFETY: handle just returned by tdx_config_production.
@@ -2980,6 +3090,11 @@ mod resilience_knob_tests {
                 super::tdx_config_set_reconnect_jitter(cfg, 9),
                 -1,
                 "invalid mode rejected"
+            );
+            assert_eq!(
+                crate::error::tdx_last_error_code(),
+                crate::error::TDX_ERR_INVALID_PARAMETER,
+                "a rejected enum value surfaces the typed invalid-parameter class"
             );
             assert_eq!(super::tdx_config_get_reconnect_jitter(cfg, &mut mode), 0);
             assert_eq!(mode, 0, "rejected mode leaves the config unchanged");
@@ -3079,6 +3194,11 @@ mod resilience_knob_tests {
                 super::tdx_config_set_fpss_host_selection(cfg, 5),
                 -1,
                 "invalid policy rejected"
+            );
+            assert_eq!(
+                crate::error::tdx_last_error_code(),
+                crate::error::TDX_ERR_INVALID_PARAMETER,
+                "a rejected enum value surfaces the typed invalid-parameter class"
             );
 
             let mut has_value = true;

--- a/ffi/src/utility.rs
+++ b/ffi/src/utility.rs
@@ -278,16 +278,89 @@ pub extern "C" fn tdx_exchange_symbol(code: i32) -> *const c_char {
 
 /// Convert a signed wire-encoded trade-sequence value to its unsigned
 /// monotonic form. Mirrors `tdbe::sequences::signed_to_unsigned`.
+///
+/// `signed` must lie in the i32 wire range
+/// (`-2_147_483_648 ..= 2_147_483_647`): the upstream terminal encodes
+/// trade sequences as i32, so a value outside that domain is not a wire
+/// sequence and would otherwise be silently reinterpreted into a
+/// look-correct-but-wrong id. Writes the converted value to `out` and
+/// returns `0` on success; returns `-1` and sets `tdx_last_error` /
+/// `tdx_last_error_code = TDX_ERR_INVALID_PARAMETER` when `signed` is
+/// outside the wire range or `out` is null, matching the typed class the
+/// Python / TypeScript bindings raise for the same input.
+///
+/// # Safety
+/// `out` must be a valid, non-null pointer to a `uint64_t` the caller
+/// keeps alive for the call duration.
 #[no_mangle]
-pub extern "C" fn tdx_sequence_signed_to_unsigned(signed: i64) -> u64 {
-    tdbe::sequences::signed_to_unsigned(signed)
+pub unsafe extern "C" fn tdx_sequence_signed_to_unsigned(signed: i64, out: *mut u64) -> i32 {
+    ffi_boundary!(-1, {
+        if out.is_null() {
+            crate::error::set_error_with_code(
+                "tdx_sequence_signed_to_unsigned: out pointer is null",
+                crate::error::TDX_ERR_INVALID_PARAMETER,
+            );
+            return -1;
+        }
+        if !(tdbe::sequences::SEQUENCE_MIN..=tdbe::sequences::SEQUENCE_MAX).contains(&signed) {
+            crate::error::set_error_with_code(
+                &format!(
+                    "tdx_sequence_signed_to_unsigned: {signed} is outside the i32 wire range (-2_147_483_648 ..= 2_147_483_647)"
+                ),
+                crate::error::TDX_ERR_INVALID_PARAMETER,
+            );
+            return -1;
+        }
+        // SAFETY: `out` is non-null per the guard above and the FFI
+        // contract pins the storage for the call duration.
+        unsafe {
+            *out = tdbe::sequences::signed_to_unsigned(signed);
+        }
+        0
+    })
 }
 
 /// Convert an unsigned monotonic trade-sequence value back to its
 /// signed wire encoding. Mirrors `tdbe::sequences::unsigned_to_signed`.
+///
+/// `unsigned` must lie in the unsigned wire range (`0 ..= 2^32 - 1`):
+/// the monotonic sequence id is never wider than one i32 cycle, so a
+/// value above that domain is not a wire sequence and would otherwise be
+/// silently reinterpreted. Writes the converted value to `out` and
+/// returns `0` on success; returns `-1` and sets `tdx_last_error` /
+/// `tdx_last_error_code = TDX_ERR_INVALID_PARAMETER` when `unsigned` is
+/// above the wire range or `out` is null, matching the typed class the
+/// Python / TypeScript bindings raise for the same input.
+///
+/// # Safety
+/// `out` must be a valid, non-null pointer to an `int64_t` the caller
+/// keeps alive for the call duration.
 #[no_mangle]
-pub extern "C" fn tdx_sequence_unsigned_to_signed(unsigned: u64) -> i64 {
-    tdbe::sequences::unsigned_to_signed(unsigned)
+pub unsafe extern "C" fn tdx_sequence_unsigned_to_signed(unsigned: u64, out: *mut i64) -> i32 {
+    ffi_boundary!(-1, {
+        if out.is_null() {
+            crate::error::set_error_with_code(
+                "tdx_sequence_unsigned_to_signed: out pointer is null",
+                crate::error::TDX_ERR_INVALID_PARAMETER,
+            );
+            return -1;
+        }
+        if unsigned > u64::from(u32::MAX) {
+            crate::error::set_error_with_code(
+                &format!(
+                    "tdx_sequence_unsigned_to_signed: {unsigned} is above the unsigned wire range (0 ..= 2^32 - 1)"
+                ),
+                crate::error::TDX_ERR_INVALID_PARAMETER,
+            );
+            return -1;
+        }
+        // SAFETY: `out` is non-null per the guard above and the FFI
+        // contract pins the storage for the call duration.
+        unsafe {
+            *out = tdbe::sequences::unsigned_to_signed(unsigned);
+        }
+        0
+    })
 }
 
 /// Look up the vendor vocabulary text for a `TdxCalendarDay.status`
@@ -442,4 +515,77 @@ pub extern "C" fn tdx_test_panic_string() -> i32 {
     ffi_boundary!(-1, {
         panic!("{}", String::from("intentional test panic via String"));
     })
+}
+
+#[cfg(test)]
+mod sequence_tests {
+    //! Wire-range validation for the trade-sequence converters. Out-of
+    //! -wire-range inputs must be rejected with the typed
+    //! invalid-parameter class rather than silently reinterpreted — the
+    //! cross-binding contract the Python `ValueError` / TypeScript
+    //! `InvalidParameterError` already honour.
+
+    #[test]
+    fn signed_to_unsigned_round_trips_in_wire_range() {
+        for signed in [i64::from(i32::MIN), -1, 0, 1, i64::from(i32::MAX)] {
+            let mut out: u64 = 0;
+            // SAFETY: `out` points at a live stack slot for the call.
+            let rc = unsafe { super::tdx_sequence_signed_to_unsigned(signed, &mut out) };
+            assert_eq!(rc, 0, "in-range input {signed} accepted");
+            assert_eq!(out, tdbe::sequences::signed_to_unsigned(signed));
+        }
+    }
+
+    #[test]
+    fn signed_to_unsigned_rejects_out_of_wire_range() {
+        for signed in [i64::from(i32::MAX) + 1, i64::from(i32::MIN) - 1] {
+            let mut out: u64 = 0;
+            crate::error::tdx_clear_error();
+            // SAFETY: `out` points at a live stack slot for the call.
+            let rc = unsafe { super::tdx_sequence_signed_to_unsigned(signed, &mut out) };
+            assert_eq!(rc, -1, "out-of-range input {signed} rejected");
+            assert_eq!(
+                crate::error::tdx_last_error_code(),
+                crate::error::TDX_ERR_INVALID_PARAMETER
+            );
+        }
+    }
+
+    #[test]
+    fn unsigned_to_signed_round_trips_in_wire_range() {
+        for unsigned in [0u64, 1, u64::from(i32::MAX as u32), u64::from(u32::MAX)] {
+            let mut out: i64 = 0;
+            // SAFETY: `out` points at a live stack slot for the call.
+            let rc = unsafe { super::tdx_sequence_unsigned_to_signed(unsigned, &mut out) };
+            assert_eq!(rc, 0, "in-range input {unsigned} accepted");
+            assert_eq!(out, tdbe::sequences::unsigned_to_signed(unsigned));
+        }
+    }
+
+    #[test]
+    fn unsigned_to_signed_rejects_above_wire_range() {
+        // 2^32 is the first value past the unsigned wire range.
+        let mut out: i64 = 0;
+        crate::error::tdx_clear_error();
+        // SAFETY: `out` points at a live stack slot for the call.
+        let rc =
+            unsafe { super::tdx_sequence_unsigned_to_signed(u64::from(u32::MAX) + 1, &mut out) };
+        assert_eq!(rc, -1, "2^32 rejected as above the wire range");
+        assert_eq!(
+            crate::error::tdx_last_error_code(),
+            crate::error::TDX_ERR_INVALID_PARAMETER
+        );
+    }
+
+    #[test]
+    fn null_out_pointer_rejected() {
+        crate::error::tdx_clear_error();
+        // SAFETY: deliberately passing null to exercise the guard.
+        let rc = unsafe { super::tdx_sequence_signed_to_unsigned(0, std::ptr::null_mut()) };
+        assert_eq!(rc, -1);
+        assert_eq!(
+            crate::error::tdx_last_error_code(),
+            crate::error::TDX_ERR_INVALID_PARAMETER
+        );
+    }
 }

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -923,8 +923,13 @@ void tdx_config_free(TdxConfig* config);
  *             reset after a continuous data-flow window configured via
  *             `tdx_config_set_reconnect_stable_window_secs`.
  *   policy=1: Manual -- no auto-reconnect.
+ * Returns 0 on success, -1 on an invalid policy (outside {0, 1}) or null
+ * config. A rejected policy sets tdx_last_error_code to
+ * TDX_ERR_INVALID_PARAMETER so an unknown value is rejected with the
+ * same typed class the Python / TypeScript bindings raise, never
+ * silently coerced to Auto.
  */
-void tdx_config_set_reconnect_policy(TdxConfig* config, int policy);
+int32_t tdx_config_set_reconnect_policy(TdxConfig* config, int policy);
 
 /**
  * Set the per-class transient-failure attempt budget for the
@@ -1541,12 +1546,21 @@ const char* tdx_calendar_status_name(int32_t code);
 int64_t tdx_timestamp_ms(int32_t date, int32_t ms_of_day);
 
 /** Convert a signed wire-encoded trade-sequence value to its unsigned
- *  monotonic form. */
-uint64_t tdx_sequence_signed_to_unsigned(int64_t signed_value);
+ *  monotonic form. `signed_value` must lie in the i32 wire range
+ *  (-2,147,483,648 ..= 2,147,483,647). Writes the result to `out` and
+ *  returns 0 on success; returns -1 and sets tdx_last_error_code to
+ *  TDX_ERR_INVALID_PARAMETER when `signed_value` is outside the wire
+ *  range or `out` is null, so an out-of-range value is rejected rather
+ *  than silently reinterpreted. */
+int32_t tdx_sequence_signed_to_unsigned(int64_t signed_value, uint64_t* out);
 
 /** Convert an unsigned monotonic trade-sequence value back to its signed
- *  wire encoding. */
-int64_t tdx_sequence_unsigned_to_signed(uint64_t unsigned_value);
+ *  wire encoding. `unsigned_value` must lie in the unsigned wire range
+ *  (0 ..= 2^32 - 1). Writes the result to `out` and returns 0 on
+ *  success; returns -1 and sets tdx_last_error_code to
+ *  TDX_ERR_INVALID_PARAMETER when `unsigned_value` is above the wire
+ *  range or `out` is null. */
+int32_t tdx_sequence_unsigned_to_signed(uint64_t unsigned_value, int64_t* out);
 
 /* ═══════════════════════════════════════════════════════════════════════ */
 /*  Streaming — #[repr(C)] event types                                    */

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -528,8 +528,16 @@ public:
     /** Stage FPSS config (port 20100, testing, unstable). */
     static Config stage();
 
-    /** Set FPSS reconnect policy. 0=Auto (default), 1=Manual. */
-    void set_reconnect_policy(int policy) { tdx_config_set_reconnect_policy(handle_.get(), policy); }
+    /** Set FPSS reconnect policy. 0=Auto (default), 1=Manual. Throws
+     *  @c tdx::InvalidParameterError when @p policy is outside the
+     *  documented `{0, 1}` set, matching the Python `ValueError` /
+     *  TypeScript `InvalidParameterError` rather than silently coercing
+     *  an unknown value to Auto. */
+    void set_reconnect_policy(int policy) {
+        if (tdx_config_set_reconnect_policy(handle_.get(), policy) != 0) {
+            detail::throw_last_ffi_error();
+        }
+    }
 
     /** Set the per-class transient-failure attempt budget. Default 3. */
     void set_reconnect_max_attempts(uint32_t max_attempts) {
@@ -638,15 +646,13 @@ public:
     }
 
     /** Set the reconnect jitter mode: 0=Full (default), 1=Equal,
-     *  2=Decorrelated, 3=None. Throws std::runtime_error on an
-     *  invalid mode. */
+     *  2=Decorrelated, 3=None. Throws @c tdx::InvalidParameterError on
+     *  an out-of-domain mode (and @c tdx::ThetaDataError on a null
+     *  handle), routing through the typed leaf the FFI error code
+     *  selects. */
     void set_reconnect_jitter(int32_t mode) {
-        const int32_t rc = tdx_config_set_reconnect_jitter(handle_.get(), mode);
-        if (rc != 0) {
-            const char* err = tdx_last_error();
-            throw std::runtime_error(
-                std::string("tdx_config_set_reconnect_jitter failed: ") +
-                (err ? err : "unknown error"));
+        if (tdx_config_set_reconnect_jitter(handle_.get(), mode) != 0) {
+            detail::throw_last_ffi_error();
         }
     }
 
@@ -788,14 +794,13 @@ public:
     }
 
     /** Set the FPSS host-selection policy: 0=Shuffled (default),
-     *  1=FixedOrder. Throws std::runtime_error on an invalid policy. */
+     *  1=FixedOrder. Throws @c tdx::InvalidParameterError on an
+     *  out-of-domain policy (and @c tdx::ThetaDataError on a null
+     *  handle), routing through the typed leaf the FFI error code
+     *  selects. */
     void set_fpss_host_selection(int32_t policy) {
-        const int32_t rc = tdx_config_set_fpss_host_selection(handle_.get(), policy);
-        if (rc != 0) {
-            const char* err = tdx_last_error();
-            throw std::runtime_error(
-                std::string("tdx_config_set_fpss_host_selection failed: ") +
-                (err ? err : "unknown error"));
+        if (tdx_config_set_fpss_host_selection(handle_.get(), policy) != 0) {
+            detail::throw_last_ffi_error();
         }
     }
 
@@ -923,16 +928,13 @@ public:
      * Set the Nexus auth URL. Default is the upstream production
      * endpoint; redirect at a staging cluster for testing.
      *
-     * Throws @c std::runtime_error if the FFI rejects the value
-     * (null handle or non-UTF-8 input).
+     * Throws a @c tdx::ThetaDataError leaf if the FFI rejects the value
+     * (null handle or non-UTF-8 input), routing through the typed class
+     * the FFI error code selects.
      */
     void set_nexus_url(const std::string& url) {
-        const int32_t rc = tdx_config_set_nexus_url(handle_.get(), url.c_str());
-        if (rc != 0) {
-            const char* err = tdx_last_error();
-            throw std::runtime_error(
-                std::string("tdx_config_set_nexus_url failed: ") +
-                (err == nullptr ? "(null config handle)" : err));
+        if (tdx_config_set_nexus_url(handle_.get(), url.c_str()) != 0) {
+            detail::throw_last_ffi_error();
         }
     }
 
@@ -948,16 +950,13 @@ public:
      * @c "rust-thetadatadx"; override to identify a deployment fleet
      * in server-side dashboards.
      *
-     * Throws @c std::runtime_error if the FFI rejects the value
-     * (null handle or non-UTF-8 input).
+     * Throws a @c tdx::ThetaDataError leaf if the FFI rejects the value
+     * (null handle or non-UTF-8 input), routing through the typed class
+     * the FFI error code selects.
      */
     void set_client_type(const std::string& client_type) {
-        const int32_t rc = tdx_config_set_client_type(handle_.get(), client_type.c_str());
-        if (rc != 0) {
-            const char* err = tdx_last_error();
-            throw std::runtime_error(
-                std::string("tdx_config_set_client_type failed: ") +
-                (err == nullptr ? "(null config handle)" : err));
+        if (tdx_config_set_client_type(handle_.get(), client_type.c_str()) != 0) {
+            detail::throw_last_ffi_error();
         }
     }
 
@@ -976,18 +975,14 @@ public:
      * @c std::uint16_t to bind an HTTP listener on @c 0.0.0.0:<port>
      * when the @c metrics-prometheus feature is compiled in.
      *
-     * Throws @c std::runtime_error on null-handle FFI failure.
+     * Throws a @c tdx::ThetaDataError leaf on a null-handle FFI failure,
+     * routing through the typed class the FFI error code selects.
      */
     void set_metrics_port(std::optional<std::uint16_t> port) {
         const bool has_value = port.has_value();
         const std::uint16_t arg = port.value_or(0);
-        const int32_t rc =
-            tdx_config_set_metrics_port(handle_.get(), has_value, arg);
-        if (rc != 0) {
-            const char* err = tdx_last_error();
-            throw std::runtime_error(
-                std::string("tdx_config_set_metrics_port failed: ") +
-                (err == nullptr ? "(null config handle)" : err));
+        if (tdx_config_set_metrics_port(handle_.get(), has_value, arg) != 0) {
+            detail::throw_last_ffi_error();
         }
     }
 
@@ -996,32 +991,26 @@ public:
      * @c std::nullopt for the disabled (`None`) sentinel; returns the
      * wrapped @c std::uint16_t when an explicit port is pinned.
      *
-     * Throws @c std::runtime_error on null-handle FFI failure.
+     * Throws a @c tdx::ThetaDataError leaf on a null-handle FFI failure,
+     * routing through the typed class the FFI error code selects.
      */
     std::optional<std::uint16_t> get_metrics_port() const {
         bool has_value = false;
         std::uint16_t port = 0;
-        const int32_t rc =
-            tdx_config_get_metrics_port(handle_.get(), &has_value, &port);
-        if (rc != 0) {
-            const char* err = tdx_last_error();
-            throw std::runtime_error(
-                std::string("tdx_config_get_metrics_port failed: ") +
-                (err == nullptr ? "(null config handle)" : err));
+        if (tdx_config_get_metrics_port(handle_.get(), &has_value, &port) != 0) {
+            detail::throw_last_ffi_error();
         }
         return has_value ? std::optional<std::uint16_t>{port} : std::nullopt;
     }
 
-    /** Set FPSS flush mode. 0=Batched (default), 1=Immediate.
-     *  Throws std::runtime_error when @p mode is outside the documented
-     *  `{0, 1}` set or when the underlying FFI returns an error. */
+    /** Set FPSS flush mode. 0=Batched (default), 1=Immediate. Throws
+     *  @c tdx::InvalidParameterError when @p mode is outside the
+     *  documented `{0, 1}` set (and @c tdx::ThetaDataError on a null
+     *  handle), routing through the typed leaf the FFI error code
+     *  selects. */
     void set_flush_mode(int mode) {
-        const int rc = tdx_config_set_flush_mode(handle_.get(), mode);
-        if (rc != 0) {
-            const char* err = tdx_last_error();
-            throw std::runtime_error(
-                std::string("tdx_config_set_flush_mode failed: ") +
-                (err == nullptr ? "(null config handle)" : err));
+        if (tdx_config_set_flush_mode(handle_.get(), mode) != 0) {
+            detail::throw_last_ffi_error();
         }
     }
 
@@ -2255,14 +2244,31 @@ inline std::string exchange_symbol(int32_t code) {
 
 /// Convert a signed wire-encoded trade-sequence value to its unsigned
 /// monotonic form. Mirrors `tdbe::sequences::signed_to_unsigned`.
+/// `signed_value` must lie in the i32 wire range
+/// (`-2'147'483'648 ..= 2'147'483'647`); a value outside that domain
+/// throws @c tdx::InvalidParameterError rather than being silently
+/// reinterpreted, matching the Python `ValueError` / TypeScript
+/// `InvalidParameterError` for the same input.
 inline uint64_t sequence_signed_to_unsigned(int64_t signed_value) {
-    return tdx_sequence_signed_to_unsigned(signed_value);
+    uint64_t out = 0;
+    if (tdx_sequence_signed_to_unsigned(signed_value, &out) != 0) {
+        detail::throw_last_ffi_error();
+    }
+    return out;
 }
 
 /// Convert an unsigned monotonic trade-sequence value back to its
 /// signed wire encoding. Mirrors `tdbe::sequences::unsigned_to_signed`.
+/// `unsigned_value` must lie in the unsigned wire range
+/// (`0 ..= 2^32 - 1`); a value above that domain throws
+/// @c tdx::InvalidParameterError rather than being silently
+/// reinterpreted.
 inline int64_t sequence_unsigned_to_signed(uint64_t unsigned_value) {
-    return tdx_sequence_unsigned_to_signed(unsigned_value);
+    int64_t out = 0;
+    if (tdx_sequence_unsigned_to_signed(unsigned_value, &out) != 0) {
+        detail::throw_last_ffi_error();
+    }
+    return out;
 }
 
 } // namespace util

--- a/sdks/cpp/tests/config_reconnect.cpp
+++ b/sdks/cpp/tests/config_reconnect.cpp
@@ -28,14 +28,17 @@ TEST_CASE("Config::set_reconnect_policy accepts Auto and Manual selectors",
     REQUIRE_NOTHROW(cfg.set_reconnect_policy(1)); // Manual
 }
 
-TEST_CASE("Config::set_reconnect_policy treats unknown selectors as Auto",
+TEST_CASE("Config::set_reconnect_policy rejects unknown selectors with InvalidParameterError",
           "[config][reconnect][offline]") {
-    // The C ABI accepts an int selector; values other than 0/1 fall
-    // through to the documented default (Auto). The wrapper must not
-    // throw on the unknown input.
+    // An unknown selector (outside {0, 1}) is rejected with the typed
+    // invalid-parameter class rather than silently coerced to Auto —
+    // the cross-binding contract the Python ValueError / TypeScript
+    // InvalidParameterError already honour. The leaf must narrow
+    // ThetaDataError so generic handlers still observe it.
     auto cfg = tdx::Config::production();
-    REQUIRE_NOTHROW(cfg.set_reconnect_policy(7));
-    REQUIRE_NOTHROW(cfg.set_reconnect_policy(-1));
+    REQUIRE_THROWS_AS(cfg.set_reconnect_policy(7), tdx::InvalidParameterError);
+    REQUIRE_THROWS_AS(cfg.set_reconnect_policy(-1), tdx::InvalidParameterError);
+    REQUIRE_THROWS_AS(cfg.set_reconnect_policy(7), tdx::ThetaDataError);
 }
 
 TEST_CASE("Config::set_reconnect_max_attempts accepts representative budgets without throwing",

--- a/sdks/python/src/util_helpers.rs
+++ b/sdks/python/src/util_helpers.rs
@@ -14,6 +14,7 @@
 //! Hand-written rather than codegen'd. The function set is finite and
 //! the codegen pipeline targets dynamic-schema endpoints.
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -66,14 +67,41 @@ fn exchange_symbol(code: i32) -> &'static str {
     tdbe::exchange::exchange_symbol(code)
 }
 
+/// Convert a signed wire-encoded trade-sequence value to its unsigned
+/// monotonic form. `signed_value` must lie in the i32 wire range
+/// (`-2_147_483_648 ..= 2_147_483_647`): the upstream terminal encodes
+/// trade sequences as i32, so a value outside that domain is not a wire
+/// sequence and is rejected with `ValueError` rather than silently
+/// reinterpreted into a look-correct-but-wrong id. A value that does not
+/// fit the `i64` parameter type still surfaces as the built-in
+/// `OverflowError` from argument coercion, unchanged.
 #[pyfunction]
-fn sequence_signed_to_unsigned(signed_value: i64) -> u64 {
-    tdbe::sequences::signed_to_unsigned(signed_value)
+fn sequence_signed_to_unsigned(signed_value: i64) -> PyResult<u64> {
+    if !(tdbe::sequences::SEQUENCE_MIN..=tdbe::sequences::SEQUENCE_MAX).contains(&signed_value) {
+        return Err(PyValueError::new_err(format!(
+            "sequence_signed_to_unsigned: {signed_value} is outside the i32 wire range \
+             (-2_147_483_648 ..= 2_147_483_647)"
+        )));
+    }
+    Ok(tdbe::sequences::signed_to_unsigned(signed_value))
 }
 
+/// Convert an unsigned monotonic trade-sequence value back to its signed
+/// wire encoding. `unsigned_value` must lie in the unsigned wire range
+/// (`0 ..= 2^32 - 1`): the monotonic sequence id is never wider than one
+/// i32 cycle, so a value above that domain is rejected with `ValueError`
+/// rather than silently reinterpreted. A negative argument still
+/// surfaces as the built-in `OverflowError` from `u64` coercion,
+/// unchanged.
 #[pyfunction]
-fn sequence_unsigned_to_signed(unsigned_value: u64) -> i64 {
-    tdbe::sequences::unsigned_to_signed(unsigned_value)
+fn sequence_unsigned_to_signed(unsigned_value: u64) -> PyResult<i64> {
+    if unsigned_value > u64::from(u32::MAX) {
+        return Err(PyValueError::new_err(format!(
+            "sequence_unsigned_to_signed: {unsigned_value} is above the unsigned wire range \
+             (0 ..= 2^32 - 1)"
+        )));
+    }
+    Ok(tdbe::sequences::unsigned_to_signed(unsigned_value))
 }
 
 /// Register the `thetadatadx.util` submodule on the parent module.

--- a/sdks/python/tests/test_util_helpers.py
+++ b/sdks/python/tests/test_util_helpers.py
@@ -67,3 +67,37 @@ def test_sequence_round_trip(util):
     for s in (0, 1, -1, 1_000_000, -1_000_000):
         u = util.sequence_signed_to_unsigned(s)
         assert util.sequence_unsigned_to_signed(u) == s
+
+
+def test_sequence_wire_range_boundaries_round_trip(util):
+    # The wire domain is the i32 cycle for the signed direction and
+    # 0 ..= 2^32 - 1 for the unsigned direction; the boundary values
+    # convert without raising.
+    assert util.sequence_signed_to_unsigned(2_147_483_647) is not None
+    assert util.sequence_signed_to_unsigned(-2_147_483_648) is not None
+    assert util.sequence_unsigned_to_signed(4_294_967_295) is not None
+
+
+def test_sequence_out_of_wire_range_raises_value_error(util):
+    # A representable integer outside the wire domain is a rejected value,
+    # not a silent reinterpret. It must raise ValueError, matching the
+    # TypeScript InvalidParameterError / C++ InvalidParameterError for the
+    # same input. Before the fix, sequence_unsigned_to_signed(2^32)
+    # returned 0.
+    with pytest.raises(ValueError):
+        util.sequence_signed_to_unsigned(2_147_483_648)  # i32::MAX + 1
+    with pytest.raises(ValueError):
+        util.sequence_signed_to_unsigned(-2_147_483_649)  # i32::MIN - 1
+    with pytest.raises(ValueError):
+        util.sequence_unsigned_to_signed(4_294_967_296)  # 2^32
+
+
+def test_sequence_representation_overflow_stays_overflow_error(util):
+    # A value that does not fit the parameter's own integer type is a
+    # representation overflow, surfaced by pyo3 argument coercion as the
+    # built-in OverflowError. This is intentionally distinct from the
+    # wire-range ValueError above and must not be reclassified: a negative
+    # passed into the u64 parameter overflows before the wire-range check
+    # can run.
+    with pytest.raises(OverflowError):
+        util.sequence_unsigned_to_signed(-1)

--- a/sdks/typescript/src/util_helpers.rs
+++ b/sdks/typescript/src/util_helpers.rs
@@ -86,7 +86,7 @@ impl Util {
     #[napi(js_name = "sequenceSignedToUnsigned")]
     pub fn sequence_signed_to_unsigned(signed_value: BigInt) -> napi::Result<BigInt> {
         let signed: i64 = bigint_to_i32(&signed_value).map(i64::from).ok_or_else(|| {
-            napi::Error::from_reason(
+            crate::invalid_parameter_err(
                 "sequenceSignedToUnsigned: BigInt outside the i32 wire range \
                  (-2_147_483_648 ..= 2_147_483_647)",
             )
@@ -105,20 +105,20 @@ impl Util {
     #[napi(js_name = "sequenceUnsignedToSigned")]
     pub fn sequence_unsigned_to_signed(unsigned_value: BigInt) -> napi::Result<BigInt> {
         if unsigned_value.sign_bit && !unsigned_value.words.iter().all(|w| *w == 0) {
-            return Err(napi::Error::from_reason(
+            return Err(crate::invalid_parameter_err(
                 "sequenceUnsignedToSigned: negative BigInt rejected; the unsigned \
                  monotonic sequence id is always non-negative",
             ));
         }
         if unsigned_value.words.len() > 1 {
-            return Err(napi::Error::from_reason(
+            return Err(crate::invalid_parameter_err(
                 "sequenceUnsignedToSigned: BigInt above the wire range \
                  (0 ..= 2^32 - 1)",
             ));
         }
         let value = unsigned_value.words.first().copied().unwrap_or(0);
         if value > u32::MAX as u64 {
-            return Err(napi::Error::from_reason(
+            return Err(crate::invalid_parameter_err(
                 "sequenceUnsignedToSigned: BigInt above the wire range \
                  (0 ..= 2^32 - 1)",
             ));


### PR DESCRIPTION
## What

Hold all four bindings (Rust FFI, Python, TypeScript, C++) to one typed-error contract for invalid configuration enums and out-of-wire-range trade-sequence values: a malformed argument surfaces the `InvalidParameterError` leaf (Python `ValueError`, TypeScript / C++ `InvalidParameterError`, FFI `TDX_ERR_INVALID_PARAMETER`) rather than being silently coerced or reinterpreted.

## Why

The same bad input reached a different fate in each binding. `tdx_config_set_reconnect_policy` returned `void` and silently coerced any unknown selector to `Auto`. The config-enum setters (`flush_mode`, `reconnect_jitter`, `fpss_host_selection`) tagged a rejected user value with the wrong error code, so the C++ wrappers threw a plain `std::runtime_error` instead of the typed leaf. The trade-sequence converters enforced the i32 wire domain only in TypeScript; Python, C++, and the FFI accepted out-of-wire-range inputs and silently reinterpreted them into a look-correct-but-wrong id. The invariant is cross-binding typed-error parity: one wrong-argument leaf, identical across the SDKs.

## Changes

- `tdx_config_set_reconnect_policy` returns `i32` and rejects values outside `{0, 1}` with `TDX_ERR_INVALID_PARAMETER` instead of coercing to `Auto`; the C++ wrapper checks the return and throws the typed leaf. The C header declaration is updated for the `void`->`i32` signature change.
- `tdx_config_set_flush_mode`, `tdx_config_set_reconnect_jitter`, and `tdx_config_set_fpss_host_selection` tag a rejected user value with `TDX_ERR_INVALID_PARAMETER`; their C++ setters now route through `detail::throw_last_ffi_error()`. The remaining config setters that threw `std::runtime_error` directly on an FFI rejection are migrated to the same typed-throw path so the leaf set is uniform.
- The trade-sequence converters reject out-of-wire-range inputs in Python, C++, and the FFI to match TypeScript; the FFI converters are reshaped to an out-param plus `i32` status so a typed code travels with the rejection. The separate representation-overflow path (negative into `u64`, value wider than the parameter's own integer type) stays the built-in `OverflowError`.

## Verification

- `cargo fmt --all -- --check`, workspace + FFI `cargo clippy -D warnings`, and the Python / TypeScript SDK clippy all clean.
- FFI tests pass (`cargo test -p thetadatadx-ffi`), including the reconnect-policy / flush-mode / jitter / host-selection typed-code regressions and the sequence wire-range tests.
- `scripts/check_binding_parity.py` and `scripts/check_c_abi_completeness.py` (against the compiled `.so` symbol table) both pass.
- The C++ test suite compiles and links against the regenerated header (no `tdx_sequence_*` signature mismatch) and `config_reconnect.cpp` passes. Standalone repros confirm `set_reconnect_policy(7)`, bad `set_flush_mode` / `set_reconnect_jitter` / `set_fpss_host_selection`, and `sequence_unsigned_to_signed(4294967296)` all throw `tdx::InvalidParameterError`.
- The Python extension confirms an out-of-wire-range value raises `ValueError` while a representation overflow still raises `OverflowError`; the TypeScript addon confirms the typed `InvalidParameterError`.

## Note

This may need a trivial rebase if #712 lands first (it also edits `thetadx.hpp`, in the include-relocation region). The regions are disjoint: this PR touches the config setters and the sequence-util helpers, not the include ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
