### PR TITLE
fix(typescript): accept a Config in the client connect factories

### DIFF
--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -4,9 +4,10 @@
  * SDK configuration. Mirrors [`thetadatadx::DirectConfig`].
  *
  * Build a config via one of the three static factories
- * ([`Config::production`] / [`Config::dev`] / [`Config::stage`]),
+ * ([`Config::production`] / [`Config::dev`] / [`Config::stage`]), tune
+ * it with the setters below, then pass it to
  * `ThetaDataDxClient.connectWithConfig` /
- * `connectFromFileWithConfig`.
+ * `ThetaDataDxClient.connectFromFileWithConfig`.
  *
  * Mutating methods follow JS convention and
  * return `void` (chain by calling `cfg.method(...)` then passing
@@ -602,6 +603,26 @@ export declare class ThetaDataDxClient {
   static connect(email: string, password: string): ThetaDataDxClient
   /** Connect with a credentials file (line 1 = email, line 2 = password). */
   static connectFromFile(path: string): ThetaDataDxClient
+  /**
+   * Connect to ThetaData against an explicit [`Config`] (`dev` /
+   * `stage` / `production`, plus any tuned setters). Historical
+   * (MDDS/gRPC) only; call startStreaming() to begin FPSS real-time
+   * data. Use `connect` for the production-default endpoint.
+   *
+   * The config is snapshot at connect time: the `Config` handle may
+   * be reused or mutated afterward without affecting this client.
+   */
+  static connectWithConfig(email: string, password: string, config: Config): ThetaDataDxClient
+  /**
+   * Connect with a credentials file (line 1 = email, line 2 =
+   * password) against an explicit [`Config`] (`dev` / `stage` /
+   * `production`, plus any tuned setters). Use `connectFromFile` for
+   * the production-default endpoint.
+   *
+   * The config is snapshot at connect time: the `Config` handle may
+   * be reused or mutated afterward without affecting this client.
+   */
+  static connectFromFileWithConfig(path: string, config: Config): ThetaDataDxClient
   /**
    * Cumulative count of FPSS events the TLS reader could not
    * publish into the event ring because the event-dispatch consumer

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -41,9 +41,10 @@ fn bigint_to_u64(name: &str, v: &napi::bindgen_prelude::BigInt) -> napi::Result<
 /// SDK configuration. Mirrors [`thetadatadx::DirectConfig`].
 ///
 /// Build a config via one of the three static factories
-/// ([`Config::production`] / [`Config::dev`] / [`Config::stage`]),
+/// ([`Config::production`] / [`Config::dev`] / [`Config::stage`]), tune
+/// it with the setters below, then pass it to
 /// `ThetaDataDxClient.connectWithConfig` /
-/// `connectFromFileWithConfig`.
+/// `ThetaDataDxClient.connectFromFileWithConfig`.
 ///
 /// Mutating methods follow JS convention and
 /// return `void` (chain by calling `cfg.method(...)` then passing
@@ -88,6 +89,18 @@ impl Config {
         Self {
             inner: Arc::new(Mutex::new(config::DirectConfig::stage())),
         }
+    }
+
+    /// Snapshot the inner [`config::DirectConfig`] for a connect call.
+    ///
+    /// The connect factories take an owned `DirectConfig`, while this
+    /// handle may be reused or mutated afterward, so the value is cloned
+    /// out under the mutex rather than moved. A poisoned mutex is
+    /// recovered (the guarded value stays valid — a setter cannot leave
+    /// the config half-written), matching the Python binding.
+    pub(crate) fn snapshot(&self) -> config::DirectConfig {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.clone()
     }
 
     // ── MDDS pool sizing ───────────────────────────────────────────

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -347,6 +347,59 @@ impl ThetaDataDxClient {
         })
     }
 
+    /// Connect to ThetaData against an explicit [`Config`] (`dev` /
+    /// `stage` / `production`, plus any tuned setters). Historical
+    /// (MDDS/gRPC) only; call startStreaming() to begin FPSS real-time
+    /// data. Use `connect` for the production-default endpoint.
+    ///
+    /// The config is snapshot at connect time: the `Config` handle may
+    /// be reused or mutated afterward without affecting this client.
+    #[napi(factory)]
+    pub fn connect_with_config(
+        email: String,
+        password: String,
+        config: &Config,
+    ) -> napi::Result<ThetaDataDxClient> {
+        let creds = auth::Credentials::new(email, password);
+        let cfg = config.snapshot();
+        let tdx = runtime()
+            .block_on(thetadatadx::ThetaDataDxClient::connect(
+                // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
+                &creds, cfg,
+            ))
+            .map_err(to_napi_err)?;
+        Ok(ThetaDataDxClient {
+            tdx: Arc::new(tdx),
+            callback: Mutex::new(None),
+        })
+    }
+
+    /// Connect with a credentials file (line 1 = email, line 2 =
+    /// password) against an explicit [`Config`] (`dev` / `stage` /
+    /// `production`, plus any tuned setters). Use `connectFromFile` for
+    /// the production-default endpoint.
+    ///
+    /// The config is snapshot at connect time: the `Config` handle may
+    /// be reused or mutated afterward without affecting this client.
+    #[napi(factory)]
+    pub fn connect_from_file_with_config(
+        path: String,
+        config: &Config,
+    ) -> napi::Result<ThetaDataDxClient> {
+        let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
+        let cfg = config.snapshot();
+        let tdx = runtime()
+            .block_on(thetadatadx::ThetaDataDxClient::connect(
+                // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
+                &creds, cfg,
+            ))
+            .map_err(to_napi_err)?;
+        Ok(ThetaDataDxClient {
+            tdx: Arc::new(tdx),
+            callback: Mutex::new(None),
+        })
+    }
+
     /// Cumulative count of FPSS events the TLS reader could not
     /// publish into the event ring because the event-dispatch consumer
     /// fell behind and the ring was full (`Producer::try_publish`


### PR DESCRIPTION
The TypeScript client could only reach production. `connect` and `connectFromFile` both hardcoded the production `DirectConfig`, so `Config.dev()` / `Config.stage()` and every `Config` setter were dead surface — unreachable from JS. The Rust core, Python, and the C ABI all accept a `Config` at connect time, so the TypeScript binding was the lone outlier.

This adds two factories alongside the production-default ones (which stay unchanged for back-compat):

- `ThetaDataDxClient.connectWithConfig(email, password, config)`
- `ThetaDataDxClient.connectFromFileWithConfig(path, config)`

Both snapshot the inner `DirectConfig` out of the `Config` handle and hand it to the core connect path, so the handle can be reused or mutated afterward without affecting the connected client. The `Config` doc comment already named these two methods as the way to apply a config; they are now real, and the wording is corrected to match.

Verified live against the dev FPSS server: `connectFromFileWithConfig(creds, Config.dev())` connects to the dev replay endpoint and streams real Quote / Trade / OHLCVC events that decode with sane prices, sizes, timestamps, and bigint-safe counters — the production-default factories would never see that replay stream.

Gates: `cargo fmt`, `cargo clippy -p thetadatadx-napi -- -D warnings`, SDK-surface and docs-site drift checks, `python3 scripts/check_binding_parity.py`, and `npm run build && npm test` (125 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)