### PR TITLE
fix(parity): symmetric subscription kind, list slicing, and config getters

### DIFF
--- a/crates/thetadatadx/build_support_bin/ticks/python_classes.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/python_classes.rs
@@ -191,7 +191,34 @@ fn render_python_string_list() -> String {
         "        format!(\"StringList({} rows, column={:?})\", self.inner.len(), self.column_name)\n",
     );
     out.push_str("    }\n\n");
-    out.push_str("    fn __getitem__(&self, idx: isize) -> PyResult<String> {\n");
+    // Integer indexing (negative-aware) AND slice indexing
+    // (`symbols[1:3]`, `symbols[::-1]`), matching the Python list protocol.
+    // A slice returns a new `StringList` over a cloned sub-Vec, preserving
+    // the `column_name` so the result still chains into `.to_polars()`
+    // with the same typed column; an integer returns one `str`.
+    out.push_str(
+        "    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {\n",
+    );
+    out.push_str("        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {\n");
+    out.push_str("            let indices = slice.indices(self.inner.len() as isize)?;\n");
+    out.push_str("            let mut rows = Vec::new();\n");
+    out.push_str("            let mut i = indices.start;\n");
+    out.push_str("            if indices.step > 0 {\n");
+    out.push_str("                while i < indices.stop {\n");
+    out.push_str("                    rows.push(self.inner[i as usize].clone());\n");
+    out.push_str("                    i += indices.step;\n");
+    out.push_str("                }\n");
+    out.push_str("            } else {\n");
+    out.push_str("                while i > indices.stop {\n");
+    out.push_str("                    rows.push(self.inner[i as usize].clone());\n");
+    out.push_str("                    i += indices.step;\n");
+    out.push_str("                }\n");
+    out.push_str("            }\n");
+    out.push_str(
+        "            return Ok(Py::new(py, StringList::new(rows, &self.column_name))?.into_any());\n",
+    );
+    out.push_str("        }\n");
+    out.push_str("        let idx: isize = key.extract()?;\n");
     out.push_str("        let len = self.inner.len() as isize;\n");
     out.push_str("        let resolved = if idx < 0 { idx + len } else { idx };\n");
     out.push_str("        if resolved < 0 || resolved >= len {\n");
@@ -201,7 +228,7 @@ fn render_python_string_list() -> String {
     );
     out.push_str("            )));\n");
     out.push_str("        }\n");
-    out.push_str("        Ok(self.inner[resolved as usize].clone())\n");
+    out.push_str("        Ok(pyo3::types::PyString::new(py, &self.inner[resolved as usize]).into_any().unbind())\n");
     out.push_str("    }\n\n");
     out.push_str(
         "    fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<StringListIter>> {\n",
@@ -886,12 +913,49 @@ fn render_python_tick_list_struct(schema: &Schema, type_name: &str, def: &TickTy
     .unwrap();
     out.push_str("    }\n\n");
 
-    // __getitem__ — supports negative indexing, raises IndexError on OOB.
+    // __getitem__ — integer indexing (negative-aware, raises IndexError
+    // on OOB) AND slice indexing (`ticks[1:3]`, `ticks[::-1]`), matching
+    // the Python list protocol the TypeScript array and C++ std::vector
+    // surfaces already satisfy. A slice returns a new `<Tick>List` over a
+    // cloned sub-Vec so the result chains straight into the same terminals
+    // (`.to_arrow()`, `.to_polars()`); an integer returns one typed tick.
+    // The single `Py<PyAny>` return unifies both shapes the way CPython's
+    // own `list.__getitem__` does.
+    // Copy tick types index out by value (no `.clone()` — clippy's
+    // `clone_on_copy` would reject it); the few non-Copy types (e.g.
+    // `OptionContract`, which carries a `String`) clone per row.
+    let row_at = if def.copy {
+        "self.inner[i as usize]"
+    } else {
+        "self.inner[i as usize].clone()"
+    };
     writeln!(
         out,
-        "    fn __getitem__(&self, idx: isize) -> PyResult<{class}> {{"
+        "    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {{"
     )
     .unwrap();
+    out.push_str("        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {\n");
+    out.push_str("            let indices = slice.indices(self.inner.len() as isize)?;\n");
+    out.push_str("            let mut rows = Vec::new();\n");
+    out.push_str("            let mut i = indices.start;\n");
+    out.push_str("            if indices.step > 0 {\n");
+    out.push_str("                while i < indices.stop {\n");
+    writeln!(out, "                    rows.push({row_at});").unwrap();
+    out.push_str("                    i += indices.step;\n");
+    out.push_str("                }\n");
+    out.push_str("            } else {\n");
+    out.push_str("                while i > indices.stop {\n");
+    writeln!(out, "                    rows.push({row_at});").unwrap();
+    out.push_str("                    i += indices.step;\n");
+    out.push_str("                }\n");
+    out.push_str("            }\n");
+    writeln!(
+        out,
+        "            return Ok(Py::new(py, {list_class}::new(rows))?.into_any());"
+    )
+    .unwrap();
+    out.push_str("        }\n");
+    out.push_str("        let idx: isize = key.extract()?;\n");
     out.push_str("        let len = self.inner.len() as isize;\n");
     out.push_str("        let resolved = if idx < 0 { idx + len } else { idx };\n");
     out.push_str("        if resolved < 0 || resolved >= len {\n");
@@ -904,10 +968,10 @@ fn render_python_tick_list_struct(schema: &Schema, type_name: &str, def: &TickTy
     out.push_str("            )));\n");
     out.push_str("        }\n");
     out.push_str("        let t = &self.inner[resolved as usize];\n");
-    out.push_str("        Ok(");
+    out.push_str("        let obj = ");
     pyclass_from_tick_expr(&mut out, type_name, def, "t", "            ");
-    // Trim the trailing newline pyclass_from_tick_expr emits inside the expression.
-    out.push_str("        )\n");
+    out.push_str("        ;\n");
+    out.push_str("        Ok(Py::new(py, obj)?.into_any())\n");
     out.push_str("    }\n\n");
 
     // __iter__

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -177,6 +177,35 @@ pub unsafe extern "C" fn tdx_config_set_flush_mode(config: *mut TdxConfig, mode:
     })
 }
 
+/// Read the configured FPSS flush mode. Same encoding as
+/// `tdx_config_set_flush_mode`: writes `0` (`Batched`) or `1`
+/// (`Immediate`) into `*out_mode`. Returns `0` on success, `-1` if
+/// either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_get_flush_mode(
+    config: *const TdxConfig,
+    out_mode: *mut i32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_mode.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const TdxConfig` returned by `tdx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        let value = match config.inner.fpss.flush_mode {
+            thetadatadx::FpssFlushMode::Batched => 0,
+            thetadatadx::FpssFlushMode::Immediate => 1,
+            _ => 0,
+        };
+        // SAFETY: out pointer checked non-null above; the FFI contract pins the storage for the call duration and forbids concurrent calls on the same handle.
+        unsafe {
+            *out_mode = value;
+        }
+        0
+    })
+}
+
 /// Set FPSS reconnect policy on a config handle.
 ///
 /// - `policy = 0`: Auto (default) -- auto-reconnect with split per-class
