### PR TITLE
docs: reference public crate paths in SDK comments

### DIFF
--- a/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
+++ b/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
@@ -1294,7 +1294,7 @@ async fn main() -> Result<(), thetadatadx::Error> {
     case 'option_flow_scanner': return `${rustHeader()}
 use thetadatadx::fpss::{FpssEvent, FpssData};
 use thetadatadx::fpss::protocol::SecTypeExt;
-use tdbe::types::enums::SecType;
+use thetadatadx::SecType;
 
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -2259,7 +2259,7 @@ inline std::string exchange_symbol(int32_t code) {
 }
 
 /// Convert a signed wire-encoded trade-sequence value to its unsigned
-/// monotonic form. Mirrors `tdbe::sequences::signed_to_unsigned`.
+/// monotonic form. Mirrors `thetadatadx::utils::sequences::signed_to_unsigned`.
 /// `signed_value` must lie in the i32 wire range
 /// (`-2'147'483'648 ..= 2'147'483'647`); a value outside that domain
 /// throws @c tdx::InvalidParameterError rather than being silently
@@ -2274,7 +2274,7 @@ inline uint64_t sequence_signed_to_unsigned(int64_t signed_value) {
 }
 
 /// Convert an unsigned monotonic trade-sequence value back to its
-/// signed wire encoding. Mirrors `tdbe::sequences::unsigned_to_signed`.
+/// signed wire encoding. Mirrors `thetadatadx::utils::sequences::unsigned_to_signed`.
 /// `unsigned_value` must lie in the unsigned wire range
 /// (`0 ..= 2^32 - 1`); a value above that domain throws
 /// @c tdx::InvalidParameterError rather than being silently
@@ -2361,7 +2361,7 @@ inline std::string_view sec_type_name(int32_t sec_type) noexcept {
 }
 
 /// Disconnect reason name (`"TooManyRequests"`, `"InvalidCredentials"`,
-/// ...). Mirrors `tdbe::types::enums::RemoveReason::as_str()` on the
+/// ...). Mirrors `thetadatadx::RemoveReason::as_str()` on the
 /// Rust core and the Python / TypeScript `reason_name` field surface.
 /// Returns `"Unspecified"` for unrecognised discriminants so callers
 /// stay total.

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -985,7 +985,7 @@ def implied_volatility(
 class AllGreeks:
     """All 23 Black-Scholes Greeks plus IV returned by ``all_greeks(...)``.
 
-    Field order mirrors ``tdbe::greeks::GreeksResult`` (the Rust
+    Field order mirrors ``thetadatadx::GreeksResult`` (the Rust
     single-source-of-truth the binding wraps): the model value and IV
     pair first, then first-, second-, and third-order Greeks, then the
     ``d1`` / ``d2`` auxiliaries. Every attribute is a plain ``float``.


### PR DESCRIPTION
## What

Three public SDK surfaces — the C++ header, the Python type stub, and the docs-site query-builder example — described types by their internal `tdbe` module path. That module is `pub(crate)`, so a reader who follows `tdbe::greeks::GreeksResult` or `use tdbe::types::enums::SecType;` lands on a path that does not resolve from outside the crate.

Each reference now points at the public re-export the type actually ships under:

- `tdbe::greeks::GreeksResult` → `thetadatadx::GreeksResult` (Python `AllGreeks` field-order note)
- `tdbe::sequences::{signed_to_unsigned,unsigned_to_signed}` → `thetadatadx::utils::sequences::*` (C++ sequence helpers)
- `tdbe::types::enums::RemoveReason::as_str()` → `thetadatadx::RemoveReason::as_str()` (C++ `reason_name`)
- `use tdbe::types::enums::SecType;` → `use thetadatadx::SecType;` (docs-site option-flow example)

The query-builder snippet now compiles as written.

## Scope

Comment and example text only — no API, codegen, or generated output changes. Internal `crate::tdbe::*` references and historical changelog entries are left untouched: the former are the correct in-crate paths, the latter accurately record the API as it shipped at the time.

## Verify

`cargo fmt --all -- --check`, `check_binding_parity.py`, `check_docs_consistency.py`, and both `generate_sdk_surfaces --check` / `generate_docs_site --check` drift gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
