### PR TITLE
ci(python): drop the 3.13t free-threaded job — pyo3 0.29 floors nogil at 3.14

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,18 +36,18 @@ jobs:
           - os: windows-latest
             python: "3.12"
             label: windows py3.12
-          # PEP 703 free-threaded build. PyO3 0.28 emits a per-version
-          # wheel (`cp313-cp313t-*`) rather than an `abi3` wheel because
-          # the free-threaded ABI is not compatible with the stable ABI
+          # PEP 703 free-threaded build. PyO3 emits a per-version wheel
+          # (`cp314-cp314t-*`) rather than an `abi3` wheel because the
+          # free-threaded ABI is not compatible with the stable ABI
           # surface — the wheel tag is intentionally narrower than the
           # baseline matrix. The `gil_used = false` attribute on the
           # `#[pymodule]` keeps the GIL disabled after import; without
           # it the free-threaded interpreter auto-re-enables the GIL
           # on first import of an extension module and defeats the
-          # entire purpose of shipping nogil wheels.
-          - os: ubuntu-latest
-            python: "3.13t"
-            label: ubuntu py3.13t (nogil)
+          # entire purpose of shipping nogil wheels. The free-threaded
+          # floor is CPython 3.14: PyO3 does not support the
+          # free-threaded build of CPython below 3.14, so 3.13t carries
+          # no nogil wheel.
           - os: ubuntu-latest
             python: "3.14t"
             label: ubuntu py3.14t (nogil)
@@ -58,10 +58,9 @@ jobs:
           components: clippy
       - uses: actions/setup-python@v6
         with:
-          # The free-threaded interpreter (`3.13t`, `3.14t`) is a
-          # PEP 703 build. `actions/setup-python@v6` honours the `t`
-          # suffix and provisions the `python3.13t` / `python3.14t`
-          # binary the matching wheel needs.
+          # The free-threaded interpreter (`3.14t`) is a PEP 703 build.
+          # `actions/setup-python@v6` honours the `t` suffix and
+          # provisions the `python3.14t` binary the matching wheel needs.
           python-version: ${{ matrix.python }}
       - run: cargo run -p thetadatadx --features config-file --bin generate_sdk_surfaces --locked -- --check
       # `too_many_arguments` is allow-listed because every offender is a
@@ -106,12 +105,12 @@ jobs:
             chmod 0755 /usr/local/bin/protoc
             protoc --version
       # PEP 703 free-threaded wheel — `--interpreter ${{ matrix.python }}`
-      # (e.g. `python3.13t`) tells maturin to emit a `cp313-cp313t-*`
+      # (e.g. `python3.14t`) tells maturin to emit a `cp314-cp314t-*`
       # tagged wheel rather than the `abi3` one. The `gil_used = false`
       # attribute on `#[pymodule]` keeps the GIL disabled after import
       # on the matching interpreter. Built on `ubuntu-latest` host (not
       # the manylinux2014 image) because the freethreaded interpreter
-      # ships in CPython 3.13+, which post-dates the CentOS 7 glibc
+      # ships in CPython 3.14+, which post-dates the CentOS 7 glibc
       # floor — the manylinux floor for nogil wheels lifts to 2.28
       # (manylinux_2_28) automatically.
       - name: Build wheel (Linux freethreaded)
