### PR TITLE
fix(docs): correct the broken streaming quickstart snippets across bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,9 @@ npm install thetadatadx
 ```
 
 ```typescript
-import { Credentials, Config, Contract, ThetaDataDxClient } from 'thetadatadx';
+import { Contract, ThetaDataDxClient } from 'thetadatadx';
 
-const client = new ThetaDataDxClient(
-  Credentials.fromFile('creds.txt'),
-  Config.production(),
-);
+const client = ThetaDataDxClient.connectFromFile('creds.txt');
 
 client.startStreaming((event) => {
   if (event.kind === 'trade') {

--- a/docs-site/docs/examples/option-chain.md
+++ b/docs-site/docs/examples/option-chain.md
@@ -20,7 +20,7 @@ expiration = tdx.option_list_expirations("SPY")[0]
 chain = tdx.option_snapshot_greeks_all("SPY", expiration)
 
 # 3. Closest-to-the-money calls by absolute delta.
-calls = [t for t in chain if t.right == 67]            # ASCII 'C'
+calls = [t for t in chain if t.right == "C"]
 for t in sorted(calls, key=lambda t: abs(t.delta - 0.5))[:5]:
     print(f"{t.strike:8.1f}  delta={t.delta:+.3f}  iv={t.implied_volatility:.4f}")
 ```

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -324,7 +324,7 @@ int main() {
     // constructed above — the previous example referenced an
     // undefined `unified` variable and would not compile.
     auto stock  = tdx::Contract::stock("AAPL");
-    auto option = tdx::Contract::option("SPY", "20260620", "550", "C");
+    auto option = tdx::Contract::option("SPY", {.expiration="20260620", .strike="550", .right="C"});
 
     fpss.subscribe(stock.quote());
     fpss.subscribe(option.trade());
@@ -346,7 +346,7 @@ All prices in streaming events are `double` (f64) -- decoded during parsing. Acc
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `tdx::Contract::stock(symbol)` | `Contract` | Stock contract |
-| `tdx::Contract::option(symbol, exp, strike, right)` | `Contract` | Option contract |
+| `tdx::Contract::option(symbol, {.expiration=, .strike=, .right=})` | `Contract` | Option contract |
 | `contract.quote()` / `.trade()` / `.open_interest()` | `SubscriptionRef` | Per-contract subscription |
 | `tdx::SecType::option().full_trades()` / `.full_open_interest()` | `SubscriptionRef` | Full-stream subscription |
 | `unified.subscribe(sub)` | `void` | Install a subscription |

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -49,7 +49,7 @@ async function main() {
   // value the polymorphic `client.subscribe(...)` accepts directly,
   // matching the documented Rust / Python shape.
   const stock  = ContractRef.stock('AAPL');
-  const option = ContractRef.option('SPY', '20260620', '550', 'C');
+  const option = ContractRef.option('SPY', { expiration: '20260620', strike: '550', right: 'C' });
 
   await using session = await tdx.streaming((event) => {
     if (event.kind === 'quote') {


### PR DESCRIPTION
The TypeScript and C++ README streaming examples and the root README TypeScript quickstart used the removed positional `Contract.option(symbol, expiration, strike, right)` signature and a non-existent `new ThetaDataDxClient(Credentials, Config)` construction, so they no longer compiled against the current named, factory-based surface. They now use the named option form `option(symbol, { expiration, strike, right })` and the `ThetaDataDxClient.connectFromFile(path)` factory, matching the generated reference and the docs-site streaming pages.

The option-chain example filtered ticks on `right == 67`, the obsolete ASCII-integer comparison that silently matches nothing now that `right` decodes to the string `"C"`, so it compares against `"C"`.

Verified: the corrected C++ designated-initializer form compiles against `thetadx.hpp` (the `OptionLeg` fields are `expiration`/`strike`/`right`), and the TypeScript and Python forms match the shapes the documentation reference and docs-site already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
