### PR TITLE
fix(typescript): expose the timestamp-ms tick accessors for cross-binding parity

### DIFF
--- a/crates/thetadatadx/build_support_bin/ticks/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/typescript.rs
@@ -18,6 +18,7 @@ use super::idents::rust_field_ident;
 use super::python_classes::strip_field_count_from_doc;
 use super::schema::{render_for_type, Schema, TickTypeDef};
 use super::sorted_type_names;
+use super::tdbe_structs::timestamp_accessor_fields;
 
 pub(super) fn render_ts_tick_classes(schema: &Schema) -> String {
     let mut out = String::new();
@@ -27,12 +28,16 @@ pub(super) fn render_ts_tick_classes(schema: &Schema) -> String {
         "// serde_json columnar returns with concrete TypeScript types in index.d.ts.\n\n",
     );
     // napi-rs requires the `BigInt` wrapper for any i64 field that crosses
-    // to JS — pull it in whenever a tick column uses one.
-    let needs_bigint = schema
-        .types
-        .values()
-        .flat_map(|def| def.columns.iter())
-        .any(|col| ts_column_needs_bigint(col.r#type.as_str()));
+    // to JS — pull it in whenever a tick column uses one, or whenever a
+    // type carries a `*_timestamp_ms` epoch accessor (epoch milliseconds
+    // are i64 and ride the same `Option<BigInt>` field, so a Greeks row
+    // with no native i64 column still needs the import).
+    let needs_bigint = schema.types.values().any(|def| {
+        def.columns
+            .iter()
+            .any(|col| ts_column_needs_bigint(col.r#type.as_str()))
+            || !timestamp_accessor_fields(def).is_empty()
+    });
     if needs_bigint {
         out.push_str("use napi::bindgen_prelude::BigInt;\n\n");
     }
@@ -287,6 +292,33 @@ fn render_ts_tick_class_struct(type_name: &str, def: &TickTypeDef) -> String {
         writeln!(out, "    /// {}", flag.doc).unwrap();
         writeln!(out, "    pub {}: bool,", flag.name).unwrap();
     }
+    // Epoch-instant convenience fields: one per milliseconds-of-day
+    // column on types that also carry `date`. Python / C++ expose these
+    // as `*_timestamp_ms()` read-side accessors; the method-less napi
+    // object surfaces the same values as precomputed `Option<BigInt>`
+    // fields (camelCased to `createdTimestampMs` ...), computed once at
+    // conversion time through the same DST-aware core. The raw integer
+    // milliseconds-of-day columns stay primary; this is a convenience at
+    // the epoch boundary, `undefined` when `date` is absent (`0`).
+    for (accessor, field) in timestamp_accessor_fields(def) {
+        writeln!(
+            out,
+            "    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "    /// `{field}` (Eastern-Time milliseconds-of-day). `undefined` when"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "    /// `date` is absent (`0`). Parity of the Python `{accessor}`"
+        )
+        .unwrap();
+        writeln!(out, "    /// property and C++ `tdx::timestamp_ms`.").unwrap();
+        writeln!(out, "    pub {accessor}: Option<BigInt>,").unwrap();
+    }
     out.push_str("}\n");
     out
 }
@@ -349,6 +381,18 @@ fn render_ts_tick_class_factory(schema: &Schema, type_name: &str, def: &TickType
             "                {}: {},",
             rust_field_ident(&flag.name),
             flag.rust_predicate("t")
+        )
+        .unwrap();
+    }
+    // Resolve each `*_timestamp_ms` epoch value once at conversion time
+    // through the shared DST-aware core (`tdbe::time::date_ms_to_epoch_ms`,
+    // the same function the Python accessor and the `tdx_timestamp_ms`
+    // FFI call) and ride it as a precomputed `Option<BigInt>` field — no
+    // date math is reimplemented in the binding.
+    for (accessor, field) in timestamp_accessor_fields(def) {
+        writeln!(
+            out,
+            "                {accessor}: tdbe::time::date_ms_to_epoch_ms(t.date, t.{field}).map(BigInt::from),"
         )
         .unwrap();
     }

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1231,6 +1231,202 @@ class = "TradeTick"
 name = "is_seller"
 typescript = "bool"
 
+# ─── `*_timestamp_ms` epoch accessors ─────────────────────────────────
+#
+# Unix-epoch-millisecond conveniences combining a tick's `date` column
+# with each of its milliseconds-of-day columns (`ms_of_day` →
+# `timestamp_ms`, `<x>_ms_of_day` → `<x>_timestamp_ms`). One schema
+# source (`tick_schema.toml` columns, projected through
+# `timestamp_accessor_fields`) emits them onto every surface, and every
+# surface funnels through the one DST-aware core
+# (`tdbe::time::date_ms_to_epoch_ms`) — no binding reimplements the
+# Eastern-Time offset rules. They stay in lockstep by construction and
+# the `generate_sdk_surfaces --check` drift gate guards a regression: a
+# milliseconds-of-day column added or dropped regenerates the Rust
+# inherent `impl`, the Python computed properties, the TypeScript object
+# fields, and (for the free-function form) the C++ side atomically.
+#
+# The shape is the idiomatic one per binding, so the surface is not
+# uniform across them: Rust + Python expose `Option<i64>` methods /
+# computed properties; C++ exposes one `tdx::timestamp_ms(date,
+# ms_of_day)` free function reused for every `(date, *_ms_of_day)` pair
+# (tick rows are C struct aliases with no member methods) over the
+# `tdx_timestamp_ms` C ABI; TypeScript carries precomputed
+# `Option<BigInt>` fields on the `#[napi(object)]` row (TS tick rows are
+# plain data objects, also method-less). Only the TypeScript half lands
+# as a struct field this checker can read, so the `[[value_field]]` rows
+# below pin that half; the Python computed properties, the Rust inherent
+# `impl`, and the single C++ free function are pinned by the shared-source
+# drift gate. Encoding a `cpp = ...` per-tick field here would assert a
+# struct member that does not exist (the C++ shape is the one free
+# function), so it is recorded in this note rather than forced into a
+# false match.
+
+[[value_field]]
+class = "EodTick"
+name = "created_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "EodTick"
+name = "last_trade_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksAllTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksAllTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksEodTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksEodTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksFirstOrderTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksFirstOrderTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksSecondOrderTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksSecondOrderTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksThirdOrderTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "GreeksThirdOrderTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "IndexPriceAtTimeTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "IvTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "IvTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "MarketValueTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "OhlcTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "OpenInterestTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "PriceTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "QuoteTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksAllTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksAllTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksFirstOrderTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksFirstOrderTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksImpliedVolatilityTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksImpliedVolatilityTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksSecondOrderTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksSecondOrderTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksThirdOrderTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeGreeksThirdOrderTick"
+name = "underlying_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeQuoteTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeQuoteTick"
+name = "quote_timestamp_ms"
+typescript = "Option<BigInt>"
+
+[[value_field]]
+class = "TradeTick"
+name = "timestamp_ms"
+typescript = "Option<BigInt>"
+
 # ─── Arrow-IPC terminal on history results ────────────────────────────
 #
 # The columnar Arrow exit on an in-band history result is present on every

--- a/sdks/typescript/__tests__/typed_surface.test.mjs
+++ b/sdks/typescript/__tests__/typed_surface.test.mjs
@@ -165,6 +165,102 @@ describe('EOD and calendar row shapes', () => {
   });
 });
 
+describe('epoch-millisecond tick accessors (cross-binding parity)', () => {
+  // Every tick row carrying a `date` column plus one or more
+  // milliseconds-of-day columns surfaces a `*TimestampMs` epoch field —
+  // the camelCase parity of the Python `*_timestamp_ms` property and the
+  // C++ `tdx::timestamp_ms` free function. The value is Unix epoch
+  // milliseconds (UTC, DST-aware), computed once at conversion time
+  // through the one shared core (`tdbe::time::date_ms_to_epoch_ms`); the
+  // raw milliseconds-of-day columns stay primary and the field is
+  // optional (`undefined` when `date` is absent). These assertions pin
+  // the JS-visible shape — name, `bigint` type, optionality — so a
+  // generator change that drops the accessor family, mistypes it, or
+  // breaks camelCase parity with Python fails here.
+
+  it('EodTick exposes createdTimestampMs and lastTradeTimestampMs as optional bigint', () => {
+    const block = dts.match(/export interface EodTick\s*\{[\s\S]*?\n\}/);
+    assert.ok(block, 'EodTick interface missing from index.d.ts');
+    assert.match(block[0], /createdTimestampMs\?\s*:\s*bigint/);
+    assert.match(block[0], /lastTradeTimestampMs\?\s*:\s*bigint/);
+  });
+
+  it('QuoteTick / TradeTick / OhlcTick expose timestampMs as optional bigint', () => {
+    for (const name of ['QuoteTick', 'TradeTick', 'OhlcTick']) {
+      const block = dts.match(new RegExp(`export interface ${name}\\s*\\{[\\s\\S]*?\\n\\}`));
+      assert.ok(block, `${name} interface missing from index.d.ts`);
+      assert.match(block[0], /timestampMs\?\s*:\s*bigint/, `${name}.timestampMs must be optional bigint`);
+    }
+  });
+
+  it('Greeks rows expose both timestampMs and underlyingTimestampMs as optional bigint', () => {
+    for (const name of ['GreeksAllTick', 'GreeksEodTick', 'IvTick']) {
+      const block = dts.match(new RegExp(`export interface ${name}\\s*\\{[\\s\\S]*?\\n\\}`));
+      assert.ok(block, `${name} interface missing from index.d.ts`);
+      assert.match(block[0], /timestampMs\?\s*:\s*bigint/, `${name}.timestampMs must be optional bigint`);
+      assert.match(
+        block[0],
+        /underlyingTimestampMs\?\s*:\s*bigint/,
+        `${name}.underlyingTimestampMs must be optional bigint`
+      );
+    }
+  });
+
+  it('TradeQuoteTick exposes the prefixed quoteTimestampMs alongside timestampMs', () => {
+    const block = dts.match(/export interface TradeQuoteTick\s*\{[\s\S]*?\n\}/);
+    assert.ok(block, 'TradeQuoteTick interface missing from index.d.ts');
+    assert.match(block[0], /timestampMs\?\s*:\s*bigint/);
+    assert.match(block[0], /quoteTimestampMs\?\s*:\s*bigint/);
+  });
+
+  it('the accessor names are the camelCase parity of the Python property names', () => {
+    // Python exposes snake_case `created_timestamp_ms`; the napi object
+    // key camelCases it to `createdTimestampMs`. Pin the mapping so a
+    // future rename on either side cannot silently break parity.
+    const pairs = [
+      ['created_timestamp_ms', 'createdTimestampMs'],
+      ['last_trade_timestamp_ms', 'lastTradeTimestampMs'],
+      ['timestamp_ms', 'timestampMs'],
+      ['underlying_timestamp_ms', 'underlyingTimestampMs'],
+      ['quote_timestamp_ms', 'quoteTimestampMs'],
+    ];
+    for (const [snake, camel] of pairs) {
+      const expected = snake.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+      assert.equal(camel, expected, `${snake} must camelCase to ${camel}`);
+      assert.ok(dts.includes(`${camel}?: bigint`), `${camel} must appear as an optional bigint field`);
+    }
+  });
+
+  it('the accessor is never a primary column — the raw msOfDay fields stay separate', () => {
+    // The epoch field rides alongside, never replaces, the raw
+    // milliseconds-of-day integer columns (raw-ms doctrine).
+    const block = dts.match(/export interface EodTick\s*\{[\s\S]*?\n\}/);
+    assert.ok(block, 'EodTick interface missing from index.d.ts');
+    assert.match(block[0], /createdMsOfDay\s*:\s*number/);
+    assert.match(block[0], /lastTradeMsOfDay\s*:\s*number/);
+  });
+
+  it('every epoch field is computed through the one shared DST-aware core, not reimplemented', () => {
+    // The generated factory resolves each accessor by calling the same
+    // `tdbe::time::date_ms_to_epoch_ms(date, ms_of_day)` the Python
+    // property and the `tdx_timestamp_ms` FFI route through — the single
+    // DST-aware implementation. No binding reimplements the Eastern-Time
+    // offset rules, so the epoch value is identical across a DST boundary
+    // (verified at the core: `date_ms_to_epoch_ms_round_trips_edt_and_est`
+    // pins 2026-01-15 09:30 EST -> 1768487400000 and the FFI/Python
+    // bindings return the same value for the same inputs).
+    const factorySrc = readFileSync(
+      resolve(__dirname, '..', 'src', '_generated', 'tick_classes.rs'),
+      'utf8'
+    );
+    const assignments = factorySrc.match(/\w*timestamp_ms:\s*tdbe::time::date_ms_to_epoch_ms\([^)]*\)\.map\(BigInt::from\)/g);
+    assert.ok(assignments, 'expected generated timestamp_ms factory assignments');
+    // 1 created + 1 last_trade + 19 timestamp_ms + 11 underlying + 1 quote
+    // = 33 epoch-millisecond fields, one per (date, *_ms_of_day) pair.
+    assert.equal(assignments.length, 33, `expected 33 epoch-ms factory assignments, found ${assignments.length}`);
+  });
+});
+
 describe('subscription getters', () => {
   it('per-contract subscriptions expose the bound contract; full streams expose secType', () => {
     const option = addon.ContractRef.option('SPY', { expiration: '20260618', strike: 550, right: 'C' });

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -1709,6 +1709,20 @@ export interface EodTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `created_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `created_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  createdTimestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `last_trade_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `last_trade_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  lastTradeTimestampMs?: bigint
 }
 
 /**
@@ -1790,6 +1804,20 @@ export interface GreeksAllTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -1846,6 +1874,20 @@ export interface GreeksEodTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -1876,6 +1918,20 @@ export interface GreeksFirstOrderTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -1905,6 +1961,20 @@ export interface GreeksSecondOrderTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -1933,6 +2003,20 @@ export interface GreeksThirdOrderTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -2069,6 +2153,13 @@ export interface IndexPriceAtTimeTick {
   exchange: number
   price: number
   date: number
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
 }
 
 /**
@@ -2199,6 +2290,20 @@ export interface IvTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -2235,6 +2340,13 @@ export interface MarketValueTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
 }
 
 /**
@@ -2260,6 +2372,13 @@ export interface OhlcTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
 }
 
 /**
@@ -2302,6 +2421,13 @@ export interface OpenInterestTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
 }
 
 /**
@@ -3426,6 +3552,13 @@ export interface PriceTick {
   msOfDay: number
   price: number
   date: number
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
 }
 
 /**
@@ -3469,6 +3602,13 @@ export interface QuoteTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
 }
 
 /**
@@ -3929,6 +4069,20 @@ export interface TradeGreeksAllTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -3966,6 +4120,20 @@ export interface TradeGreeksFirstOrderTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -3997,6 +4165,20 @@ export interface TradeGreeksImpliedVolatilityTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -4033,6 +4215,20 @@ export interface TradeGreeksSecondOrderTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -4068,6 +4264,20 @@ export interface TradeGreeksThirdOrderTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  underlyingTimestampMs?: bigint
 }
 
 /**
@@ -4108,6 +4318,20 @@ export interface TradeQuoteTick {
   expiration?: number
   strike?: number
   right?: string
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `quote_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `quote_timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  quoteTimestampMs?: bigint
 }
 
 /**
@@ -4151,6 +4375,13 @@ export interface TradeTick {
   regularTradingHours: boolean
   /** True when the trade is seller-initiated (ext_condition1 == 12). */
   isSeller: boolean
+  /**
+   * Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+   * `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+   * `date` is absent (`0`). Parity of the Python `timestamp_ms`
+   * property and C++ `tdx::timestamp_ms`.
+   */
+  timestampMs?: bigint
 }
 
 /**

--- a/sdks/typescript/src/_generated/tick_classes.rs
+++ b/sdks/typescript/src/_generated/tick_classes.rs
@@ -41,6 +41,16 @@ pub struct EodTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `created_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `created_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub created_timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `last_trade_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `last_trade_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub last_trade_timestamp_ms: Option<BigInt>,
 }
 
 /// Full union Greeks tick -- every Greek the v3 server publishes on the
@@ -79,6 +89,16 @@ pub struct GreeksAllTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// End-of-day union Greeks tick -- every Greek the v3 server publishes on
@@ -129,6 +149,16 @@ pub struct GreeksEodTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// First-order Greeks tick -- the strict column subset emitted by the
@@ -153,6 +183,16 @@ pub struct GreeksFirstOrderTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Second-order Greeks tick -- the strict column subset emitted by the
@@ -176,6 +216,16 @@ pub struct GreeksSecondOrderTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Third-order Greeks tick -- the strict column subset emitted by the
@@ -198,6 +248,16 @@ pub struct GreeksThirdOrderTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Index price-at-time tick -- the trade-shaped row the v3 server
@@ -216,6 +276,11 @@ pub struct IndexPriceAtTimeTick {
     pub exchange: i32,
     pub price: f64,
     pub date: i32,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
 }
 
 /// Interest rate tick. End-of-day interest rate (percent).
@@ -246,6 +311,16 @@ pub struct IvTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Market value tick -- quoted bid/ask/price for a symbol.
@@ -261,6 +336,11 @@ pub struct MarketValueTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
 }
 
 /// OHLC tick. Aggregated bar data including SIP-rule VWAP.
@@ -280,6 +360,11 @@ pub struct OhlcTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
 }
 
 /// Open interest tick.
@@ -293,6 +378,11 @@ pub struct OpenInterestTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
 }
 
 /// Option contract. Contract specification.
@@ -314,6 +404,11 @@ pub struct PriceTick {
     pub ms_of_day: i32,
     pub price: f64,
     pub date: i32,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
 }
 
 /// Quote tick. NBBO quote data.
@@ -335,6 +430,11 @@ pub struct QuoteTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
 }
 
 /// Per-trade union Greeks tick -- every Greek the v3 server publishes on
@@ -380,6 +480,16 @@ pub struct TradeGreeksAllTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon
@@ -411,6 +521,16 @@ pub struct TradeGreeksFirstOrderTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Per-trade implied-volatility tick (single `implied_volatility` +
@@ -436,6 +556,16 @@ pub struct TradeGreeksImpliedVolatilityTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma /
@@ -466,6 +596,16 @@ pub struct TradeGreeksSecondOrderTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Per-trade third-order Greeks tick (speed / zomma / color / ultima)
@@ -495,6 +635,16 @@ pub struct TradeGreeksThirdOrderTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `underlying_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `underlying_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub underlying_timestamp_ms: Option<BigInt>,
 }
 
 /// Combined trade + quote tick.
@@ -529,6 +679,16 @@ pub struct TradeQuoteTick {
     pub expiration: Option<i32>,
     pub strike: Option<f64>,
     pub right: Option<String>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `quote_ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `quote_timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub quote_timestamp_ms: Option<BigInt>,
 }
 
 /// Trade tick. Core unit of trade data.
@@ -566,6 +726,11 @@ pub struct TradeTick {
     pub regular_trading_hours: bool,
     /// True when the trade is seller-initiated (ext_condition1 == 12).
     pub is_seller: bool,
+    /// Unix epoch milliseconds (UTC, DST-aware) combining `date` with
+    /// `ms_of_day` (Eastern-Time milliseconds-of-day). `undefined` when
+    /// `date` is absent (`0`). Parity of the Python `timestamp_ms`
+    /// property and C++ `tdx::timestamp_ms`.
+    pub timestamp_ms: Option<BigInt>,
 }
 
 fn calendar_days_to_class_vec(ticks: &[tick::CalendarDay]) -> Vec<CalendarDay> {
@@ -608,6 +773,8 @@ fn eod_ticks_to_class_vec(ticks: &[tick::EodTick]) -> Vec<EodTick> {
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                created_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.created_ms_of_day).map(BigInt::from),
+                last_trade_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.last_trade_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -649,6 +816,8 @@ fn greeks_all_ticks_to_class_vec(ticks: &[tick::GreeksAllTick]) -> Vec<GreeksAll
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -702,6 +871,8 @@ fn greeks_eod_ticks_to_class_vec(ticks: &[tick::GreeksEodTick]) -> Vec<GreeksEod
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -729,6 +900,8 @@ fn greeks_first_order_ticks_to_class_vec(ticks: &[tick::GreeksFirstOrderTick]) -
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -755,6 +928,8 @@ fn greeks_second_order_ticks_to_class_vec(ticks: &[tick::GreeksSecondOrderTick])
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -780,6 +955,8 @@ fn greeks_third_order_ticks_to_class_vec(ticks: &[tick::GreeksThirdOrderTick]) -
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -801,6 +978,7 @@ fn index_price_at_time_ticks_to_class_vec(ticks: &[tick::IndexPriceAtTimeTick]) 
                 exchange: t.exchange,
                 price: t.price,
                 date: t.date,
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -837,6 +1015,8 @@ fn iv_ticks_to_class_vec(ticks: &[tick::IvTick]) -> Vec<IvTick> {
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -855,6 +1035,7 @@ fn market_value_ticks_to_class_vec(ticks: &[tick::MarketValueTick]) -> Vec<Marke
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -877,6 +1058,7 @@ fn ohlc_ticks_to_class_vec(ticks: &[tick::OhlcTick]) -> Vec<OhlcTick> {
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -893,6 +1075,7 @@ fn open_interest_ticks_to_class_vec(ticks: &[tick::OpenInterestTick]) -> Vec<Ope
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -920,6 +1103,7 @@ fn price_ticks_to_class_vec(ticks: &[tick::PriceTick]) -> Vec<PriceTick> {
                 ms_of_day: t.ms_of_day,
                 price: t.price,
                 date: t.date,
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -944,6 +1128,7 @@ fn quote_ticks_to_class_vec(ticks: &[tick::QuoteTick]) -> Vec<QuoteTick> {
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -992,6 +1177,8 @@ fn trade_greeks_all_ticks_to_class_vec(ticks: &[tick::TradeGreeksAllTick]) -> Ve
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -1026,6 +1213,8 @@ fn trade_greeks_first_order_ticks_to_class_vec(ticks: &[tick::TradeGreeksFirstOr
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -1054,6 +1243,8 @@ fn trade_greeks_implied_volatility_ticks_to_class_vec(ticks: &[tick::TradeGreeks
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -1087,6 +1278,8 @@ fn trade_greeks_second_order_ticks_to_class_vec(ticks: &[tick::TradeGreeksSecond
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -1119,6 +1312,8 @@ fn trade_greeks_third_order_ticks_to_class_vec(ticks: &[tick::TradeGreeksThirdOr
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                underlying_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.underlying_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -1156,6 +1351,8 @@ fn trade_quote_ticks_to_class_vec(ticks: &[tick::TradeQuoteTick]) -> Vec<TradeQu
                 expiration: t.has_contract_id().then_some(t.expiration),
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
+                quote_timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.quote_ms_of_day).map(BigInt::from),
             }
         })
         .collect()
@@ -1190,6 +1387,7 @@ fn trade_ticks_to_class_vec(ticks: &[tick::TradeTick]) -> Vec<TradeTick> {
                 is_incremental_volume: t.volume_type == 0,
                 regular_trading_hours: (34200000..=57600000).contains(&t.ms_of_day),
                 is_seller: t.ext_condition1 == 12,
+                timestamp_ms: tdbe::time::date_ms_to_epoch_ms(t.date, t.ms_of_day).map(BigInt::from),
             }
         })
         .collect()


### PR DESCRIPTION
## What

The TypeScript tick rows were missing the `*TimestampMs` epoch accessors that Python (`*_timestamp_ms` computed properties) and C++ (`tdx::timestamp_ms` free function over the `tdx_timestamp_ms` C ABI) already expose. A TypeScript client holding `{date, createdMsOfDay}` had no way to reach the Eastern-Time-to-UTC, DST-aware epoch milliseconds without reimplementing the US DST rules — a client-facing parity break, and one the parity guard did not track, which is why it stayed hidden.

## How

The tick codegen now iterates `timestamp_accessor_fields(def)` — the same schema-derived helper the Python pyclass emitter uses — and emits one precomputed `Option<BigInt>` field per `(date, *_ms_of_day)` pair, camelCased to `createdTimestampMs` / `lastTradeTimestampMs` / `timestampMs` / `underlyingTimestampMs` / `quoteTimestampMs`. The set and the per-type gating are one-for-one with Python (1 created + 1 last_trade + 19 `timestampMs` + 11 underlying + 1 quote = 33 fields). The method-less `#[napi(object)]` row surfaces the value as a field — the established shape for the flag-word accessors — rather than a method, and the value resolves through the one shared DST-aware core, `tdbe::time::date_ms_to_epoch_ms`, the identical function the Python property and the `tdx_timestamp_ms` FFI route through, so no binding reimplements the offset rules.

`sdks/parity.toml` gains a `[[value_field]]` row per accessor pinning the TypeScript half's `Option<BigInt>` type; the Python computed properties, the Rust inherent `impl`, and the single C++ free function stay pinned by the shared-source `generate_sdk_surfaces --check` drift gate. The guard now trips on future drift of this family instead of letting it hide.

## Cross-binding value parity (DST boundary)

09:30 ET (`ms_of_day = 34_200_000`), Unix epoch milliseconds, verified against the FFI `tdx_timestamp_ms`, the Python `created_timestamp_ms` property, and `zoneinfo` (America/New_York). The TypeScript field is produced by the identical core call:

| input | EST winter (2026-01-15) | EDT summer (2026-07-15) | absent date (0) |
| --- | --- | --- | --- |
| FFI `tdx_timestamp_ms` | `1768487400000` | `1784122200000` | `-1` (sentinel) |
| Python `created_timestamp_ms` | `1768487400000` | `1784122200000` | `None` |
| shared core `date_ms_to_epoch_ms` | `1768487400000` | `1784122200000` | `None` |

Winter resolves 09:30 ET to 14:30 UTC (UTC-5, EST); summer to 13:30 UTC (UTC-4, EDT) — the one-hour DST shift.

## Verification

- `cargo fmt --all -- --check`; `cargo clippy` on the napi crate and the generator `-D warnings`.
- `generate_sdk_surfaces --check` drift gate passes (only `_generated/tick_classes.rs` and the napi-regenerated `index.d.ts` changed).
- `python3 scripts/check_binding_parity.py` passes with the 33 new `[[value_field]]` rows (49 value-field rows total, up from 16); confirmed the guard trips when a row's declared type is drifted off `Option<BigInt>`.
- `npm ci && npm run build:debug && npm test` green (119 tests, 7 new under `epoch-millisecond tick accessors (cross-binding parity)`); the regression test pins the field names, `bigint` typing, optionality, camelCase parity with Python, and that every field routes through the shared core.
- `cargo test -p tdbe time::` green (16 tests, including `date_ms_to_epoch_ms_round_trips_edt_and_est`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)