### PR TITLE
fix: clear the tdbe-fold CI fallout in docs-site, the TS factory test, and README anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ common `ThetaDataError` base.
 | [`ffi/`](ffi/) | release artifacts | C ABI for embedders |
 | [`tools/cli`](tools/cli/) | `tdx` | Command-line client |
 | [`tools/server`](tools/server/) | `thetadatadx-server` | Local HTTP / WebSocket server |
-| [`tools/mcp`](tools/mcp/) | `thetadatadx-mcp` | MCP server exposing every endpoint to AI clients |
+| [`tools/mcp`](tools/mcp/) | `thetadatadx-mcp` | MCP server exposing every historical endpoint to AI clients |
 | [`docs-site`](docs-site/) | — | Documentation site (GitHub Pages) |
 
 ## Documentation

--- a/docs-site/docs/streaming/options/full-open-interest.md
+++ b/docs-site/docs/streaming/options/full-open-interest.md
@@ -18,7 +18,7 @@ The snippets below assume a connected client with streaming started — see [Get
 ```rust
 use thetadatadx::fpss::protocol::SecTypeExt;
 use thetadatadx::fpss::{FpssData, FpssEvent};
-use tdbe::types::enums::SecType;
+use thetadatadx::SecType;
 
 tdx.start_streaming(|event: &FpssEvent| {
     if let FpssEvent::Data(FpssData::OpenInterest { contract, open_interest, .. }) = event {

--- a/docs-site/docs/streaming/options/full-trade.md
+++ b/docs-site/docs/streaming/options/full-trade.md
@@ -18,7 +18,7 @@ The snippets below assume a connected client with streaming started — see [Get
 ```rust
 use thetadatadx::fpss::protocol::SecTypeExt;
 use thetadatadx::fpss::{FpssData, FpssEvent};
-use tdbe::types::enums::SecType;
+use thetadatadx::SecType;
 
 tdx.start_streaming(|event: &FpssEvent| {
     if let FpssEvent::Data(FpssData::Trade { contract, price, size, .. }) = event {

--- a/docs-site/docs/streaming/stocks/full-trade.md
+++ b/docs-site/docs/streaming/stocks/full-trade.md
@@ -18,7 +18,7 @@ The snippets below assume a connected client with streaming started — see [Get
 ```rust
 use thetadatadx::fpss::protocol::SecTypeExt;
 use thetadatadx::fpss::{FpssData, FpssEvent};
-use tdbe::types::enums::SecType;
+use thetadatadx::SecType;
 
 tdx.start_streaming(|event: &FpssEvent| {
     if let FpssEvent::Data(FpssData::Trade { contract, price, size, .. }) = event {

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -154,6 +154,8 @@ with tdx.streaming(on_event) as session:
     session.subscribe_many([option.quote(), option.trade(), option.open_interest()])
 ```
 
+The option constructor is `Contract.option(symbol, *, expiration, strike, right)` — the leg parameters are keyword-only, so the call site always reads `expiration=…, strike=…, right=…` and never depends on argument order. Pair it with `Contract.stock(symbol)` for equities.
+
 Or take a whole-market feed — every option trade across the universe, no per-contract setup:
 
 ```python

--- a/sdks/typescript/__tests__/typed_surface.test.mjs
+++ b/sdks/typescript/__tests__/typed_surface.test.mjs
@@ -171,7 +171,7 @@ describe('epoch-millisecond tick accessors (cross-binding parity)', () => {
   // the camelCase parity of the Python `*_timestamp_ms` property and the
   // C++ `tdx::timestamp_ms` free function. The value is Unix epoch
   // milliseconds (UTC, DST-aware), computed once at conversion time
-  // through the one shared core (`tdbe::time::date_ms_to_epoch_ms`); the
+  // through the one shared core (`thetadatadx::time::date_ms_to_epoch_ms`); the
   // raw milliseconds-of-day columns stay primary and the field is
   // optional (`undefined` when `date` is absent). These assertions pin
   // the JS-visible shape — name, `bigint` type, optionality — so a
@@ -242,7 +242,7 @@ describe('epoch-millisecond tick accessors (cross-binding parity)', () => {
 
   it('every epoch field is computed through the one shared DST-aware core, not reimplemented', () => {
     // The generated factory resolves each accessor by calling the same
-    // `tdbe::time::date_ms_to_epoch_ms(date, ms_of_day)` the Python
+    // `thetadatadx::time::date_ms_to_epoch_ms(date, ms_of_day)` the Python
     // property and the `tdx_timestamp_ms` FFI route through — the single
     // DST-aware implementation. No binding reimplements the Eastern-Time
     // offset rules, so the epoch value is identical across a DST boundary
@@ -253,7 +253,7 @@ describe('epoch-millisecond tick accessors (cross-binding parity)', () => {
       resolve(__dirname, '..', 'src', '_generated', 'tick_classes.rs'),
       'utf8'
     );
-    const assignments = factorySrc.match(/\w*timestamp_ms:\s*tdbe::time::date_ms_to_epoch_ms\([^)]*\)\.map\(BigInt::from\)/g);
+    const assignments = factorySrc.match(/\w*timestamp_ms:\s*thetadatadx::time::date_ms_to_epoch_ms\([^)]*\)\.map\(BigInt::from\)/g);
     assert.ok(assignments, 'expected generated timestamp_ms factory assignments');
     // 1 created + 1 last_trade + 19 timestamp_ms + 11 underlying + 1 quote
     // = 33 epoch-millisecond fields, one per (date, *_ms_of_day) pair.


### PR DESCRIPTION
Follow-up to #721 (already merged). Folding `tdbe` into `thetadatadx` left three CI checks red that the SDK-surface drift gate did not cover — each because the data-format layer is now reached as `thetadatadx::*` rather than the former `tdbe::*` crate path. This makes all three green on `main`.

## 1. Wire-schema / docs-site drift

`cargo run -p thetadatadx --features config-file,__internal --bin generate_docs_site --locked -- --check` failed: three checked-in streaming pages embedded a Rust example whose import line is emitted as `use thetadatadx::SecType;` after the fold, but still carried the old `use tdbe::types::enums::SecType;`. The `generate_docs_site` binary is a separate generator from `generate_sdk_surfaces`, so the SDK-surface drift check passed while the docs-site tree was stale. Regenerated `docs-site/docs/streaming/{stocks/full-trade,options/full-trade,options/full-open-interest}.md`; `--check` now matches the registries.

## 2. TypeScript timestamp-factory test

The typed-surface test pinned the epoch-millisecond factory family by matching the literal `tdbe::time::date_ms_to_epoch_ms` against the generated `tick_classes.rs`. The 33 factory assignments were never lost — they route through the public `thetadatadx::time::date_ms_to_epoch_ms` after the fold — so the regex and its comments are updated to the public path. `npm test` is green (119 passing).

## 3. Docs-consistency anchors

`python3 scripts/check_docs_consistency.py` requires the root README to describe the MCP server as exposing "every historical endpoint" (the rewrite had dropped "historical") and the Python README to document the keyword-only `Contract.option(symbol, *, expiration, strike, right)` signature. Both restored in the vendor-grade voice the README rewrites established. The "Documentation site (GitHub Pages)" anchor the checker also wants was already present, so it is untouched.

## Verification

Every previously-failing check passes locally, and the full CI-equivalent set is green: `generate_docs_site --check`, `generate_sdk_surfaces --check`, `refresh_grpc_snapshot` with a clean `git diff`, `check_docs_consistency.py`, `check_binding_parity.py` (and `--selftest` + the harness), `check_c_abi_completeness.py` (263 symbols), `check_version_sync.py`, `check_lockfile_drift.py`, the safety-comment check, `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo doc`, the wrapped `cargo test` (1091 passing), the TypeScript `npm test` (119 passing), the Python wheel build + import (no `tdbe` symbol), and `cargo build` for the workspace plus the four excluded crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)