### PR TITLE
feat(typescript): add historical-result streaming to the TypeScript SDK

### DIFF
--- a/crates/thetadatadx/build_support_bin/endpoints/sdk_render/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/endpoints/sdk_render/typescript.rs
@@ -21,14 +21,26 @@
 //! parameter. `timeoutMs` rides in the same object: when set, the call is
 //! given a deadline; on expiry the Promise rejects and the underlying
 //! request is cancelled. The `ThetaDataDxClient` handle remains usable.
+//!
+//! Every history endpoint that returns a typed row collection also gets a
+//! `<endpoint>Stream(...args, options, callback)` server-stream companion
+//! (the TypeScript surface of the Python builders' `.stream(handler)`).
+//! Instead of buffering the whole response, it pumps each decoded gRPC
+//! chunk to `callback(chunk: Tick[])` through a napi-rs
+//! `ThreadsafeFunction`, so peak memory tracks one chunk rather than the
+//! full result — the path the `Config.setWarnOnBufferedThresholdBytes`
+//! warning points oversized buffered pulls at. The coverage set mirrors
+//! the Python streaming builders exactly (non-snapshot, non-FPSS-kind
+//! endpoints that decode to a row collection); snapshot endpoints and the
+//! flat `StringList` list endpoints have no stream companion.
 
 use std::fmt::Write as _;
 
 use super::super::helpers::{compose_endpoint_doc, is_streaming_endpoint};
 use super::super::model::GeneratedEndpoint;
 use super::super::sdk_helpers::{
-    builder_params, is_time_arg, method_params, render_rust_doc_block, sdk_method_arg_name,
-    to_camel_case, to_go_exported_name, ts_class_name, ts_class_vec_converter,
+    builder_params, is_snapshot_endpoint, is_time_arg, method_params, render_rust_doc_block,
+    sdk_method_arg_name, to_camel_case, to_go_exported_name, ts_class_name, ts_class_vec_converter,
 };
 
 pub(super) fn render_typescript_historical_methods(endpoints: &[GeneratedEndpoint]) -> String {
@@ -52,9 +64,32 @@ pub(super) fn render_typescript_historical_methods(endpoints: &[GeneratedEndpoin
     {
         out.push_str(&render_typescript_endpoint_method(endpoint));
         out.push('\n');
+        // Server-stream terminal companion. Emitted for every endpoint
+        // that gets `.stream(handler)` / `.stream_async(handler)` on the
+        // Python parsed builders (see `python.rs::write_sync_stream_terminal`):
+        // a non-snapshot, non-streaming-kind history endpoint that returns a
+        // typed row collection. Snapshot endpoints (≤10 rows) and the
+        // `StringList` list endpoints (which return bare strings, not a tick
+        // collection) are excluded — streaming a handful of rows or a flat
+        // string list buys nothing over the buffered method.
+        if endpoint_streams(endpoint) {
+            out.push_str(&render_typescript_endpoint_stream_method(endpoint));
+            out.push('\n');
+        }
     }
     out.push_str("}\n");
     out
+}
+
+/// True when an endpoint gets the `<endpoint>Stream(callback)` server-stream
+/// terminal. Mirrors the Python parsed-builder predicate
+/// (`!is_snapshot && !is_streaming_kind`) and additionally excludes the
+/// `StringList` list endpoints — those return a flat `string[]`, not a typed
+/// row collection, so the row-chunk callback shape does not apply.
+fn endpoint_streams(endpoint: &GeneratedEndpoint) -> bool {
+    !is_snapshot_endpoint(endpoint)
+        && !is_streaming_endpoint(endpoint)
+        && endpoint.return_type != "StringList"
 }
 
 /// `stock_history_eod` -> `StockHistoryEodOptions`.
@@ -321,6 +356,204 @@ fn render_typescript_endpoint_method(endpoint: &GeneratedEndpoint) -> String {
         ts_class_vec_converter(&endpoint.return_type)
     )
     .unwrap();
+    out.push_str("    }\n");
+    out
+}
+
+/// Emit the `<endpoint>Stream(...callback)` server-stream terminal — the
+/// TypeScript companion to the Python parsed builder's `.stream(handler)`.
+///
+/// The method takes the endpoint's required positional parameters, then the
+/// same trailing `Options` object the buffered method takes (so `timeoutMs`
+/// and every optional builder param ride along identically), and finally a
+/// JS `callback`. Each decoded gRPC chunk is converted to the typed row
+/// array (`Tick[]`) and delivered to `callback` through a napi-rs
+/// `ThreadsafeFunction`, which routes the call onto the Node main thread —
+/// the only thread allowed to execute V8. The decoder-owned chunk is dropped
+/// the moment the converter returns, so peak memory tracks one chunk, never
+/// the full response: the memory-bounded path the `Config` doc points
+/// buffered callers at.
+///
+/// The callback is the LAST positional argument (after the options object)
+/// rather than riding inside the options object: a `ThreadsafeFunction`
+/// cannot be a `#[napi(object)]` field, and a trailing function argument is
+/// the JavaScript idiom for a stream sink. `callback(chunk: Tick[]) => void`
+/// is invoked once per gRPC chunk; a slow callback applies bounded
+/// back-pressure (`Blocking` call mode) rather than dropping rows.
+fn render_typescript_endpoint_stream_method(endpoint: &GeneratedEndpoint) -> String {
+    let method_params = method_params(endpoint);
+    let builder_params = builder_params(endpoint);
+    let camel_name = to_camel_case(&endpoint.name);
+    let stream_camel = format!("{camel_name}Stream");
+    let struct_name = options_struct_name(endpoint);
+    let tick_class = ts_class_name(&endpoint.return_type);
+    let vec_converter = ts_class_vec_converter(&endpoint.return_type);
+    let mut out = String::new();
+
+    let doc = format!(
+        "Stream `{name}` rows into `callback` without materialising the full \
+         response in memory. `callback(chunk: {tick}[]) => void` is invoked once \
+         per server chunk; the chunk is freed before the next is fetched, so peak \
+         memory tracks a single chunk rather than the whole result. This is the \
+         memory-bounded companion to [`ThetaDataDxClient::{camel}`] — prefer it \
+         for multi-day or full-universe pulls. The returned Promise resolves when \
+         the stream drains and rejects (typed like the buffered method) on a wire \
+         or decode error. Cancelling the Promise drops the in-flight request. \
+         `options` carries the same optional builder parameters and `timeoutMs` \
+         as the buffered method; the `callback` is the trailing argument.",
+        name = endpoint.name,
+        tick = tick_class,
+        camel = camel_name,
+    );
+    out.push_str(&render_rust_doc_block("    ", &doc));
+    writeln!(out, "    #[napi(js_name = \"{stream_camel}\")]").unwrap();
+    writeln!(out, "    pub async fn {name}_stream(", name = endpoint.name).unwrap();
+    out.push_str("        &self,\n");
+    for param in &method_params {
+        writeln!(
+            out,
+            "        {}: {},",
+            sdk_method_arg_name(param),
+            ts_napi_arg_type(param)
+        )
+        .unwrap();
+    }
+    writeln!(out, "        options: Option<{struct_name}>,").unwrap();
+    // `ErrorStrategy::Fatal` (the `false` const generic): the chunk array is
+    // passed to `call` directly, not as a `Result`, and a JS-callback throw
+    // surfaces through Node's own `uncaughtException` — matching the FPSS
+    // streaming callback contract on this same client.
+    writeln!(
+        out,
+        "        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<{tick_class}>, (), Vec<{tick_class}>, napi::Status, false>,"
+    )
+    .unwrap();
+    out.push_str("    ) -> napi::Result<()> {\n");
+
+    out.push_str("        let options = options.unwrap_or_default();\n");
+    out.push_str("        let timeout_ms = match options.timeout_ms {\n");
+    out.push_str("            Some(ms) => Some(validate_timeout_ms(ms)?),\n");
+    out.push_str("            None => None,\n");
+    out.push_str("        };\n");
+    out.push_str("        let tdx = self.tdx.clone();\n");
+
+    let has_symbols = method_params
+        .iter()
+        .any(|param| param.param_type == "Symbols");
+    if has_symbols {
+        out.push_str("        let symbols = normalize_symbols(symbols);\n");
+    }
+    for param in &method_params {
+        let arg_name = sdk_method_arg_name(param);
+        match param.param_type.as_str() {
+            "Date" | "Expiration" => {
+                writeln!(out, "        let {arg_name} = normalize_date({arg_name});").unwrap();
+            }
+            _ if is_time_arg(param) => {
+                writeln!(out, "        let {arg_name} = normalize_time({arg_name});").unwrap();
+            }
+            _ => {}
+        }
+    }
+    for param in &builder_params {
+        match param.param_type.as_str() {
+            "Date" | "Expiration" => {
+                writeln!(
+                    out,
+                    "        let {} = normalize_optional_date(options.{});",
+                    param.name, param.name
+                )
+                .unwrap();
+            }
+            _ if is_time_arg(param) => {
+                writeln!(
+                    out,
+                    "        let {} = normalize_optional_time(options.{});",
+                    param.name, param.name
+                )
+                .unwrap();
+            }
+            _ => {
+                writeln!(out, "        let {} = options.{};", param.name, param.name).unwrap();
+            }
+        }
+    }
+
+    // Bind the callback behind an `Arc`: the `FnMut(&[Tick]) + Send` chunk
+    // closure the core `request.stream` takes captures the handle, and
+    // `ThreadsafeFunction` is `Send + Sync` but does not implement `Clone`
+    // in napi-rs 3.x — the outer `Arc` is the canonical share path (same as
+    // the FPSS `startStreaming` registration on this client).
+    out.push_str("        let callback = std::sync::Arc::new(callback);\n");
+
+    let positional_args = method_params
+        .iter()
+        .map(|param| {
+            if param.param_type == "Symbols" {
+                "&refs".into()
+            } else if matches!(param.param_type.as_str(), "Date" | "Expiration")
+                || is_time_arg(param)
+            {
+                format!("{}.as_str()", sdk_method_arg_name(param))
+            } else {
+                format!("&{}", sdk_method_arg_name(param))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    // The builder + the gRPC server-stream run on `runtime()` (the reactor
+    // that owns the connection's sockets), spawned off the V8 thread exactly
+    // like the buffered method, so the Node event loop stays free for the
+    // whole drain.
+    out.push_str("        spawn_endpoint_task(async move {\n");
+    if has_symbols {
+        out.push_str(
+            "            let refs: Vec<&str> = symbols.iter().map(|s| s.as_str()).collect();\n",
+        );
+    }
+    writeln!(
+        out,
+        "            let mut request = tdx.{}({});",
+        endpoint.name, positional_args
+    )
+    .unwrap();
+    for param in &builder_params {
+        writeln!(out, "            if let Some(value) = {} {{", param.name).unwrap();
+        let setter_arg = match param.param_type.as_str() {
+            "Int" | "Float" | "Bool" => "value".to_string(),
+            _ => "value.as_str()".to_string(),
+        };
+        writeln!(
+            out,
+            "                request = request.{}({});",
+            param.name, setter_arg
+        )
+        .unwrap();
+        out.push_str("            }\n");
+    }
+    out.push_str("            if let Some(ms) = timeout_ms {\n");
+    out.push_str(
+        "                request = request.with_deadline(std::time::Duration::from_millis(ms));\n",
+    );
+    out.push_str("            }\n");
+    // Per-chunk: convert the decoder-owned `&[Tick]` to the typed napi row
+    // array and hand it to the `ThreadsafeFunction`. `Blocking` applies
+    // bounded back-pressure when the tsfn queue is full (a stalled Node
+    // event loop) instead of silently dropping rows; the converted `Vec`
+    // and the wire chunk are both dropped before the next chunk is fetched.
+    out.push_str("            request\n");
+    out.push_str("                .stream(|chunk| {\n");
+    writeln!(
+        out,
+        "                    let rows = {vec_converter}(chunk);"
+    )
+    .unwrap();
+    out.push_str("                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);\n");
+    out.push_str("                })\n");
+    out.push_str("                .await\n");
+    out.push_str("        })\n");
+    out.push_str("        .await\n");
     out.push_str("    }\n");
     out
 }

--- a/scripts/check_binding_parity.py
+++ b/scripts/check_binding_parity.py
@@ -1210,6 +1210,227 @@ def _check_utility_rows(
     return errors
 
 
+# ─── Historical server-stream surface discovery ─────────────────────
+#
+# The endpoint codegen casts an endpoint's snake_case name to PascalCase
+# / camelCase with INITIALISM awareness: the segments `eod` / `ohlc` /
+# `iv` / `dte` / `nbbo` render as all-caps (`EOD`, `OHLC`, ...) in the
+# TypeScript `js_name` (`stockHistoryEODStream`) but as title-case in the
+# Python builder struct (`StockHistoryEodBuilder`). A naive
+# `camelCase → snake_case` inverse would split `EOD` into `e_o_d`. The
+# helper below collapses any run of consecutive uppercase letters into a
+# single segment, so both `stockHistoryEOD` and `StockHistoryEod` invert
+# to the canonical `stock_history_eod` row name.
+
+
+def _endpoint_method_to_snake(name: str) -> str:
+    """Invert an endpoint method / builder stem to its snake_case name,
+    collapsing initialism runs (`EOD`, `OHLC`) into one segment.
+
+    `stockHistoryEOD` -> `stock_history_eod`;
+    `StockHistoryEod` -> `stock_history_eod`;
+    `optionHistoryTradeGreeksImpliedVolatility` ->
+    `option_history_trade_greeks_implied_volatility`.
+    """
+    # Boundary BEFORE an uppercase run that is followed by a lowercase
+    # (start of a new title-case word): `...EODStream` keeps `EOD`
+    # together but splits before `Stream`'s `S...tream`.
+    s = re.sub(r"(?<=[a-z0-9])([A-Z])", r"_\1", name)
+    s = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", s)
+    return s.lower()
+
+#
+# The buffered historical endpoints have a server-stream companion on
+# every binding — the `.stream(handler)` core primitive surfaced as a
+# per-binding terminal:
+#
+#   * Python: `fn stream` + `fn stream_async` on each `<Endpoint>Builder`
+#     pyclass (generated into
+#     `sdks/python/src/_generated/historical_methods.rs`).
+#   * TypeScript: a `<endpoint>Stream` method on the `ThetaDataDxClient`
+#     napi class (generated into
+#     `sdks/typescript/src/_generated/historical_methods.rs`).
+#   * C ABI: a `tdx_<endpoint>_stream` extern "C" symbol in `ffi/src/`.
+#   * C++: an `<endpoint>_stream` member on the `UnifiedClient` wrapper
+#     (`thetadx.hpp` + its `.inc` fragments).
+#
+# These methods live on per-endpoint builders / as endpoint-named
+# methods, NOT on a class the `[[method]]` rows already cover, so without
+# this dedicated family a binding could ship streaming on some endpoints
+# and silently omit it on others (or on a whole binding) with no checker
+# noticing — the exact gap the cross-binding contract exists to close.
+# Each `[[historical_streaming]]` row pins one endpoint's streaming
+# presence across the four bindings.
+
+
+def _collect_python_streaming_endpoints(py_src: pathlib.Path) -> set[str]:
+    """Snake_case endpoint names whose Python `<Endpoint>Builder` pyclass
+    exposes a `fn stream` terminal.
+
+    Walks every `impl <Name>Builder { ... }` block and records the
+    builder's endpoint name (the CamelCase struct stem, lowered to
+    snake_case) when the body declares `fn stream(`. The async companion
+    `fn stream_async` rides on the same builder, so the sync terminal is
+    the canonical presence signal.
+    """
+    out: set[str] = set()
+    if not py_src.is_dir():
+        return out
+    impl_re = re.compile(r"impl\s+(\w+)Builder\s*\{")
+    for rs in py_src.rglob("*.rs"):
+        text = rs.read_text(encoding="utf-8")
+        for header in impl_re.finditer(text):
+            stem = header.group(1)
+            body_start = header.end()
+            depth = 1
+            i = body_start
+            while i < len(text) and depth > 0:
+                c = text[i]
+                if c == "{":
+                    depth += 1
+                elif c == "}":
+                    depth -= 1
+                i += 1
+            body = text[body_start : i - 1]
+            if re.search(r"\bfn\s+stream\s*\(", body):
+                out.add(_endpoint_method_to_snake(stem))
+    return out
+
+
+def _collect_typescript_streaming_endpoints(
+    ts_methods: dict[str, set[str]],
+) -> set[str]:
+    """Snake_case endpoint names whose `ThetaDataDxClient` napi class
+    exposes a `<endpoint>Stream` method.
+
+    Reuses the already-collected `{class: {method, ...}}` map. A method
+    whose camelCase name ends in `Stream` is a historical server-stream
+    terminal; strip the suffix and lower to snake_case to recover the
+    endpoint name. The FPSS lifecycle methods (`startStreaming` /
+    `stopStreaming` / `isStreaming`) do NOT end in the bare `Stream`
+    token preceded by an endpoint stem — they are excluded because
+    stripping `Stream` would leave `starting` / `stopping` / `is`, none
+    of which name an endpoint (and they are tracked by their own
+    `[[method]]` rows regardless).
+    """
+    out: set[str] = set()
+    methods = ts_methods.get("ThetaDataDxClient", set())
+    lifecycle = {"startStreaming", "stopStreaming", "isStreaming"}
+    for method in methods:
+        if method in lifecycle:
+            continue
+        if method.endswith("Stream") and len(method) > len("Stream"):
+            stem = method[: -len("Stream")]
+            out.add(_endpoint_method_to_snake(stem))
+    return out
+
+
+def _collect_ffi_streaming_endpoints(ffi_src: pathlib.Path) -> set[str]:
+    """Snake_case endpoint names whose `tdx_<endpoint>_stream` extern "C"
+    symbol exists in `ffi/src/`.
+
+    The FPSS `tdx_unified_*` / `tdx_fpss_*` callback symbols never match
+    the `tdx_<name>_stream` shape (their stems are `unified` / `fpss`
+    and they end in `set_callback` / `reconnect` / `shutdown`, not
+    `_stream`), so they are not mistaken for a historical endpoint.
+    """
+    out: set[str] = set()
+    if not ffi_src.is_dir():
+        return out
+    fn_re = re.compile(r"\bfn\s+tdx_(\w+)_stream\s*\(")
+    for rs in ffi_src.rglob("*.rs"):
+        text = rs.read_text(encoding="utf-8")
+        for m in fn_re.finditer(text):
+            out.add(m.group(1))
+    return out
+
+
+def _collect_cpp_streaming_endpoints(cpp_methods: dict[str, set[str]]) -> set[str]:
+    """Snake_case endpoint names whose C++ `UnifiedClient` wrapper exposes
+    an `<endpoint>_stream` member.
+
+    Reuses the already-collected C++ `{class: {method, ...}}` map. The
+    historical endpoints live on the `UnifiedClient` class body in
+    `thetadx.hpp` (the C++ name the `ThetaDataDxClient` parity rows alias
+    to). A member whose snake_case name ends in `_stream` is a
+    server-stream terminal; strip the suffix to recover the endpoint
+    name.
+    """
+    out: set[str] = set()
+    methods = cpp_methods.get("UnifiedClient", set()) | cpp_methods.get(
+        "ThetaDataDxClient", set()
+    )
+    for method in methods:
+        if method.endswith("_stream") and len(method) > len("_stream"):
+            out.add(method[: -len("_stream")])
+    return out
+
+
+def _check_historical_streaming_rows(
+    rows: list[dict[str, Any]],
+    py_stream: set[str],
+    ts_stream: set[str],
+    cpp_stream: set[str],
+    ffi_stream: set[str],
+) -> list[str]:
+    """Per-endpoint cross-binding gate for `[[historical_streaming]]` rows.
+
+    Each row declares a snake_case endpoint `name` plus the expected
+    server-stream presence in Python / TypeScript / C++ / the C ABI. The
+    checker compares the declared state against the actual binding state
+    and returns a list of mismatch strings (empty when every row
+    matches).
+
+    Beyond the per-row check, the collected sets are reconciled against
+    the union of declared row names: an endpoint that streams on ANY
+    binding but has no row at all trips the gate, so a newly-streamed
+    endpoint cannot slip in untracked.
+    """
+    errors: list[str] = []
+    declared_names = {row.get("name") for row in rows if row.get("name")}
+    for row in rows:
+        name = row.get("name")
+        if not name:
+            errors.append(f"  [[historical_streaming]] row missing `name`: {row!r}")
+            continue
+        camel = _snake_to_camel(name)
+        pascal = camel[:1].upper() + camel[1:] if camel else camel
+        for lang, actual_set, hint in (
+            ("python", py_stream, f"`fn stream` on the `{pascal}Builder` pyclass"),
+            ("typescript", ts_stream, f"`{camel}Stream` on the `ThetaDataDxClient` napi class"),
+            ("cpp", cpp_stream, f"`{name}_stream(` on the C++ `UnifiedClient` body"),
+            ("ffi", ffi_stream, f"`tdx_{name}_stream` extern \"C\" symbol"),
+        ):
+            declared = row.get(lang, False)
+            actual = name in actual_set
+            if declared != actual:
+                verb = "missing" if declared and not actual else "unexpected"
+                errors.append(
+                    f"  {name}.{lang}: declared={declared}, actual={actual} "
+                    f"({verb} -- expected {hint})"
+                )
+    # Reverse-direction orphan check: any endpoint that streams on a
+    # binding but has no row is undocumented drift.
+    seen = py_stream | ts_stream | cpp_stream | ffi_stream
+    for endpoint in sorted(seen - declared_names):
+        on = sorted(
+            lang
+            for lang, s in (
+                ("python", py_stream),
+                ("typescript", ts_stream),
+                ("cpp", cpp_stream),
+                ("ffi", ffi_stream),
+            )
+            if endpoint in s
+        )
+        errors.append(
+            f"  {endpoint}: streams on {on} but has no "
+            f"[[historical_streaming]] row. Add one declaring its "
+            f"per-binding presence so the surface stays tracked."
+        )
+    return errors
+
+
 # ─── Main gate ──────────────────────────────────────────────────────
 
 
@@ -1452,6 +1673,9 @@ def main(argv: list[str] | None = None) -> int:
     method_rows: list[dict[str, Any]] = data.get("method", [])
     value_field_rows: list[dict[str, Any]] = data.get("value_field", [])
     utility_rows: list[dict[str, Any]] = data.get("utility", [])
+    historical_streaming_rows: list[dict[str, Any]] = data.get(
+        "historical_streaming", []
+    )
     if not rows:
         print("parity.toml has no [[class]] rows", file=sys.stderr)
         return 1
@@ -1521,6 +1745,19 @@ def main(argv: list[str] | None = None) -> int:
     ffi_utils = _collect_ffi_utility_functions(FFI_SRC)
     utility_errors = _check_utility_rows(
         utility_rows, py_utils, ts_utils, cpp_utils, ffi_utils
+    )
+
+    # Historical server-stream surface ([[historical_streaming]] rows) —
+    # the `.stream(handler)` / `<endpoint>Stream` / `tdx_<endpoint>_stream`
+    # terminal per endpoint. These live on per-endpoint builders or as
+    # endpoint-named methods, NOT on a class the `[[method]]` rows cover,
+    # so they would otherwise drift silently across bindings.
+    py_stream = _collect_python_streaming_endpoints(PY_SRC)
+    ts_stream = _collect_typescript_streaming_endpoints(ts_class_methods)
+    cpp_stream = _collect_cpp_streaming_endpoints(cpp_class_methods)
+    ffi_stream = _collect_ffi_streaming_endpoints(FFI_SRC)
+    historical_streaming_errors = _check_historical_streaming_rows(
+        historical_streaming_rows, py_stream, ts_stream, cpp_stream, ffi_stream
     )
 
     # Public-surface vocabulary: no public client identifier may embed
@@ -1622,6 +1859,17 @@ def main(argv: list[str] | None = None) -> int:
             print(e)
         print()
 
+    if historical_streaming_errors:
+        had_errors = True
+        print(
+            f"check_binding_parity: {len(historical_streaming_errors)} "
+            f"historical-streaming mismatch(es) (per-endpoint "
+            f"`[[historical_streaming]]` granularity):"
+        )
+        for e in historical_streaming_errors:
+            print(e)
+        print()
+
     if surface_vocab_errors:
         had_errors = True
         print(
@@ -1666,11 +1914,13 @@ def main(argv: list[str] | None = None) -> int:
     n_methods = len(method_rows)
     n_value_fields = len(value_field_rows)
     n_utilities = len(utility_rows)
+    n_hist_stream = len(historical_streaming_rows)
     print(
         f"check_binding_parity: clean "
         f"({n_class} class rows + {n_dotted} field rows + "
         f"{n_methods} method rows + {n_value_fields} value-field rows + "
         f"{n_utilities} utility rows + "
+        f"{n_hist_stream} historical-streaming rows + "
         f"{n_fields} rust pub fields checked; "
         f"py_classes={len(py_classes)} ts_classes={len(ts_classes)} "
         f"cpp_classes={len(cpp_classes)} "
@@ -2281,6 +2531,93 @@ def _run_selftest() -> int:
     _case("utility negative — unexpected C++ decl trips", _case_utility_negative_unexpected)
     _case("utility — TS collector skips impl methods", _case_utility_ts_free_fn_collector_skips_methods)
     _case("utility — FFI collector strips tdx_ prefix", _case_utility_ffi_collector_strips_prefix)
+
+    # ── Historical server-stream surface selftests ────────────────
+
+    def _case_hist_stream_positive_all_bound() -> None:
+        """An endpoint streaming on every declared binding is silent."""
+        rows = [
+            {
+                "name": "option_history_trade",
+                "python": True,
+                "typescript": True,
+                "cpp": True,
+                "ffi": True,
+            }
+        ]
+        s = {"option_history_trade"}
+        errors = _check_historical_streaming_rows(rows, s, s, s, s)
+        assert errors == [], f"all-bound row must be silent; got {errors!r}"
+
+    def _case_hist_stream_missing_on_cpp_trips() -> None:
+        """Row claims C++ streams but the C++ member is absent — trips."""
+        rows = [
+            {
+                "name": "option_history_trade",
+                "python": True,
+                "typescript": True,
+                "cpp": True,
+                "ffi": True,
+            }
+        ]
+        bound = {"option_history_trade"}
+        errors = _check_historical_streaming_rows(
+            rows, bound, bound, set(), bound
+        )
+        assert any("cpp" in e and "missing" in e for e in errors), (
+            f"missing C++ stream member must trip; got {errors!r}"
+        )
+
+    def _case_hist_stream_ts_only_state_is_silent() -> None:
+        """The TS-first ship state (py+ts true, cpp+ffi false) is silent
+        when Python + TS stream and C++ + FFI do not — the intended
+        intermediate parity the matrix tracks.
+        """
+        rows = [
+            {
+                "name": "option_history_trade",
+                "python": True,
+                "typescript": True,
+                "cpp": False,
+                "ffi": False,
+            }
+        ]
+        bound = {"option_history_trade"}
+        errors = _check_historical_streaming_rows(
+            rows, bound, bound, set(), set()
+        )
+        assert errors == [], f"TS-first state must be silent; got {errors!r}"
+
+    def _case_hist_stream_untracked_orphan_trips() -> None:
+        """An endpoint streaming on a binding with no row at all trips
+        the reverse-direction orphan check.
+        """
+        errors = _check_historical_streaming_rows(
+            [], set(), {"option_history_trade"}, set(), set()
+        )
+        assert any(
+            "option_history_trade" in e and "no [[historical_streaming]] row" in e
+            for e in errors
+        ), f"untracked streaming endpoint must trip; got {errors!r}"
+
+    def _case_hist_stream_initialism_inverse() -> None:
+        """`stockHistoryEODStream` (TS) and `StockHistoryEod` (Python
+        builder stem) both invert to the canonical `stock_history_eod`,
+        so the two collectors agree on the row name.
+        """
+        assert _endpoint_method_to_snake("stockHistoryEOD") == "stock_history_eod"
+        assert _endpoint_method_to_snake("StockHistoryEod") == "stock_history_eod"
+        assert (
+            _endpoint_method_to_snake("optionHistoryGreeksImpliedVolatility")
+            == "option_history_greeks_implied_volatility"
+        )
+        assert _endpoint_method_to_snake("stockHistoryOHLCRange") == "stock_history_ohlc_range"
+
+    _case("hist-stream positive — all four bindings stream", _case_hist_stream_positive_all_bound)
+    _case("hist-stream negative — missing C++ member trips", _case_hist_stream_missing_on_cpp_trips)
+    _case("hist-stream positive — TS-first ship state is silent", _case_hist_stream_ts_only_state_is_silent)
+    _case("hist-stream negative — untracked streaming endpoint trips", _case_hist_stream_untracked_orphan_trips)
+    _case("hist-stream — initialism-aware inverse agrees across bindings", _case_hist_stream_initialism_inverse)
 
     # ── Public-surface vocabulary guard selftests ──────────────────
 

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1490,3 +1490,262 @@ typescript = "Option<BigInt>"
 # guard a regression. They are free functions, not methods on a tracked
 # class, so they are not expressible as `[[method]]` / `[[value_field]]`
 # rows — this note records the contract the drift gates enforce.
+
+
+# ─── Historical server-stream surface ([[historical_streaming]]) ──────
+#
+# Every buffered historical endpoint has a server-stream companion: the
+# core `request.stream(handler)` primitive surfaced as a per-binding
+# terminal that pumps each decoded gRPC chunk through a callback with
+# memory bounded to a single chunk, never the full result. The terminal
+# is named per language idiom:
+#
+#   python      — `.stream(handler)` + `.stream_async(handler)` on the
+#                 `<Endpoint>Builder` pyclass.
+#   typescript  — `<endpoint>Stream(...args, options, callback)` on the
+#                 `ThetaDataDxClient` napi class.
+#   cpp         — `<endpoint>_stream(...args, callback, options)` on the
+#                 C++ `UnifiedClient` wrapper.
+#   ffi         — the `tdx_<endpoint>_stream(...)` extern "C" symbol.
+#
+# These terminals live on per-endpoint builders / as endpoint-named
+# methods, NOT on a class the `[[method]]` rows cover, so without this
+# family a binding could ship streaming on some endpoints and silently
+# omit it on others (or on a whole binding) with no checker noticing.
+# The collector set is reconciled against these rows in both directions:
+# a declared row that does not match the binding state fails, and an
+# endpoint that streams on any binding without a row fails. `name` is the
+# canonical snake_case endpoint name (initialisms collapse: the codegen
+# emits `stockHistoryEODStream` in TS and `StockHistoryEodBuilder` in
+# Python, both tracked here as `stock_history_eod`).
+
+[[historical_streaming]]
+name = "index_at_time_price"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "index_history_eod"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "index_history_ohlc"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "index_history_price"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "interest_rate_history_eod"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_at_time_quote"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_at_time_trade"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_eod"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_greeks_all"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_greeks_eod"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_greeks_first_order"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_greeks_implied_volatility"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_greeks_second_order"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_greeks_third_order"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_ohlc"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_open_interest"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_quote"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_trade"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_trade_greeks_all"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_trade_greeks_first_order"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_trade_greeks_implied_volatility"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_trade_greeks_second_order"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_trade_greeks_third_order"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_history_trade_quote"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "option_list_contracts"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "stock_at_time_quote"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "stock_at_time_trade"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "stock_history_eod"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "stock_history_ohlc"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "stock_history_ohlc_range"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "stock_history_quote"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "stock_history_trade"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port
+
+[[historical_streaming]]
+name = "stock_history_trade_quote"
+python = true
+typescript = true
+cpp = false       # pending the C-ABI + C++ server-stream port
+ffi = false       # pending the C-ABI server-stream port

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -38,11 +38,14 @@ export declare class Config {
   /**
    * Set the warning threshold (in bytes) for buffered (non-streaming)
    * historical responses. Endpoints whose decoded total exceeds this
-   * value emit a Rust-side `tracing::warn!` pointing the caller at
-   * the `.stream()` surface; the data is still delivered. `0n`
-   * disables the warning entirely. Default is `100n * 1024n * 1024n`
-   * (100 MiB). Byte budgets can exceed `u32::MAX`, so the setter
-   * takes a `BigInt` matching the underlying `usize` field.
+   * value emit a Rust-side `tracing::warn!` pointing the caller at the
+   * matching `<endpoint>Stream(...)` method (e.g. `optionHistoryTradeStream`),
+   * which delivers the same rows chunk-by-chunk through a callback with
+   * memory bounded to a single chunk; the buffered data is still
+   * delivered. `0n` disables the warning entirely. Default is
+   * `100n * 1024n * 1024n` (100 MiB). Byte budgets can exceed
+   * `u32::MAX`, so the setter takes a `BigInt` matching the underlying
+   * `usize` field.
    */
   setWarnOnBufferedThresholdBytes(n: bigint): void
   /**
@@ -793,6 +796,8 @@ export declare class ThetaDataDxClient {
    * Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
    */
   stockHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
+  /** Stream `stock_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  stockHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: StockHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
   /**
    * Fetch intraday OHLC bars for a stock on a single date.
    *
@@ -807,6 +812,8 @@ export declare class ThetaDataDxClient {
    * - `venue`: `"nqb"`
    */
   stockHistoryOHLC(symbol: string, date: string | Date, options?: StockHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Stream `stock_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryOHLC`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  stockHistoryOHLCStream(symbol: string, date: string | Date, options: StockHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
   /**
    * Fetch all trades for a stock on a given date.
    *
@@ -819,6 +826,8 @@ export declare class ThetaDataDxClient {
    * - `venue`: `"nqb"`
    */
   stockHistoryTrade(symbol: string, date: string | Date, options?: StockHistoryTradeOptions | undefined | null): Promise<Array<TradeTick>>
+  /** Stream `stock_history_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryTrade`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  stockHistoryTradeStream(symbol: string, date: string | Date, options: StockHistoryTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
   /**
    * Fetch NBBO quotes for a stock on a given date at a given interval.
    *
@@ -834,6 +843,8 @@ export declare class ThetaDataDxClient {
    * - `venue`: `"nqb"`
    */
   stockHistoryQuote(symbol: string, date: string | Date, options?: StockHistoryQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
+  /** Stream `stock_history_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  stockHistoryQuoteStream(symbol: string, date: string | Date, options: StockHistoryQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
   /**
    * Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
    *
@@ -847,6 +858,8 @@ export declare class ThetaDataDxClient {
    * - `venue`: `"nqb"`
    */
   stockHistoryTradeQuote(symbol: string, date: string | Date, options?: StockHistoryTradeQuoteOptions | undefined | null): Promise<Array<TradeQuoteTick>>
+  /** Stream `stock_history_trade_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeQuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryTradeQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  stockHistoryTradeQuoteStream(symbol: string, date: string | Date, options: StockHistoryTradeQuoteOptions | undefined | null, callback: ((arg: Array<TradeQuoteTick>) => void)): Promise<void>
   /**
    * Fetch the trade at a specific time of day across a date range.
    *
@@ -862,6 +875,8 @@ export declare class ThetaDataDxClient {
    * - `venue`: `"nqb"`
    */
   stockAtTimeTrade(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeTradeOptions | undefined | null): Promise<Array<TradeTick>>
+  /** Stream `stock_at_time_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockAtTimeTrade`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  stockAtTimeTradeStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: StockAtTimeTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
   /**
    * Fetch the quote at a specific time of day across a date range.
    *
@@ -877,6 +892,8 @@ export declare class ThetaDataDxClient {
    * - `venue`: `"nqb"`
    */
   stockAtTimeQuote(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: StockAtTimeQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
+  /** Stream `stock_at_time_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockAtTimeQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  stockAtTimeQuoteStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: StockAtTimeQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
   /**
    * List all available option underlying symbols.
    *
@@ -918,6 +935,8 @@ export declare class ThetaDataDxClient {
    * This endpoint is updated real-time.
    */
   optionListContracts(requestType: string, symbol: string, date: string | Date, options?: OptionListContractsOptions | undefined | null): Promise<Array<OptionContract>>
+  /** Stream `option_list_contracts` rows into `callback` without materialising the full response in memory. `callback(chunk: OptionContract[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionListContracts`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionListContractsStream(requestType: string, symbol: string, date: string | Date, options: OptionListContractsOptions | undefined | null, callback: ((arg: Array<OptionContract>) => void)): Promise<void>
   /**
    * Get the latest OHLC snapshot for an option contract.
    *
@@ -1069,6 +1088,8 @@ export declare class ThetaDataDxClient {
    * - `right`: `"both"`
    */
   optionHistoryEOD(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
+  /** Stream `option_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryEODStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options: OptionHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
   /**
    * Fetch intraday OHLC bars for an option contract.
    *
@@ -1084,6 +1105,8 @@ export declare class ThetaDataDxClient {
    * - `end_time`: `"16:00:00"`
    */
   optionHistoryOHLC(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Stream `option_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryOHLC`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryOHLCStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
   /**
    * Fetch all trades for an option contract on a given date.
    *
@@ -1099,6 +1122,8 @@ export declare class ThetaDataDxClient {
    * - `end_time`: `"16:00:00"`
    */
   optionHistoryTrade(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeOptions | undefined | null): Promise<Array<TradeTick>>
+  /** Stream `option_history_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTrade`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryTradeStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
   /**
    * Fetch NBBO quotes for an option contract on a given date.
    *
@@ -1114,6 +1139,8 @@ export declare class ThetaDataDxClient {
    * - `end_time`: `"16:00:00"`
    */
   optionHistoryQuote(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
+  /** Stream `option_history_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryQuoteStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
   /**
    * Fetch combined trade + quote ticks for an option contract.
    *
@@ -1130,6 +1157,8 @@ export declare class ThetaDataDxClient {
    * - `exclusive`: `true`
    */
   optionHistoryTradeQuote(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeQuoteOptions | undefined | null): Promise<Array<TradeQuoteTick>>
+  /** Stream `option_history_trade_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeQuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryTradeQuoteStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeQuoteOptions | undefined | null, callback: ((arg: Array<TradeQuoteTick>) => void)): Promise<void>
   /**
    * Fetch open interest history for an option contract.
    *
@@ -1142,6 +1171,8 @@ export declare class ThetaDataDxClient {
    * - `right`: `"both"`
    */
   optionHistoryOpenInterest(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryOpenInterestOptions | undefined | null): Promise<Array<OpenInterestTick>>
+  /** Stream `option_history_open_interest` rows into `callback` without materialising the full response in memory. `callback(chunk: OpenInterestTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryOpenInterest`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryOpenInterestStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryOpenInterestOptions | undefined | null, callback: ((arg: Array<OpenInterestTick>) => void)): Promise<void>
   /**
    * Fetch end-of-day Greeks history for an option contract.
    *
@@ -1157,6 +1188,8 @@ export declare class ThetaDataDxClient {
    * - `underlyer_use_nbbo`: `false`
    */
   optionHistoryGreeksEOD(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options?: OptionHistoryGreeksEodOptions | undefined | null): Promise<Array<GreeksEodTick>>
+  /** Stream `option_history_greeks_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksEodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryGreeksEODStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, options: OptionHistoryGreeksEodOptions | undefined | null, callback: ((arg: Array<GreeksEodTick>) => void)): Promise<void>
   /**
    * Fetch all Greeks history for an option contract (intraday, sampled by interval).
    *
@@ -1175,6 +1208,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryGreeksAll(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksAllOptions | undefined | null): Promise<Array<GreeksAllTick>>
+  /** Stream `option_history_greeks_all` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksAllTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksAll`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryGreeksAllStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksAllOptions | undefined | null, callback: ((arg: Array<GreeksAllTick>) => void)): Promise<void>
   /**
    * Fetch all Greeks on each trade for an option contract.
    *
@@ -1192,6 +1227,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryTradeGreeksAll(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksAllOptions | undefined | null): Promise<Array<TradeGreeksAllTick>>
+  /** Stream `option_history_trade_greeks_all` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksAllTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksAll`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryTradeGreeksAllStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksAllOptions | undefined | null, callback: ((arg: Array<TradeGreeksAllTick>) => void)): Promise<void>
   /**
    * Fetch first-order Greeks history (intraday, sampled by interval).
    *
@@ -1210,6 +1247,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryGreeksFirstOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksFirstOrderOptions | undefined | null): Promise<Array<GreeksFirstOrderTick>>
+  /** Stream `option_history_greeks_first_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksFirstOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksFirstOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryGreeksFirstOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksFirstOrderOptions | undefined | null, callback: ((arg: Array<GreeksFirstOrderTick>) => void)): Promise<void>
   /**
    * Fetch first-order Greeks on each trade for an option contract.
    *
@@ -1227,6 +1266,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryTradeGreeksFirstOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksFirstOrderOptions | undefined | null): Promise<Array<TradeGreeksFirstOrderTick>>
+  /** Stream `option_history_trade_greeks_first_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksFirstOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksFirstOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryTradeGreeksFirstOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksFirstOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksFirstOrderTick>) => void)): Promise<void>
   /**
    * Fetch second-order Greeks history (intraday, sampled by interval).
    *
@@ -1245,6 +1286,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryGreeksSecondOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksSecondOrderOptions | undefined | null): Promise<Array<GreeksSecondOrderTick>>
+  /** Stream `option_history_greeks_second_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksSecondOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksSecondOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryGreeksSecondOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksSecondOrderOptions | undefined | null, callback: ((arg: Array<GreeksSecondOrderTick>) => void)): Promise<void>
   /**
    * Fetch second-order Greeks on each trade for an option contract.
    *
@@ -1262,6 +1305,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryTradeGreeksSecondOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksSecondOrderOptions | undefined | null): Promise<Array<TradeGreeksSecondOrderTick>>
+  /** Stream `option_history_trade_greeks_second_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksSecondOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksSecondOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryTradeGreeksSecondOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksSecondOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksSecondOrderTick>) => void)): Promise<void>
   /**
    * Fetch third-order Greeks history (intraday, sampled by interval).
    *
@@ -1280,6 +1325,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryGreeksThirdOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksThirdOrderOptions | undefined | null): Promise<Array<GreeksThirdOrderTick>>
+  /** Stream `option_history_greeks_third_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksThirdOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksThirdOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryGreeksThirdOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksThirdOrderOptions | undefined | null, callback: ((arg: Array<GreeksThirdOrderTick>) => void)): Promise<void>
   /**
    * Fetch third-order Greeks on each trade for an option contract.
    *
@@ -1297,6 +1344,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryTradeGreeksThirdOrder(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksThirdOrderOptions | undefined | null): Promise<Array<TradeGreeksThirdOrderTick>>
+  /** Stream `option_history_trade_greeks_third_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksThirdOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksThirdOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryTradeGreeksThirdOrderStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksThirdOrderOptions | undefined | null, callback: ((arg: Array<TradeGreeksThirdOrderTick>) => void)): Promise<void>
   /**
    * Fetch implied volatility history (intraday, sampled by interval).
    *
@@ -1314,6 +1363,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryGreeksImpliedVolatility(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryGreeksImpliedVolatilityOptions | undefined | null): Promise<Array<IvTick>>
+  /** Stream `option_history_greeks_implied_volatility` rows into `callback` without materialising the full response in memory. `callback(chunk: IvTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksImpliedVolatility`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryGreeksImpliedVolatilityStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryGreeksImpliedVolatilityOptions | undefined | null, callback: ((arg: Array<IvTick>) => void)): Promise<void>
   /**
    * Fetch implied volatility on each trade for an option contract.
    *
@@ -1330,6 +1381,8 @@ export declare class ThetaDataDxClient {
    * - `version`: `"latest"`
    */
   optionHistoryTradeGreeksImpliedVolatility(symbol: string, expiration: string | Date, date: string | Date, options?: OptionHistoryTradeGreeksImpliedVolatilityOptions | undefined | null): Promise<Array<TradeGreeksImpliedVolatilityTick>>
+  /** Stream `option_history_trade_greeks_implied_volatility` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksImpliedVolatilityTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksImpliedVolatility`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionHistoryTradeGreeksImpliedVolatilityStream(symbol: string, expiration: string | Date, date: string | Date, options: OptionHistoryTradeGreeksImpliedVolatilityOptions | undefined | null, callback: ((arg: Array<TradeGreeksImpliedVolatilityTick>) => void)): Promise<void>
   /**
    * Fetch the trade at a specific time of day across a date range for an option.
    *
@@ -1343,6 +1396,8 @@ export declare class ThetaDataDxClient {
    * - `right`: `"both"`
    */
   optionAtTimeTrade(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeTradeOptions | undefined | null): Promise<Array<TradeTick>>
+  /** Stream `option_at_time_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionAtTimeTrade`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionAtTimeTradeStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: OptionAtTimeTradeOptions | undefined | null, callback: ((arg: Array<TradeTick>) => void)): Promise<void>
   /**
    * Fetch the quote at a specific time of day across a date range for an option.
    *
@@ -1354,6 +1409,8 @@ export declare class ThetaDataDxClient {
    * - `right`: `"both"`
    */
   optionAtTimeQuote(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: OptionAtTimeQuoteOptions | undefined | null): Promise<Array<QuoteTick>>
+  /** Stream `option_at_time_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionAtTimeQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  optionAtTimeQuoteStream(symbol: string, expiration: string | Date, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: OptionAtTimeQuoteOptions | undefined | null, callback: ((arg: Array<QuoteTick>) => void)): Promise<void>
   /**
    * List all available index symbols.
    *
@@ -1393,6 +1450,8 @@ export declare class ThetaDataDxClient {
    * - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
    */
   indexHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
+  /** Stream `index_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::indexHistoryEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  indexHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: IndexHistoryEodOptions | undefined | null, callback: ((arg: Array<EodTick>) => void)): Promise<void>
   /**
    * Fetch intraday OHLC bars for an index.
    *
@@ -1406,6 +1465,8 @@ export declare class ThetaDataDxClient {
    * - `end_time`: `"16:00:00"`
    */
   indexHistoryOHLC(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Stream `index_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::indexHistoryOHLC`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  indexHistoryOHLCStream(symbol: string, startDate: string | Date, endDate: string | Date, options: IndexHistoryOhlcOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
   /**
    * Fetch intraday price history for an index.
    *
@@ -1420,6 +1481,8 @@ export declare class ThetaDataDxClient {
    * - `end_time`: `"16:00:00"`
    */
   indexHistoryPrice(symbol: string, date: string | Date, options?: IndexHistoryPriceOptions | undefined | null): Promise<Array<PriceTick>>
+  /** Stream `index_history_price` rows into `callback` without materialising the full response in memory. `callback(chunk: PriceTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::indexHistoryPrice`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  indexHistoryPriceStream(symbol: string, date: string | Date, options: IndexHistoryPriceOptions | undefined | null, callback: ((arg: Array<PriceTick>) => void)): Promise<void>
   /**
    * Fetch the index price at a specific time of day across a date range.
    *
@@ -1427,6 +1490,8 @@ export declare class ThetaDataDxClient {
    * - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
    */
   indexAtTimePrice(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: IndexAtTimePriceOptions | undefined | null): Promise<Array<IndexPriceAtTimeTick>>
+  /** Stream `index_at_time_price` rows into `callback` without materialising the full response in memory. `callback(chunk: IndexPriceAtTimeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::indexAtTimePrice`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  indexAtTimePriceStream(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options: IndexAtTimePriceOptions | undefined | null, callback: ((arg: Array<IndexPriceAtTimeTick>) => void)): Promise<void>
   /**
    * Check whether the market is open today.
    *
@@ -1463,6 +1528,8 @@ export declare class ThetaDataDxClient {
    *   `TREASURY_Y7`, `TREASURY_Y10`, `TREASURY_Y20`, `TREASURY_Y30`.
    */
   interestRateHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: InterestRateHistoryEodOptions | undefined | null): Promise<Array<InterestRateTick>>
+  /** Stream `interest_rate_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: InterestRateTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::interestRateHistoryEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  interestRateHistoryEODStream(symbol: string, startDate: string | Date, endDate: string | Date, options: InterestRateHistoryEodOptions | undefined | null, callback: ((arg: Array<InterestRateTick>) => void)): Promise<void>
   /**
    * Fetch intraday OHLC bars across a date range (start_date..end_date). This is a dedicated upstream route, distinct from the single-date stock_history_ohlc; the `_range` suffix mirrors the vendor's separate `ohlc_range` route.
    *
@@ -1473,6 +1540,8 @@ export declare class ThetaDataDxClient {
    * - `venue`: `"nqb"`
    */
   stockHistoryOHLCRange(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryOhlcRangeOptions | undefined | null): Promise<Array<OhlcTick>>
+  /** Stream `stock_history_ohlc_range` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryOHLCRange`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
+  stockHistoryOHLCRangeStream(symbol: string, startDate: string | Date, endDate: string | Date, options: StockHistoryOhlcRangeOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
   /**
    * Start FPSS streaming and register a JS callback for incoming events.
    *

--- a/sdks/typescript/src/_generated/historical_methods.rs
+++ b/sdks/typescript/src/_generated/historical_methods.rs
@@ -1727,6 +1727,40 @@ impl ThetaDataDxClient {
         Ok(eod_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `stock_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "stockHistoryEODStream")]
+    pub async fn stock_history_eod_stream(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryEODOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<EodTick>, (), Vec<EodTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.stock_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = eod_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch intraday OHLC bars for a stock on a single date.
     ///
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
@@ -1787,6 +1821,62 @@ impl ThetaDataDxClient {
         Ok(ohlc_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `stock_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryOHLC`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "stockHistoryOHLCStream")]
+    pub async fn stock_history_ohlc_stream(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryOHLCOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<OhlcTick>, (), Vec<OhlcTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.stock_history_ohlc(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = ohlc_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch all trades for a stock on a given date.
     ///
     /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
@@ -1839,6 +1929,58 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(trade_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `stock_history_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryTrade`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "stockHistoryTradeStream")]
+    pub async fn stock_history_trade_stream(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryTradeOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeTick>, (), Vec<TradeTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let date = normalize_date(date);
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.stock_history_trade(&symbol, date.as_str());
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
@@ -1902,6 +2044,62 @@ impl ThetaDataDxClient {
         Ok(quote_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `stock_history_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "stockHistoryQuoteStream")]
+    pub async fn stock_history_quote_stream(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryQuoteOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<QuoteTick>, (), Vec<QuoteTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.stock_history_quote(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = quote_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     ///
     /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
@@ -1961,6 +2159,62 @@ impl ThetaDataDxClient {
         Ok(trade_quote_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `stock_history_trade_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeQuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryTradeQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "stockHistoryTradeQuoteStream")]
+    pub async fn stock_history_trade_quote_stream(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryTradeQuoteOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeQuoteTick>, (), Vec<TradeQuoteTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let date = normalize_date(date);
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let exclusive = options.exclusive;
+        let venue = options.venue;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.stock_history_trade_quote(&symbol, date.as_str());
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = exclusive {
+                request = request.exclusive(value);
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_quote_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch the trade at a specific time of day across a date range.
     ///
     /// #### Real-time request:
@@ -2006,6 +2260,46 @@ impl ThetaDataDxClient {
         Ok(trade_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `stock_at_time_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockAtTimeTrade`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "stockAtTimeTradeStream")]
+    pub async fn stock_at_time_trade_stream(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockAtTimeTradeOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeTick>, (), Vec<TradeTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let venue = options.venue;
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.stock_at_time_trade(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch the quote at a specific time of day across a date range.
     ///
     /// #### Real-time request:
@@ -2049,6 +2343,46 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(quote_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `stock_at_time_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockAtTimeQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "stockAtTimeQuoteStream")]
+    pub async fn stock_at_time_quote_stream(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockAtTimeQuoteOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<QuoteTick>, (), Vec<QuoteTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let venue = options.venue;
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.stock_at_time_quote(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = quote_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// List all available option underlying symbols.
@@ -2213,6 +2547,43 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(option_contracts_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_list_contracts` rows into `callback` without materialising the full response in memory. `callback(chunk: OptionContract[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionListContracts`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionListContractsStream")]
+    pub async fn option_list_contracts_stream(
+        &self,
+        request_type: String,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionListContractsOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<OptionContract>, (), Vec<OptionContract>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let date = normalize_date(date);
+        let max_dte = options.max_dte;
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_list_contracts(&request_type, &symbol, date.as_str());
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = option_contracts_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Get the latest OHLC snapshot for an option contract.
@@ -2944,6 +3315,58 @@ impl ThetaDataDxClient {
         Ok(eod_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryEODStream")]
+    pub async fn option_history_eod_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryEODOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<EodTick>, (), Vec<EodTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_eod(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = eod_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch intraday OHLC bars for an option contract.
     ///
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
@@ -3015,6 +3438,72 @@ impl ThetaDataDxClient {
         Ok(ohlc_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryOHLC`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryOHLCStream")]
+    pub async fn option_history_ohlc_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryOHLCOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<OhlcTick>, (), Vec<OhlcTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_ohlc(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = ohlc_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch all trades for an option contract on a given date.
     ///
     /// - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
@@ -3084,6 +3573,72 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(trade_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_history_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTrade`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryTradeStream")]
+    pub async fn option_history_trade_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeTick>, (), Vec<TradeTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_trade(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch NBBO quotes for an option contract on a given date.
@@ -3159,6 +3714,76 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(quote_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_history_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryQuoteStream")]
+    pub async fn option_history_quote_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryQuoteOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<QuoteTick>, (), Vec<QuoteTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_quote(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = quote_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch combined trade + quote ticks for an option contract.
@@ -3237,6 +3862,76 @@ impl ThetaDataDxClient {
         Ok(trade_quote_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_trade_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeQuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryTradeQuoteStream")]
+    pub async fn option_history_trade_quote_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeQuoteOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeQuoteTick>, (), Vec<TradeQuoteTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let exclusive = options.exclusive;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_trade_quote(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = exclusive {
+                request = request.exclusive(value);
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_quote_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch open interest history for an option contract.
     ///
     /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
@@ -3295,6 +3990,64 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(open_interest_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_history_open_interest` rows into `callback` without materialising the full response in memory. `callback(chunk: OpenInterestTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryOpenInterest`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryOpenInterestStream")]
+    pub async fn option_history_open_interest_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryOpenInterestOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<OpenInterestTick>, (), Vec<OpenInterestTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_open_interest(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = open_interest_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch end-of-day Greeks history for an option contract.
@@ -3372,6 +4125,78 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(greeks_eod_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_history_greeks_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksEodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryGreeksEODStream")]
+    pub async fn option_history_greeks_eod_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksEODOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<GreeksEodTick>, (), Vec<GreeksEodTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let strike = options.strike;
+        let right = options.right;
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let underlyer_use_nbbo = options.underlyer_use_nbbo;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_greeks_eod(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = underlyer_use_nbbo {
+                request = request.underlyer_use_nbbo(value);
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = greeks_eod_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
@@ -3464,6 +4289,88 @@ impl ThetaDataDxClient {
         Ok(greeks_all_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_greeks_all` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksAllTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksAll`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryGreeksAllStream")]
+    pub async fn option_history_greeks_all_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksAllOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<GreeksAllTick>, (), Vec<GreeksAllTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_greeks_all(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = greeks_all_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch all Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
@@ -3551,6 +4458,88 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(trade_greeks_all_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_history_trade_greeks_all` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksAllTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksAll`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryTradeGreeksAllStream")]
+    pub async fn option_history_trade_greeks_all_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksAllOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeGreeksAllTick>, (), Vec<TradeGreeksAllTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_trade_greeks_all(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_greeks_all_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch first-order Greeks history (intraday, sampled by interval).
@@ -3643,6 +4632,88 @@ impl ThetaDataDxClient {
         Ok(greeks_first_order_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_greeks_first_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksFirstOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksFirstOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryGreeksFirstOrderStream")]
+    pub async fn option_history_greeks_first_order_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksFirstOrderOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<GreeksFirstOrderTick>, (), Vec<GreeksFirstOrderTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_greeks_first_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = greeks_first_order_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch first-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -3730,6 +4801,88 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(trade_greeks_first_order_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_history_trade_greeks_first_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksFirstOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksFirstOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryTradeGreeksFirstOrderStream")]
+    pub async fn option_history_trade_greeks_first_order_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksFirstOrderOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeGreeksFirstOrderTick>, (), Vec<TradeGreeksFirstOrderTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_trade_greeks_first_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_greeks_first_order_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch second-order Greeks history (intraday, sampled by interval).
@@ -3822,6 +4975,88 @@ impl ThetaDataDxClient {
         Ok(greeks_second_order_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_greeks_second_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksSecondOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksSecondOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryGreeksSecondOrderStream")]
+    pub async fn option_history_greeks_second_order_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksSecondOrderOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<GreeksSecondOrderTick>, (), Vec<GreeksSecondOrderTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_greeks_second_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = greeks_second_order_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch second-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -3909,6 +5144,88 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(trade_greeks_second_order_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_history_trade_greeks_second_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksSecondOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksSecondOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryTradeGreeksSecondOrderStream")]
+    pub async fn option_history_trade_greeks_second_order_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksSecondOrderOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeGreeksSecondOrderTick>, (), Vec<TradeGreeksSecondOrderTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_trade_greeks_second_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_greeks_second_order_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch third-order Greeks history (intraday, sampled by interval).
@@ -4001,6 +5318,88 @@ impl ThetaDataDxClient {
         Ok(greeks_third_order_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_greeks_third_order` rows into `callback` without materialising the full response in memory. `callback(chunk: GreeksThirdOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksThirdOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryGreeksThirdOrderStream")]
+    pub async fn option_history_greeks_third_order_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksThirdOrderOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<GreeksThirdOrderTick>, (), Vec<GreeksThirdOrderTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_greeks_third_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = greeks_third_order_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch third-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
@@ -4088,6 +5487,88 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(trade_greeks_third_order_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_history_trade_greeks_third_order` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksThirdOrderTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksThirdOrder`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryTradeGreeksThirdOrderStream")]
+    pub async fn option_history_trade_greeks_third_order_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksThirdOrderOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeGreeksThirdOrderTick>, (), Vec<TradeGreeksThirdOrderTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_trade_greeks_third_order(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_greeks_third_order_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch implied volatility history (intraday, sampled by interval).
@@ -4179,6 +5660,88 @@ impl ThetaDataDxClient {
         Ok(iv_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_greeks_implied_volatility` rows into `callback` without materialising the full response in memory. `callback(chunk: IvTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryGreeksImpliedVolatility`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryGreeksImpliedVolatilityStream")]
+    pub async fn option_history_greeks_implied_volatility_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryGreeksImpliedVolatilityOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<IvTick>, (), Vec<IvTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_greeks_implied_volatility(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = iv_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch implied volatility on each trade for an option contract.
     ///
     /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
@@ -4267,6 +5830,88 @@ impl ThetaDataDxClient {
         Ok(trade_greeks_implied_volatility_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_history_trade_greeks_implied_volatility` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeGreeksImpliedVolatilityTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionHistoryTradeGreeksImpliedVolatility`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionHistoryTradeGreeksImpliedVolatilityStream")]
+    pub async fn option_history_trade_greeks_implied_volatility_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionHistoryTradeGreeksImpliedVolatilityOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeGreeksImpliedVolatilityTick>, (), Vec<TradeGreeksImpliedVolatilityTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let date = normalize_date(date);
+        let strike = options.strike;
+        let right = options.right;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let annual_dividend = options.annual_dividend;
+        let rate_type = options.rate_type;
+        let rate_value = options.rate_value;
+        let version = options.version;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_history_trade_greeks_implied_volatility(&symbol, expiration.as_str(), date.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = annual_dividend {
+                request = request.annual_dividend(value);
+            }
+            if let Some(value) = rate_type {
+                request = request.rate_type(value.as_str());
+            }
+            if let Some(value) = rate_value {
+                request = request.rate_value(value);
+            }
+            if let Some(value) = version {
+                request = request.version(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_greeks_implied_volatility_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch the trade at a specific time of day across a date range for an option.
     ///
     /// - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
@@ -4324,6 +5969,60 @@ impl ThetaDataDxClient {
         Ok(trade_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `option_at_time_trade` rows into `callback` without materialising the full response in memory. `callback(chunk: TradeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionAtTimeTrade`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionAtTimeTradeStream")]
+    pub async fn option_at_time_trade_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionAtTimeTradeOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<TradeTick>, (), Vec<TradeTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_at_time_trade(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = trade_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch the quote at a specific time of day across a date range for an option.
     ///
     /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
@@ -4377,6 +6076,60 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(quote_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `option_at_time_quote` rows into `callback` without materialising the full response in memory. `callback(chunk: QuoteTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::optionAtTimeQuote`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "optionAtTimeQuoteStream")]
+    pub async fn option_at_time_quote_stream(
+        &self,
+        symbol: String,
+        expiration: Either<String, chrono::DateTime<chrono::Utc>>,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<OptionAtTimeQuoteOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<QuoteTick>, (), Vec<QuoteTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let expiration = normalize_date(expiration);
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let strike = options.strike;
+        let right = options.right;
+        let max_dte = options.max_dte;
+        let strike_range = options.strike_range;
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.option_at_time_quote(&symbol, expiration.as_str(), start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(value) = strike {
+                request = request.strike(value.as_str());
+            }
+            if let Some(value) = right {
+                request = request.right(value.as_str());
+            }
+            if let Some(value) = max_dte {
+                request = request.max_dte(value);
+            }
+            if let Some(value) = strike_range {
+                request = request.strike_range(value);
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = quote_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// List all available index symbols.
@@ -4565,6 +6318,40 @@ impl ThetaDataDxClient {
         Ok(eod_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `index_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::indexHistoryEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "indexHistoryEODStream")]
+    pub async fn index_history_eod_stream(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryEODOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<EodTick>, (), Vec<EodTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.index_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = eod_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch intraday OHLC bars for an index.
     ///
     /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
@@ -4612,6 +6399,52 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(ohlc_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `index_history_ohlc` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::indexHistoryOHLC`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "indexHistoryOHLCStream")]
+    pub async fn index_history_ohlc_stream(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryOHLCOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<OhlcTick>, (), Vec<OhlcTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.index_history_ohlc(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = ohlc_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Fetch intraday price history for an index.
@@ -4670,6 +6503,58 @@ impl ThetaDataDxClient {
         Ok(price_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `index_history_price` rows into `callback` without materialising the full response in memory. `callback(chunk: PriceTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::indexHistoryPrice`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "indexHistoryPriceStream")]
+    pub async fn index_history_price_stream(
+        &self,
+        symbol: String,
+        date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexHistoryPriceOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<PriceTick>, (), Vec<PriceTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let date = normalize_date(date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let start_date = normalize_optional_date(options.start_date);
+        let end_date = normalize_optional_date(options.end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.index_history_price(&symbol, date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = start_date {
+                request = request.start_date(value.as_str());
+            }
+            if let Some(value) = end_date {
+                request = request.end_date(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = price_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch the index price at a specific time of day across a date range.
     ///
     /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
@@ -4701,6 +6586,42 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(index_price_at_time_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `index_at_time_price` rows into `callback` without materialising the full response in memory. `callback(chunk: IndexPriceAtTimeTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::indexAtTimePrice`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "indexAtTimePriceStream")]
+    pub async fn index_at_time_price_stream(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        time_of_day: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<IndexAtTimePriceOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<IndexPriceAtTimeTick>, (), Vec<IndexPriceAtTimeTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let time_of_day = normalize_time(time_of_day);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.index_at_time_price(&symbol, start_date.as_str(), end_date.as_str(), time_of_day.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = index_price_at_time_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
     /// Check whether the market is open today.
@@ -4823,6 +6744,40 @@ impl ThetaDataDxClient {
         Ok(interest_rate_ticks_to_class_vec(&ticks))
     }
 
+    /// Stream `interest_rate_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: InterestRateTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::interestRateHistoryEOD`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "interestRateHistoryEODStream")]
+    pub async fn interest_rate_history_eod_stream(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<InterestRateHistoryEODOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<InterestRateTick>, (), Vec<InterestRateTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.interest_rate_history_eod(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = interest_rate_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
+    }
+
     /// Fetch intraday OHLC bars across a date range (start_date..end_date). This is a dedicated upstream route, distinct from the single-date stock_history_ohlc; the `_range` suffix mirrors the vendor's separate `ohlc_range` route.
     ///
     /// Defaults (upstream):
@@ -4871,6 +6826,56 @@ impl ThetaDataDxClient {
         })
         .await?;
         Ok(ohlc_ticks_to_class_vec(&ticks))
+    }
+
+    /// Stream `stock_history_ohlc_range` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to [`ThetaDataDxClient::stockHistoryOHLCRange`] — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument.
+    #[napi(js_name = "stockHistoryOHLCRangeStream")]
+    pub async fn stock_history_ohlc_range_stream(
+        &self,
+        symbol: String,
+        start_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        end_date: Either<String, chrono::DateTime<chrono::Utc>>,
+        options: Option<StockHistoryOHLCRangeOptions>,
+        callback: napi::threadsafe_function::ThreadsafeFunction<Vec<OhlcTick>, (), Vec<OhlcTick>, napi::Status, false>,
+    ) -> napi::Result<()> {
+        let options = options.unwrap_or_default();
+        let timeout_ms = match options.timeout_ms {
+            Some(ms) => Some(validate_timeout_ms(ms)?),
+            None => None,
+        };
+        let tdx = self.tdx.clone();
+        let start_date = normalize_date(start_date);
+        let end_date = normalize_date(end_date);
+        let interval = options.interval;
+        let start_time = normalize_optional_time(options.start_time);
+        let end_time = normalize_optional_time(options.end_time);
+        let venue = options.venue;
+        let callback = std::sync::Arc::new(callback);
+        spawn_endpoint_task(async move {
+            let mut request = tdx.stock_history_ohlc_range(&symbol, start_date.as_str(), end_date.as_str());
+            if let Some(value) = interval {
+                request = request.interval(value.as_str());
+            }
+            if let Some(value) = start_time {
+                request = request.start_time(value.as_str());
+            }
+            if let Some(value) = end_time {
+                request = request.end_time(value.as_str());
+            }
+            if let Some(value) = venue {
+                request = request.venue(value.as_str());
+            }
+            if let Some(ms) = timeout_ms {
+                request = request.with_deadline(std::time::Duration::from_millis(ms));
+            }
+            request
+                .stream(|chunk| {
+                    let rows = ohlc_ticks_to_class_vec(chunk);
+                    callback.call(rows, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
+                })
+                .await
+        })
+        .await
     }
 
 }

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -132,11 +132,14 @@ impl Config {
 
     /// Set the warning threshold (in bytes) for buffered (non-streaming)
     /// historical responses. Endpoints whose decoded total exceeds this
-    /// value emit a Rust-side `tracing::warn!` pointing the caller at
-    /// the `.stream()` surface; the data is still delivered. `0n`
-    /// disables the warning entirely. Default is `100n * 1024n * 1024n`
-    /// (100 MiB). Byte budgets can exceed `u32::MAX`, so the setter
-    /// takes a `BigInt` matching the underlying `usize` field.
+    /// value emit a Rust-side `tracing::warn!` pointing the caller at the
+    /// matching `<endpoint>Stream(...)` method (e.g. `optionHistoryTradeStream`),
+    /// which delivers the same rows chunk-by-chunk through a callback with
+    /// memory bounded to a single chunk; the buffered data is still
+    /// delivered. `0n` disables the warning entirely. Default is
+    /// `100n * 1024n * 1024n` (100 MiB). Byte budgets can exceed
+    /// `u32::MAX`, so the setter takes a `BigInt` matching the underlying
+    /// `usize` field.
     #[napi(js_name = "setWarnOnBufferedThresholdBytes")]
     pub fn set_warn_on_buffered_threshold_bytes(
         &self,


### PR DESCRIPTION
## Summary

Historical-result streaming existed in the Rust and Python SDKs but was absent from TypeScript, leaving a confirmed cross-binding capability gap. The `Config.setWarnOnBufferedThresholdBytes` doc even pointed oversized buffered pulls at a `.stream()` surface that TypeScript did not expose. This adds the streaming terminal to the TypeScript SDK, corrects the doc, and closes the parity gate's blind spot so the surface can no longer drift unnoticed.

## What changed

Every historical builder that streams in Python now has a `<endpoint>Stream(...args, options, callback)` method on the TypeScript `ThetaDataDxClient` (e.g. `optionHistoryTradeStream`, `stockHistoryTradeStream`). Each decoded server chunk is delivered to the JS `callback(chunk: Tick[])` through a napi-rs `ThreadsafeFunction`, so peak memory tracks a single chunk rather than the whole response — the memory-bounded path the buffered-threshold warning points at. The coverage set mirrors the Python streaming builders exactly: non-snapshot, non-FPSS-kind history endpoints that decode to a typed row collection (33 endpoints). Snapshot endpoints and the flat `StringList` list endpoints have no stream companion, matching Python.

The cross-binding parity gate previously tracked methods only on a fixed set of classes, so the per-endpoint builder `.stream` / `*Stream` terminals were invisible to it and could ship on some bindings while silently missing on others. A new `[[historical_streaming]]` row family enumerates the streaming terminal per endpoint across Python, TypeScript, C++, and the C ABI; the collectors reconcile the declared rows against the actual binding state in both directions, including a reverse-direction check that fails on any endpoint that streams without a row. C++ and the C ABI are recorded as not-yet-bound pending their port, so the gap is explicit and tracked.

## Verification

All local gates pass: `cargo fmt --all -- --check` (workspace and the TypeScript addon crate), `cargo clippy -- -D warnings` (both), `generate_sdk_surfaces --check`, `generate_docs_site --check`, `check_binding_parity.py` (now 33 historical-streaming rows), the parity selftest (43 cases, 5 new for the streaming family), and `check_docs_consistency.py`. The TypeScript addon builds and `index.d.ts` carries all 33 `Stream` methods.

Live proof against the production backend: streaming `optionHistoryTrade` for QQQ all-strikes on one day delivered 140,963 rows across 246 incremental chunks (largest single chunk 8,192 rows, ~6% of the total — peak callback memory is one chunk, not the full result), and the streamed row set matched the buffered `optionHistoryTrade` result for the same query exactly (identical count and content fingerprint).

## Follow-up

C++ and the C ABI streaming terminals are tracked as the next step; their `[[historical_streaming]]` columns flip to bound when they land. The parity gate already enumerates the rows, so the port cannot be marked done without the symbols actually existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
