### PR TITLE
fix(tls): build client configs with an explicit crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,6 +3413,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rustls",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -140,6 +140,14 @@ sha2 = "0.11.0"
 # `query` enables `RequestBuilder::query` for URL parameter encoding.
 reqwest = { version = "0.13.3", features = ["json", "query", "rustls-no-provider"], default-features = false }
 
+# Trust-root verifier for the auth HTTP client. `rustls-no-provider` leaves
+# reqwest without a baked provider, so its TLS config is built explicitly with
+# the ring provider and this platform verifier (the same trust mechanism reqwest
+# would otherwise pick up) and handed to reqwest via `use_preconfigured_tls`.
+# Already in the graph transitively through reqwest; declared directly so the
+# auth client needs no process-global default.
+rustls-platform-verifier = "0.6.2"
+
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }
 # Cryptographically random bytes for scratch-file disambiguation and ephemeral

--- a/crates/thetadatadx/src/auth/nexus.rs
+++ b/crates/thetadatadx/src/auth/nexus.rs
@@ -238,6 +238,37 @@ pub async fn authenticate(creds: &Credentials) -> Result<AuthResponse, Error> {
     authenticate_at(NEXUS_AUTH_URL, creds).await
 }
 
+/// Build the rustls config for the auth HTTP client with an explicit ring
+/// provider so the handshake needs no process-global default.
+///
+/// reqwest is pinned with `rustls-no-provider`, so it has no provider baked in
+/// and would otherwise read `CryptoProvider::get_default()` — panicking when no
+/// global default is installed. Building the config here and handing it to
+/// reqwest via `use_preconfigured_tls` mirrors reqwest's own default path
+/// (ring provider + platform-verifier trust roots) without depending on global
+/// state. ALPN is set explicitly because a preconfigured config bypasses
+/// reqwest's ALPN defaulting; `h2` + `http/1.1` matches reqwest's auto mode.
+fn auth_tls_config() -> Result<rustls::ClientConfig, Error> {
+    let provider = std::sync::Arc::new(rustls::crypto::ring::default_provider());
+    let verifier = std::sync::Arc::new(
+        rustls_platform_verifier::Verifier::new(provider.clone()).map_err(|e| Error::Auth {
+            kind: crate::error::AuthErrorKind::NetworkError,
+            message: format!("failed to build TLS trust verifier: {e}"),
+        })?,
+    );
+    let mut config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| Error::Auth {
+            kind: crate::error::AuthErrorKind::NetworkError,
+            message: format!("failed to build TLS config: {e}"),
+        })?
+        .dangerous()
+        .with_custom_certificate_verifier(verifier)
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    Ok(config)
+}
+
 /// Authenticate against the Nexus API and return the session info.
 ///
 /// Identical to [`authenticate`] but accepts a caller-supplied URL.
@@ -259,6 +290,7 @@ pub async fn authenticate_at(url: &str, creds: &Credentials) -> Result<AuthRespo
     let auth_start = std::time::Instant::now();
 
     let client = reqwest::Client::builder()
+        .use_preconfigured_tls(auth_tls_config()?)
         .timeout(Duration::from_secs(10))
         .connect_timeout(Duration::from_secs(5))
         .build()