@@ -257,7 +256,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.13t", "3.14t"]
+        python: ["3.14t"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -307,9 +306,9 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           # The abi3 wheel is the one tagged with the host Python the
-          # build job ran on (`3.12`). The freethreaded wheels carry
-          # separate matrix entries (`3.13t`, `3.14t`) and are not part
-          # of the abi3 compatibility surface.
+          # build job ran on (`3.12`). The freethreaded wheel carries
+          # its own matrix entry (`3.14t`) and is not part of the abi3
+          # compatibility surface.
           name: wheel-${{ runner.os }}-3.12
           path: dist/
       - shell: bash
@@ -331,7 +330,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.13t", "3.14t"]
+        python: ["3.14t"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -31,7 +31,7 @@ pip install thetadatadx[arrow]    # raw pyarrow.Table
 pip install thetadatadx[all]      # every optional adapter
 ```
 
-Binary wheels ship for Linux, macOS, and Windows and require no Rust toolchain. Wheels use CPython's stable ABI (`abi3`), so one wheel per platform covers Python 3.12 and up; free-threaded (`3.13t` / `3.14t`) builds run with the GIL disabled and are selected automatically by `pip`.
+Binary wheels ship for Linux, macOS, and Windows and require no Rust toolchain. Wheels use CPython's stable ABI (`abi3`), so one wheel per platform covers Python 3.12 and up; the free-threaded (`3.14t`) build runs with the GIL disabled and is selected automatically by `pip`.
 
 ## Quick start
 

--- a/sdks/python/benches/bench_parallel_throughput.py
+++ b/sdks/python/benches/bench_parallel_throughput.py
@@ -3,9 +3,9 @@
 Measures historical-endpoint throughput while a CPU-bound Python thread
 hammers the interpreter. Under the GIL the CPU thread time-slices with
 the dispatcher thread, so the historical thread sees ~half the
-throughput. Under free-threaded Python (`python3.13t`, `python3.14t`)
-the two threads run on separate cores in parallel and the historical
-thread sees near-baseline throughput.
+throughput. Under free-threaded Python (`python3.14t`) the two threads
+run on separate cores in parallel and the historical thread sees
+near-baseline throughput.
 
 The bench does not need live FPSS credentials. It exercises a pure-Rust
 fast path that already drops the GIL via `Python::detach(|| ...)` in
@@ -15,11 +15,11 @@ reveals whether the SDK actually releases the GIL on the hot path.
 
 Run on both interpreters and compare::
 
-    python3.13   benches/bench_parallel_throughput.py
-    python3.13t  benches/bench_parallel_throughput.py
+    python3.14   benches/bench_parallel_throughput.py
+    python3.14t  benches/bench_parallel_throughput.py
 
 The healthy SDK shows `overhead < 1.5x` on both. Higher overhead on
-3.13 with a held GIL (or a regression) makes the contention thread
+3.14 with a held GIL (or a regression) makes the contention thread
 starve the dispatcher.
 
 Output format is line-delimited JSON so CI can parse without a second

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -39,16 +39,20 @@ python-source = "python"
 # Stable ABI: one wheel per platform covers every CPython 3.12+ release.
 #
 # The `abi3-py312` feature is unconditionally enabled here even on
-# the free-threaded `3.13t` / `3.14t` build matrix entries — PyO3
-# emits a benign warning at build time for those entries
+# the free-threaded `3.14t` build matrix entry — PyO3 emits a benign
+# warning at build time for that entry
 # ("free-threaded build ignores abi3"), but the wheel selection is
 # correct either way: maturin's
-# `--interpreter python3.13t` flag overrides the abi3 emission and
-# tags the wheel `cp313-cp313t-*` (PEP 703 free-threaded ABI, not
-# abi3). The abi3 feature is then a no-op on those builds. Documented
+# `--interpreter python3.14t` flag overrides the abi3 emission and
+# tags the wheel `cp314-cp314t-*` (PEP 703 free-threaded ABI, not
+# abi3). The abi3 feature is then a no-op on that build. Documented
 # as intended; flipping it on / off per matrix entry would require a
 # maturin overlay file that maintains two source-of-truth feature
 # lists. See the GH Actions log for the documented warning shape.
+#
+# The free-threaded floor is CPython 3.14: PyO3 does not support the
+# free-threaded build of CPython below 3.14, so no 3.13t nogil wheel
+# is produced.
 features = ["pyo3/abi3-py312"]
 
 [project.optional-dependencies]

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1759,7 +1759,7 @@ fn split_date_range(start: &str, end: &str) -> PyResult<Vec<(String, String)>> {
 /// happens in compiled Rust — Python is just the interface.
 ///
 /// `gil_used = false` opts the module into PEP 703 free-threaded
-/// interpreters (`python3.13t`, `python3.14t`). Without this attribute
+/// interpreters (`python3.14t`). Without this attribute
 /// the free-threaded build automatically re-enables the GIL on the
 /// first import of this module — which would defeat the entire purpose
 /// of shipping nogil wheels. Every `#[pyclass]` carries either

--- a/sdks/python/tests/test_no_gil.py
+++ b/sdks/python/tests/test_no_gil.py
@@ -197,7 +197,7 @@ def test_parallel_throughput_bench_runs() -> None:
 
     # On a free-threaded interpreter, pin the actual nogil claim. The
     # `sys._is_gil_enabled` probe is the load-bearing source of truth
-    # (Python 3.13t / 3.14t); falling back via `getattr` so the GIL-
+    # (Python 3.14t); falling back via `getattr` so the GIL-
     # build path leaves this assertion latent.
     is_gil_enabled = getattr(sys, "_is_gil_enabled", None)
     if is_gil_enabled is not None and is_gil_enabled() is False:


### PR DESCRIPTION
## Summary

Follow-up to #726 (pyo3 0.29 upgrade). The free-threaded `3.13t` wheel job fails under the upgraded binding because PyO3 0.29 raised its free-threaded support floor to CPython 3.14.

## Root cause

PyO3 0.29's `pyo3-ffi` build script hard-errors against a free-threaded interpreter below 3.14:

```
error: PyO3 does not support the free-threaded build of CPython versions below 3.14, the selected Python version is 3.13
```

The floor is a build-time constant (`MIN_FREE_THREADED_VERSION = 3.14` in `pyo3-ffi`). PyO3 0.28 supported `3.13t`; 0.29 does not. So the `Build wheel (ubuntu py3.13t (nogil))` matrix entry fails at its `Clippy (Python SDK)` step (exit 101) — the failure is the build script rejecting the interpreter, not a fixable clippy lint. Under the supported nogil target (`3.14t`) the exact CI clippy command passes clean.

This is why the local clippy run on #726 was green: it ran against a GIL (`abi3`) interpreter, where the free-threaded floor never applies. Reproduced locally with `PYO3_PYTHON=$(which python3.13t) cargo clippy --all-targets -- -D warnings -A clippy::too_many_arguments` (the exact CI step), which fails identically; the same command on `3.14t` passes.

## Fix

The 3.13 free-threaded build can no longer produce a nogil wheel under pyo3 0.29, so `3.13t` is removed from the three matrices that referenced it:

- `build` (wheel build + clippy)
- `nogil-throughput` (parallel-throughput gate)
- `freethreaded` (GIL-stays-disabled smoke)

`3.14t` remains as the supported nogil target; the 3.12-and-up `abi3` surface is untouched. The build-manifest and docstring examples that named `3.13t` / `cp313-cp313t` are refreshed so the documented wheel set matches what is produced. This is the accurate fix for the upstream floor change, not a lint suppression.

## Verification

- EXACT CI free-threaded clippy on the supported target — `PYO3_PYTHON=$(which python3.14t) cargo clippy --all-targets -- -D warnings -A clippy::too_many_arguments` — passes clean.
- Regular GIL clippy + `cargo fmt --all --check` (workspace + Python crate): clean, no regression.
- Generator byte-identical drift check (58 files): clean.
- Free-threaded `3.14t` wheel builds end-to-end (`maturin build --release --interpreter python3.14t` -> `cp314-cp314t` tag), installs in a `3.14t` venv, imports, and `sys._is_gil_enabled()` returns `False` (the `gil_used = false` attribute holds — mirrors the `freethreaded` smoke job).
- `python.yml` parses as valid YAML.
