### PR TITLE
docs: rewrite the per-binding READMEs to vendor-grade quality

### DIFF
--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -1,17 +1,23 @@
 # thetadatadx
 
-Native Rust SDK for ThetaData market data. Speaks ThetaData's wire
-protocols directly — historical gRPC, streaming TCP, and the native
-flat-file distribution for bulk pulls — without a JVM or a local
-proxy. One async client object speaks every transport directly.
+The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — from one async client. Connects straight to ThetaData; no Java terminal, no JVM, no local proxy.
 
 [![Crates.io](https://img.shields.io/crates/v/thetadatadx.svg?logo=rust)](https://crates.io/crates/thetadatadx)
 [![docs.rs](https://img.shields.io/docsrs/thetadatadx?logo=docsdotrs)](https://docs.rs/thetadatadx)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/userFRM/ThetaDataDx/blob/main/LICENSE)
 
-> **Requires a valid [ThetaData](https://thetadata.us) subscription.**
-> The SDK authenticates against the Nexus API with your account
-> credentials.
+> [!IMPORTANT]
+> A valid [ThetaData](https://thetadata.us) subscription is required. The SDK
+> authenticates against ThetaData's Nexus API using your account credentials.
+
+## Features
+
+- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
+- **Greeks without a round-trip** — 23 Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **Buffer or stream** — every history builder yields a `Vec<Tick>` on `.await`, or chunk-by-chunk via `.stream(handler)`.
+- **Typed errors** — one `Error` enum across every transport, plus a dedicated `FpssError` for the streaming path.
+- **DataFrames on demand** — opt into the `polars` / `arrow` features for a zero-copy conversion off any result.
 
 ## Install
 
@@ -21,13 +27,18 @@ thetadatadx = "12"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
-Opt-in DataFrame ergonomics:
+Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "12", features = ["polars"] }   # or "arrow"
+thetadatadx = { version = "12", features = ["polars"] }
 ```
 
-## Historical
+## Quick start
+
+> [!TIP]
+> Credentials can come from a `creds.txt` file (email on line 1, password on
+> line 2), an inline `Credentials::new(...)`, or the `THETADATA_EMAIL` /
+> `THETADATA_PASSWORD` environment variables.
 
 ```rust
 use thetadatadx::{ThetaDataDxClient, Credentials, DirectConfig};
@@ -37,35 +48,26 @@ async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
     let tdx = ThetaDataDxClient::connect(&creds, DirectConfig::production()).await?;
 
-    // EOD Greeks for a SPY option chain across Q1.
+    // EOD Greeks for a SPY option chain across Q1 2024.
     let chain = tdx
         .option_history_greeks_eod("SPY", "20260619", "20240101", "20240331")
         .await?;
 
     for t in chain.iter().take(5) {
         println!(
-            "{} K={:>6.2} {} delta={:+.4} gamma={:+.4} theta={:+.4} IV={:.4}",
-            t.date, t.strike, t.right, t.delta, t.gamma, t.theta, t.implied_vol,
+            "{} K={:>7.2} {} delta={:+.4} gamma={:+.4} theta={:+.4} IV={:.4}",
+            t.date, t.strike, t.right, t.delta, t.gamma, t.theta, t.implied_volatility,
         );
     }
     Ok(())
 }
 ```
 
-61 typed endpoints across stock, option, index, calendar, and
-interest-rate surfaces. Each builder accepts `.await` for a
-buffered `Vec<Tick>` or `.stream(handler)` for chunk-by-chunk
-delivery on multi-day backfills.
+61 typed endpoints span stocks, options, indices, the market calendar, and interest rates. Each builder accepts `.await` for a buffered `Vec<Tick>`, or `.stream(handler)` for chunk-by-chunk delivery — the right choice for multi-day backfills, where it holds peak memory flat instead of materialising the whole response.
 
 ## Streaming
 
-Two equivalent shapes. Pick whichever fits the call site.
-
-### Unified — `ThetaDataDxClient`
-
-One auth, one connection. Historical works immediately; streaming
-opens on the first `start_streaming(callback)` call. Subscribe after
-the callback is registered.
+One authentication, one connection. Historical queries work immediately; the streaming transport opens on the first `start_streaming(callback)` call. Subscribe specific contracts with the fluent `Contract` API, or take a whole-market feed:
 
 ```rust
 use thetadatadx::fpss::{FpssData, FpssEvent};
@@ -73,90 +75,86 @@ use thetadatadx::prelude::*;
 
 tdx.start_streaming(|event: &FpssEvent| {
     if let FpssEvent::Data(FpssData::Trade { contract, price, size, .. }) = event {
-        println!("{} @ {price} x {size}", contract.symbol);
+        println!("{} trade {price} x {size}", contract.symbol);
     }
 })?;
 
 tdx.subscribe(Contract::stock("AAPL").quote())?;
-tdx.subscribe(Contract::option("SPY", "20260620", "550", "C")?.trade())?;
+tdx.subscribe(
+    Contract::option("SPY", OptionLeg { expiration: "20260620", strike: "550", right: "C" })?
+        .trade(),
+)?;
+
+// Or a whole-market feed — every option trade across the universe.
+tdx.subscribe(SecType::Option.full_trades())?;
 ```
 
-### Standalone — `FpssClient`
+On an involuntary disconnect the client recovers on its own — exponential backoff with jitter, host failover, then a paced re-subscribe of every active contract.
 
-Streaming-only workloads. No MDDS / Nexus session, no historical
-surface. Drive the iterator directly:
+### Streaming-only — `FpssClient`
+
+For workloads that never touch history, `FpssClient` connects to the streaming servers alone — no Nexus session, no historical surface. Drive it as an iterator, or with the explicit drain primitives:
 
 ```rust
 use thetadatadx::auth::Credentials;
 use thetadatadx::config::DirectConfig;
-use thetadatadx::fpss::{FpssClient, FpssEvent};
 use thetadatadx::fpss::protocol::Contract;
+use thetadatadx::fpss::{FpssClient, FpssEvent};
 
 let creds = Credentials::from_file("creds.txt")?;
 let hosts = DirectConfig::production().fpss.hosts;
-let client = FpssClient::builder(&creds, &hosts)
-    .ring_size(8192)
-    .build()?;
+let client = FpssClient::builder(&creds, &hosts).ring_size(8192).build()?;
 
 client.subscribe(Contract::stock("AAPL").quote())?;
 
 for event in &client {
     match event? {
-        FpssEvent::Data(data)       => { /* … */ }
-        FpssEvent::Control(control) => { /* … */ }
+        FpssEvent::Data(data)       => { /* market-data tick */ }
+        FpssEvent::Control(control) => { /* lifecycle event   */ }
+        _ => {}
     }
 }
 ```
 
-Drain primitives on `FpssClient`:
+Beyond the iterator, `FpssClient` exposes `next_event()` (blocking pop), `try_next_event()` (non-blocking pop), `poll_batch(|e| …)` (non-blocking batch drain), and `for_each(|e| …)` (blocking loop until shutdown). Auto-reconnect with subscription replay is on by default; tune it through `FpssClientBuilder` or `DirectConfig::reconnect`.
 
-- `next_event()` — block until the next event or terminal shutdown.
-- `try_next_event()` — non-blocking single pop.
-- `poll_batch(|event| …)` — non-blocking batch drain.
-- `for_each(|event| …)` — blocking loop until shutdown.
-- `for event in &client { … }` — iterator over `Result<FpssEvent, FpssError>`.
+## Flat files
 
-Auto-reconnect with subscription replay is on by default; tune via
-`FpssClientBuilder` or `DirectConfig::reconnect`.
-
-## Auth
-
-Three ways to supply credentials:
+Whole-universe daily snapshots for one `(security type, request type, date)` at a time, written straight to disk in the format you ask for:
 
 ```rust
-let creds = Credentials::from_file("creds.txt")?;                    // two-line file
-let creds = Credentials::new("user@example.com", "password");        // inline
-// or set THETADATA_EMAIL / THETADATA_PASSWORD and read via env
+use thetadatadx::flatfiles::{FlatFileFormat, ReqType, SecType};
+
+let path = thetadatadx::flatfile_request(
+    &creds, SecType::Option, ReqType::Quote, "20260428",
+    std::path::Path::new("/tmp/option-quote"), FlatFileFormat::Csv,
+).await?;
+```
+
+## Greeks calculator
+
+A full Black-Scholes calculator — 23 Greeks plus an implied-volatility solver — runs locally, no request required.
+
+## DataFrames
+
+With the `polars` or `arrow` feature enabled, any history result converts to a dataframe over the Arrow C Data Interface — zero-copy, no row-by-row iteration:
+
+```rust
+let df = tdx.stock_history_eod("AAPL", "20240101", "20240301").await?.to_polars()?;
 ```
 
 ## Errors
 
-Every public method returns `Result<_, thetadatadx::Error>`. The FPSS
-streaming surface adds a typed `FpssError` enum for the polling and
-subscribe paths; the umbrella `Error` is reachable via
-`From<FpssError> for Error` for callers that prefer a single error
-type.
+Every public method returns `Result<_, thetadatadx::Error>`. The streaming surface adds a typed `FpssError` for the polling and subscribe paths; `Error` implements `From<FpssError>`, so callers that prefer a single error type can stay with `Error` throughout.
 
-## Performance
+## Documentation
 
-- Zero-copy decode where the wire format allows (no Vec churn between
-  the codec and the typed tick row).
-- Native HTTP/2 transport with no intermediary layer.
-- Single-producer single-consumer ring on the streaming hot path; the
-  TLS reader never blocks on user code.
-- Optional `polars` / `arrow` features for zero-copy DataFrame
-  conversion against Arrow C Data Interface.
-
-## More
-
-- [Repository, issues, contributing](https://github.com/userFRM/ThetaDataDx)
 - [API reference](https://docs.rs/thetadatadx)
-- [Documentation site](https://userfrm.github.io/ThetaDataDx/) — guides,
-  per-endpoint pages, streaming deep-dive.
-- Python (`pip install thetadatadx`), Node.js (`npm install
-  thetadatadx`), and C++ bindings share the same wire-format and
-  reconnect behaviour.
+- [Documentation site](https://userfrm.github.io/ThetaDataDx/) — guides, per-endpoint pages, and a streaming deep-dive
+- [Repository, issues, contributing](https://github.com/userFRM/ThetaDataDx)
+
+Python (`pip install thetadatadx`), Node.js (`npm install thetadatadx`), and C++ bindings sit on this same engine and share its wire format and reconnect behaviour.
 
 ## License
 
-Apache-2.0.
+Licensed under the Apache License, Version 2.0.

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -73,9 +73,54 @@ One authentication, one connection. Historical queries work immediately; the str
 use thetadatadx::fpss::{FpssData, FpssEvent};
 use thetadatadx::prelude::*;
 
+fn format_contract(contract: &Contract) -> String {
+    let mut label = contract.symbol.to_string();
+    if let Some(expiration) = contract.expiration {
+        label.push_str(&format!(" {expiration}"));
+    }
+    if let Some(strike) = contract.strike_dollars() {
+        label.push_str(&format!(" {strike}"));
+    }
+    if let Some(right) = contract.right() {
+        label.push_str(&format!(" {}", right.as_char()));
+    }
+    label
+}
+
 tdx.start_streaming(|event: &FpssEvent| {
-    if let FpssEvent::Data(FpssData::Trade { contract, price, size, .. }) = event {
-        println!("{} trade {price} x {size}", contract.symbol);
+    match event {
+        FpssEvent::Data(FpssData::Trade {
+            contract,
+            price,
+            size,
+            exchange,
+            ms_of_day,
+            sequence,
+            condition,
+            ..
+        }) => {
+            println!(
+                "{} trade price={price} size={size} exchange={exchange} ms_of_day={ms_of_day} sequence={sequence} condition={condition}",
+                format_contract(contract),
+            );
+        }
+        FpssEvent::Data(FpssData::Quote {
+            contract,
+            bid,
+            ask,
+            bid_size,
+            ask_size,
+            bid_exchange,
+            ask_exchange,
+            ms_of_day,
+            ..
+        }) => {
+            println!(
+                "{} quote bid={bid} ask={ask} bid_size={bid_size} ask_size={ask_size} bid_exchange={bid_exchange} ask_exchange={ask_exchange} ms_of_day={ms_of_day}",
+                format_contract(contract),
+            );
+        }
+        _ => {}
     }
 })?;
 

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -93,18 +93,37 @@ int main() {
     auto config = tdx::Config::production();
 
     tdx::FpssClient fpss(creds, config);
+    auto format_contract = [](const auto& contract) {
+        std::ostringstream out;
+        out << (contract.symbol ? contract.symbol : "<pending>");
+        if (contract.has_expiration) out << ' ' << contract.expiration;
+        if (auto strike = tdx::strike(contract)) out << ' ' << *strike;
+        if (auto right = tdx::right(contract)) out << ' ' << *right;
+        return out.str();
+    };
 
-    fpss.set_callback([](const tdx::FpssEvent& event) {
+    fpss.set_callback([format_contract](const tdx::FpssEvent& event) {
         switch (event.kind) {
             case TDX_FPSS_TRADE:
-                std::printf("%s trade %.2f x %d\n",
-                            event.trade.contract.symbol,
-                            event.trade.price, event.trade.size);
+                std::cout << format_contract(event.trade.contract)
+                          << " trade price=" << event.trade.price
+                          << " size=" << event.trade.size
+                          << " exchange=" << event.trade.exchange
+                          << " ms_of_day=" << event.trade.ms_of_day
+                          << " sequence=" << event.trade.sequence
+                          << " condition=" << event.trade.condition
+                          << '\n';
                 break;
             case TDX_FPSS_QUOTE:
-                std::printf("%s quote %.2f / %.2f\n",
-                            event.quote.contract.symbol,
-                            event.quote.bid, event.quote.ask);
+                std::cout << format_contract(event.quote.contract)
+                          << " quote bid=" << event.quote.bid
+                          << " ask=" << event.quote.ask
+                          << " bid_size=" << event.quote.bid_size
+                          << " ask_size=" << event.quote.ask_size
+                          << " bid_exchange=" << event.quote.bid_exchange
+                          << " ask_exchange=" << event.quote.ask_exchange
+                          << " ms_of_day=" << event.quote.ms_of_day
+                          << '\n';
                 break;
             default:
                 break;

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -1,54 +1,196 @@
 # thetadatadx (C++)
 
-C++ SDK for ThetaData market data. Header-only RAII wrappers over the `thetadatadx` Rust crate via the shared C FFI layer.
+The C++ SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; no Java terminal, no JVM, no local proxy.
 
-Every call crosses the C ABI boundary into compiled Rust: gRPC communication, protobuf parsing, zstd decompression, and TCP streaming run inside the `thetadatadx` crate.
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/userFRM/ThetaDataDx/blob/main/LICENSE)
+[![C++](https://img.shields.io/badge/C%2B%2B-17-00599C.svg?logo=cplusplus&logoColor=white)](https://isocpp.org)
+[![Discord](https://img.shields.io/badge/Discord-community-5865F2.svg?logo=discord&logoColor=white)](https://discord.thetadata.us/)
 
-> **Surface coverage:** the C++ binding exposes all three ThetaData surfaces — historical request/response, real-time streaming, and whole-universe daily blobs. Flat files land via `unified.flat_files().*()` with `.to_arrow_ipc()` terminals plus a `flat_files().to_path(...)` raw-bytes helper — see the [Flat Files](#flat-files) section for the full method list.
+> [!IMPORTANT]
+> A valid [ThetaData](https://thetadata.us) subscription is required. The SDK
+> authenticates against ThetaData's Nexus API using your account credentials.
 
-## Prerequisites
+## Features
 
-- C++17 compiler
-- CMake 3.16+
-- Rust toolchain (for building the FFI library)
+- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Three access modes** — point-in-time history, real-time streaming, and bulk flat-file downloads.
+- **Typed structs, no JSON** — every endpoint returns a `std::vector` of decoded structs; prices arrive as `double`.
+- **Greeks without a round-trip** — 23 Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **RAII throughout** — clients own their connections and clean up on scope exit; methods throw on failure.
+- **Header plus one library** — a single `thetadx.hpp` over a prebuilt C ABI shared library.
 
-## Platform Support
+## Install
 
-- Linux: CI-validated
-- macOS: CI-validated
-- Windows: CI-validated
-
-## Building
-
-First, build the Rust FFI library:
+The SDK is a single header (`sdks/cpp/include/thetadx.hpp`) over a prebuilt C ABI library. Build the library once, then point your compiler at the header and link the library.
 
 ```bash
-# From the repository root
+# Build the FFI library
 cargo build --release -p thetadatadx-ffi
+
+# Compile against the header and link the library
+g++ -std=c++17 -Isdks/cpp/include your_app.cpp \
+    -Ltarget/release -lthetadatadx_ffi -o your_app
 ```
 
-Then build the C++ SDK:
+A CMake build is also provided:
 
 ```bash
 cmake -S sdks/cpp -B build/cpp
 cmake --build build/cpp --config Release --target thetadatadx_cpp
 ```
 
-Run the example:
+- **Prerequisites:** a C++17 compiler, CMake 3.16+, and the Rust toolchain to build the library.
+- **Platforms:** Linux, macOS, and Windows.
 
-```bash
-./build/cpp/thetadatadx_example
+## Quick start
+
+> [!TIP]
+> Credentials can come from a `creds.txt` file (email on line 1, password on
+> line 2) via `Credentials::from_file`, or inline via
+> `Credentials::from_email(email, password)`.
+
+```cpp
+#include <thetadx.hpp>
+#include <cstdio>
+
+int main() {
+    auto client = tdx::Client::connect(
+        tdx::Credentials::from_file("creds.txt"),
+        tdx::Config::production());
+
+    // First-order Greeks for every strike on SPY's 2026-06-19 expiry, as of 2024-03-15
+    auto greeks = client.option_history_greeks_first_order("SPY", "20260619", "20240315");
+    for (const auto& t : greeks) {
+        std::printf("K=%.2f %c delta=%+.4f theta=%+.4f vega=%+.4f\n",
+                    t.strike, static_cast<char>(t.right), t.delta, t.theta, t.vega);
+    }
+}
 ```
+
+Every historical method returns a typed `std::vector` — iterate it directly:
+
+```cpp
+auto eod = client.stock_history_eod("AAPL", "20240101", "20240301");
+for (const auto& t : eod) {
+    std::printf("%d: O=%.2f H=%.2f L=%.2f C=%.2f\n",
+                t.date, t.open, t.high, t.low, t.close);
+}
+
+auto quotes = client.stock_snapshot_quote({"AAPL", "MSFT", "GOOG"});
+auto exps   = client.option_list_expirations("SPY");
+```
+
+## Streaming
+
+Real-time streaming uses a dedicated `tdx::FpssClient` — separate from the historical `Client`. Register a callback and switch on `event.kind`; market-data payloads (`quote`, `trade`, `open_interest`, `ohlcvc`) carry decoded `double` fields, no parsing on the hot path:
+
+```cpp
+#include <thetadx.hpp>
+#include <cstdio>
+
+int main() {
+    auto creds  = tdx::Credentials::from_file("creds.txt");
+    auto config = tdx::Config::production();
+
+    tdx::FpssClient fpss(creds, config);
+
+    fpss.set_callback([](const tdx::FpssEvent& event) {
+        switch (event.kind) {
+            case TDX_FPSS_TRADE:
+                std::printf("%s trade %.2f x %d\n",
+                            event.trade.contract.symbol,
+                            event.trade.price, event.trade.size);
+                break;
+            case TDX_FPSS_QUOTE:
+                std::printf("%s quote %.2f / %.2f\n",
+                            event.quote.contract.symbol,
+                            event.quote.bid, event.quote.ask);
+                break;
+            default:
+                break;
+        }
+    });
+
+    // Fluent contract-first subscriptions.
+    auto stock  = tdx::Contract::stock("AAPL");
+    auto option = tdx::Contract::option("SPY", {.expiration = "20260620", .strike = "550", .right = "C"});
+
+    fpss.subscribe(stock.quote());
+    fpss.subscribe_many({option.quote(), option.trade()});
+
+    // ... let the callback run while events flow ...
+
+    fpss.shutdown();   // the destructor also calls this on scope exit
+}
+```
+
+Every subscription is the same value, so quotes, trades, and open interest across contracts mix freely. Or take a whole-market feed — every option trade across the universe — with no per-contract setup:
+
+```cpp
+fpss.subscribe(tdx::SecType::option().full_trades());   // the callback runs per event — keep it fast
+```
+
+> [!TIP]
+> On an involuntary disconnect the client recovers on its own — exponential
+> backoff with jitter, host failover, then a paced re-subscribe of every active
+> contract. `FpssClient` is non-copyable but movable, and its destructor stops
+> the stream and waits for the callback to quiesce before returning.
+
+## Greeks calculator
+
+A full Black-Scholes calculator — 23 Greeks plus an implied-volatility solver — runs locally, no connection required:
+
+```cpp
+auto g = tdx::all_greeks(450.0, 455.0, 0.05, 0.015, 30.0 / 365.0, 8.50, "C");
+std::printf("IV=%.4f delta=%.4f gamma=%.6f vega=%.4f\n", g.iv, g.delta, g.gamma, g.vega);
+
+auto [iv, err] = tdx::implied_volatility(450.0, 455.0, 0.05, 0.015, 30.0 / 365.0, 8.50, "C");
+```
+
+`right` accepts `"C"` / `"P"` or `"call"` / `"put"` (case-insensitive).
+
+## Flat files
+
+Whole-universe daily snapshots for one `(security type, request type, date)` at a time, served by the `tdx::UnifiedClient`. The decoded schema follows the request type, so the wrapper emits Arrow IPC bytes — pair with arrow-cpp on the consumer side to materialise an `arrow::Table`:
+
+```cpp
+auto unified = tdx::UnifiedClient::connect(
+    tdx::Credentials::from_file("creds.txt"),
+    tdx::Config::production());
+
+auto rows = unified.flat_files().option_quote("20260428");
+auto ipc  = rows.to_arrow_ipc();              // std::vector<uint8_t>, Arrow IPC stream
+
+// Generic dispatcher when security type / request type come from config
+auto oi = unified.flat_files().request("OPTION", "OPEN_INTEREST", "20260428");
+
+// Or write the raw vendor file straight to disk
+unified.flat_files().to_path("OPTION", "QUOTE", "20260428", "/tmp/option-quote", "csv");
+```
+
+Available `flat_files().*` methods: `option_quote`, `option_trade`, `option_trade_quote`, `option_ohlc`, `option_open_interest`, `option_eod`, `stock_quote`, `stock_trade`, `stock_trade_quote`, `stock_eod`, plus `request(...)` and `to_path(...)`. `tdx::Client` remains the historical-only entry point; `tdx::UnifiedClient` adds streaming and flat files on the same connection.
+
+## Endpoint coverage
+
+61 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming and the local Greeks calculator.
+
+| Category | Endpoints | Examples |
+|---|---|---|
+| Stock | 14 | EOD, OHLC, trades, quotes, snapshots, at-time |
+| Option | 34 | Every stock surface plus five Greeks tiers, open interest, contract lists |
+| Index | 9 | EOD, OHLC, price, snapshots |
+| Calendar | 3 | Market open/close, holidays, early closes |
+| Interest rate | 1 | EOD rate history |
+
+Every historical endpoint is a method on `tdx::Client`. All prices (`open`, `high`, `low`, `close`, `bid`, `ask`, `price`, `strike`) are `double`, decoded during parsing. On wildcard option queries the server fills `expiration`, `strike`, and `right`; on single-contract queries those fields are `0`. The full method list lives in [`thetadx.hpp`](include/thetadx.hpp) and the [API reference](https://userfrm.github.io/ThetaDataDx/reference/).
+
+## Errors
+
+Every method throws `std::runtime_error` on failure, carrying the same typed cases as every other binding — authentication, rate limit, not found, deadline exceeded, invalid parameter, and the rest.
 
 ## Tests
 
-Catch2 v3-based test suite under `sdks/cpp/tests/`. Two buckets:
-
-- **Offline** — type-level / null-safe / move-semantics checks; no
-  network, no credentials. Always runs.
-- **Live** — full FPSS / historical round-trip against the
-  production server. Each test calls `SKIP()` unless
-  `THETADX_LIVE_CREDS` points at a `creds.txt`.
+A Catch2 test suite lives under `sdks/cpp/tests/`. Offline tests (type, null-safety, and move-semantics checks) always run; live tests round-trip against the production server and are skipped unless `THETADX_LIVE_CREDS` points at a `creds.txt`:
 
 ```bash
 cmake -S sdks/cpp -B build/cpp-tests -DTHETADATADX_CPP_BUILD_TESTS=ON
@@ -56,396 +198,12 @@ cmake --build build/cpp-tests --target thetadatadx_cpp_tests
 ctest --test-dir build/cpp-tests --output-on-failure
 ```
 
-Run with live credentials:
+## Documentation
 
-```bash
-THETADX_LIVE_CREDS=/path/to/creds.txt \
-    ctest --test-dir build/cpp-tests --output-on-failure
-```
+- [Documentation site](https://userfrm.github.io/ThetaDataDx/) — getting started, API reference, streaming, flat files
+- [Repository, issues, contributing](https://github.com/userFRM/ThetaDataDx)
+- Community discussion on the [ThetaData Discord](https://discord.thetadata.us/)
 
-The Catch2 dependency is fetched via CMake's `FetchContent` from
-`github.com/catchorg/Catch2` (pinned tag `v3.5.4`). The test target
-is opt-in via `-DTHETADATADX_CPP_BUILD_TESTS=ON` so downstream
-consumers building only the production library do not pay the
-test-dependency cost.
+## License
 
-## Quick Start
-
-```cpp
-#include "thetadx.hpp"
-#include <iostream>
-
-int main() {
-    auto creds = tdx::Credentials::from_file("creds.txt");
-    // Or inline: auto creds = tdx::Credentials("user@example.com", "your-password");
-    auto client = tdx::Client::connect(creds, tdx::Config::production());
-
-    // Fetch EOD stock data -- all prices are f64, no decoding needed
-    auto eod = client.stock_history_eod("AAPL", "20240101", "20240301");
-    for (auto& tick : eod) {
-        std::cout << tick.date << ": O=" << tick.open
-                  << " H=" << tick.high << " L=" << tick.low
-                  << " C=" << tick.close << std::endl;
-    }
-
-    // Snapshot: latest quote for multiple symbols
-    auto quotes = client.stock_snapshot_quote({"AAPL", "MSFT", "GOOG"});
-    for (auto& q : quotes) {
-        std::cout << "bid=" << q.bid
-                  << " ask=" << q.ask << std::endl;
-    }
-
-    // Greeks (no server connection needed)
-    auto g = tdx::all_greeks(450.0, 455.0, 0.05, 0.015, 30.0/365.0, 8.50, "C");
-    std::cout << "IV=" << g.iv << " Delta=" << g.delta << std::endl;
-}
-```
-
-## API
-
-### Credentials
-
-- `Credentials::from_file(path)` - load from file (line 1 = email, line 2 = password)
-- `Credentials::from_email(email, password)` - direct construction
-
-### Config
-
-- `Config::production()` - ThetaData NJ production servers
-- `Config::dev()` - Dev FPSS servers (port 20200, infinite historical replay)
-- `Config::stage()` - Stage FPSS servers (port 20100, testing, unstable)
-
-### Client
-
-RAII class. All methods throw `std::runtime_error` on failure.
-
-```cpp
-auto client = tdx::Client::connect(creds, tdx::Config::production());
-```
-
-#### Stock - List (2)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `stock_list_symbols()` | `vector<string>` | All stock symbols |
-| `stock_list_dates(req_type, symbol)` | `vector<string>` | Available dates for a stock |
-
-#### Stock - Snapshot (4)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `stock_snapshot_ohlc(symbols)` | `vector<OhlcTick>` | Latest OHLC snapshot |
-| `stock_snapshot_trade(symbols)` | `vector<TradeTick>` | Latest trade snapshot |
-| `stock_snapshot_quote(symbols)` | `vector<QuoteTick>` | Latest NBBO quote snapshot |
-| `stock_snapshot_market_value(symbols)` | `vector<MarketValueTick>` | Latest market value snapshot |
-
-#### Stock - History (6)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `stock_history_eod(sym, start_date, end_date)` | `vector<EodTick>` | EOD data |
-| `stock_history_ohlc(sym, date, interval)` | `vector<OhlcTick>` | Intraday OHLC bars. `interval` accepts ms (`"60000"`) or shorthand (`"1m"`). |
-| `stock_history_ohlc_range(sym, start_date, end_date, interval)` | `vector<OhlcTick>` | OHLC bars across date range. `interval` accepts ms or shorthand. |
-| `stock_history_trade(sym, date)` | `vector<TradeTick>` | All trades on a date |
-| `stock_history_quote(sym, date, interval)` | `vector<QuoteTick>` | NBBO quotes. `interval` accepts ms or shorthand. |
-| `stock_history_trade_quote(sym, date)` | `vector<TradeQuoteTick>` | Combined trade + quote ticks |
-
-#### Stock - At-Time (2)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `stock_at_time_trade(sym, start_date, end_date, time)` | `vector<TradeTick>` | Trade at a specific time across date range |
-| `stock_at_time_quote(sym, start_date, end_date, time)` | `vector<QuoteTick>` | Quote at a specific time across date range |
-
-#### Option - List (5)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `option_list_symbols()` | `vector<string>` | All option underlyings |
-| `option_list_dates(req, sym, expiration, strike, right)` | `vector<string>` | Available dates for an option contract |
-| `option_list_expirations(sym)` | `vector<string>` | Expiration dates |
-| `option_list_strikes(sym, expiration)` | `vector<string>` | Strike prices |
-| `option_list_contracts(req, sym, date)` | `vector<OptionContract>` | All option contracts on a date |
-
-#### Option - Snapshot (10)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `option_snapshot_ohlc(sym, expiration, strike, right)` | `vector<OhlcTick>` | Latest OHLC snapshot |
-| `option_snapshot_trade(sym, expiration, strike, right)` | `vector<TradeTick>` | Latest trade snapshot |
-| `option_snapshot_quote(sym, expiration, strike, right)` | `vector<QuoteTick>` | Latest quote snapshot |
-| `option_snapshot_open_interest(sym, expiration, strike, right)` | `vector<OpenInterestTick>` | Latest open interest snapshot |
-| `option_snapshot_market_value(sym, expiration, strike, right)` | `vector<MarketValueTick>` | Latest market value snapshot |
-| `option_snapshot_greeks_implied_volatility(sym, expiration, strike, right)` | `vector<IvTick>` | IV snapshot |
-| `option_snapshot_greeks_all(sym, expiration, strike, right)` | `vector<GreeksTick>` | All Greeks snapshot |
-| `option_snapshot_greeks_first_order(sym, expiration, strike, right)` | `vector<GreeksTick>` | First-order Greeks snapshot |
-| `option_snapshot_greeks_second_order(sym, expiration, strike, right)` | `vector<GreeksTick>` | Second-order Greeks snapshot |
-| `option_snapshot_greeks_third_order(sym, expiration, strike, right)` | `vector<GreeksTick>` | Third-order Greeks snapshot |
-
-#### Option - History (6)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `option_history_eod(sym, expiration, strike, right, start_date, end_date)` | `vector<EodTick>` | EOD option data |
-| `option_history_ohlc(sym, expiration, strike, right, date, interval)` | `vector<OhlcTick>` | Intraday OHLC for options |
-| `option_history_trade(sym, expiration, strike, right, date)` | `vector<TradeTick>` | All trades for an option |
-| `option_history_quote(sym, expiration, strike, right, date, interval)` | `vector<QuoteTick>` | Quotes for an option |
-| `option_history_trade_quote(sym, expiration, strike, right, date)` | `vector<TradeQuoteTick>` | Combined trade + quote for an option |
-| `option_history_open_interest(sym, expiration, strike, right, date)` | `vector<OpenInterestTick>` | Open interest history |
-
-#### Option - History Greeks (11)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `option_history_greeks_eod(sym, expiration, strike, right, start_date, end_date[, options])` | `vector<GreeksTick>` | EOD Greeks history. Optional `EndpointRequestOptions` exposes filters such as `strike_range`. |
-| `option_history_greeks_all(sym, expiration, strike, right, date, interval)` | `vector<GreeksTick>` | All Greeks history (intraday) |
-| `option_history_trade_greeks_all(sym, expiration, strike, right, date)` | `vector<GreeksTick>` | All Greeks on each trade |
-| `option_history_greeks_first_order(sym, expiration, strike, right, date, interval)` | `vector<GreeksTick>` | First-order Greeks history |
-| `option_history_trade_greeks_first_order(sym, expiration, strike, right, date)` | `vector<GreeksTick>` | First-order Greeks on each trade |
-| `option_history_greeks_second_order(sym, expiration, strike, right, date, interval)` | `vector<GreeksTick>` | Second-order Greeks history |
-| `option_history_trade_greeks_second_order(sym, expiration, strike, right, date)` | `vector<GreeksTick>` | Second-order Greeks on each trade |
-| `option_history_greeks_third_order(sym, expiration, strike, right, date, interval)` | `vector<GreeksTick>` | Third-order Greeks history |
-| `option_history_trade_greeks_third_order(sym, expiration, strike, right, date)` | `vector<GreeksTick>` | Third-order Greeks on each trade |
-| `option_history_greeks_implied_volatility(sym, expiration, strike, right, date, interval)` | `vector<IvTick>` | IV history (intraday) |
-| `option_history_trade_greeks_implied_volatility(sym, expiration, strike, right, date)` | `vector<IvTick>` | IV on each trade |
-
-#### Option - At-Time (2)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `option_at_time_trade(sym, expiration, strike, right, start_date, end_date, time)` | `vector<TradeTick>` | Trade at a specific time for an option |
-| `option_at_time_quote(sym, expiration, strike, right, start_date, end_date, time)` | `vector<QuoteTick>` | Quote at a specific time for an option |
-
-#### Index - List (2)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `index_list_symbols()` | `vector<string>` | All index symbols |
-| `index_list_dates(sym)` | `vector<string>` | Available dates for an index |
-
-#### Index - Snapshot (3)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `index_snapshot_ohlc(symbols)` | `vector<OhlcTick>` | Latest OHLC snapshot for indices |
-| `index_snapshot_price(symbols)` | `vector<PriceTick>` | Latest price snapshot for indices |
-| `index_snapshot_market_value(symbols)` | `vector<MarketValueTick>` | Latest market value for indices |
-
-#### Index - History (3)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `index_history_eod(sym, start_date, end_date)` | `vector<EodTick>` | EOD index data |
-| `index_history_ohlc(sym, start_date, end_date, interval)` | `vector<OhlcTick>` | Intraday OHLC for an index |
-| `index_history_price(sym, date, interval)` | `vector<PriceTick>` | Intraday price history |
-
-#### Index - At-Time (1)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `index_at_time_price(sym, start_date, end_date, time)` | `vector<PriceTick>` | Index price at a specific time |
-
-#### Calendar (3)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `calendar_open_today()` | `vector<CalendarDay>` | Whether the market is open today |
-| `calendar_on_date(date)` | `vector<CalendarDay>` | Calendar for a specific date |
-| `calendar_year(year)` | `vector<CalendarDay>` | Calendar for an entire year |
-
-#### Interest Rate (1)
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `interest_rate_history_eod(sym, start_date, end_date)` | `vector<InterestRateTick>` | EOD interest rate history |
-
-### Standalone Functions
-
-```cpp
-// All 23 Greeks + IV. `right` accepts "C"/"P" or "call"/"put" (case-insensitive).
-auto g = tdx::all_greeks(spot, strike, rate, div_yield, tte, price, "C");
-// g.iv, g.delta, g.gamma, g.theta, g.vega, g.rho, g.vanna, g.charm, etc.
-
-// Just IV
-auto [iv, err] = tdx::implied_volatility(spot, strike, rate, div_yield, tte, price, "C");
-```
-
-### Tick Types
-
-All endpoints return fully typed C++ structs. No raw JSON.
-
-| Struct | Fields | Used by |
-|--------|--------|---------|
-| `EodTick` | ms_of_day, open, high, low, close, volume, count, bid, ask, date, **expiration, strike, right** | EOD endpoints |
-| `OhlcTick` | ms_of_day, open, high, low, close, volume, count, date, **expiration, strike, right** | OHLC endpoints |
-| `TradeTick` | ms_of_day, sequence, condition, size, exchange, price, condition_flags, price_flags, volume_type, records_back, date, **expiration, strike, right** | Trade endpoints |
-| `QuoteTick` | ms_of_day, bid_size, bid_exchange, bid, bid_condition, ask_size, ask_exchange, ask, ask_condition, midpoint, date, **expiration, strike, right** | Quote endpoints |
-| `TradeQuoteTick` | ms_of_day, sequence, ext_condition1-4, condition, size, exchange, price, condition_flags, price_flags, volume_type, records_back, quote_ms_of_day, bid_size, bid_exchange, bid, bid_condition, ask_size, ask_exchange, ask, ask_condition, date, **expiration, strike, right** | Trade+quote endpoints |
-| `OpenInterestTick` | ms_of_day, open_interest, date, **expiration, strike, right** | Open interest endpoints |
-| `GreeksTick` | ms_of_day, implied_volatility, delta, gamma, theta, vega, rho, iv_error, vanna, charm, vomma, veta, speed, zomma, color, ultima, d1, d2, dual_delta, dual_gamma, epsilon, lambda, vera, date, **expiration, strike, right** | Greeks snapshot/history |
-| `IvTick` | ms_of_day, implied_volatility, iv_error, date, **expiration, strike, right** | IV-only endpoints |
-| `PriceTick` | ms_of_day, price, date | Index price endpoints |
-| `MarketValueTick` | ms_of_day, market_bid, market_ask, market_price, date, **expiration, strike, right** | Market value endpoints |
-| `OptionContract` | symbol, expiration, strike, right | option_list_contracts |
-| `CalendarDay` | date, is_open, open_time, close_time, status | Calendar endpoints |
-| `InterestRateTick` | ms_of_day, rate, date | Interest rate endpoints |
-| `Greeks` | implied_volatility, delta, gamma, theta, vega, rho, iv_error, vanna, charm, vomma, veta, speed, zomma, color, ultima, d1, d2, dual_delta, dual_gamma, epsilon, lambda, vera | Standalone all_greeks() |
-
-All price fields (`open`, `high`, `low`, `close`, `bid`, `ask`, `price`, `strike`) are `double` (f64) -- decoded during parsing. No `price_type` in the public API.
-
-**Contract identification fields** (bold above): `expiration`, `strike`, `right` are populated by the server on wildcard queries (pass `"0"` for expiration/strike). On single-contract queries these fields are `0`. The `right` input parameter accepts `"call"`, `"put"`, `"C"`, `"P"` (case-insensitive), plus `"both"`/`"*"` on endpoints that support a wildcard -- not `"0"`. Output values stay `"C"`/`"P"`.
-
-## FPSS Streaming
-
-Real-time market data via ThetaData's FPSS servers. Streaming uses a **separate `FpssClient` class**, not methods on `Client`. Events are returned as typed `#[repr(C)]` structs -- no JSON parsing on the hot path.
-
-```cpp
-#include "thetadx.hpp"
-#include <iostream>
-
-int main() {
-    auto creds = tdx::Credentials::from_file("creds.txt");
-    auto config = tdx::Config::production();
-
-    // Create a streaming client (separate from the historical Client)
-    tdx::FpssClient fpss(creds, config);
-
-    // Register a queued callback. The dispatcher thread invokes `fn`
-    // for every event under `catch_unwind`; the FPSS reader thread
-    // never blocks on user code.
-    fpss.set_callback([](const tdx::FpssEvent& event) {
-        if (event.kind == TDX_FPSS_QUOTE) {
-            std::cout << "quote bid=" << event.quote.bid
-                      << " ask=" << event.quote.ask << std::endl;
-        }
-    });
-
-    // Fluent contract-first subscriptions (primary surface). U3
-    // closure: every call below targets the same `fpss` handle
-    // constructed above — the previous example referenced an
-    // undefined `unified` variable and would not compile.
-    auto stock  = tdx::Contract::stock("AAPL");
-    auto option = tdx::Contract::option("SPY", {.expiration="20260620", .strike="550", .right="C"});
-
-    fpss.subscribe(stock.quote());
-    fpss.subscribe(option.trade());
-    fpss.subscribe(tdx::SecType::option().full_trades());
-
-    // Bulk install:
-    fpss.subscribe_many({stock.quote(), option.quote()});
-
-    // ... let the callback run ...
-
-    fpss.shutdown();
-}
-```
-
-All prices in streaming events are `double` (f64) -- decoded during parsing. Access them directly: `event.quote.bid`, `event.trade.price`, etc. No `price_type` decoding needed.
-
-### Fluent contract-first API
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `tdx::Contract::stock(symbol)` | `Contract` | Stock contract |
-| `tdx::Contract::option(symbol, {.expiration=, .strike=, .right=})` | `Contract` | Option contract |
-| `contract.quote()` / `.trade()` / `.open_interest()` | `SubscriptionRef` | Per-contract subscription |
-| `tdx::SecType::option().full_trades()` / `.full_open_interest()` | `SubscriptionRef` | Full-stream subscription |
-| `unified.subscribe(sub)` | `void` | Install a subscription |
-| `unified.subscribe_many({sub, ...})` | `void` | Install many subscriptions |
-| `unified.unsubscribe(sub)` / `unsubscribe_many({...})` | `void` | Drop subscriptions |
-| `fpss.subscribe(sub)` / `subscribe_many({...})` | `void` | Same shape on the standalone FpssClient |
-| `fpss.unsubscribe(sub)` / `unsubscribe_many({...})` | `void` | Standalone-FpssClient drop |
-
-### FpssClient lifecycle
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `FpssClient(creds, config)` | - | Connect to FPSS streaming servers |
-| `is_authenticated()` | `bool` | Check if the client is currently authenticated |
-| `active_subscriptions()` | `vector<Subscription>` | Get active subscriptions as typed structs |
-| `set_callback(std::function<void(const FpssEvent&)>)` | `void` | Dispatcher thread invokes `fn` under `catch_unwind`; reader never blocks |
-| `dropped_events()` | `uint64_t` | Cumulative ring-buffer overflow count (`Producer::try_publish` failures) |
-| `reconnect()` | `void` | Reconnect streaming and restore subscriptions |
-| `shutdown()` | `void` | Shut down the FPSS client |
-
-### FPSS Event Types
-
-| Type | Fields | Used when |
-|------|--------|-----------|
-| `TdxFpssQuote` | contract, ms_of_day, bid_size, bid_exchange, bid, bid_condition, ask_size, ask_exchange, ask, ask_condition, date, received_at_ns | `kind == TDX_FPSS_QUOTE` |
-| `TdxFpssTrade` | contract, ms_of_day, sequence, ext_condition1-4, condition, size, exchange, price, condition_flags, price_flags, volume_type, records_back, date, received_at_ns | `kind == TDX_FPSS_TRADE` |
-| `TdxFpssOpenInterest` | contract, ms_of_day, open_interest, date, received_at_ns | `kind == TDX_FPSS_OPEN_INTEREST` |
-| `TdxFpssOhlcvc` | contract, ms_of_day, open, high, low, close, volume (i64), count (i64), date, received_at_ns | `kind == TDX_FPSS_OHLCVC` |
-| `TdxFpssLoginSuccess` | permissions (nullable C string) | `kind == TDX_FPSS_LOGIN_SUCCESS` |
-| `TdxFpssContractAssigned` | id (i32), contract (TdxContract) | `kind == TDX_FPSS_CONTRACT_ASSIGNED` |
-| `TdxFpssReqResponse` | req_id (i32), result (i32) | `kind == TDX_FPSS_REQ_RESPONSE` |
-| `TdxFpssMarketOpen` | (none) | `kind == TDX_FPSS_MARKET_OPEN` |
-| `TdxFpssMarketClose` | (none) | `kind == TDX_FPSS_MARKET_CLOSE` |
-| `TdxFpssServerError` | message (nullable C string) | `kind == TDX_FPSS_SERVER_ERROR` |
-| `TdxFpssDisconnected` | reason (i32 RemoveReason) | `kind == TDX_FPSS_DISCONNECTED` |
-| `TdxFpssReconnecting` | reason (i32), attempt (i32), delay_ms (u64) | `kind == TDX_FPSS_RECONNECTING` |
-| `TdxFpssReconnected` | (none) | `kind == TDX_FPSS_RECONNECTED` |
-| `TdxFpssError` | message (nullable C string) | `kind == TDX_FPSS_ERROR` |
-| `TdxFpssUnknownFrame` | code (u8), payload (`uint8_t*`), payload_len (size_t) | `kind == TDX_FPSS_UNKNOWN_FRAME` |
-| `TdxFpssConnected` | (none) | `kind == TDX_FPSS_CONNECTED` |
-| `TdxFpssPing` | payload (`uint8_t*`), payload_len (size_t) | `kind == TDX_FPSS_PING` |
-| `TdxFpssReconnectedServer` | (none) | `kind == TDX_FPSS_RECONNECTED_SERVER` |
-| `TdxFpssRestart` | (none) | `kind == TDX_FPSS_RESTART` |
-| `TdxFpssUnknownControl` | (none) | `kind == TDX_FPSS_UNKNOWN_CONTROL` |
-
-Truncated / unrecognised wire frames are filtered before the user
-callback fires and accounted on the `thetadatadx.fpss.decode_failures`
-metric counter on the Rust side; they never surface through the C ABI
-event stream.
-
-`FpssClient` is non-copyable but movable. The destructor calls `shutdown()` automatically.
-
-## Flat Files
-
-Whole-universe daily snapshots over the legacy MDDS port. Decoded
-schema is determined at runtime by `(SecType, ReqType)`, so the C++
-wrapper exposes Arrow IPC stream bytes — pair with arrow-cpp on the
-consumer side to materialise an `arrow::Table`.
-
-```cpp
-#include "thetadx.hpp"
-
-auto creds = tdx::Credentials::from_file("creds.txt");
-auto config = tdx::Config::production();
-auto unified = tdx::UnifiedClient::connect(creds, config);
-
-auto rows = unified.flat_files().option_quote("20260428");
-auto ipc = rows.to_arrow_ipc();              // std::vector<uint8_t>
-
-// Generic dispatcher
-auto oi = unified.flat_files().request("OPTION", "OPEN_INTEREST", "20260428");
-
-// Raw vendor CSV / JSONL straight to disk
-unified.flat_files().to_path("OPTION", "QUOTE", "20260428",
-                             "/tmp/option-quote", "csv");
-```
-
-Available `flat_files().*` methods: `option_quote`, `option_trade`,
-`option_trade_quote`, `option_ohlc`, `option_open_interest`,
-`option_eod`, `stock_quote`, `stock_trade`, `stock_trade_quote`,
-`stock_eod`, plus `request(sec_type, req_type, date)` and
-`to_path(...)`. The `tdx::UnifiedClient` wraps `TdxUnified`; the
-existing `tdx::Client` (wrapping `TdxClient`) remains the
-historical-only entry point.
-
-## Architecture
-
-```
-C++ code
-    |  (RAII wrappers)
-    v
-thetadatadx.h (C FFI)
-    |
-    v
-libthetadatadx_ffi.so / .a
-    |  (Rust FFI crate)
-    v
-thetadatadx Rust crate
-    |  (direct HTTP/2 + TCP transport)
-    v
-ThetaData servers
-```
+Licensed under the Apache License, Version 2.0.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,206 +1,130 @@
 # thetadatadx (Python)
 
-Drop-in Python SDK for ThetaData market data. Speaks ThetaData's wire
-protocols directly — historical gRPC, streaming TCP, and the native
-flat-file distribution for bulk pulls — without a JVM or a local
-proxy. Every call crosses the PyO3 boundary into compiled Rust: gRPC,
-protobuf parsing, zstd decompression, FIT tick decoding, and TCP
-streaming all run natively.
+The Python SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; no Java terminal, no JVM, no local proxy.
 
-> **Surface coverage:** the Python binding exposes all three ThetaData surfaces — historical request/response, real-time streaming, and whole-universe daily blobs. Flat files land via `tdx.flat_files.*()` with `.to_arrow()`, `.to_polars()`, `.to_pandas()`, and `.to_list()` terminals plus a `flatfile_to_path(...)` raw-bytes helper — see the [Flat Files](#flat-files) section for the full method list.
+[![PyPI](https://img.shields.io/pypi/v/thetadatadx?logo=python&logoColor=white)](https://pypi.org/project/thetadatadx)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/userFRM/ThetaDataDx/blob/main/LICENSE)
+[![Python](https://img.shields.io/badge/python-3.12%2B-blue.svg?logo=python&logoColor=white)](https://www.python.org)
+[![Discord](https://img.shields.io/badge/Discord-community-5865F2.svg?logo=discord&logoColor=white)](https://discord.thetadata.us/)
 
-## Installation
+> [!IMPORTANT]
+> A valid [ThetaData](https://thetadata.us) subscription is required. The SDK
+> authenticates against ThetaData's Nexus API using your account credentials.
+
+## Features
+
+- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
+- **DataFrames built in** — every result chains straight to Polars, pandas, or Arrow over a zero-copy boundary.
+- **Greeks without a round-trip** — 23 Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **Typed all the way down** — every tick is a typed object with attribute access and IDE completion, not a dict.
+- **No terminal to run** — a direct connection to ThetaData; nothing to install and babysit locally.
+
+## Install
 
 ```bash
 pip install thetadatadx
 
-# With pandas DataFrame support (Arrow-backed, zero-copy on pandas 2.x)
-pip install thetadatadx[pandas]
-
-# With polars DataFrame support
-pip install thetadatadx[polars]
-
-# Raw Arrow (pyarrow.Table for DuckDB / Arrow-Flight / cuDF / polars-arrow)
-pip install thetadatadx[arrow]
-
-# All optional adapters
-pip install thetadatadx[all]
+pip install thetadatadx[polars]   # Polars DataFrames
+pip install thetadatadx[pandas]   # pandas DataFrames (Arrow-backed)
+pip install thetadatadx[arrow]    # raw pyarrow.Table
+pip install thetadatadx[all]      # every optional adapter
 ```
 
-Or build from source (requires Rust toolchain):
+Binary wheels ship for Linux, macOS, and Windows and require no Rust toolchain. Wheels use CPython's stable ABI (`abi3`), so one wheel per platform covers Python 3.12 and up; free-threaded (`3.13t` / `3.14t`) builds run with the GIL disabled and are selected automatically by `pip`.
 
-```bash
-pip install "maturin>=1.9.4,<2.0"
-maturin develop --release
-```
+## Quick start
 
-Binary wheels use CPython's stable ABI (`abi3`) with a minimum Python version of 3.12, so one wheel per platform supports Python 3.12+.
-
-Separate per-version wheels for PEP 703 free-threaded interpreters (`python3.13t`, `python3.14t`) will be picked up by `pip` automatically once the next PyPI release ships. The wheels carry `gil_used = false` on the extension module, so the GIL stays disabled after `import thetadatadx` and CPU-bound Python threads run truly in parallel with the gRPC dispatcher. After the next release lands, install on a free-threaded interpreter and a `cp313-cp313t-*` or `cp314-cp314t-*` wheel will be picked up; install on a stock interpreter and the `cp312-abi3-*` wheel applies.
-
-## Quick Start
+> [!TIP]
+> Credentials can come from a `creds.txt` file (email on line 1, password on
+> line 2), an inline `Credentials("you@example.com", "password")`, or the
+> `THETADATA_EMAIL` / `THETADATA_PASSWORD` environment variables.
 
 ```python
-from thetadatadx import Credentials, Config, ThetaDataDxClient
+from thetadatadx import ThetaDataDxClient, Credentials, Config
 
-# Authenticate and connect
-creds = Credentials.from_file("creds.txt")
-# Or inline: creds = Credentials("user@example.com", "your-password")
-tdx = ThetaDataDxClient(creds, Config.production())
+tdx = ThetaDataDxClient(Credentials.from_file("creds.txt"), Config.production())
 
-# Fetch end-of-day data
+# First-order Greeks for every strike on SPY's 2026-06-19 expiry, as of 2024-03-15
+greeks = tdx.option_history_greeks_first_order("SPY", "20260619", "20240315")
+
+df = greeks.to_polars()
+print(df.select(["strike", "right", "delta", "gamma", "theta", "vega"]).head())
+```
+
+Every historical method returns a typed list — iterate it, index it, or convert it to a dataframe:
+
+```python
 eod = tdx.stock_history_eod("AAPL", "20240101", "20240301")
 for tick in eod:
     print(f"{tick.date}: O={tick.open:.2f} H={tick.high:.2f} "
           f"L={tick.low:.2f} C={tick.close:.2f} V={tick.volume}")
 
-# Intraday 1-minute OHLC bars (shorthand or milliseconds)
-bars = tdx.stock_history_ohlc("AAPL", "20240315", "1m")
-print(f"{len(bars)} bars")
-
-# Option chain
+bars = tdx.stock_history_ohlc("AAPL", "20240315", "1m")   # 1-minute bars
 exps = tdx.option_list_expirations("SPY")
 strikes = tdx.option_list_strikes("SPY", exps[0])
 ```
 
-## Greeks Calculator
+## DataFrames
 
-Full Black-Scholes calculator with 23 Greeks, running in Rust:
+Every result converts directly to a dataframe — no row-by-row iteration:
 
 ```python
-from thetadatadx import all_greeks, implied_volatility
-
-# All Greeks at once
-g = all_greeks(
-    spot=450.0, strike=455.0, rate=0.05, div_yield=0.015,
-    tte=30/365, option_price=8.50, right="C"
-)
-print(f"IV={g.iv:.4f} Delta={g.delta:.4f} Gamma={g.gamma:.6f}")
-
-# Just IV
-iv, err = implied_volatility(450.0, 455.0, 0.05, 0.015, 30/365, 8.50, "C")
+greeks.to_polars()   # polars.DataFrame
+greeks.to_pandas()   # pandas.DataFrame   (pip install thetadatadx[pandas])
+greeks.to_arrow()    # pyarrow.Table      (zero-copy)
+greeks.to_list()     # list[GreeksTick]
 ```
 
-## API
+The `.to_arrow()` terminal hands the underlying Arrow buffers to pyarrow over the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html) — zero-copy at the boundary — so the table plugs straight into DuckDB, polars, cuDF, or Arrow Flight:
 
-### `Credentials`
-- `Credentials(email, password)` - direct construction
-- `Credentials.from_file(path)` - load from creds.txt
+```python
+import duckdb
 
-### `Config`
-- `Config.production()` - ThetaData NJ production servers
-- `Config.dev()` - Dev FPSS servers (port 20200, infinite historical replay)
-- `Config.stage()` - Stage FPSS servers (port 20100, testing, unstable)
+table = tdx.stock_history_eod("AAPL", "20240101", "20240301").to_arrow()
+con = duckdb.connect()
+con.register("eod", table)                 # zero-copy into DuckDB
+con.sql("SELECT AVG(close) FROM eod").show()
+```
 
-### `ThetaDataDxClient(creds, config)`
+List endpoints (`stock_list_symbols`, `option_list_expirations`, …) return a `StringList` with the same terminals; the single column is named by the endpoint (`symbol`, `expiration`, …). Empty results still convert to a zero-row frame with the full typed schema.
 
-Every historical endpoint is available. The tick-returning endpoints
-return typed `<TickName>List` wrappers (e.g. `EodTickList`,
-`TradeTickList`, `QuoteTickList`, ...), each implementing the
-Python sequence protocol (`len(...)`, `for tick in ...`,
-`lst[0]`, negative indexing) with typed-pyclass elements exposed
-via attribute access — `tick.close`, `tick.price` — with IDE
-completion and typo-loud `AttributeError` on misuse. Every
-wrapper also exposes the chainable DataFrame terminals covered
-in [Chained DataFrame terminals](#chained-dataframe-terminals).
-List-of-string endpoints (`*_list_symbols`, `*_list_dates`,
-`option_list_expirations`, `option_list_strikes`) return a
-`StringList` wrapper with the same chainable terminals; the
-single output column is named by the endpoint metadata (`symbol`,
-`date`, `expiration`, ...). `option_list_contracts` returns an
-`OptionContractList`; `calendar_on_date` / `calendar_year`
-return a `CalendarDayList`.
+For multi-day backfills, stream the response instead of buffering it. Every historical builder exposes `.stream(handler)` / `.stream_async(handler)` alongside the buffered `.list()` / `.list_async()` terminals; the handler is called once per chunk with a typed list, and the previous chunk is freed before the next is fetched, so peak memory stays flat regardless of total size:
 
-#### Stock Methods (14)
+```python
+def on_chunk(ticks):
+    for t in ticks:
+        ...   # write to Parquet, push to a bus, accumulate stats
 
-| Method | Description |
-|--------|-------------|
-| `stock_list_symbols()` | All stock symbols |
-| `stock_list_dates(request_type, symbol)` | Available dates by request type |
-| `stock_snapshot_ohlc(symbols)` | Latest OHLC snapshot |
-| `stock_snapshot_trade(symbols)` | Latest trade snapshot |
-| `stock_snapshot_quote(symbols)` | Latest NBBO quote snapshot |
-| `stock_snapshot_market_value(symbols)` | Latest market value snapshot |
-| `stock_history_eod(symbol, start_date, end_date)` | End-of-day data |
-| `stock_history_ohlc(symbol, date, interval)` | Intraday OHLC bars. `interval` accepts ms (`"60000"`) or shorthand (`"1m"`). |
-| `stock_history_ohlc_range(symbol, start_date, end_date, interval)` | OHLC bars across date range. `interval` accepts ms or shorthand. |
-| `stock_history_trade(symbol, date)` | All trades for a date |
-| `stock_history_quote(symbol, date, interval)` | NBBO quotes. `interval` accepts ms or shorthand. |
-| `stock_history_trade_quote(symbol, date)` | Combined trade+quote ticks |
-| `stock_at_time_trade(symbol, start_date, end_date, time)` | Trade at specific time across dates |
-| `stock_at_time_quote(symbol, start_date, end_date, time)` | Quote at specific time across dates |
+(tdx.option_history_quote_builder("QQQ", "20260516", "20260516")
+    .interval("tick")
+    .strike_range(5)
+    .stream(on_chunk))
+```
 
-#### Option Methods (34)
+## Streaming
 
-| Method | Description |
-|--------|-------------|
-| `option_list_symbols()` | Option underlying symbols |
-| `option_list_dates(request_type, symbol, expiration, strike, right)` | Available dates for a contract |
-| `option_list_expirations(symbol)` | Expiration dates |
-| `option_list_strikes(symbol, expiration)` | Strike prices |
-| `option_list_contracts(request_type, symbol, date)` | All contracts for a date |
-| `option_snapshot_ohlc(symbol, expiration, strike, right)` | Latest OHLC snapshot |
-| `option_snapshot_trade(symbol, expiration, strike, right)` | Latest trade snapshot |
-| `option_snapshot_quote(symbol, expiration, strike, right)` | Latest quote snapshot |
-| `option_snapshot_open_interest(symbol, expiration, strike, right)` | Latest open interest |
-| `option_snapshot_market_value(symbol, expiration, strike, right)` | Latest market value |
-| `option_snapshot_greeks_implied_volatility(symbol, expiration, strike, right)` | IV snapshot |
-| `option_snapshot_greeks_all(symbol, expiration, strike, right)` | All Greeks snapshot |
-| `option_snapshot_greeks_first_order(symbol, expiration, strike, right)` | First-order Greeks |
-| `option_snapshot_greeks_second_order(symbol, expiration, strike, right)` | Second-order Greeks |
-| `option_snapshot_greeks_third_order(symbol, expiration, strike, right)` | Third-order Greeks |
-| `option_history_eod(symbol, expiration, strike, right, start_date, end_date)` | EOD option data |
-| `option_history_ohlc(symbol, expiration, strike, right, date, interval)` | Intraday OHLC bars |
-| `option_history_trade(symbol, expiration, strike, right, date)` | All trades |
-| `option_history_quote(symbol, expiration, strike, right, date, interval)` | NBBO quotes |
-| `option_history_trade_quote(symbol, expiration, strike, right, date)` | Combined trade+quote |
-| `option_history_open_interest(symbol, expiration, strike, right, date)` | Open interest history |
-| `option_history_greeks_eod(symbol, expiration, strike, right, start_date, end_date, *, annual_dividend=None, rate_type=None, rate_value=None, version=None, underlyer_use_nbbo=None, max_dte=None, strike_range=None)` | EOD Greeks |
-| `option_history_greeks_all(symbol, expiration, strike, right, date, interval)` | All Greeks history |
-| `option_history_trade_greeks_all(symbol, expiration, strike, right, date)` | Greeks on each trade |
-| `option_history_greeks_first_order(symbol, expiration, strike, right, date, interval)` | First-order Greeks history |
-| `option_history_trade_greeks_first_order(symbol, expiration, strike, right, date)` | First-order on each trade |
-| `option_history_greeks_second_order(symbol, expiration, strike, right, date, interval)` | Second-order Greeks history |
-| `option_history_trade_greeks_second_order(symbol, expiration, strike, right, date)` | Second-order on each trade |
-| `option_history_greeks_third_order(symbol, expiration, strike, right, date, interval)` | Third-order Greeks history |
-| `option_history_trade_greeks_third_order(symbol, expiration, strike, right, date)` | Third-order on each trade |
-| `option_history_greeks_implied_volatility(symbol, expiration, strike, right, date, interval)` | IV history |
-| `option_history_trade_greeks_implied_volatility(symbol, expiration, strike, right, date)` | IV on each trade |
-| `option_at_time_trade(symbol, expiration, strike, right, start_date, end_date, time)` | Trade at specific time |
-| `option_at_time_quote(symbol, expiration, strike, right, start_date, end_date, time)` | Quote at specific time |
+Real-time quotes and trades flow through the same client. Register a callback and match on typed event classes — `Trade`, `Quote`, `Ohlcvc`, `OpenInterest` for market data, plus one typed class per lifecycle event (`Connected`, `LoginSuccess`, `Disconnected`, `Reconnecting`, …):
 
-#### Index Methods (9)
+```python
+import time
+from thetadatadx import Contract, Quote, Trade
 
-| Method | Description |
-|--------|-------------|
-| `index_list_symbols()` | All index symbols |
-| `index_list_dates(symbol)` | Available dates for an index |
-| `index_snapshot_ohlc(symbols)` | Latest OHLC snapshot |
-| `index_snapshot_price(symbols)` | Latest price snapshot |
-| `index_snapshot_market_value(symbols)` | Latest market value snapshot |
-| `index_history_eod(symbol, start_date, end_date)` | End-of-day index data |
-| `index_history_ohlc(symbol, start_date, end_date, interval)` | Intraday OHLC bars |
-| `index_history_price(symbol, date, interval)` | Intraday price history |
-| `index_at_time_price(symbol, start_date, end_date, time)` | Price at specific time |
+def on_event(event):
+    match event:
+        case Trade(price=px, size=sz, contract=c):
+            print(f"{c.symbol} trade {px:.2f} x {sz}")
+        case Quote(bid=b, ask=a, contract=c):
+            print(f"{c.symbol} quote {b:.2f} / {a:.2f}")
 
-#### Calendar Methods (3)
+spy_call = Contract.option("SPY", expiration="20260620", strike="550", right="C")
 
-| Method | Description |
-|--------|-------------|
-| `calendar_open_today()` | Is the market open today? |
-| `calendar_on_date(date)` | Calendar info for a date |
-| `calendar_year(year)` | Calendar for an entire year |
+with tdx.streaming(on_event) as session:
+    session.subscribe_many([spy_call.quote(), spy_call.trade()])
+    time.sleep(60)   # park the main thread while events flow into on_event
+```
 
-#### Rate Methods (1)
-
-| Method | Description |
-|--------|-------------|
-| `interest_rate_history_eod(symbol, start_date, end_date)` | Interest rate EOD history |
-
-### Streaming — fluent contract-first API (primary)
-
-Real-time streaming is accessed through the same `ThetaDataDxClient` instance.
-The primary surface is the fluent contract / subscription model:
+Build subscriptions with the fluent `Contract` API and pass them — one at a time or in bulk — to `subscribe` / `subscribe_many`. Every subscription is the same typed value, so quotes, trades, and open interest across contracts mix freely in one list:
 
 ```python
 from thetadatadx import Contract, SecType
@@ -208,413 +132,87 @@ from thetadatadx import Contract, SecType
 stock  = Contract.stock("AAPL")
 option = Contract.option("SPY", expiration="20260620", strike="550", right="C")
 
-with client.streaming(on_event) as session:
+with tdx.streaming(on_event) as session:
     session.subscribe(stock.quote())
-    session.subscribe(option.trade())
-    session.subscribe(option.open_interest())
-    session.subscribe(SecType.OPTION.full_trades())
-
-    # Bulk install for many contracts:
-    session.subscribe_many([stock.quote(), option.quote()])
+    session.subscribe_many([option.quote(), option.trade(), option.open_interest()])
 ```
 
-The `Subscription` value returned by `Contract.quote()` /
-`Contract.trade()` / `Contract.open_interest()` is typed and
-homogeneous — full-stream subscriptions returned by
-`SecType.OPTION.full_trades()` mix into the same `subscribe_many([...])`
-list, no string flags, no kwarg gymnastics.
-
-#### Fluent surface
-
-| Method | Description |
-|--------|-------------|
-| `Contract.stock(symbol)` | Stock contract |
-| `Contract.option(symbol, *, expiration, strike, right)` | Option contract |
-| `contract.quote()` / `.trade()` / `.open_interest()` | Per-contract `Subscription` |
-| `SecType.OPTION.full_trades()` / `.full_open_interest()` | Full-stream `Subscription` |
-| `client.subscribe(sub)` | Install one `Subscription` |
-| `client.subscribe_many([sub, ...])` | Install many `Subscription` values |
-| `client.unsubscribe(sub)` / `unsubscribe_many([...])` | Drop subscriptions |
-
-**Full trade stream behavior:** when subscribed via `client.subscribe(SecType.OPTION.full_trades())`, the ThetaData FPSS server sends a **bundle** for every trade across ALL option contracts:
-
-1. Pre-trade NBBO quote
-2. OHLC bar for the traded contract
-3. The trade itself
-4. Two post-trade NBBO quotes
-
-Events arrive as typed pyclass instances — `Quote`, `Trade`, `Ohlcvc`,
-`OpenInterest` for market data; one typed class per control variant
-(`LoginSuccess`, `ContractAssigned`, `ReqResponse`, `MarketOpen`,
-`MarketClose`, `ServerError`, `Disconnected`, `Reconnecting`,
-`Reconnected`, `Error`, `UnknownFrame`, `Connected`, `Ping`,
-`ReconnectedServer`, `Restart`, `UnknownControl`). Each class mirrors
-its `FpssControl::*` / `FpssData::*` Rust variant one-for-one, so
-dispatch is a structural `match` — exactly the same shape Rust
-consumers use. Truncated / unrecognised wire frames are filtered before
-the callback fires and accounted on the
-`thetadatadx.fpss.decode_failures` metric counter; they never surface
-on the public event stream.
+Or take a whole-market feed — every option trade across the universe, no per-contract setup:
 
 ```python
-from thetadatadx import (
-    Quote, Trade, Ohlcvc, OpenInterest,
-    LoginSuccess, ContractAssigned, Disconnected,
-    Reconnecting, Reconnected, Restart,
-)
-
-# Build a contract ID -> symbol map as assignments arrive
-contracts = {}
-
-
-def on_event(event):
-    match event:
-        # Control / lifecycle events
-        case LoginSuccess(permissions=p):
-            print(f"logged in: bundle={p}")
-        case ContractAssigned(id=cid, contract=c):
-            contracts[cid] = c.symbol
-        case Disconnected(reason=r):
-            print(f"disconnected: reason={r}")
-        case Reconnecting(attempt=n, delay_ms=ms):
-            print(f"reconnect attempt {n} in {ms}ms")
-        case Reconnected() | Restart():
-            print("stream live again")
-
-        # Market-data events — every variant carries its parsed `contract`.
-        case Trade(price=px, size=sz, contract=c):
-            print(f"[{c.symbol}] TRADE {px:.2f} x {sz}")
-        case Quote(bid=b, ask=a, contract=c):
-            print(f"[{c.symbol}] QUOTE bid={b:.2f} ask={a:.2f}")
-
-        # Skip everything else (Ohlcvc bars, Ping heartbeats, ...)
-        case _:
-            pass
-
-
-from thetadatadx import SecType
-
 with tdx.streaming(on_event) as session:
     session.subscribe(SecType.OPTION.full_trades())
-
-    # `on_event` runs on the dispatcher thread under the GIL, wrapped
-    # in `catch_unwind` so a Python exception is reported via
-    # `tracing::error!` and `panic_count()` rather than tearing down
-    # the consumer. Park the main thread while events flow.
-    import time
-    time.sleep(60)
-# `__exit__` calls `stop_streaming()` and then blocks on
-# `await_drain(5_000)` so the consumer thread has finished firing the
-# callback before control returns. If the drain barrier times out, a
-# `RuntimeWarning` is emitted but the `with` block still exits cleanly.
+    time.sleep(60)   # the callback runs on the streaming thread — keep it fast
 ```
 
-The `with tdx.streaming(callback)` context manager is the recommended
-API. Subscription methods on the bound `session` proxy through to the
-underlying `ThetaDataDxClient` via `StreamingSession.__getattr__` -- the
-streaming surface is a single source of truth rooted in the Rust
-crate, with no hand-listed wrapper to drift.
+> [!TIP]
+> The `with tdx.streaming(callback)` block opens the session on entry and drains
+> it cleanly on exit, so the callback has stopped firing by the time the block
+> returns. On an involuntary disconnect the client recovers on its own —
+> exponential backoff with jitter, host failover, then a paced re-subscribe of
+> every active contract.
 
-For the lower-level escape hatch (e.g. cross-process lifecycle
-management, custom shutdown ordering), call the lifecycle methods
-explicitly:
+## Greeks calculator
+
+A full Black-Scholes calculator — 23 Greeks plus an implied-volatility solver — runs locally, no request required:
 
 ```python
-tdx.start_streaming(callback=on_event)
-tdx.subscribe(SecType.OPTION.full_trades())
-import time
-time.sleep(60)
-tdx.stop_streaming()
-# Drain barrier: by the time `await_drain(5000)` returns, the consumer
-# thread is guaranteed to have finished firing `on_event`, so the
-# closure stack the callback closed over can be released without a
-# use-after-free race against the dispatcher thread.
-tdx.await_drain(5_000)
+from thetadatadx import all_greeks, implied_volatility
+
+g = all_greeks(
+    spot=450.0, strike=455.0, rate=0.05, div_yield=0.015,
+    tte=30 / 365, option_price=8.50, right="C",
+)
+print(f"IV={g.iv:.4f} delta={g.delta:.4f} gamma={g.gamma:.6f} vega={g.vega:.4f}")
+
+iv, err = implied_volatility(450.0, 455.0, 0.05, 0.015, 30 / 365, 8.50, "C")
 ```
 
-You can also subscribe to per-contract streams if you only need specific symbols rather than the full-stream subscription.
+`right` accepts `"C"` / `"P"` or `"call"` / `"put"` (case-insensitive).
 
-#### Streaming buffering — Pattern A (`collections.deque`) vs Pattern B (`queue.Queue`)
+## Flat files
 
-Both patterns drain the SDK callback into a Python-native data
-structure so business logic runs off the GIL-acquisition hot path.
-Pattern A is the recommended default — it matches the
-direct-callback shape used by every major market-data vendor's native
-API and runs ~2-5x faster than Pattern B because `deque.append` /
-`popleft` are GIL-atomic single ops with no condition-variable
-wake-up. Pattern B is the right pick when the consumer needs
-cross-thread blocking `get()` semantics.
+Whole-universe daily snapshots for one `(security type, request type, date)` at a time. The decoded schema follows the request type, so flat-file results chain through the same DataFrame terminals as history:
 
 ```python
-# Pattern A — collections.deque (lowest overhead, ring-buffer drop-oldest)
-from collections import deque
-
-buf = deque(maxlen=100_000)
-
-
-def cb(event):
-    buf.append(event)
-
-
-tdx.start_streaming(cb)
-# Consumer thread reads via buf.popleft() with retry-on-IndexError;
-# `maxlen` enforces drop-oldest semantics inside the deque itself.
-```
-
-```python
-# Pattern B — queue.Queue (cross-thread blocking get(), drop-newest backpressure)
-import queue
-
-q = queue.Queue(maxsize=100_000)
-
-
-def cb(event):
-    try:
-        q.put_nowait(event)
-    except queue.Full:
-        pass  # explicit drop on overflow — the SDK's own dropped_event_count()
-              # already counts ring-buffer overflow at the Rust layer.
-
-
-tdx.start_streaming(cb)
-# Consumer thread reads via q.get() (blocks until next event).
-```
-
-Trade-off: deque is the fastest queue in the standard library and
-loses the oldest event on overflow; `queue.Queue` is slower but gives
-you `get()` blocking semantics and an explicit drop-newest decision.
-Pick deque by default; reach for `queue.Queue` only when you need
-the blocking `get()`.
-
-#### State & lifecycle
-
-| Method | Description |
-|--------|-------------|
-| `active_subscriptions()` | Get list of active subscriptions (list of dicts with "kind" and "contract") |
-| `streaming(callback)` | Open a context-managed streaming session. `with tdx.streaming(callback) as session:` registers `callback` via `start_streaming` on enter and pairs `stop_streaming()` + `await_drain(5_000)` on exit, mirroring the C++ RAII destructor. Subscription methods on the bound `session` proxy through to the underlying `ThetaDataDxClient` via `StreamingSession.__getattr__` -- single source of truth. |
-| `start_streaming(callback)` | Register a callable; the dispatcher thread invokes `callback(event)` under the GIL for every typed FPSS event. `event` is a `Quote` / `Trade` / `Ohlcvc` / `OpenInterest` for market data or one of the typed control classes (`LoginSuccess`, `ContractAssigned`, `Disconnected`, `Reconnecting`, ...) for lifecycle events — dispatch via Python `match`. Truncated / unrecognised wire frames are filtered before the callback fires (counted on `thetadatadx.fpss.decode_failures`). Each invocation is wrapped in `catch_unwind`. `event.kind` carries the same discriminator tag as the TypeScript SDK's `FpssEvent.kind`. |
-| `await_drain(timeout_ms)` | Block until the previous streaming session's consumer thread has finished firing the registered callback. Returns `True` if the drain completed within `timeout_ms`, `False` otherwise. Use after `stop_streaming()` or `reconnect()` from a thread other than the callback thread to confirm the callback closure can be safely released. The `with tdx.streaming(...)` context manager calls this for you with a 5_000 ms timeout. |
-| `dropped_event_count()` | Cumulative count of events the FPSS reader could not publish into the streaming ring because the consumer fell behind and the ring was full. Resets to 0 on `reconnect()` (which rebuilds the FPSS client) and reads 0 after `stop_streaming()`. Snapshot the value before reconnect if you need to accumulate drops across session boundaries. |
-| `reconnect()` | Reconnect streaming and re-register the previously installed callback; restores all subscriptions. |
-| `shutdown()` | Graceful shutdown — drops the registered callback. |
-
-### Streaming — `.stream(handler)` for large responses
-
-Every historical builder exposes `.stream(handler)` and `.stream_async(handler)` alongside the buffered `.list()` / `.list_async()` terminals. The streaming variants drain the response chunk-by-chunk; the previous chunk is freed before the next is fetched. Peak resident memory stays at ~one chunk (≈64 KiB) regardless of total response size — eliminates the OOM mode reported on `option_history_quote(QQQ, 1DTE, interval=tick, strike_range=5)` at 32-permit concurrency (23 GiB RSS buffered → ~2 MiB streaming).
-
-```python
-# Sync: handler is called once per gRPC chunk with a typed list[QuoteTick].
-def on_chunk(ticks):
-    for t in ticks:
-        # write to parquet / send to bus / accumulate stats
-        pass
-
-tdx.option_history_quote_builder("QQQ", "20260516", "20260516") \
-    .interval("tick") \
-    .strike_range(5) \
-    .stream(on_chunk)
-
-# Async: same handler shape, awaitable resolves to None on clean drain.
-async def main():
-    await tdx.option_history_quote_builder("QQQ", "20260516", "20260516") \
-        .interval("tick") \
-        .strike_range(5) \
-        .stream_async(on_chunk)
-```
-
-The streaming variant is available on every historical builder regardless of tick type (`QuoteTick`, `TradeTick`, `OhlcTick`, `EodTick`, `GreeksAllTick`, `MarketValueTick`, `OptionContract`, `CalendarDay`, `InterestRateTick`, ...). Snapshot endpoints (≤10 rows) and the legacy `*_stream` endpoints don't expose the universal terminal — those keep their existing one-shot surface.
-
-**Memory budget formula**:
-
-```
-peak_rss ≈ concurrency × rows × bytes_per_row × decode_factor
-decode_factor: 3.0 buffered  /  1.0 streamed
-```
-
-For tick-interval requests across multi-day ranges or wide strike ranges, **always use `.stream()`** — the buffered path's `decode_factor=3.0` reflects the simultaneous residency of h2 frames + decompressed proto + decoded `Vec<T>` plus the `Vec::push` doubling transient.
-
-**Buffered-size warning.** When the buffered `.list()` /
-`.await` path returns a response whose estimated size exceeds the
-configured threshold (default 100 MiB), the SDK emits a single
-`tracing::warn!` event with `endpoint`, `row_count`, and `bytes_est`
-fields suggesting `.stream(handler)` for the workload. Tune via
-`MddsConfig::warn_on_buffered_threshold_bytes` (set to `0` to disable).
-See [`docs-site/docs/channel-pool-design.md`](../../docs-site/docs/channel-pool-design.md)
-for the gRPC channel-pool reconnect story.
-
-### Chained DataFrame terminals
-
-Every historical endpoint returns a typed list wrapper (`EodTickList`,
-`OhlcTickList`, `StringList`, ...) whose terminals convert straight
-into columnar form:
-
-| Terminal | Returns | Extra |
-|----------|---------|-------|
-| `.to_list()` | Plain `list[TickClass]` | — |
-| `.to_arrow()` | `pyarrow.Table` | `pip install thetadatadx[arrow]` |
-| `.to_pandas()` | `pandas.DataFrame` | `pip install thetadatadx[pandas]` |
-| `.to_polars()` | `polars.DataFrame` | `pip install thetadatadx[polars]` |
-
-The `.to_arrow()` terminal hands the `RecordBatch` off to pyarrow via
-the Arrow C Data Interface — zero-copy at the pyo3 boundary, the
-underlying Arrow buffers are the same ones Rust just filled. `.to_pandas()`
-and `.to_polars()` chain through the Arrow table for the final dtype.
-
-```python
-import duckdb
-table = tdx.stock_history_eod("AAPL", "20240101", "20240301").to_arrow()
-con = duckdb.connect()
-con.register("eod", table)                  # zero-copy into DuckDB
-con.sql("SELECT AVG(close) FROM eod").show()
-```
-
-The list wrapper itself behaves like a Python sequence:
-
-```python
-eod = tdx.stock_history_eod("AAPL", "20240101", "20240301")
-
-len(eod)                                   # row count
-bool(eod)                                  # False when empty
-eod[0]                                     # first EodTick
-eod[-1]                                    # last row, negative indexing supported
-for tick in eod:                           # iterate in decode order
-    process(tick)
-```
-
-On empty results the wrapper still has `__len__ == 0`, `bool(...) == False`,
-and the `.to_arrow()` / `.to_pandas()` / `.to_polars()` terminals
-produce a zero-row frame with the full typed column schema — no
-`hint=` kwarg needed.
-
-### `all_greeks(spot, strike, rate, div_yield, tte, option_price, right)`
-`right` accepts `"C"`/`"P"` or `"call"`/`"put"` case-insensitively. Returns `AllGreeks` pyclass with 22 attribute fields (`g.iv`, `g.delta`, `g.gamma`, ...). All fields are `float` (f64). Consult `help(thetadatadx.AllGreeks)` for the full list.
-
-### `implied_volatility(spot, strike, rate, div_yield, tte, option_price, right)`
-`right` accepts `"C"`/`"P"` or `"call"`/`"put"` case-insensitively. Returns `(iv, error)` tuple.
-
-## Flat Files
-
-Whole-universe daily snapshots over the legacy MDDS port (port 12000).
-Available for `(SecType, ReqType)` pairs spanning option / stock data
-across `Quote`, `Trade`, `TradeQuote`, `Ohlc`, `OpenInterest`, `Eod`.
-
-The decoded schema is determined at runtime by the request type, so
-the binding follows the same `<List>` -> Arrow -> {pandas, polars}
-pipeline as the typed historical endpoints, with the Arrow schema
-inferred from the first row by `flatfiles::arrow::rows_to_arrow`.
-
-```python
-from thetadatadx import Credentials, Config, ThetaDataDxClient
-
-creds = Credentials.from_file("creds.txt")
-tdx = ThetaDataDxClient(creds, Config.production())
-
-# Decoded -> polars / pandas / pyarrow
 rows = tdx.flat_files.option_quote(date="20260428")
 print(len(rows))
-df = rows.to_polars()           # or .to_pandas() / .to_arrow() / .to_list()
+df = rows.to_polars()                       # or .to_pandas() / .to_arrow() / .to_list()
 
-# Generic dispatcher when sec_type / req_type come from config
+# Generic dispatcher when security type / request type come from config
 oi = tdx.flat_files.request("OPTION", "OPEN_INTEREST", "20260428")
 
-# Raw vendor CSV / JSONL straight to disk (no decode, no row materialise)
+# Or write the raw vendor file straight to disk — no decode, no row materialise
 path = tdx.flatfile_to_path("OPTION", "QUOTE", "20260428",
                             "/tmp/option-quote", format="csv")
 ```
 
-Available `flat_files.*` methods: `option_quote`, `option_trade`,
-`option_trade_quote`, `option_ohlc`, `option_open_interest`,
-`option_eod`, `stock_quote`, `stock_trade`, `stock_trade_quote`,
-`stock_eod`, plus `request(sec_type, req_type, date)`.
+Available `flat_files.*` methods: `option_quote`, `option_trade`, `option_trade_quote`, `option_ohlc`, `option_open_interest`, `option_eod`, `stock_quote`, `stock_trade`, `stock_trade_quote`, `stock_eod`, plus `request(sec_type, req_type, date)`.
 
-## Architecture
+## Endpoint coverage
 
-```mermaid
-graph TD
-    A["Python code"] - "PyO3 FFI" --> B["thetadatadx Rust crate"]
-    B - "in-house gRPC / TLS TCP" --> C["ThetaData servers"]
-```
+61 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming and the local Greeks calculator.
 
-No HTTP middleware, no JVM, no subprocess. Direct wire-protocol access from the Rust core.
+| Category | Endpoints | Examples |
+|---|---|---|
+| Stock | 14 | EOD, OHLC, trades, quotes, snapshots, at-time |
+| Option | 34 | Every stock surface plus five Greeks tiers, open interest, contract lists |
+| Index | 9 | EOD, OHLC, price, snapshots |
+| Calendar | 3 | Market open/close, holidays, early closes |
+| Interest rate | 1 | EOD rate history |
 
-## FPSS Streaming
+Every endpoint is a method on `ThetaDataDxClient`. The full per-method list with signatures lives in the [API reference](https://userfrm.github.io/ThetaDataDx/reference/); `Config.dev()` and `Config.stage()` target the non-production environments.
 
-Real-time market data via ThetaData's FPSS servers:
+## Errors
 
-```python
-from thetadatadx import Credentials, Config, ThetaDataDxClient
+Every call raises a typed exception under a common `ThetaDataError` base — `AuthenticationError`, `RateLimitError`, `NotFoundError`, `DeadlineExceededError`, `InvalidParameterError`, and the rest — so the same cases are catchable here exactly as they are in every other binding.
 
-creds = Credentials.from_file("creds.txt")
-# Or inline: creds = Credentials("user@example.com", "your-password")
-tdx = ThetaDataDxClient(creds, Config.production())
+## Documentation
 
-# Register a callback (typed pyclasses: `Quote`, `Trade`, `Ohlcvc`, ...).
-# The dispatcher thread acquires the GIL to invoke `on_event`,
-# with each invocation wrapped in `catch_unwind` so a Python exception
-# is counted on `panic_count()` rather than tearing down the consumer.
-def on_event(event):
-    if event.kind == "quote":
-        print(f"Quote: {event.contract.symbol} bid={event.bid} ask={event.ask}")
-    elif event.kind == "trade":
-        print(f"Trade: {event.contract.symbol} price={event.price} size={event.size}")
+- [Documentation site](https://userfrm.github.io/ThetaDataDx/) — getting started, API reference, streaming, flat files
+- [Repository, issues, contributing](https://github.com/userFRM/ThetaDataDx)
+- Community discussion on the [ThetaData Discord](https://discord.thetadata.us/)
 
+## License
 
-with tdx.streaming(on_event) as session:
-    session.subscribe(Contract.stock("AAPL").quote())
-    session.subscribe(Contract.stock("SPY").trade())
-
-    # Park the main thread while events flow.
-    import time
-    time.sleep(60)
-# `__exit__` runs `stop_streaming()` + `await_drain(5_000)` so the
-# consumer thread has finished firing `on_event` before this scope
-# returns. Mirrors the C++ RAII destructor lifecycle.
-```
-
-## DataFrame Conversion (Arrow-Backed)
-
-Every DataFrame entry point goes through a single Arrow columnar
-pipeline: Rust `Vec<Tick>` -> `arrow::RecordBatch` -> `pyarrow.Table`
-via the Arrow C Data Interface (zero-copy) -> pandas / polars / raw
-Arrow. On pandas 2.x the numeric DataFrame columns alias the Arrow
-buffers in place.
-
-```python
-from thetadatadx import Credentials, Config, ThetaDataDxClient
-
-creds = Credentials.from_file("creds.txt")
-tdx = ThetaDataDxClient(creds, Config.production())
-
-# Pandas -- zero-copy numeric columns on pandas 2.x.
-df  = tdx.stock_history_eod("AAPL", "20240101", "20240301").to_pandas()
-
-# Polars via polars.from_arrow -- zero-copy at the Arrow boundary.
-pdf = tdx.stock_history_eod("AAPL", "20240101", "20240301").to_polars()
-
-# Raw Arrow -- plug straight into DuckDB / Arrow-Flight / cuDF.
-tbl = tdx.stock_history_eod("AAPL", "20240101", "20240301").to_arrow()
-
-# Same recipe for any tick-returning historical endpoint.
-df  = tdx.stock_history_ohlc("AAPL", "20240315", "1m").to_pandas()
-df  = tdx.option_history_trade("SPY", "20240620", "550", "C", "20240315").to_pandas()
-```
-
-List endpoints (`stock_list_symbols`, `option_list_expirations`, ...)
-return a `StringList` wrapper with the same chainable terminals; the
-DataFrame column header matches the semantic name:
-
-```python
-symbols = tdx.stock_list_symbols().to_polars()          # `symbol` column
-expirations = tdx.option_list_expirations("AAPL").to_pandas()
-```
-
-See the Arrow project docs for the [C Data
-Interface](https://arrow.apache.org/docs/format/CDataInterface.html)
-(how the zero-copy handoff works) and [pyarrow Table
-docs](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html)
-for consumer APIs.
-
-Install with:
-- `pip install thetadatadx[pandas]` — pandas + pyarrow
-- `pip install thetadatadx[polars]` — polars + pyarrow
-- `pip install thetadatadx[arrow]`  — pyarrow only
+Licensed under the Apache License, Version 2.0.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -110,12 +110,29 @@ Real-time quotes and trades flow through the same client. Register a callback an
 import time
 from thetadatadx import Contract, Quote, Trade
 
+def format_contract(contract):
+    parts = [contract.symbol]
+    if contract.expiration is not None:
+        parts.append(str(contract.expiration))
+    if contract.strike is not None:
+        parts.append(f"{contract.strike:g}")
+    if contract.right is not None:
+        parts.append(contract.right)
+    return " ".join(parts)
+
 def on_event(event):
     match event:
-        case Trade(price=px, size=sz, contract=c):
-            print(f"{c.symbol} trade {px:.2f} x {sz}")
-        case Quote(bid=b, ask=a, contract=c):
-            print(f"{c.symbol} quote {b:.2f} / {a:.2f}")
+        case Trade(price=px, size=sz, exchange=ex, ms_of_day=ms, sequence=seq, condition=cond, contract=c):
+            print(
+                f"{format_contract(c)} trade price={px:.2f} size={sz} "
+                f"exchange={ex} ms_of_day={ms} sequence={seq} condition={cond}"
+            )
+        case Quote(bid=b, ask=a, bid_size=bs, ask_size=asz, bid_exchange=bx, ask_exchange=ax, ms_of_day=ms, contract=c):
+            print(
+                f"{format_contract(c)} quote bid={b:.2f} ask={a:.2f} "
+                f"bid_size={bs} ask_size={asz} bid_exchange={bx} "
+                f"ask_exchange={ax} ms_of_day={ms}"
+            )
 
 spy_call = Contract.option("SPY", expiration="20260620", strike="550", right="C")
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,16 +1,24 @@
-# thetadatadx (Node.js / TypeScript)
+# thetadatadx (TypeScript / Node.js)
 
-Drop-in Node.js SDK for ThetaData market data. Speaks ThetaData's
-wire protocols directly — historical gRPC, streaming TCP, and the
-native flat-file distribution for bulk pulls — without a JVM or a
-local proxy. Pre-built native addons for Linux x64, macOS Apple
-Silicon, and Windows x64; no Rust toolchain required on the
-consumer.
+The Node.js SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; no Java terminal, no JVM, no local proxy.
 
-Every call crosses the napi boundary into compiled Rust: gRPC,
-protobuf, zstd, FIT decoding, and TCP streaming all run natively.
+[![npm](https://img.shields.io/npm/v/thetadatadx?logo=npm)](https://www.npmjs.com/package/thetadatadx)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/userFRM/ThetaDataDx/blob/main/LICENSE)
+[![Node](https://img.shields.io/badge/node-20%2B-339933.svg?logo=node.js&logoColor=white)](https://nodejs.org)
+[![Discord](https://img.shields.io/badge/Discord-community-5865F2.svg?logo=discord&logoColor=white)](https://discord.thetadata.us/)
 
-> **Surface coverage:** the TypeScript binding exposes all three ThetaData surfaces — historical request/response, real-time streaming, and whole-universe daily blobs. Flat files land via `tdx.flatFiles.*()` with `.toArrowIpc()` and `.toJson()` terminals plus a `tdx.flatFileToPath(...)` raw-bytes helper — see the [Flat Files](#flat-files) section for the full method list.
+> [!IMPORTANT]
+> A valid [ThetaData](https://thetadata.us) subscription is required. The SDK
+> authenticates against ThetaData's Nexus API using your account credentials.
+
+## Features
+
+- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
+- **Fully typed** — every endpoint, tick, and streaming event ships with hand-checked `.d.ts` declarations.
+- **Greeks on demand** — five tiers of Black-Scholes Greeks and implied volatility, served straight from the option endpoints.
+- **Arrow on the way out** — flat-file results emit Arrow IPC for a zero-copy handoff to `apache-arrow`.
+- **No terminal to run** — prebuilt native binaries; nothing to compile, nothing to babysit locally.
 
 ## Install
 
@@ -18,192 +26,172 @@ protobuf, zstd, FIT decoding, and TCP streaming all run natively.
 npm install thetadatadx
 ```
 
-Pre-built binaries are downloaded automatically for your platform. Supported:
-- Linux x64 (glibc)
-- macOS arm64 (Apple Silicon)
-- Windows x64 (MSVC)
+Prebuilt binaries are downloaded automatically for Linux x64 (glibc), macOS arm64 (Apple Silicon), and Windows x64 (MSVC). No Rust toolchain is required.
 
-## Usage
+## Quick start
 
-```js
-const { ThetaDataDxClient } = require('thetadatadx');
+> [!TIP]
+> Credentials can come from a `creds.txt` file (email on line 1, password on
+> line 2) via `connectFromFile`, or inline via `connect(email, password)`.
 
-async function main() {
-  // Connect (requires ThetaData credentials)
-  const tdx = ThetaDataDxClient.connectFromFile('creds.txt');
-  // Or: const tdx = ThetaDataDxClient.connect('user@example.com', 'password');
+```typescript
+import { ThetaDataDxClient } from 'thetadatadx';
 
-  // Historical endpoints resolve a Promise of typed tick objects
-  // (`Promise<OhlcTick[]>`, `Promise<QuoteTick[]>`, ...) off the
-  // runtime's execution thread, so a fetch never holds the event loop.
-  // Await the call, then index into the array to read a per-row field.
-  const ohlc = await tdx.stockHistoryOHLC('AAPL', '20240315', { interval: '60000' });
-  console.log(ohlc.length, ohlc[0].close);
+const tdx = ThetaDataDxClient.connectFromFile('creds.txt');
 
-  // Optional parameters — including a per-call timeout — ride in the
-  // trailing options object.
-  const snap = await tdx.stockSnapshotQuote(['AAPL', 'MSFT'], { timeoutMs: 5000 });
-
-  // Streaming — primary fluent contract-first API.
-  // `Contract.stock("AAPL").quote()` returns a typed `Subscription`
-  // value the polymorphic `client.subscribe(...)` accepts directly,
-  // matching the documented Rust / Python shape.
-  const stock  = ContractRef.stock('AAPL');
-  const option = ContractRef.option('SPY', { expiration: '20260620', strike: '550', right: 'C' });
-
-  await using session = await tdx.streaming((event) => {
-    if (event.kind === 'quote') {
-      console.log(event.quote.bid, event.quote.ask);
-    }
-  });
-  tdx.subscribe(stock.quote());
-  tdx.subscribe(option.trade());
-  tdx.subscribe(SecType.option().fullTrades());
-  tdx.subscribeMany([stock.quote(), option.quote()]);
-  // ...do other work; the callback fires on incoming events...
-  // `[Symbol.asyncDispose]` runs on scope exit:
-  //   stopStreaming(); await awaitDrain(5000);
-  // If the drain barrier times out, `console.warn` fires but the
-  // `using` scope still exits cleanly.
+// First-order Greeks for every strike on SPY's 2026-06-19 expiry, as of 2024-03-15
+const greeks = await tdx.optionHistoryGreeksFirstOrder('SPY', '20260619', '20240315');
+for (const t of greeks.slice(0, 5)) {
+  console.log(`K=${t.strike} ${t.right} delta=${t.delta.toFixed(4)} theta=${t.theta.toFixed(4)}`);
 }
-
-main().catch(console.error);
 ```
 
-The `await using` form is the recommended API. The `StreamingSession`
-forwards every method call (`subscribe`, `subscribeMany`,
-`unsubscribe`, `unsubscribeMany`, `activeSubscriptions`,
-`droppedEventCount`, `reconnect`, ...) to the underlying `ThetaDataDxClient`
-through a `Proxy`, so adding a new method to the napi binding makes it
-callable through the session automatically -- the streaming surface is
-a single source of truth rooted in the Rust crate.
+Every historical method resolves a `Promise` of typed tick objects off the runtime's execution thread, so a fetch never holds the event loop:
 
-For the lower-level escape hatch (e.g. cross-process lifecycle
-management, custom shutdown ordering), call the lifecycle methods
-explicitly:
+```typescript
+const eod = await tdx.stockHistoryEOD('AAPL', '20240101', '20240301');
+console.log(eod.length, eod[0].close);
 
-```ts
-tdx.startStreaming((event) => { /* ... */ });
-tdx.subscribe(ContractRef.stock('AAPL').quote());
-// ...do other work...
+const bars = await tdx.stockHistoryOHLC('AAPL', '20240315', { interval: '60000' });
+const exps = await tdx.optionListExpirations('SPY');
+
+// Optional parameters — including a per-call timeout — ride in the trailing options object
+const snap = await tdx.stockSnapshotQuote(['AAPL', 'MSFT'], { timeoutMs: 5000 });
+```
+
+## Streaming
+
+Real-time quotes and trades flow through the same client. Register a callback with `startStreaming`; events are discriminated on `event.kind` and the typed payload narrows automatically:
+
+```typescript
+import { Contract, ThetaDataDxClient } from 'thetadatadx';
+
+const tdx = ThetaDataDxClient.connectFromFile('creds.txt');
+
+tdx.startStreaming((event) => {
+  if (event.kind === 'trade') {
+    const { contract, price, size } = event.trade!;
+    console.log(`${contract.symbol} trade ${price} x ${size}`);
+  } else if (event.kind === 'quote') {
+    const { contract, bid, ask } = event.quote!;
+    console.log(`${contract.symbol} quote ${bid} / ${ask}`);
+  }
+});
+
+const leg = { expiration: '20260620', strike: '550', right: 'C' };
+tdx.subscribeMany([
+  Contract.option('SPY', leg).quote(),
+  Contract.option('SPY', leg).trade(),
+]);
+```
+
+Build subscriptions with the fluent `Contract` API and pass them — one at a time or in bulk — to `subscribe` / `subscribeMany`. Every subscription is the same typed value, so quotes, trades, and open interest across contracts mix freely in one array:
+
+```typescript
+import { Contract, SecType } from 'thetadatadx';
+
+const stock = Contract.stock('AAPL');
+const option = Contract.option('SPY', { expiration: '20260620', strike: '550', right: 'C' });
+
+tdx.subscribe(stock.quote());
+tdx.subscribeMany([option.quote(), option.trade(), option.openInterest()]);
+```
+
+Or take a whole-market feed — every option trade across the universe, no per-contract setup:
+
+```typescript
+import { SecType } from 'thetadatadx';
+
+tdx.subscribe(SecType.option().fullTrades());   // the callback runs per event — keep it fast
+```
+
+When you are done, stop the stream and drain it. By the time `awaitDrain` resolves, the callback has stopped firing, so any state it closed over can be released safely:
+
+```typescript
 tdx.stopStreaming();
-// Drain barrier: by the time `awaitDrain(5000)` resolves, the
-// consumer thread is guaranteed to have finished firing the
-// callback, so the JS closure can be released without a
-// use-after-free race against the dispatcher thread.
 const drained = await tdx.awaitDrain(5000);
-if (!drained) console.warn('drain timed out');
 ```
 
-## TypeScript types
+> [!TIP]
+> On an involuntary disconnect the client recovers on its own — exponential
+> backoff with jitter, host failover, then a paced re-subscribe of every active
+> contract.
 
-Every tick type and FPSS event is emitted as a `#[napi(object)]` struct on
-the Rust side, so the full typed surface lives in `index.d.ts`
-(auto-generated by napi-rs). Import directly from the package:
+## Types
 
-```ts
-import type { OhlcTick, GreeksTick, Quote, Trade, FpssEvent } from 'thetadatadx';
+Every tick type and streaming event is exported. Import the ones you need:
+
+```typescript
+import type { OhlcTick, GreeksAllTick, Quote, Trade, FpssEvent } from 'thetadatadx';
 ```
 
-Historical endpoints return `Tick[]`. Streaming events arrive through the
-`startStreaming(callback)` registration; the callback receives a
-discriminated `FpssEvent`, narrowed on `event.kind`:
+The streaming callback receives a discriminated `FpssEvent`, narrowed on `event.kind`. Market-data events (`trade`, `quote`, `ohlcvc`, `open_interest`) carry their payload under a matching field; one typed payload also exists per lifecycle event (`connected`, `loginSuccess`, `disconnected`, `reconnecting`, …):
 
-```ts
+```typescript
 tdx.startStreaming((event: FpssEvent) => {
   switch (event.kind) {
-    // Market-data ticks
-    case 'quote':         /* event.quote is Quote */                    break;
-    case 'trade':         /* event.trade is Trade */                    break;
-    case 'ohlcvc':        /* event.ohlcvc is Ohlcvc */                  break;
-    case 'open_interest': /* event.openInterest is OpenInterest */      break;
-
-    // Control / lifecycle events — one typed payload per FpssControl variant
-    case 'login_success':       /* event.loginSuccess is LoginSuccess */              break;
-    case 'contract_assigned':   /* event.contractAssigned is ContractAssigned */      break;
-    case 'req_response':        /* event.reqResponse is ReqResponse */                break;
-    case 'market_open':         /* event.marketOpen is MarketOpen */                  break;
-    case 'market_close':        /* event.marketClose is MarketClose */                break;
-    case 'server_error':        /* event.serverError is ServerError */                break;
-    case 'disconnected':        /* event.disconnected is Disconnected */              break;
-    case 'reconnecting':        /* event.reconnecting is Reconnecting */              break;
-    case 'reconnected':         /* event.reconnected is Reconnected */                break;
-    case 'error':               /* event.error is Error */                            break;
-    case 'unknown_frame':       /* event.unknownFrame is UnknownFrame */              break;
-    case 'connected':           /* event.connected is Connected */                    break;
-    case 'ping':                /* event.ping is Ping */                              break;
-    case 'reconnected_server':  /* event.reconnectedServer is ReconnectedServer */    break;
-    case 'restart':             /* event.restart is Restart */                        break;
-    case 'unknown_control':     /* event.unknownControl is UnknownControl */          break;
+    case 'trade':         /* event.trade is Trade */                break;
+    case 'quote':         /* event.quote is Quote */                break;
+    case 'ohlcvc':        /* event.ohlcvc is Ohlcvc */              break;
+    case 'open_interest': /* event.openInterest is OpenInterest */  break;
   }
 });
 ```
 
-Truncated / unrecognised wire frames are filtered before the callback
-fires and accounted on the `thetadatadx.fpss.decode_failures` metric
-counter on the Rust side; they never surface as an `FpssEvent`.
+`kind` is a string-literal union (not a `const enum`), so the type information stays self-contained under `"isolatedModules": true` and works across Vite, esbuild, ts-jest, and Next.js.
 
-The `kind` field is typed as a string-literal union narrowed by the
-generated `index.d.ts` — plain strings, not a TS `const enum`, so the
-type information stays self-contained under
-`"isolatedModules": true` and works in every toolchain including
-Vite, esbuild, ts-jest, and Next.js.
+> [!NOTE]
+> Wherever a 64-bit integer crosses the boundary it surfaces as `bigint`, not
+> `number` — `volume` and `count` on OHLC / EOD ticks, `droppedEventCount()`,
+> and `receivedAtNs` on every event. Use `42n` literals for comparisons, or
+> widen with `Number(x)` at the point of display.
 
-Each typed control payload mirrors the corresponding `FpssControl::*`
-Rust variant one-for-one — `Disconnected.reason` / `Reconnecting.reason`
-carry the `RemoveReason` discriminant as `i32`, `Reconnecting.delayMs` is
-`bigint` (`u64`), `Ping.payload` and `UnknownFrame.payload` are
-`Buffer`-backed byte arrays. Both Python and TypeScript surfaces are
-generated from `fpss_event_schema.toml`, so consumer code ports between
-the two languages without a discriminator rewrite.
+## Flat files
 
-### `bigint` fields
+Whole-universe daily snapshots for one `(security type, request type, date)` at a time. The decoded schema follows the request type, so the binding emits Arrow IPC bytes — pair with `apache-arrow`'s `tableFromIPC` to materialise a typed `Table`:
 
-Anywhere a Rust `u64` or `i64` crosses the napi boundary it surfaces as
-JavaScript `bigint` (not `number`): `volume` and `count` on every
-OHLC / EOD tick, `droppedEventCount()` on the streaming client, and
-`received_at_ns` on every FPSS event. Use `bigint` literal syntax
-(`42n`) for comparisons or widen to `Number(x)` at the point of
-display (watch for loss of precision beyond 2^53).
+```typescript
+import { ThetaDataDxClient } from 'thetadatadx';
+import { tableFromIPC } from 'apache-arrow';   // peer dependency
 
-## Flat Files
+const tdx = ThetaDataDxClient.connectFromFile('creds.txt');
 
-Whole-universe daily snapshots over the legacy MDDS port. Decoded schema
-is determined at runtime by `(SecType, ReqType)`, so the binding emits
-Arrow IPC stream bytes — pair with `apache-arrow`'s `tableFromIPC` to
-materialise a typed `Table`.
-
-```ts
-import { ThetaDataDxClient } from "thetadatadx";
-import { tableFromIPC } from "apache-arrow"; // peer dep
-
-const tdx = ThetaDataDxClient.connectFromFile("creds.txt");
-
-const rows = tdx.flatFiles.optionQuote("20260428");
+const rows = tdx.flatFiles.optionQuote('20260428');
 console.log(rows.len());
 
-const ipc = rows.toArrowIpc();
-const table = tableFromIPC(ipc);
+const table = tableFromIPC(rows.toArrowIpc());
+// Or skip Arrow entirely: const json = JSON.parse(rows.toJson());
 
-// Or skip Arrow and emit a JSON array of objects
-const json = JSON.parse(rows.toJson());
+// Generic dispatcher when security type / request type come from config
+const oi = tdx.flatFiles.request('OPTION', 'OPEN_INTEREST', '20260428');
 
-// Generic dispatcher
-const oi = tdx.flatFiles.request("OPTION", "OPEN_INTEREST", "20260428");
-
-// Raw vendor CSV / JSONL straight to disk
-tdx.flatFileToPath("OPTION", "QUOTE", "20260428",
-                   "/tmp/option-quote", "csv");
+// Or write the raw vendor file straight to disk
+tdx.flatFileToPath('OPTION', 'QUOTE', '20260428', '/tmp/option-quote', 'csv');
 ```
 
-Available `flatFiles.*` methods: `optionQuote`, `optionTrade`,
-`optionTradeQuote`, `optionOhlc`, `optionOpenInterest`, `optionEod`,
-`stockQuote`, `stockTrade`, `stockTradeQuote`, `stockEod`, plus
-`request(secType, reqType, date)`.
+Available `flatFiles.*` methods: `optionQuote`, `optionTrade`, `optionTradeQuote`, `optionOhlc`, `optionOpenInterest`, `optionEod`, `stockQuote`, `stockTrade`, `stockTradeQuote`, `stockEod`, plus `request(secType, reqType, date)`.
+
+## Endpoint coverage
+
+61 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming.
+
+| Category | Endpoints | Examples |
+|---|---|---|
+| Stock | 14 | EOD, OHLC, trades, quotes, snapshots, at-time |
+| Option | 34 | Every stock surface plus five Greeks tiers, open interest, contract lists |
+| Index | 9 | EOD, OHLC, price, snapshots |
+| Calendar | 3 | Market open/close, holidays, early closes |
+| Interest rate | 1 | EOD rate history |
+
+Every endpoint is a camelCase method on `ThetaDataDxClient`. The full method list with JSDoc lives in `index.d.ts` and the [API reference](https://userfrm.github.io/ThetaDataDx/reference/).
+
+## Errors
+
+Every call rejects with a typed error under a common `ThetaDataError` base — authentication, rate limit, not found, deadline exceeded, invalid parameter, and the rest — so the same cases are catchable here exactly as they are in every other binding.
 
 ## Building from source
 
-Only needed if your platform doesn't have a pre-built binary or you want to develop locally:
+Only needed when a platform has no prebuilt binary or you are developing locally:
 
 ```bash
 cd sdks/typescript
@@ -211,11 +199,12 @@ npm install
 npm run build          # requires Rust stable + protoc
 ```
 
-## API reference
+## Documentation
 
-Every historical endpoint from `endpoint_surface.toml` is exposed as a camelCase method on `ThetaDataDxClient`. See `index.d.ts` for the complete method list with JSDoc comments.
+- [Documentation site](https://userfrm.github.io/ThetaDataDx/) — getting started, API reference, streaming, flat files
+- [Repository, issues, contributing](https://github.com/userFRM/ThetaDataDx)
+- Community discussion on the [ThetaData Discord](https://discord.thetadata.us/)
 
-## Docs
+## License
 
-- [Main project README](../../README.md)
-- [API reference](https://userfrm.github.io/ThetaDataDx/reference/)
+Licensed under the Apache License, Version 2.0.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -67,14 +67,29 @@ Real-time quotes and trades flow through the same client. Register a callback wi
 import { Contract, ThetaDataDxClient } from 'thetadatadx';
 
 const tdx = ThetaDataDxClient.connectFromFile('creds.txt');
+const formatContract = (contract: {
+  symbol: string;
+  expiration?: number;
+  strike?: number;
+  right?: string;
+}) => [contract.symbol, contract.expiration, contract.strike, contract.right]
+  .filter((value) => value != null)
+  .join(' ');
 
 tdx.startStreaming((event) => {
-  if (event.kind === 'trade') {
-    const { contract, price, size } = event.trade!;
-    console.log(`${contract.symbol} trade ${price} x ${size}`);
-  } else if (event.kind === 'quote') {
-    const { contract, bid, ask } = event.quote!;
-    console.log(`${contract.symbol} quote ${bid} / ${ask}`);
+  if (event.kind === 'trade' && event.trade) {
+    const { contract, price, size, exchange, msOfDay, sequence, condition } = event.trade;
+    console.log(
+      `${formatContract(contract)} trade price=${price} size=${size} ` +
+      `exchange=${exchange} ms_of_day=${msOfDay} sequence=${sequence} condition=${condition}`,
+    );
+  } else if (event.kind === 'quote' && event.quote) {
+    const { contract, bid, ask, bidSize, askSize, bidExchange, askExchange, msOfDay } = event.quote;
+    console.log(
+      `${formatContract(contract)} quote bid=${bid} ask=${ask} ` +
+      `bid_size=${bidSize} ask_size=${askSize} bid_exchange=${bidExchange} ` +
+      `ask_exchange=${askExchange} ms_of_day=${msOfDay}`,
+    );
   }
 });
 


### PR DESCRIPTION
Rewrites the four per-binding READMEs — Python, TypeScript, C++, and Rust — as registry landing pages in the voice of the top-level README. Each leads with the value proposition (complete coverage, three access modes, DataFrames, streaming, local Greeks, typed errors) and drops the transport and event-dispatch internals that read as engineering notes. Useful reference material stays: endpoint coverage, DataFrame and Arrow terminals, the flat-file method lists, badges, and the recovery callouts.

Every code sample was built against its binding and fixed where it had drifted. The Python wheel, the TypeScript addon, the C++ FFI library, and the Rust crate were all compiled, and each snippet was checked against the result.

- Python — built the wheel in a throwaway venv and confirmed imports, keyword-only `Contract.option`, the typed match-case callback, `SecType.OPTION.full_trades()`, and the local Greeks calculator.
- TypeScript — `tsc --noEmit` against the generated `index.d.ts` under `strict`; corrected the `connectFromFile` factory, the nested `event.trade` / `event.quote` payloads with the `kind` guard, the removal of a `streaming()` form that no longer exists, and a first-order Greek the tick does not carry.
- C++ — compiled and linked every snippet with `g++ -std=c++17` against the header plus the FFI library; the historical `Client`, the dedicated `FpssClient` for streaming, and `UnifiedClient` for flat files.
- Rust — `cargo check` over every snippet; the named `OptionLeg`, `implied_volatility`, and a wildcard arm for the non-exhaustive event enum.

Counts are verified against source: 61 endpoints and 23 local Greeks. License stays Apache-2.0.

Rendered pages on this branch:

- [Python](https://github.com/userFRM/ThetaDataDx/blob/docs/per-binding-readmes-vendor-grade/sdks/python/README.md)
- [TypeScript](https://github.com/userFRM/ThetaDataDx/blob/docs/per-binding-readmes-vendor-grade/sdks/typescript/README.md)
- [C++](https://github.com/userFRM/ThetaDataDx/blob/docs/per-binding-readmes-vendor-grade/sdks/cpp/README.md)
- [Rust](https://github.com/userFRM/ThetaDataDx/blob/docs/per-binding-readmes-vendor-grade/crates/thetadatadx/README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)