--- a/crates/thetadatadx/src/flatfiles/mdds_spki.rs
+++ b/crates/thetadatadx/src/flatfiles/mdds_spki.rs
@@ -35,19 +35,12 @@ pub(crate) struct MddsSpkiVerifier {
 
 impl MddsSpkiVerifier {
     pub(crate) fn new() -> Arc<Self> {
-        // If another component already installed a provider (FPSS does the
-        // same dance on its TLS path), reuse its signature algorithms.
-        // Otherwise fall back to ring and install it as the process
-        // default — racing with a concurrent installer is fine, since the
-        // local `algs` is captured before the install attempt.
-        let algs = if let Some(provider) = rustls::crypto::CryptoProvider::get_default() {
-            provider.signature_verification_algorithms
-        } else {
-            let provider = rustls::crypto::ring::default_provider();
-            let algs = provider.signature_verification_algorithms;
-            let _ = provider.install_default();
-            algs
-        };
+        // Take the signature algorithms straight from the ring provider rather
+        // than the process-global default. ring is the sole provider in the dep
+        // graph and is what each `ClientConfig` is built with, so the algorithms
+        // match what `rustls` uses on the wire — without depending on any global
+        // installer having fired first.
+        let algs = rustls::crypto::ring::default_provider().signature_verification_algorithms;
         Arc::new(Self { algs })
     }
 }

--- a/crates/thetadatadx/src/flatfiles/session.rs
+++ b/crates/thetadatadx/src/flatfiles/session.rs
@@ -45,10 +45,14 @@ pub(crate) struct MddsHost<'a> {
 
 /// Open a TLS connection to a single MDDS host with SPKI pinning.
 pub(crate) async fn connect_tls(target: MddsHost<'_>) -> Result<TlsStream<TcpStream>, Error> {
-    let cfg = ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(MddsSpkiVerifier::new())
-        .with_no_client_auth();
+    // Build the config with an explicit ring provider so the handshake needs
+    // no process-global default. ring is the sole provider in the dep graph.
+    let cfg =
+        ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()?
+            .dangerous()
+            .with_custom_certificate_verifier(MddsSpkiVerifier::new())
+            .with_no_client_auth();
     let connector = TlsConnector::from(Arc::new(cfg));
     let server_name: ServerName<'static> =
         ServerName::try_from(target.host.to_string()).map_err(|e| {

--- a/crates/thetadatadx/src/fpss/connection.rs
+++ b/crates/thetadatadx/src/fpss/connection.rs
@@ -260,12 +260,16 @@ pub(crate) fn connect_to_servers(
 /// expiry problem into an open **MITM + credential harvest** hole -- the
 /// very next frame after the handshake contains the user's email + password),
 /// we pin on the leaf's SPKI. See [`super::pinning`] for the full rationale.
-fn tls_client_config() -> Arc<ClientConfig> {
-    let config = ClientConfig::builder()
-        .dangerous()
-        .with_custom_certificate_verifier(PinnedVerifier::new())
-        .with_no_client_auth();
-    Arc::new(config)
+fn tls_client_config() -> Result<Arc<ClientConfig>, crate::error::Error> {
+    // Build the config with an explicit ring provider so the handshake needs
+    // no process-global default. ring is the sole provider in the dep graph.
+    let config =
+        ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()?
+            .dangerous()
+            .with_custom_certificate_verifier(PinnedVerifier::new())
+            .with_no_client_auth();
+    Ok(Arc::new(config))
 }
 
 /// Arm `SO_KEEPALIVE` on the freshly-connected socket.
@@ -353,7 +357,7 @@ fn try_connect(
             message: format!("invalid TLS server name '{host}': {e}"),
         })?;
 
-    let tls_conn = ClientConnection::new(tls_client_config(), server_name).map_err(|e| {
+    let tls_conn = ClientConnection::new(tls_client_config()?, server_name).map_err(|e| {
         crate::error::Error::Fpss {
             kind: crate::error::FpssErrorKind::ConnectionRefused,
             message: format!("TLS setup for {addr} failed: {e}"),

--- a/crates/thetadatadx/src/mdds/client.rs
+++ b/crates/thetadatadx/src/mdds/client.rs
@@ -495,9 +495,14 @@ fn build_rustls_config() -> Result<Arc<rustls::ClientConfig>, Error> {
     for cert in webpki_roots::TLS_SERVER_ROOTS.iter().cloned() {
         root_store.roots.push(cert);
     }
-    let mut config = rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+    // Build the config with an explicit ring provider so the handshake needs
+    // no process-global default. ring is the sole provider in the dep graph.
+    let mut config = rustls::ClientConfig::builder_with_provider(std::sync::Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()?
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
     config.alpn_protocols = vec![b"h2".to_vec()];
     Ok(Arc::new(config))
 }


### PR DESCRIPTION
Build every client TLS config with an explicit ring crypto provider so a connection needs no process-global rustls default to be installed first. A standalone Rust consumer can now call `connect()` directly; previously the first handshake read the process-global default provider and failed cryptically when none was installed.

The FPSS, MDDS, and flatfiles paths now use `ClientConfig::builder_with_provider(ring)` with explicit protocol versions instead of `ClientConfig::builder()`, and the MDDS SPKI verifier reads its signature algorithms straight from the ring provider rather than `CryptoProvider::get_default()`.

The auth HTTP client surfaced a fourth path: reqwest is pinned with `rustls-no-provider`, so it has no baked provider and otherwise reads the global default, panicking when none is installed. Its TLS config is now built with an explicit ring provider plus the platform-verifier trust roots and handed to reqwest via `use_preconfigured_tls`, mirroring reqwest's own default trust path without global state.

ring is the sole provider in the dependency graph, so the explicit provider matches what rustls uses on the wire on every path.

The process-global installer hook is left in place unchanged; the point is that a connection no longer depends on it.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`: clean.
- `cargo test --workspace --features thetadatadx/__test-helpers`: 1097 passed, 0 failed.
- SDK-surface and docs-site generated-file drift `--check`, `check_docs_consistency.py`, `check_binding_parity.py`, `check_lockfile_drift.py`: clean. The only lockfile change promotes `rustls-platform-verifier` (already present transitively) to a direct dependency.
- Live standalone proof against production and dev data servers, with no manual provider install of any kind: the auth, MDDS, and FPSS handshakes all succeed. A historical stock EOD query returned rows and an FPSS subscribe delivered live ticks on both presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)