### PR TITLE
docs(python): complete the unified-client and Contract type stub

### DIFF
--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -221,6 +221,7 @@ class Contract:
     def quote(self) -> Subscription: ...
     def trade(self) -> Subscription: ...
     def open_interest(self) -> Subscription: ...
+    def market_value(self) -> Subscription: ...
 
     def __repr__(self) -> str: ...
     def __eq__(self, other: object) -> bool: ...
@@ -276,7 +277,7 @@ class Subscription:
 
     @property
     def kind(self) -> str: ...
-    """`"quote"` / `"trade"` / `"open_interest"` / `"full_trades"` / `"full_open_interest"`."""
+    """`"quote"` / `"trade"` / `"open_interest"` / `"market_value"` / `"full_trades"` / `"full_open_interest"`."""
 
     @property
     def is_full(self) -> bool: ...
@@ -658,12 +659,42 @@ class ThetaDataDxClient:
         session across auto-reconnects."""
         ...
 
+    # Session identity + subscription tier.
+    def session_uuid(self) -> str:
+        """Server-assigned session UUID for the live streaming connection."""
+        ...
+    def subscription_info(self) -> List[Tuple[str, str]]:
+        """Subscription-tier snapshot captured at authentication time.
+
+        One ``(asset_class, tier)`` tuple per asset class the Nexus auth
+        payload carries, in stable declaration order: ``stock`` /
+        ``options`` / ``indices`` / ``interest_rate``.
+        """
+        ...
+
     # Context managers.
     def streaming(self, callback: EventCallback) -> StreamingSession: ...
 
-    # FLATFILES namespace getter.
+    # FLATFILES namespace getter + direct-to-disk helper.
     @property
     def flat_files(self) -> FlatFilesNamespace: ...
+    def flatfile_to_path(
+        self,
+        sec_type: str,
+        req_type: str,
+        date: str,
+        path: str,
+        format: Optional[str] = None,
+    ) -> str:
+        """Pull a flat-file blob and write it to ``path`` without decoding
+        rows.
+
+        ``sec_type`` / ``req_type`` accept the same strings as
+        ``flat_files.request(...)``; ``format`` is ``"csv"`` (default) or
+        ``"jsonl"``. Returns the final on-disk path (extension
+        auto-appended if absent).
+        """
+        ...
 
     def __repr__(self) -> str: ...
 


### PR DESCRIPTION
Closes the type-stub gaps on the hand-mirrored load-bearing pyclasses. The runtime already exposes these; this is typing-only, so IDE completion and mypy now see the full surface.

`ThetaDataDxClient` is the one pyclass the project mirrors method-for-method in `__init__.pyi` (it deliberately carries no per-class `__getattr__` fallback, so the stubtest gate catches drift on it), but three public methods were absent from the stub: `session_uuid()`, `subscription_info()`, and `flatfile_to_path()`. They are added with accurate signatures and return types.

`Contract.market_value()` is added to the already-declared `Contract` stub so the fluent builder's market-value subscription is typed alongside `quote()` / `trade()` / `open_interest()`, and the `Subscription.kind` docstring now lists `"market_value"`.

The generator-emitted historical builders, typed tick-list wrappers, and string enums remain on the module-level `__getattr__ -> Any` fallback. That is the existing sanctioned design: the stubtest gate runs with `--ignore-missing-stub` precisely so that 100+ codegen-emitted classes do not need a hand-typed mirror that would drift on every codegen pass. This change completes only the load-bearing classes the stub already enumerates.

Verified with the exact CI gate (`python -m mypy.stubtest thetadatadx --allowlist sdks/python/stubtest_allowlist.txt --ignore-missing-stub --ignore-disjoint-bases --ignore-positional-only`): `Success: no issues found in 2 modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)