### PR TITLE
fix(typescript): sync the lockfile with the platform optional dependencies

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1823,6 +1823,57 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/thetadatadx-darwin-arm64": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/thetadatadx-darwin-arm64/-/thetadatadx-darwin-arm64-12.0.0.tgz",
+      "integrity": "sha512-TuyPH7tQobUeb06REjfzVx6q6tzH01HzMKHTMV51Ro9M7bY1cVT6ztABXPEhuPGj2l6yu7HwGC+JWtJC0KHr3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/thetadatadx-linux-x64-gnu": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/thetadatadx-linux-x64-gnu/-/thetadatadx-linux-x64-gnu-12.0.0.tgz",
+      "integrity": "sha512-N9BuS6PXnoY2YyLuTMGhTKyFNKUhA6yEJvqJc48qKRNrw1IjNVjXKmdj1NAh099zxwiGa63PWTj6eoRVrCGqAA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/thetadatadx-win32-x64-msvc": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/thetadatadx-win32-x64-msvc/-/thetadatadx-win32-x64-msvc-12.0.0.tgz",
+      "integrity": "sha512-+/7MVCheigax8PvnpNleNDbAjJ6rEXqfnVAqpIKtkx1q0MxXJLe1wBpJXWEyfCjH2jJ316kauagGbvbOXSsZZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",


### PR DESCRIPTION
`npm ci` in `sdks/typescript` failed with EUSAGE: the lockfile declared `thetadatadx-darwin-arm64`, `thetadatadx-linux-x64-gnu`, and `thetadatadx-win32-x64-msvc` under the root `optionalDependencies` but carried no package records for them. A user following the documented `npm ci && npm run build` flow hit `Missing: thetadatadx-* from lock file`.

This adds the `resolved`, `integrity`, `cpu`, `os`, `libc`, `license`, and `engines` records for the three platform packages at `12.0.0`, taken verbatim from the registry. The change is strictly additive: three package entries added, none changed, none removed, and the root dependency declarations are untouched.

Verified in `sdks/typescript`:

- `npm ci` now succeeds and installs the host-matching native binary; the off-platform packages are skipped on os/cpu mismatch as expected.
- `npm run build` succeeds.
- `npm test` passes all 125 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)