@@ -1627,6 +1656,29 @@ pub unsafe extern "C" fn tdx_config_set_derive_ohlcvc(config: *mut TdxConfig, en
     })
 }
 
+/// Read the configured FPSS OHLCVC-derivation flag. Writes `true` /
+/// `false` into `*out_enabled`. Returns `0` on success, `-1` if either
+/// pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_get_derive_ohlcvc(
+    config: *const TdxConfig,
+    out_enabled: *mut bool,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_enabled.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const TdxConfig` returned by `tdx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        // SAFETY: out pointer checked non-null above; caller pins the storage for the call duration.
+        unsafe {
+            *out_enabled = config.inner.fpss.derive_ohlcvc;
+        }
+        0
+    })
+}
+
 // ── FlatFilesConfig ────────────────────────────────────────────────
 //
 // Per-field setters/getters on `DirectConfig.flatfiles` mirror the
@@ -1975,6 +2027,31 @@ pub unsafe extern "C" fn tdx_config_set_concurrent_requests(config: *mut TdxConf
     })
 }
 
+/// Read the configured concurrent in-flight gRPC request count. Writes
+/// the value into `*out_n` (`0` = auto-detect from the subscription
+/// tier). A stored value above `u32::MAX` saturates to `u32::MAX`.
+/// Returns `0` on success, `-1` if either pointer is null.
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_get_concurrent_requests(
+    config: *const TdxConfig,
+    out_n: *mut u32,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_n.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const TdxConfig` returned by `tdx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        let value = u32::try_from(config.inner.mdds.concurrent_requests).unwrap_or(u32::MAX);
+        // SAFETY: out pointer checked non-null above; caller pins the storage for the call duration.
+        unsafe {
+            *out_n = value;
+        }
+        0
+    })
+}
+
 /// Set the `warn_on_buffered_threshold_bytes` ceiling on a config
 /// handle. Streaming endpoints log a `tracing::warn!` when a
 /// pre-stream-API caller receives a buffered response whose decoded
