### PR TITLE
fix(fpss): prefer the last-known-good host on reconnect

### DIFF
--- a/crates/thetadatadx/src/fpss/connection.rs
+++ b/crates/thetadatadx/src/fpss/connection.rs
@@ -65,9 +65,12 @@ pub(crate) struct ConnectWithStreamArgs<'a> {
     pub creds: &'a Credentials,
     pub stream: FpssStream,
     pub server_addr: String,
-    /// Host list in the order the reconnect path should try, i.e.
-    /// AFTER [`order_hosts`] has applied the selection policy.
+    /// Declared FPSS host list. The initial connect applies
+    /// [`order_hosts`] with `preferred = None`; reconnects may promote
+    /// the last stable host while re-running the policy on the tail.
     pub hosts: &'a [(String, u16)],
+    pub host_selection: HostSelectionPolicy,
+    pub host_shuffle_seed: u64,
     pub ring_size: usize,
     pub derive_ohlcvc: bool,
     pub flush_mode: FpssFlushMode,
@@ -143,16 +146,27 @@ pub(crate) fn order_hosts(
     hosts: &[(String, u16)],
     policy: HostSelectionPolicy,
     seed: u64,
+    preferred: Option<usize>,
 ) -> Vec<(String, u16)> {
-    match policy {
-        HostSelectionPolicy::FixedOrder => hosts.to_vec(),
+    let preferred = preferred.and_then(|idx| hosts.get(idx).map(|host| (idx, host.clone())));
+    let preferred_idx = preferred.as_ref().map(|(idx, _)| *idx);
+    let mut ordered = match policy {
+        HostSelectionPolicy::FixedOrder => hosts
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| preferred_idx != Some(*idx))
+            .map(|(_, host)| host.clone())
+            .collect(),
         // `HostSelectionPolicy` is non_exhaustive; route any future
         // variant added without an arm here to the safe default.
         _ => {
             // Group by hostname, preserving first-seen group order as
             // the pre-shuffle baseline.
             let mut groups: Vec<(String, Vec<u16>)> = Vec::new();
-            for (host, port) in hosts {
+            for (idx, (host, port)) in hosts.iter().enumerate() {
+                if preferred_idx == Some(idx) {
+                    continue;
+                }
                 match groups.iter_mut().find(|(h, _)| h == host) {
                     Some((_, ports)) => ports.push(*port),
                     None => groups.push((host.clone(), vec![*port])),
@@ -183,7 +197,11 @@ pub(crate) fn order_hosts(
             }
             ordered
         }
+    };
+    if let Some((_, preferred_host)) = preferred {
+        ordered.insert(0, preferred_host);
     }
+    ordered
 }
 
 /// Establish a TLS connection to the first reachable FPSS server.
@@ -454,7 +472,7 @@ mod tests {
     #[test]
     fn order_hosts_fixed_order_preserves_declaration() {
         let hosts = production_hosts();
-        let ordered = order_hosts(&hosts, HostSelectionPolicy::FixedOrder, 42);
+        let ordered = order_hosts(&hosts, HostSelectionPolicy::FixedOrder, 42, None);
         assert_eq!(ordered, hosts);
     }
 
@@ -464,14 +482,14 @@ mod tests {
     #[test]
     fn order_hosts_shuffled_is_deterministic_per_seed() {
         let hosts = production_hosts();
-        let a = order_hosts(&hosts, HostSelectionPolicy::Shuffled, 7);
-        let b = order_hosts(&hosts, HostSelectionPolicy::Shuffled, 7);
+        let a = order_hosts(&hosts, HostSelectionPolicy::Shuffled, 7, None);
+        let b = order_hosts(&hosts, HostSelectionPolicy::Shuffled, 7, None);
         assert_eq!(a, b, "same seed must produce the same order");
         // A different seed must be able to produce a different order;
         // with 2 groups x 2 ports there are 8 distinct outcomes, so
         // scanning a small seed range must find at least one divergence.
         let found_divergent =
-            (0..32_u64).any(|s| order_hosts(&hosts, HostSelectionPolicy::Shuffled, s) != a);
+            (0..32_u64).any(|s| order_hosts(&hosts, HostSelectionPolicy::Shuffled, s, None) != a);
         assert!(found_divergent, "shuffle must depend on the seed");
     }
 
@@ -482,7 +500,7 @@ mod tests {
     fn order_hosts_shuffled_interleaves_fault_domains() {
         let hosts = production_hosts();
         for seed in 0..64_u64 {
-            let ordered = order_hosts(&hosts, HostSelectionPolicy::Shuffled, seed);
+            let ordered = order_hosts(&hosts, HostSelectionPolicy::Shuffled, seed, None);
             assert_eq!(ordered.len(), 4, "no hosts may be lost");
             // Same multiset of entries.
             let mut sorted_in = hosts.clone();
@@ -508,7 +526,7 @@ mod tests {
         let hosts = production_hosts();
         let mut first_hosts = std::collections::HashSet::new();
         for seed in 0..64_u64 {
-            let ordered = order_hosts(&hosts, HostSelectionPolicy::Shuffled, seed);
+            let ordered = order_hosts(&hosts, HostSelectionPolicy::Shuffled, seed, None);
             first_hosts.insert(ordered[0].0.clone());
         }
         assert_eq!(
@@ -524,7 +542,7 @@ mod tests {
     fn order_hosts_handles_degenerate_shapes() {
         let single = vec![("nj-a.thetadata.us".to_string(), 20000)];
         assert_eq!(
-            order_hosts(&single, HostSelectionPolicy::Shuffled, 1),
+            order_hosts(&single, HostSelectionPolicy::Shuffled, 1, None),
             single
         );
 
@@ -534,12 +552,60 @@ mod tests {
             ("a.example".to_string(), 3),
             ("b.example".to_string(), 9),
         ];
-        let ordered = order_hosts(&asymmetric, HostSelectionPolicy::Shuffled, 5);
+        let ordered = order_hosts(&asymmetric, HostSelectionPolicy::Shuffled, 5, None);
         assert_eq!(ordered.len(), 4);
         let mut sorted_in = asymmetric.clone();
         let mut sorted_out = ordered.clone();
         sorted_in.sort();
         sorted_out.sort();
         assert_eq!(sorted_in, sorted_out);
+    }
+
+    #[test]
+    fn order_hosts_reconnect_pins_last_known_good_host_first() {
+        let hosts = production_hosts();
+        let ordered = order_hosts(&hosts, HostSelectionPolicy::FixedOrder, 42, Some(2));
+        assert_eq!(ordered[0], hosts[2]);
+    }
+
+    #[test]
+    fn order_hosts_reconnect_tail_still_follows_policy() {
+        let hosts = production_hosts();
+        let preferred = 2;
+        let ordered = order_hosts(&hosts, HostSelectionPolicy::Shuffled, 17, Some(preferred));
+        let tail_hosts: Vec<(String, u16)> = hosts
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| *idx != preferred)
+            .map(|(_, host)| host.clone())
+            .collect();
+        let tail = order_hosts(&tail_hosts, HostSelectionPolicy::Shuffled, 17, None);
+        assert_eq!(ordered[0], hosts[preferred]);
+        assert_eq!(&ordered[1..], tail);
+    }
+
+    #[test]
+    fn order_hosts_cold_connect_remains_pure_policy() {
+        let hosts = production_hosts();
+        let ordered = order_hosts(&hosts, HostSelectionPolicy::FixedOrder, 42, None);
+        assert_eq!(ordered, hosts);
+    }
+
+    #[test]
+    fn order_hosts_shuffled_tail_still_varies_after_pinning() {
+        let hosts = production_hosts();
+        let preferred = 2;
+        let tails: std::collections::HashSet<Vec<(String, u16)>> = (0..32_u64)
+            .map(|seed| {
+                let ordered =
+                    order_hosts(&hosts, HostSelectionPolicy::Shuffled, seed, Some(preferred));
+                assert_eq!(ordered[0], hosts[preferred]);
+                ordered[1..].to_vec()
+            })
+            .collect();
+        assert!(
+            tails.len() > 1,
+            "pinning the first reconnect target must still leave a shuffled tail"
+        );
     }
 }

--- a/crates/thetadatadx/src/fpss/io_loop/mod.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/mod.rs
@@ -57,8 +57,8 @@ use crate::tdbe::types::enums::{RemoveReason, StreamMsgType};
 use crate::auth::Credentials;
 use crate::backoff::{BackoffSchedule, JitterMode};
 use crate::config::{
-    FpssFlushMode, ReconnectAttemptClass, ReconnectAttemptLimits, ReconnectPolicy,
-    RATE_LIMITED_JITTER_WINDOW,
+    FpssFlushMode, HostSelectionPolicy, ReconnectAttemptClass, ReconnectAttemptLimits,
+    ReconnectPolicy, RATE_LIMITED_JITTER_WINDOW,
 };
 use crate::error::Error;
 
@@ -151,10 +151,12 @@ pub(in crate::fpss) struct IoLoopArgs<P> {
     /// Mirrors [`crate::config::ReconnectConfig::replay_pace_ms`].
     pub replay_pace_ms: u64,
     pub creds: Credentials,
-    /// Host list in per-client selection order (see
-    /// [`connection::order_hosts`]). The reconnect path additionally
-    /// promotes the last successfully-connected address to the front.
+    /// Declared FPSS host list. Reconnect re-applies the configured
+    /// selection policy to this list, optionally pinning the last
+    /// stable host first.
     pub hosts: Vec<(String, u16)>,
+    pub host_selection: HostSelectionPolicy,
+    pub host_shuffle_seed: u64,
     pub active_subs: ActiveSubs,
     pub active_full_subs: ActiveFullSubs,
     pub dropped: Arc<AtomicU64>,
@@ -175,8 +177,7 @@ pub(in crate::fpss) struct IoLoopArgs<P> {
     pub last_event_at_ns: Arc<AtomicI64>,
     /// Address of the server this session is currently connected to.
     /// Updated after every successful (re)connect + login; read by
-    /// `last_connected_addr()` on the owning client and used by the
-    /// reconnect path to try the last-good host first.
+    /// `last_connected_addr()` on the owning client.
     pub connected_addr: Arc<Mutex<String>>,
     /// Shared monotonic request-id counter. The auto-reconnect path
     /// allocates fresh `req_id` values from this counter for each
@@ -187,6 +188,12 @@ pub(in crate::fpss) struct IoLoopArgs<P> {
     /// Widened to `AtomicI64`; the wire boundary clamps to a positive
     /// `i32` via [`super::wire_req_id`].
     pub next_req_id: Arc<AtomicI64>,
+}
+
+fn host_index(hosts: &[(String, u16)], addr: &str) -> Option<usize> {
+    hosts
+        .iter()
+        .position(|(host, port)| format!("{host}:{port}") == addr)
 }
 
 // Reason: all parameters are moved into this function from a spawned thread closure.
@@ -216,6 +223,8 @@ where
         replay_pace_ms,
         creds,
         hosts,
+        host_selection,
+        host_shuffle_seed,
         active_subs,
         active_full_subs,
         dropped,
@@ -333,6 +342,14 @@ where
     // `io_read_slice` long, plus scheduling), so the deadline now
     // holds regardless of the configured slice size.
     let read_timeout_ms_total = u64::try_from(read_timeout.as_millis()).unwrap_or(u64::MAX);
+    let mut current_host = host_index(
+        &hosts,
+        &connected_addr
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone(),
+    );
+    let mut last_known_good_host = None;
 
     'session: loop {
         // Session-local liveness clock: starts at session entry so a
@@ -603,7 +620,9 @@ where
                 // session that ran cleanly for >= `stable_window`
                 // before this drop earns a fresh budget across all
                 // classes.
-                reconnect_state.maybe_reset_after_stable(limits);
+                if reconnect_state.maybe_reset_after_stable(limits) {
+                    last_known_good_host = current_host;
+                }
                 let attempt = reconnect_state.record(class);
                 let budget = limits.budget_for(class);
                 // Two stop conditions, whichever trips first: the
@@ -758,25 +777,20 @@ where
         }
 
         // --- Attempt new TLS connection and re-authenticate ---
-        // Try the last successfully-connected address first: after a
-        // brief blip on a healthy host, the host that was just working
-        // is the best first guess, and skipping straight back to
-        // list-front would burn a connect timeout against a host that
-        // may still be down. The remaining hosts follow in the
-        // client's selection order.
+        // Pin the most recent host that survived the stable window,
+        // then re-apply the configured policy to the remaining hosts.
+        // Cold connects and unstable sessions stay pure-policy.
         let new_stream = {
-            let last_good = connected_addr
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .clone();
-            let mut ordered: Vec<(&str, u16)> = Vec::with_capacity(hosts.len());
-            for (h, p) in &hosts {
-                if format!("{h}:{p}") == last_good {
-                    ordered.insert(0, (h.as_str(), *p));
-                } else {
-                    ordered.push((h.as_str(), *p));
-                }
-            }
+            let ordered_hosts = connection::order_hosts(
+                &hosts,
+                host_selection,
+                host_shuffle_seed,
+                last_known_good_host,
+            );
+            let ordered: Vec<(&str, u16)> = ordered_hosts
+                .iter()
+                .map(|(host, port)| (host.as_str(), *port))
+                .collect();
             connection::connect_to_servers(&ordered, connect_timeout, read_timeout, keepalive)
         };
 
@@ -889,7 +903,8 @@ where
         // the owning client reflects the live session.
         *connected_addr
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = new_addr;
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = new_addr.clone();
+        current_host = host_index(&hosts, &new_addr);
 
         // Set the short I/O read timeout on the new stream so the io
         // loop can drain commands between reads. Matches the
@@ -1268,12 +1283,14 @@ impl ReconnectCounters {
     /// Decide whether the connection that just disconnected ran long
     /// enough to be considered "stable" — if so, reset all counters
     /// before scheduling the next attempt.
-    fn maybe_reset_after_stable(&mut self, limits: &ReconnectAttemptLimits) {
+    fn maybe_reset_after_stable(&mut self, limits: &ReconnectAttemptLimits) -> bool {
         if let Some(t) = self.last_data_at {
             if t.elapsed() >= limits.stable_window {
                 self.reset_counters();
+                return true;
             }
         }
+        false
     }
 
     /// Wall-clock time since the first attempt of the current
@@ -1421,19 +1438,19 @@ mod tests {
         counters.record(ReconnectAttemptClass::RateLimited);
         counters.record(ReconnectAttemptClass::ServerRestart);
         // No data received yet → no reset.
-        counters.maybe_reset_after_stable(&limits);
+        assert!(!counters.maybe_reset_after_stable(&limits));
         assert_eq!(counters.transient, 2);
         assert_eq!(counters.rate_limited, 1);
         assert_eq!(counters.server_restart, 1);
 
         counters.note_data_received();
         // Data received but not long enough → still no reset.
-        counters.maybe_reset_after_stable(&limits);
+        assert!(!counters.maybe_reset_after_stable(&limits));
         assert_eq!(counters.transient, 2);
         assert_eq!(counters.rate_limited, 1);
 
         std::thread::sleep(Duration::from_millis(8));
-        counters.maybe_reset_after_stable(&limits);
+        assert!(counters.maybe_reset_after_stable(&limits));
         assert_eq!(counters.transient, 0, "stable-window elapsed → reset");
         assert_eq!(counters.rate_limited, 0);
         assert_eq!(counters.server_restart, 0);

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -739,6 +739,8 @@ struct SpawnArgs<'a, P> {
     server_addr: String,
     creds: &'a Credentials,
     hosts: &'a [(String, u16)],
+    host_selection: HostSelectionPolicy,
+    host_shuffle_seed: u64,
     derive_ohlcvc: bool,
     flush_mode: FpssFlushMode,
     policy: ReconnectPolicy,
@@ -844,8 +846,7 @@ pub struct FpssClient {
     /// [`FpssClient::last_event_received_at_unix_nanos`].
     last_event_at_ns: Arc<AtomicI64>,
     /// Address of the live session's server. Updated by the I/O
-    /// thread after every successful reconnect; the reconnect path
-    /// also tries this address first.
+    /// thread after every successful reconnect.
     connected_addr: Arc<Mutex<String>>,
     /// Replay pacing snapshot for [`Self::restore_subscriptions`].
     /// Mirrors the builder's `replay_burst_size` / `replay_pace_ms`.
@@ -1013,12 +1014,11 @@ impl FpssClient {
                 i64::from(*crate::config::fpss_bounds::KEEPALIVE_RETRIES.end()),
             ));
         }
-        // Apply the host-selection policy once per client: the order
-        // produced here is the client's connect AND failover order for
-        // its whole lifetime (the reconnect path additionally promotes
-        // the last-good address to the front).
+        // Apply the host-selection policy once for the cold connect.
+        // Reconnects reuse the same seed, optionally pinning the last
+        // stable host ahead of a policy-ordered tail.
         let seed = host_shuffle_seed.unwrap_or_else(crate::backoff::entropy_u64);
-        let ordered_hosts = connection::order_hosts(hosts, host_selection, seed);
+        let ordered_hosts = connection::order_hosts(hosts, host_selection, seed, None);
         let keepalive = connection::TcpKeepaliveSpec {
             idle: Duration::from_secs(keepalive_idle_secs),
             interval: Duration::from_secs(keepalive_interval_secs),
@@ -1036,7 +1036,9 @@ impl FpssClient {
             creds,
             stream,
             server_addr,
-            hosts: &ordered_hosts,
+            hosts,
+            host_selection,
+            host_shuffle_seed: seed,
             ring_size,
             derive_ohlcvc,
             flush_mode,
@@ -1059,8 +1061,9 @@ impl FpssClient {
 
     /// Connect using a pre-established stream (for testing with mock sockets).
     ///
-    /// `hosts` is the full FPSS server list, needed for auto-reconnect to try
-    /// all servers. Pass an empty slice to disable reconnection to other servers.
+    /// `hosts` is the declared FPSS server list, needed for auto-reconnect to
+    /// re-apply the host-selection policy. Pass an empty slice to disable
+    /// reconnection to other servers.
     ///
     /// Returns the connected client with its internal poller bundled
     /// in; drain via [`Self::next_event`] / [`Self::poll_batch`] /
@@ -1073,6 +1076,8 @@ impl FpssClient {
             mut stream,
             server_addr,
             hosts,
+            host_selection,
+            host_shuffle_seed,
             ring_size,
             derive_ohlcvc,
             flush_mode,
@@ -1233,6 +1238,8 @@ impl FpssClient {
             server_addr,
             creds,
             hosts,
+            host_selection,
+            host_shuffle_seed,
             derive_ohlcvc,
             flush_mode,
             policy,
@@ -1284,6 +1291,8 @@ impl FpssClient {
             server_addr,
             creds,
             hosts,
+            host_selection,
+            host_shuffle_seed,
             derive_ohlcvc,
             flush_mode,
             policy,
@@ -1356,6 +1365,8 @@ impl FpssClient {
                     replay_pace_ms,
                     creds: io_creds,
                     hosts: io_hosts,
+                    host_selection,
+                    host_shuffle_seed,
                     active_subs: io_active_subs,
                     active_full_subs: io_active_full_subs,
                     dropped: io_dropped,


### PR DESCRIPTION
## Summary
Record the host that survives the stable window and promote it to the front of the reconnect order.
Re-apply the configured host-selection policy to the remaining hosts so fixed order stays fixed and shuffled tails still spread reconnect load.
Cold connects remain unchanged because they still use pure policy ordering with no preferred host.

## Testing
cargo fmt --all -- --check
cargo clippy --workspace -- -D warnings
setsid timeout --kill-after=10s 600s cargo test -p thetadatadx fpss

Closes #691
🤖 Generated with [Claude Code](https://claude.com/claude-code)