@@ -2080,10 +2157,73 @@ mod pool_sizing_tests {
         assert!(!cfg.is_null());
         // SAFETY: handle just returned by tdx_config_production.
         unsafe {
+            let mut current: u32 = 99;
             super::tdx_config_set_concurrent_requests(cfg, 8);
             assert_eq!((*cfg).inner.mdds.concurrent_requests, 8);
+            assert_eq!(
+                super::tdx_config_get_concurrent_requests(cfg, &mut current),
+                0
+            );
+            assert_eq!(current, 8);
             super::tdx_config_set_concurrent_requests(cfg, 0);
             assert_eq!((*cfg).inner.mdds.concurrent_requests, 0);
+            assert_eq!(
+                super::tdx_config_get_concurrent_requests(cfg, &mut current),
+                0
+            );
+            assert_eq!(current, 0);
+            // Null-pointer guard on the getter returns -1.
+            assert_eq!(
+                super::tdx_config_get_concurrent_requests(std::ptr::null(), &mut current),
+                -1
+            );
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn flush_mode_round_trips() {
+        let cfg = super::tdx_config_production();
+        assert!(!cfg.is_null());
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            let mut mode: i32 = -1;
+            // Default is Batched (0).
+            assert_eq!(super::tdx_config_get_flush_mode(cfg, &mut mode), 0);
+            assert_eq!(mode, 0);
+            assert_eq!(super::tdx_config_set_flush_mode(cfg, 1), 0);
+            assert_eq!(super::tdx_config_get_flush_mode(cfg, &mut mode), 0);
+            assert_eq!(mode, 1);
+            assert_eq!(super::tdx_config_set_flush_mode(cfg, 0), 0);
+            assert_eq!(super::tdx_config_get_flush_mode(cfg, &mut mode), 0);
+            assert_eq!(mode, 0);
+            // Null-pointer guard on the getter returns -1.
+            assert_eq!(
+                super::tdx_config_get_flush_mode(std::ptr::null(), &mut mode),
+                -1
+            );
+            super::tdx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn derive_ohlcvc_round_trips() {
+        let cfg = super::tdx_config_production();
+        assert!(!cfg.is_null());
+        // SAFETY: handle just returned by tdx_config_production.
+        unsafe {
+            let mut enabled = false;
+            super::tdx_config_set_derive_ohlcvc(cfg, 0);
+            assert_eq!(super::tdx_config_get_derive_ohlcvc(cfg, &mut enabled), 0);
+            assert!(!enabled);
+            super::tdx_config_set_derive_ohlcvc(cfg, 1);
+            assert_eq!(super::tdx_config_get_derive_ohlcvc(cfg, &mut enabled), 0);
+            assert!(enabled);
+            // Null-pointer guard on the getter returns -1.
+            assert_eq!(
+                super::tdx_config_get_derive_ohlcvc(std::ptr::null(), &mut enabled),
+                -1
+            );
             super::tdx_config_free(cfg);
         }
     }

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -1423,11 +1423,24 @@ int32_t tdx_config_get_metrics_port(const TdxConfig* config, bool* out_has_value
 int tdx_config_set_flush_mode(TdxConfig* config, int mode);
 
 /**
+ * Read the current streaming flush mode. Same encoding as
+ * tdx_config_set_flush_mode: writes 0 (Batched) or 1 (Immediate) into
+ * *out_mode. Returns 0 on success, -1 if either pointer is null.
+ */
+int32_t tdx_config_get_flush_mode(const TdxConfig* config, int32_t* out_mode);
+
+/**
  * Set streaming OHLCVC derivation on a config handle.
  *   enabled=1 (default): derive OHLCVC bars locally from trade events.
  *   enabled=0: only emit server-sent OHLCVC frames (lower overhead).
  */
 void tdx_config_set_derive_ohlcvc(TdxConfig* config, int enabled);
+
+/**
+ * Read the current OHLCVC-derivation flag. Writes true/false into
+ * *out_enabled. Returns 0 on success, -1 if either pointer is null.
+ */
+int32_t tdx_config_get_derive_ohlcvc(const TdxConfig* config, bool* out_enabled);
 
 /* ── Decode pool sizing ── */
 
@@ -1440,6 +1453,13 @@ void tdx_config_set_derive_ohlcvc(TdxConfig* config, int enabled);
  *     with a `tracing::warn!` if exceeded.
  */
 void tdx_config_set_concurrent_requests(TdxConfig* config, uint32_t n);
+
+/**
+ * Read the current concurrent in-flight gRPC request count. Writes the
+ * value into *out_n (0 = auto-detect from the tier). Returns 0 on
+ * success, -1 if either pointer is null.
+ */
+int32_t tdx_config_get_concurrent_requests(const TdxConfig* config, uint32_t* out_n);
 
 /**
  * Set the warn_on_buffered_threshold_bytes ceiling on a config.

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -1063,8 +1063,27 @@ public:
         }
     }
 
+    /** Read the current FPSS flush mode. Same encoding as
+     *  @c set_flush_mode: `0` = Batched, `1` = Immediate. Returns `0`
+     *  (Batched) on a null handle (matching the C ABI's `-1` failure
+     *  mapping at the boundary). */
+    int flush_mode() const {
+        int32_t mode = 0;
+        tdx_config_get_flush_mode(handle_.get(), &mode);
+        return mode;
+    }
+
     /** Set whether to derive OHLCVC bars locally from trades. */
     void set_derive_ohlcvc(bool enabled) { tdx_config_set_derive_ohlcvc(handle_.get(), enabled ? 1 : 0); }
+
+    /** Read the current OHLCVC-derivation flag. Returns `false` on a
+     *  null handle (matching the C ABI's `-1` failure mapping at the
+     *  boundary). */
+    bool derive_ohlcvc() const {
+        bool enabled = false;
+        tdx_config_get_derive_ohlcvc(handle_.get(), &enabled);
+        return enabled;
+    }
 
     // ── MDDS pool sizing ──
 
@@ -1077,6 +1096,19 @@ public:
      */
     void set_concurrent_requests(std::uint32_t n) {
         tdx_config_set_concurrent_requests(handle_.get(), n);
+    }
+
+    /**
+     * Read the current concurrent in-flight gRPC request count.
+     *
+     * Returns the configured value (`0` = auto-detect from the tier),
+     * or `0` on a null handle (matching the C ABI's `-1` failure
+     * mapping at the boundary).
+     */
+    std::uint32_t concurrent_requests() const {
+        std::uint32_t n = 0;
+        tdx_config_get_concurrent_requests(handle_.get(), &n);
+        return n;
     }
 
     /**
@@ -1154,6 +1186,7 @@ using FpssPing = TdxFpssPing;
 using FpssReconnected = TdxFpssReconnected;
 using FpssReconnectedServer = TdxFpssReconnectedServer;
 using FpssReconnecting = TdxFpssReconnecting;
+using FpssReconnectsExhausted = TdxFpssReconnectsExhausted;
 using FpssReqResponse = TdxFpssReqResponse;
 using FpssRestart = TdxFpssRestart;
 using FpssServerError = TdxFpssServerError;

--- a/sdks/cpp/tests/config_pool_sizing.cpp
+++ b/sdks/cpp/tests/config_pool_sizing.cpp
@@ -1,8 +1,8 @@
-// MDDS pool-sizing setter on tdx::Config.
+// MDDS pool-sizing setter + getter on tdx::Config.
 //
-// Offline test pinning the contract that `set_concurrent_requests`
-// on the `tdx::Config` C++ wrapper invokes the underlying C ABI
-// without crashing.
+// Offline test pinning the contract that `set_concurrent_requests` and
+// the `concurrent_requests()` readback getter on the `tdx::Config` C++
+// wrapper round-trip through the underlying C ABI.
 
 #include <cstdint>
 
@@ -11,16 +11,17 @@
 #include "thetadx.h"
 #include "thetadx.hpp"
 
-TEST_CASE("Config::set_concurrent_requests round-trips", "[config][pool_sizing][offline]") {
+TEST_CASE("Config concurrent_requests setter + getter round-trip", "[config][pool_sizing][offline]") {
     auto cfg = tdx::Config::production();
-    // The setter takes a uint32_t and returns void; the round-trip is
-    // observable through the FFI handle's underlying MddsConfig field,
-    // which the offline test cannot reach directly. The C++ test
-    // therefore asserts only that the setter accepts a range of values
-    // without throwing — the actual round-trip is exercised by the
-    // Rust-side `ffi::auth::pool_sizing_tests::concurrent_requests_round_trips`.
-    REQUIRE_NOTHROW(cfg.set_concurrent_requests(0));
-    REQUIRE_NOTHROW(cfg.set_concurrent_requests(1));
-    REQUIRE_NOTHROW(cfg.set_concurrent_requests(8));
-    REQUIRE_NOTHROW(cfg.set_concurrent_requests(32));
+    // The readback getter mirrors the Python `Config.concurrent_requests`
+    // and TypeScript `concurrentRequests` surfaces, so a value set
+    // through the C++ wrapper reads back through the same wrapper.
+    cfg.set_concurrent_requests(0);
+    REQUIRE(cfg.concurrent_requests() == 0u);
+    cfg.set_concurrent_requests(1);
+    REQUIRE(cfg.concurrent_requests() == 1u);
+    cfg.set_concurrent_requests(8);
+    REQUIRE(cfg.concurrent_requests() == 8u);
+    cfg.set_concurrent_requests(32);
+    REQUIRE(cfg.concurrent_requests() == 32u);
 }

--- a/sdks/cpp/tests/lifecycle.cpp
+++ b/sdks/cpp/tests/lifecycle.cpp
@@ -37,6 +37,24 @@ TEST_CASE("Config setters do not throw on a fresh config handle", "[lifecycle][o
     REQUIRE_NOTHROW(config.set_derive_ohlcvc(true));
 }
 
+TEST_CASE("Config flush_mode / derive_ohlcvc getters round-trip", "[lifecycle][offline]") {
+    // The readback getters mirror the Python `Config.flush_mode` /
+    // `.derive_ohlcvc` and TypeScript `flushMode` / `deriveOhlcvc`
+    // surfaces, so a value set through the C++ wrapper reads back
+    // through the same wrapper.
+    auto config = tdx::Config::production();
+
+    config.set_flush_mode(1);
+    REQUIRE(config.flush_mode() == 1);
+    config.set_flush_mode(0);
+    REQUIRE(config.flush_mode() == 0);
+
+    config.set_derive_ohlcvc(false);
+    REQUIRE(config.derive_ohlcvc() == false);
+    config.set_derive_ohlcvc(true);
+    REQUIRE(config.derive_ohlcvc() == true);
+}
+
 TEST_CASE("Client::connect succeeds against the production server", "[lifecycle][live]") {
     const auto creds_path = env_or_empty("THETADX_LIVE_CREDS");
     if (creds_path.empty()) {

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1137,7 +1137,28 @@ class = "Config"
 name = "flushMode"
 python = true
 typescript = true
-cpp = false  # follow-up — mirror getter in sdks/cpp/include/thetadx.hpp
+cpp = true
+
+# The `deriveOhlcvc` / `concurrentRequests` readback getters are exposed
+# on every binding: Python (`Config.derive_ohlcvc` / `.concurrent_requests`
+# properties), TypeScript (`Config.deriveOhlcvc` / `.concurrentRequests`
+# getters), C++ (`Config::derive_ohlcvc()` / `::concurrent_requests()`
+# over the FFI `tdx_config_get_derive_ohlcvc` / `_concurrent_requests`
+# symbols). The matching setters are tracked by the dotted `[[class]]`
+# rows `FpssConfig.derive_ohlcvc` / `MddsConfig.concurrent_requests`.
+[[method]]
+class = "Config"
+name = "deriveOhlcvc"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "Config"
+name = "concurrentRequests"
+python = true
+typescript = true
+cpp = true
 
 # Custom reconnect-policy callback registration. A field-shaped getter
 # is meaningless for a callback, so the registration is tracked as a

--- a/sdks/python/src/_generated/tick_classes.rs
+++ b/sdks/python/src/_generated/tick_classes.rs
@@ -1779,7 +1779,25 @@ impl CalendarDayList {
         format!("CalendarDayList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<CalendarDay> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, CalendarDayList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -1788,14 +1806,15 @@ impl CalendarDayList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            CalendarDay {
+        let obj =             CalendarDay {
                 date: t.date,
                 is_open: t.is_open,
                 open_time: t.open_time,
                 close_time: t.close_time,
                 status: t.status.as_str().to_string(),
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<CalendarDayListIter>> {
@@ -1948,7 +1967,25 @@ impl EodTickList {
         format!("EodTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<EodTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, EodTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -1957,7 +1994,7 @@ impl EodTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            EodTick {
+        let obj =             EodTick {
                 created_ms_of_day: t.created_ms_of_day,
                 last_trade_ms_of_day: t.last_trade_ms_of_day,
                 open: t.open,
@@ -1979,7 +2016,8 @@ impl EodTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<EodTickListIter>> {
@@ -2173,7 +2211,25 @@ impl GreeksAllTickList {
         format!("GreeksAllTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<GreeksAllTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, GreeksAllTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -2182,7 +2238,7 @@ impl GreeksAllTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            GreeksAllTick {
+        let obj =             GreeksAllTick {
                 ms_of_day: t.ms_of_day,
                 bid: t.bid,
                 ask: t.ask,
@@ -2215,7 +2271,8 @@ impl GreeksAllTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<GreeksAllTickListIter>> {
@@ -2443,7 +2500,25 @@ impl GreeksEodTickList {
         format!("GreeksEodTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<GreeksEodTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, GreeksEodTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -2452,7 +2527,7 @@ impl GreeksEodTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            GreeksEodTick {
+        let obj =             GreeksEodTick {
                 ms_of_day: t.ms_of_day,
                 open: t.open,
                 high: t.high,
@@ -2497,7 +2572,8 @@ impl GreeksEodTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<GreeksEodTickListIter>> {
@@ -2723,7 +2799,25 @@ impl GreeksFirstOrderTickList {
         format!("GreeksFirstOrderTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<GreeksFirstOrderTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, GreeksFirstOrderTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -2732,7 +2826,7 @@ impl GreeksFirstOrderTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            GreeksFirstOrderTick {
+        let obj =             GreeksFirstOrderTick {
                 ms_of_day: t.ms_of_day,
                 bid: t.bid,
                 ask: t.ask,
@@ -2751,7 +2845,8 @@ impl GreeksFirstOrderTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<GreeksFirstOrderTickListIter>> {
@@ -2924,7 +3019,25 @@ impl GreeksSecondOrderTickList {
         format!("GreeksSecondOrderTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<GreeksSecondOrderTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, GreeksSecondOrderTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -2933,7 +3046,7 @@ impl GreeksSecondOrderTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            GreeksSecondOrderTick {
+        let obj =             GreeksSecondOrderTick {
                 ms_of_day: t.ms_of_day,
                 bid: t.bid,
                 ask: t.ask,
@@ -2951,7 +3064,8 @@ impl GreeksSecondOrderTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<GreeksSecondOrderTickListIter>> {
@@ -3121,7 +3235,25 @@ impl GreeksThirdOrderTickList {
         format!("GreeksThirdOrderTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<GreeksThirdOrderTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, GreeksThirdOrderTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -3130,7 +3262,7 @@ impl GreeksThirdOrderTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            GreeksThirdOrderTick {
+        let obj =             GreeksThirdOrderTick {
                 ms_of_day: t.ms_of_day,
                 bid: t.bid,
                 ask: t.ask,
@@ -3147,7 +3279,8 @@ impl GreeksThirdOrderTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<GreeksThirdOrderTickListIter>> {
@@ -3311,7 +3444,25 @@ impl IndexPriceAtTimeTickList {
         format!("IndexPriceAtTimeTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<IndexPriceAtTimeTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, IndexPriceAtTimeTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -3320,7 +3471,7 @@ impl IndexPriceAtTimeTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            IndexPriceAtTimeTick {
+        let obj =             IndexPriceAtTimeTick {
                 ms_of_day: t.ms_of_day,
                 sequence: t.sequence,
                 ext_condition1: t.ext_condition1,
@@ -3333,7 +3484,8 @@ impl IndexPriceAtTimeTickList {
                 price: t.price,
                 date: t.date,
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<IndexPriceAtTimeTickListIter>> {
@@ -3480,7 +3632,25 @@ impl InterestRateTickList {
         format!("InterestRateTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<InterestRateTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, InterestRateTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -3489,11 +3659,12 @@ impl InterestRateTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            InterestRateTick {
+        let obj =             InterestRateTick {
                 date: t.date,
                 rate: t.rate,
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<InterestRateTickListIter>> {
@@ -3634,7 +3805,25 @@ impl IvTickList {
         format!("IvTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<IvTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, IvTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -3643,7 +3832,7 @@ impl IvTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            IvTick {
+        let obj =             IvTick {
                 ms_of_day: t.ms_of_day,
                 bid: t.bid,
                 bid_implied_volatility: t.bid_implied_volatility,
@@ -3659,7 +3848,8 @@ impl IvTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<IvTickListIter>> {
@@ -3818,7 +4008,25 @@ impl MarketValueTickList {
         format!("MarketValueTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<MarketValueTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, MarketValueTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -3827,7 +4035,7 @@ impl MarketValueTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            MarketValueTick {
+        let obj =             MarketValueTick {
                 ms_of_day: t.ms_of_day,
                 market_bid: t.market_bid,
                 market_ask: t.market_ask,
@@ -3837,7 +4045,8 @@ impl MarketValueTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<MarketValueTickListIter>> {
@@ -3988,7 +4197,25 @@ impl OhlcTickList {
         format!("OhlcTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<OhlcTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, OhlcTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -3997,7 +4224,7 @@ impl OhlcTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            OhlcTick {
+        let obj =             OhlcTick {
                 ms_of_day: t.ms_of_day,
                 open: t.open,
                 high: t.high,
@@ -4011,7 +4238,8 @@ impl OhlcTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<OhlcTickListIter>> {
@@ -4164,7 +4392,25 @@ impl OpenInterestTickList {
         format!("OpenInterestTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<OpenInterestTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, OpenInterestTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -4173,7 +4419,7 @@ impl OpenInterestTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            OpenInterestTick {
+        let obj =             OpenInterestTick {
                 ms_of_day: t.ms_of_day,
                 open_interest: t.open_interest,
                 date: t.date,
@@ -4181,7 +4427,8 @@ impl OpenInterestTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<OpenInterestTickListIter>> {
@@ -4320,7 +4567,25 @@ impl OptionContractList {
         format!("OptionContractList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<OptionContract> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize].clone());
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize].clone());
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, OptionContractList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -4329,13 +4594,14 @@ impl OptionContractList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            OptionContract {
+        let obj =             OptionContract {
                 symbol: t.symbol.clone(),
                 expiration: t.expiration,
                 strike: t.strike,
                 right: if t.right == '\0' { String::new() } else { t.right.to_string() },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<OptionContractListIter>> {
@@ -4469,7 +4735,25 @@ impl PriceTickList {
         format!("PriceTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<PriceTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, PriceTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -4478,12 +4762,13 @@ impl PriceTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            PriceTick {
+        let obj =             PriceTick {
                 ms_of_day: t.ms_of_day,
                 price: t.price,
                 date: t.date,
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<PriceTickListIter>> {
@@ -4626,7 +4911,25 @@ impl QuoteTickList {
         format!("QuoteTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<QuoteTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, QuoteTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -4635,7 +4938,7 @@ impl QuoteTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            QuoteTick {
+        let obj =             QuoteTick {
                 ms_of_day: t.ms_of_day,
                 bid_size: t.bid_size,
                 bid_exchange: t.bid_exchange,
@@ -4651,7 +4954,8 @@ impl QuoteTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<QuoteTickListIter>> {
@@ -4840,7 +5144,25 @@ impl TradeGreeksAllTickList {
         format!("TradeGreeksAllTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<TradeGreeksAllTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, TradeGreeksAllTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -4849,7 +5171,7 @@ impl TradeGreeksAllTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            TradeGreeksAllTick {
+        let obj =             TradeGreeksAllTick {
                 ms_of_day: t.ms_of_day,
                 sequence: t.sequence,
                 ext_condition1: t.ext_condition1,
@@ -4889,7 +5211,8 @@ impl TradeGreeksAllTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<TradeGreeksAllTickListIter>> {
@@ -5112,7 +5435,25 @@ impl TradeGreeksFirstOrderTickList {
         format!("TradeGreeksFirstOrderTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<TradeGreeksFirstOrderTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, TradeGreeksFirstOrderTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -5121,7 +5462,7 @@ impl TradeGreeksFirstOrderTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            TradeGreeksFirstOrderTick {
+        let obj =             TradeGreeksFirstOrderTick {
                 ms_of_day: t.ms_of_day,
                 sequence: t.sequence,
                 ext_condition1: t.ext_condition1,
@@ -5147,7 +5488,8 @@ impl TradeGreeksFirstOrderTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<TradeGreeksFirstOrderTickListIter>> {
@@ -5336,7 +5678,25 @@ impl TradeGreeksImpliedVolatilityTickList {
         format!("TradeGreeksImpliedVolatilityTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<TradeGreeksImpliedVolatilityTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, TradeGreeksImpliedVolatilityTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -5345,7 +5705,7 @@ impl TradeGreeksImpliedVolatilityTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            TradeGreeksImpliedVolatilityTick {
+        let obj =             TradeGreeksImpliedVolatilityTick {
                 ms_of_day: t.ms_of_day,
                 sequence: t.sequence,
                 ext_condition1: t.ext_condition1,
@@ -5365,7 +5725,8 @@ impl TradeGreeksImpliedVolatilityTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<TradeGreeksImpliedVolatilityTickListIter>> {
@@ -5547,7 +5908,25 @@ impl TradeGreeksSecondOrderTickList {
         format!("TradeGreeksSecondOrderTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<TradeGreeksSecondOrderTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, TradeGreeksSecondOrderTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -5556,7 +5935,7 @@ impl TradeGreeksSecondOrderTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            TradeGreeksSecondOrderTick {
+        let obj =             TradeGreeksSecondOrderTick {
                 ms_of_day: t.ms_of_day,
                 sequence: t.sequence,
                 ext_condition1: t.ext_condition1,
@@ -5581,7 +5960,8 @@ impl TradeGreeksSecondOrderTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<TradeGreeksSecondOrderTickListIter>> {
@@ -5772,7 +6152,25 @@ impl TradeGreeksThirdOrderTickList {
         format!("TradeGreeksThirdOrderTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<TradeGreeksThirdOrderTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, TradeGreeksThirdOrderTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -5781,7 +6179,7 @@ impl TradeGreeksThirdOrderTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            TradeGreeksThirdOrderTick {
+        let obj =             TradeGreeksThirdOrderTick {
                 ms_of_day: t.ms_of_day,
                 sequence: t.sequence,
                 ext_condition1: t.ext_condition1,
@@ -5805,7 +6203,8 @@ impl TradeGreeksThirdOrderTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<TradeGreeksThirdOrderTickListIter>> {
@@ -5999,7 +6398,25 @@ impl TradeQuoteTickList {
         format!("TradeQuoteTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<TradeQuoteTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, TradeQuoteTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -6008,7 +6425,7 @@ impl TradeQuoteTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            TradeQuoteTick {
+        let obj =             TradeQuoteTick {
                 ms_of_day: t.ms_of_day,
                 sequence: t.sequence,
                 ext_condition1: t.ext_condition1,
@@ -6037,7 +6454,8 @@ impl TradeQuoteTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<TradeQuoteTickListIter>> {
@@ -6232,7 +6650,25 @@ impl TradeTickList {
         format!("TradeTickList({} rows)", self.inner.len())
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<TradeTick> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize]);
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, TradeTickList::new(rows))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -6241,7 +6677,7 @@ impl TradeTickList {
             )));
         }
         let t = &self.inner[resolved as usize];
-        Ok(            TradeTick {
+        let obj =             TradeTick {
                 ms_of_day: t.ms_of_day,
                 sequence: t.sequence,
                 ext_condition1: t.ext_condition1,
@@ -6261,7 +6697,8 @@ impl TradeTickList {
                 strike: t.has_contract_id().then_some(t.strike),
                 right: if t.right == '\0' { None } else { Some(t.right.to_string()) },
             }
-        )
+        ;
+        Ok(Py::new(py, obj)?.into_any())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<TradeTickListIter>> {
@@ -7248,7 +7685,25 @@ impl StringList {
         format!("StringList({} rows, column={:?})", self.inner.len(), self.column_name)
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<String> {
+    fn __getitem__(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if let Ok(slice) = key.cast::<pyo3::types::PySlice>() {
+            let indices = slice.indices(self.inner.len() as isize)?;
+            let mut rows = Vec::new();
+            let mut i = indices.start;
+            if indices.step > 0 {
+                while i < indices.stop {
+                    rows.push(self.inner[i as usize].clone());
+                    i += indices.step;
+                }
+            } else {
+                while i > indices.stop {
+                    rows.push(self.inner[i as usize].clone());
+                    i += indices.step;
+                }
+            }
+            return Ok(Py::new(py, StringList::new(rows, &self.column_name))?.into_any());
+        }
+        let idx: isize = key.extract()?;
         let len = self.inner.len() as isize;
         let resolved = if idx < 0 { idx + len } else { idx };
         if resolved < 0 || resolved >= len {
@@ -7256,7 +7711,7 @@ impl StringList {
                 "StringList index {} out of range (len={})", idx, self.inner.len()
             )));
         }
-        Ok(self.inner[resolved as usize].clone())
+        Ok(pyo3::types::PyString::new(py, &self.inner[resolved as usize]).into_any().unbind())
     }
 
     fn __iter__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<StringListIter>> {

--- a/sdks/python/src/fluent.rs
+++ b/sdks/python/src/fluent.rs
@@ -245,9 +245,9 @@ pub(crate) struct PySubscription {
 
 #[pymethods]
 impl PySubscription {
-    /// One of `"quote"`, `"trade"`, `"open_interest"`, `"full_trades"`,
-    /// or `"full_open_interest"` — the wire-level kind for this
-    /// subscription.
+    /// One of `"quote"`, `"trade"`, `"open_interest"`,
+    /// `"market_value"`, `"full_trades"`, or `"full_open_interest"` —
+    /// the wire-level kind for this subscription.
     #[getter]
     fn kind(&self) -> &'static str {
         match &self.inner {
@@ -255,6 +255,7 @@ impl PySubscription {
                 SubscriptionKind::Quote => "quote",
                 SubscriptionKind::Trade => "trade",
                 SubscriptionKind::OpenInterest => "open_interest",
+                SubscriptionKind::MarketValue => "market_value",
                 _ => "unknown",
             },
             protocol::Subscription::Full { kind, .. } => match kind {

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -998,7 +998,7 @@ impl Config {
 
     /// Get the current OHLCVC derivation setting.
     #[getter]
-    fn get_derive_ohlcvc(&self) -> bool {
+    fn derive_ohlcvc(&self) -> bool {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         guard.fpss.derive_ohlcvc
     }
@@ -1094,7 +1094,7 @@ impl Config {
 
     /// Current `concurrent_requests` setting (``0`` = auto-detect).
     #[getter]
-    fn get_concurrent_requests(&self) -> usize {
+    fn concurrent_requests(&self) -> usize {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         guard.mdds.concurrent_requests
     }

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -571,8 +571,9 @@ export declare class SecType {
  */
 export declare class Subscription {
   /**
-   * One of `"quote"`, `"trade"`, `"open_interest"`, `"full_trades"`,
-   * `"full_open_interest"` — the wire-level kind.
+   * One of `"quote"`, `"trade"`, `"open_interest"`,
+   * `"market_value"`, `"full_trades"`, `"full_open_interest"` — the
+   * wire-level kind.
    */
   get kind(): string
   /** `true` for full-stream (security-type-scoped) subscriptions. */

--- a/sdks/typescript/src/fluent.rs
+++ b/sdks/typescript/src/fluent.rs
@@ -265,8 +265,9 @@ pub struct Subscription {
 
 #[napi]
 impl Subscription {
-    /// One of `"quote"`, `"trade"`, `"open_interest"`, `"full_trades"`,
-    /// `"full_open_interest"` — the wire-level kind.
+    /// One of `"quote"`, `"trade"`, `"open_interest"`,
+    /// `"market_value"`, `"full_trades"`, `"full_open_interest"` — the
+    /// wire-level kind.
     #[napi(getter)]
     pub fn kind(&self) -> String {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
@@ -275,6 +276,7 @@ impl Subscription {
                 SubscriptionKind::Quote => "quote",
                 SubscriptionKind::Trade => "trade",
                 SubscriptionKind::OpenInterest => "open_interest",
+                SubscriptionKind::MarketValue => "market_value",
                 _ => "unknown",
             },
             protocol::Subscription::Full { kind, .. } => match kind {


### PR DESCRIPTION
Three cross-binding cosmetic disparities closed so a quant gets the same surface and behavior in every binding, not just the same capability.

## `Subscription.kind` for market value

`Subscription.kind` returned `"unknown"` for a market-value subscription on Python and TypeScript even though `Contract.market_value()` is a valid subscription. Both now return `"market_value"`, matching the wire vocabulary the FPSS event surface already uses. The Rust core and C++ `FluentSubscription` already classified it correctly.

## Python tick-list slicing

The Python tick `*List` wrappers and `StringList` now support slicing: `ticks[1:3]`, `ticks[::-1]`, and `ticks[::2]` return a new typed list that still chains into `.to_arrow()` / `.to_pandas()` / `.to_polars()`, while an integer index returns one row as before and out-of-range integers still raise `IndexError`. TypeScript returns native arrays and C++ returns `std::vector`, both of which already slice, so this brings Python to the same list protocol. The slice path is emitted from the tick-list generator: Copy tick types are indexed by value, the few non-Copy types clone per row.

## C++ config readback getters

`tdx::Config` gained `flush_mode()`, `derive_ohlcvc()`, and `concurrent_requests()` readback getters (setter-only before; Python and TypeScript expose both directions), each forwarding through a new C ABI getter (`tdx_config_get_flush_mode` / `_derive_ohlcvc` / `_concurrent_requests`). The missing `tdx::FpssReconnectsExhausted` type alias was added to the FPSS event alias block so every event variant has one. The Python `derive_ohlcvc` / `concurrent_requests` property getters drop their `get_` prefix to match the consistent bare-getter spelling; the Python property names are unchanged.

## Gate

The parity matrix flips `Config.flushMode` to bound on C++ and adds `deriveOhlcvc` / `concurrentRequests` getter rows, so the gate fails if any of the three C++ readback getters regress. Verified locally: `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings` plus clippy on both SDK crates, `generate_sdk_surfaces --check`, `generate_docs_site --check`, `check_binding_parity.py`, `check_docs_consistency.py`, the C-ABI completeness check against the built `.so`, the workspace test suite, and new FFI getter round-trip tests plus C++ getter round-trip tests. Functionally confirmed the built wheel slices (`ticks[1:3]`), the built Node addon reports `marketValue().kind === "market_value"`, and the C++ getters round-trip against the linked library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)