### PR TITLE
feat(cpp)!: unify Config getter shape, snake_case kind labels, add mdds endpoint knob

### DIFF
--- a/crates/thetadatadx/src/fpss/protocol/subscription.rs
+++ b/crates/thetadatadx/src/fpss/protocol/subscription.rs
@@ -59,6 +59,46 @@ impl SubscriptionKind {
             Self::MarketValue => StreamMsgType::RemoveMarketValue,
         }
     }
+
+    /// Stable snake_case wire-kind label for a per-contract subscription,
+    /// identical across every binding.
+    ///
+    /// This is the single source of the per-contract subscription-kind
+    /// string the C ABI (`tdx_unified_active_subscriptions`), the C++
+    /// `FluentSubscription::kind_string`, and the Python / TypeScript
+    /// `Subscription.kind` accessors all surface. Returning a fixed label
+    /// here keeps the bindings from drifting onto the enum's `Debug`
+    /// spelling, which is PascalCase and would diverge per language.
+    #[must_use]
+    pub fn kind_str(self) -> &'static str {
+        match self {
+            Self::Quote => "quote",
+            Self::Trade => "trade",
+            Self::OpenInterest => "open_interest",
+            Self::MarketValue => "market_value",
+        }
+    }
+
+    /// Stable snake_case label for this kind when carried as a
+    /// *full-stream* subscription, or `None` if the kind has no
+    /// full-stream form on the FPSS wire.
+    ///
+    /// Full-stream snapshots
+    /// ([`crate::ThetaDataDxClient::active_full_subscriptions`]) store the
+    /// kind as a [`SubscriptionKind`], but the cross-binding label carries
+    /// the `full_` prefix so a full-stream open-interest row never reads
+    /// the same as a per-contract one. Only `Trade` and `OpenInterest`
+    /// have a full-stream broadcast; `Quote` and `MarketValue` are
+    /// per-contract only and return `None` (the binding drops the row),
+    /// matching the Python / TypeScript projections.
+    #[must_use]
+    pub fn full_kind_str(self) -> Option<&'static str> {
+        match self {
+            Self::Trade => Some("full_trades"),
+            Self::OpenInterest => Some("full_open_interest"),
+            Self::Quote | Self::MarketValue => None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -81,6 +121,26 @@ pub enum FullSubscriptionKind {
     Trades,
     /// Full-stream open-interest subscription.
     OpenInterest,
+}
+
+impl FullSubscriptionKind {
+    /// Stable snake_case wire-kind label, identical across every binding.
+    ///
+    /// Full-stream kinds carry the `full_` prefix
+    /// (`full_trades` / `full_open_interest`) so a full-stream
+    /// open-interest subscription never renders the same label as a
+    /// per-contract one (both would be the bare enum `Debug` spelling
+    /// `OpenInterest` otherwise). The C ABI
+    /// (`tdx_unified_active_full_subscriptions`), the C++
+    /// `FluentSubscription::kind_string`, and the Python / TypeScript
+    /// `Subscription.kind` accessors all read this label.
+    #[must_use]
+    pub fn kind_str(self) -> &'static str {
+        match self {
+            Self::Trades => "full_trades",
+            Self::OpenInterest => "full_open_interest",
+        }
+    }
 }
 
 /// Typed, fluent market-data subscription.
@@ -293,6 +353,45 @@ mod tests {
     }
 
     // ---- Fluent Subscription tests ----------------------------------
+
+    #[test]
+    fn subscription_kind_str_is_snake_case() {
+        assert_eq!(SubscriptionKind::Quote.kind_str(), "quote");
+        assert_eq!(SubscriptionKind::Trade.kind_str(), "trade");
+        assert_eq!(SubscriptionKind::OpenInterest.kind_str(), "open_interest");
+        assert_eq!(SubscriptionKind::MarketValue.kind_str(), "market_value");
+    }
+
+    #[test]
+    fn subscription_kind_full_str_prefixes_and_filters() {
+        assert_eq!(SubscriptionKind::Trade.full_kind_str(), Some("full_trades"));
+        assert_eq!(
+            SubscriptionKind::OpenInterest.full_kind_str(),
+            Some("full_open_interest")
+        );
+        // Quote / MarketValue have no full-stream form on the wire.
+        assert_eq!(SubscriptionKind::Quote.full_kind_str(), None);
+        assert_eq!(SubscriptionKind::MarketValue.full_kind_str(), None);
+    }
+
+    #[test]
+    fn full_subscription_kind_str_is_prefixed() {
+        assert_eq!(FullSubscriptionKind::Trades.kind_str(), "full_trades");
+        assert_eq!(
+            FullSubscriptionKind::OpenInterest.kind_str(),
+            "full_open_interest"
+        );
+    }
+
+    #[test]
+    fn full_open_interest_never_collides_with_per_contract() {
+        // The collision the snake_case labels exist to prevent: a
+        // per-contract OI and a full-stream OI must read differently.
+        assert_ne!(
+            SubscriptionKind::OpenInterest.kind_str(),
+            FullSubscriptionKind::OpenInterest.kind_str()
+        );
+    }
 
     #[test]
     fn contract_quote_returns_per_contract_subscription() {

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -1644,13 +1644,13 @@ pub unsafe extern "C" fn tdx_config_get_retry_jitter(
 
 /// Set FPSS OHLCVC derivation on a config handle.
 ///
-/// - `enabled = 1` (default): derive OHLCVC bars locally from trade events
-/// - `enabled = 0`: only emit server-sent OHLCVC frames (lower overhead)
+/// - `enabled = true` (default): derive OHLCVC bars locally from trade events
+/// - `enabled = false`: only emit server-sent OHLCVC frames (lower overhead)
 #[no_mangle]
-pub unsafe extern "C" fn tdx_config_set_derive_ohlcvc(config: *mut TdxConfig, enabled: i32) {
+pub unsafe extern "C" fn tdx_config_set_derive_ohlcvc(config: *mut TdxConfig, enabled: bool) {
     ffi_boundary!((), {
         let config = require_config_mut!(config);
-        config.inner.fpss.derive_ohlcvc = enabled != 0;
+        config.inner.fpss.derive_ohlcvc = enabled;
     })
 }
 
@@ -2009,6 +2009,107 @@ pub unsafe extern "C" fn tdx_config_get_metrics_port(
     })
 }
 
+// ── MDDS endpoint ──────────────────────────────────────────────────
+//
+// The historical (MDDS) gRPC host / port advanced overrides. Both
+// default to the upstream production endpoint; point them at a known
+// host to redirect the historical channel (e.g. a refused endpoint in
+// structural tests that prove the streaming-only surface never opens
+// it). The host crosses the ABI as a `*const c_char` (validated non-null
+// + UTF-8); the port is a bare `u16`.
+
+/// Set the historical (MDDS) gRPC host on a config handle.
+///
+/// `host` must be a non-null, NUL-terminated, valid-UTF-8 C string.
+/// Returns `0` on success, `-1` if `config` is null or `host` is
+/// null / not valid UTF-8 (the diagnostic is written to thread-local
+/// storage retrievable via `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_set_mdds_host(
+    config: *mut TdxConfig,
+    host: *const c_char,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() {
+            set_error("config handle is null");
+            return -1;
+        }
+        // SAFETY: caller supplies a NUL-terminated C string allocated by the host runtime; cstr_to_str validates non-null + UTF-8.
+        let host = match unsafe { cstr_to_str(host) } {
+            Ok(Some(s)) => s,
+            Ok(None) => {
+                set_error("mdds_host is null");
+                return -1;
+            }
+            Err(e) => {
+                set_error(&format!("mdds_host is not valid UTF-8: {e}"));
+                return -1;
+            }
+        };
+        // SAFETY: config is a non-null pointer returned by tdx_config_* and not yet freed.
+        let config = unsafe { &mut *config };
+        config.inner.mdds.host = host.to_string();
+        0
+    })
+}
+
+/// Read the current historical (MDDS) gRPC host.
+///
+/// On success, returns a heap-owned NUL-terminated C string the caller
+/// MUST release with `tdx_string_free`. Returns null if `config` is
+/// null or the stored value contains an interior NUL (the diagnostic is
+/// written to `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_get_mdds_host(config: *const TdxConfig) -> *mut c_char {
+    ffi_boundary!(ptr::null_mut(), {
+        if config.is_null() {
+            set_error("config handle is null");
+            return ptr::null_mut();
+        }
+        // SAFETY: config is a non-null `*const TdxConfig` returned by `tdx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        match std::ffi::CString::new(config.inner.mdds.host.as_str()) {
+            Ok(c) => c.into_raw(),
+            Err(e) => {
+                set_error(&format!("mdds_host contains an interior NUL: {e}"));
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Set the historical (MDDS) gRPC port on a config handle.
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_set_mdds_port(config: *mut TdxConfig, port: u16) {
+    ffi_boundary!((), {
+        let config = require_config_mut!(config);
+        config.inner.mdds.port = port;
+    })
+}
+
+/// Read the configured historical (MDDS) gRPC port. Writes the value
+/// into `*out_port`. Returns `0` on success, `-1` if either pointer is
+/// null.
+#[no_mangle]
+pub unsafe extern "C" fn tdx_config_get_mdds_port(
+    config: *const TdxConfig,
+    out_port: *mut u16,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if config.is_null() || out_port.is_null() {
+            set_error("config or out-parameter pointer is null");
+            return -1;
+        }
+        // SAFETY: config is a non-null `*const TdxConfig` returned by `tdx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        // SAFETY: out pointer checked non-null above; caller pins the storage for the call duration.
+        unsafe {
+            *out_port = config.inner.mdds.port;
+        }
+        0
+    })
+}
+
 // ── MDDS pool sizing ───────────────────────────────────────────────
 
 /// Set the number of concurrent in-flight gRPC requests on a config
@@ -2211,11 +2312,11 @@ mod pool_sizing_tests {
         assert!(!cfg.is_null());
         // SAFETY: handle just returned by tdx_config_production.
         unsafe {
-            let mut enabled = false;
-            super::tdx_config_set_derive_ohlcvc(cfg, 0);
+            let mut enabled = true;
+            super::tdx_config_set_derive_ohlcvc(cfg, false);
             assert_eq!(super::tdx_config_get_derive_ohlcvc(cfg, &mut enabled), 0);
             assert!(!enabled);
-            super::tdx_config_set_derive_ohlcvc(cfg, 1);
+            super::tdx_config_set_derive_ohlcvc(cfg, true);
             assert_eq!(super::tdx_config_get_derive_ohlcvc(cfg, &mut enabled), 0);
             assert!(enabled);
             // Null-pointer guard on the getter returns -1.

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -268,7 +268,10 @@ include!("fpss_event_converter.rs");
 /// A single active subscription entry.
 #[repr(C)]
 pub struct TdxSubscription {
-    /// Subscription kind as a C string (e.g. "Quote", "Trade", "`OpenInterest`").
+    /// Subscription kind as a snake_case C string. Per-contract:
+    /// `"quote"` / `"trade"` / `"open_interest"` / `"market_value"`.
+    /// Full-stream: `"full_trades"` / `"full_open_interest"`. Matches the
+    /// Python / TypeScript `Subscription.kind` labels.
     pub kind: *const c_char,
     /// Contract identifier as a C string (e.g. "SPY" or "SPY 20260417 550 C").
     pub contract: *const c_char,
@@ -918,7 +921,8 @@ pub unsafe extern "C" fn tdx_unified_active_subscriptions(
         let handle = unsafe { &*handle };
         match handle.inner.active_subscriptions() {
             Ok(subs) => build_subscription_array(
-                subs.iter().map(|(k, c)| (format!("{k:?}"), format!("{c}"))),
+                subs.iter()
+                    .map(|(k, c)| (k.kind_str().to_string(), format!("{c}"))),
             ),
             Err(e) => {
                 set_error_from(&e);
@@ -933,8 +937,10 @@ pub unsafe extern "C" fn tdx_unified_active_subscriptions(
 ///
 /// Each entry's `contract` field carries the security-type discriminant
 /// (`"Stock"` / `"Option"` / `"Index"`) the full-stream subscription is
-/// bound to. The `kind` field is the subscription kind discriminant
-/// (`"Trade"` / `"OpenInterest"` / `"Quote"`).
+/// bound to. The `kind` field is the snake_case full-stream kind label
+/// (`"full_trades"` / `"full_open_interest"`), matching the Python /
+/// TypeScript `Subscription.kind` accessors. Per-contract-only kinds
+/// (`Quote` / `MarketValue`) have no full-stream form and are omitted.
 ///
 /// Caller must free the result with `tdx_subscription_array_free`.
 #[no_mangle]
@@ -949,10 +955,10 @@ pub unsafe extern "C" fn tdx_unified_active_full_subscriptions(
         // SAFETY: handle is a non-null pointer returned by the matching tdx_*_new and not yet passed to tdx_*_free.
         let handle = unsafe { &*handle };
         match handle.inner.active_full_subscriptions() {
-            Ok(subs) => build_subscription_array(
-                subs.iter()
-                    .map(|(k, st)| (format!("{k:?}"), format!("{st:?}"))),
-            ),
+            Ok(subs) => build_subscription_array(subs.iter().filter_map(|(k, st)| {
+                k.full_kind_str()
+                    .map(|kind| (kind.to_string(), format!("{st:?}")))
+            })),
             Err(e) => {
                 set_error_from(&e);
                 ptr::null_mut()
@@ -1686,7 +1692,7 @@ pub unsafe extern "C" fn tdx_fpss_active_subscriptions(
         let subs = client.active_subscriptions();
         build_subscription_array(
             subs.into_iter()
-                .map(|(kind, contract)| (format!("{kind:?}"), format!("{contract}"))),
+                .map(|(kind, contract)| (kind.kind_str().to_string(), format!("{contract}"))),
         )
     })
 }

--- a/scripts/check_binding_parity.py
+++ b/scripts/check_binding_parity.py
@@ -998,16 +998,22 @@ def _check_method_rows(
 
         # C++: `<snake>(` member declaration inside the matching
         # class body in `thetadx.hpp`. C++ alias names route through
-        # `CPP_ALIASES` (`Contract` -> `FluentContract`).
+        # `CPP_ALIASES` (`Contract` -> `FluentContract`). Readback
+        # getters on the C++ `Config` carry a uniform `get_` prefix
+        # (`get_flush_mode`), where Python exposes the field-shaped
+        # property (`flush_mode`) and TypeScript the camelCase getter
+        # (`flushMode`); accept the `get_`-prefixed C++ form so the
+        # per-language naming convention does not read as drift.
         declared_cpp = row.get("cpp", False)
         cpp_class = _cpp_class_for(class_name)
-        actual_cpp = snake in cpp_methods.get(cpp_class, set())
+        cpp_class_methods = cpp_methods.get(cpp_class, set())
+        actual_cpp = snake in cpp_class_methods or f"get_{snake}" in cpp_class_methods
         if declared_cpp != actual_cpp:
             verb = "missing" if declared_cpp and not actual_cpp else "unexpected"
             errors.append(
                 f"  {class_name}.{camel}.cpp: declared={declared_cpp}, "
                 f"actual={actual_cpp} ({verb} -- expected `{snake}(` "
-                f"inside `class {cpp_class}` body in "
+                f"or `get_{snake}(` inside `class {cpp_class}` body in "
                 f"sdks/cpp/include/thetadx.hpp)"
             )
 
@@ -2300,6 +2306,27 @@ def _run_selftest() -> int:
             f"C++ alias must resolve to FluentContract; got {errors!r}"
         )
 
+    def _case_method_cpp_get_prefix_resolves() -> None:
+        """C++ readback getter with the `get_` prefix matches a bare row."""
+        rows = [
+            {
+                "class": "Config",
+                "name": "flushMode",
+                "python": True,
+                "typescript": True,
+                "cpp": True,
+            }
+        ]
+        py_methods = {"Config": {"flush_mode"}}
+        ts_methods = {"Config": {"flushMode"}}
+        # C++ exposes the readback getter as `get_flush_mode`; the gate
+        # accepts the `get_`-prefixed convention against the bare row.
+        cpp_methods = {"Config": {"get_flush_mode"}}
+        errors = _check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+        assert errors == [], (
+            f"C++ `get_`-prefixed getter must satisfy a bare row; got {errors!r}"
+        )
+
     def _case_method_unexpected_extra() -> None:
         """Declared `false` but method exists on the source — trips."""
         rows = [
@@ -2364,6 +2391,7 @@ def _run_selftest() -> int:
     _case("method negative — declared Python but missing in source", _case_method_python_missing)
     _case("method negative — declared TS but missing js_name", _case_method_typescript_missing)
     _case("method positive — C++ alias routes Contract -> FluentContract", _case_method_cpp_alias_resolves)
+    _case("method positive — C++ `get_` prefix satisfies a bare getter row", _case_method_cpp_get_prefix_resolves)
     _case("method negative — stale `false` row with method present", _case_method_unexpected_extra)
     _case("method negative — malformed row missing class or name", _case_method_row_missing_class_or_name)
     _case("method positive — class-scoped TS lookup isolates classes", _case_method_class_scoping_isolates_classes)

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -756,7 +756,7 @@ typedef struct {
 /* ── Subscription types (active_subscriptions) ── */
 
 typedef struct {
-    const char* kind;      /* "Quote", "Trade", or "OpenInterest" */
+    const char* kind;      /* snake_case: per-contract "quote"/"trade"/"open_interest"/"market_value", full-stream "full_trades"/"full_open_interest" */
     const char* contract;  /* "SPY" or "SPY 20260417 550 C" */
 } TdxSubscription;
 
@@ -1431,10 +1431,10 @@ int32_t tdx_config_get_flush_mode(const TdxConfig* config, int32_t* out_mode);
 
 /**
  * Set streaming OHLCVC derivation on a config handle.
- *   enabled=1 (default): derive OHLCVC bars locally from trade events.
- *   enabled=0: only emit server-sent OHLCVC frames (lower overhead).
+ *   enabled=true (default): derive OHLCVC bars locally from trade events.
+ *   enabled=false: only emit server-sent OHLCVC frames (lower overhead).
  */
-void tdx_config_set_derive_ohlcvc(TdxConfig* config, int enabled);
+void tdx_config_set_derive_ohlcvc(TdxConfig* config, bool enabled);
 
 /**
  * Read the current OHLCVC-derivation flag. Writes true/false into
@@ -1443,6 +1443,29 @@ void tdx_config_set_derive_ohlcvc(TdxConfig* config, int enabled);
 int32_t tdx_config_get_derive_ohlcvc(const TdxConfig* config, bool* out_enabled);
 
 /* ── Decode pool sizing ── */
+
+/**
+ * Set the historical (MDDS) gRPC host. host must be a non-null,
+ * NUL-terminated, valid-UTF-8 C string. Returns 0 on success, -1 if
+ * config is null or host is null / not valid UTF-8.
+ */
+int32_t tdx_config_set_mdds_host(TdxConfig* config, const char* host);
+
+/**
+ * Read the current historical (MDDS) gRPC host. Returns a heap-owned
+ * NUL-terminated C string the caller MUST free with tdx_string_free, or
+ * null if config is null or the value contains an interior NUL.
+ */
+char* tdx_config_get_mdds_host(const TdxConfig* config);
+
+/** Set the historical (MDDS) gRPC port. */
+void tdx_config_set_mdds_port(TdxConfig* config, uint16_t port);
+
+/**
+ * Read the configured historical (MDDS) gRPC port. Writes the value
+ * into *out_port. Returns 0 on success, -1 if either pointer is null.
+ */
+int32_t tdx_config_get_mdds_port(const TdxConfig* config, uint16_t* out_port);
 
 /**
  * Set the number of concurrent in-flight gRPC requests.
@@ -1877,8 +1900,9 @@ TdxSubscriptionArray* tdx_unified_active_subscriptions(const TdxUnified* handle)
 /** Get active full-stream subscriptions as typed array. Each entry's
  *  `contract` field carries the security-type discriminant
  *  ("Stock" / "Option" / "Index") the full-stream subscription is bound
- *  to; the `kind` field is the subscription kind discriminant
- *  ("Trade" / "OpenInterest" / "Quote"). Returns null on error.
+ *  to; the `kind` field is the snake_case full-stream kind label
+ *  ("full_trades" / "full_open_interest"), matching the Python /
+ *  TypeScript `Subscription.kind` accessor. Returns null on error.
  *  Caller must free with tdx_subscription_array_free. */
 TdxSubscriptionArray* tdx_unified_active_full_subscriptions(const TdxUnified* handle);
 

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -612,10 +612,12 @@ public:
         tdx_config_set_reconnect_wait_ms(handle_.get(), ms);
     }
 
-    /** Current reconnect wait_ms (default 2_000). Returns -1 if the
-     *  config handle is null (matches the C ABI sentinel). */
-    int32_t get_reconnect_wait_ms(uint64_t* out_ms) const {
-        return tdx_config_get_reconnect_wait_ms(handle_.get(), out_ms);
+    /** Current reconnect wait_ms (default 2_000). Returns the default on
+     *  a null config handle. */
+    uint64_t get_reconnect_wait_ms() const {
+        uint64_t out{};
+        tdx_config_get_reconnect_wait_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Set the reconnect delay (ms) honoured for `TooManyRequests`
@@ -625,23 +627,31 @@ public:
     }
 
     /** Current reconnect wait_rate_limited_ms (default 130_000). */
-    int32_t get_reconnect_wait_rate_limited_ms(uint64_t* out_ms) const {
-        return tdx_config_get_reconnect_wait_rate_limited_ms(handle_.get(), out_ms);
+    uint64_t get_reconnect_wait_rate_limited_ms() const {
+        uint64_t out{};
+        tdx_config_get_reconnect_wait_rate_limited_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Current reconnect policy selector: 0=Auto, 1=Manual, 2=Custom. */
-    int32_t get_reconnect_policy(int32_t* out_policy) const {
-        return tdx_config_get_reconnect_policy(handle_.get(), out_policy);
+    int32_t get_reconnect_policy() const {
+        int32_t out{};
+        tdx_config_get_reconnect_policy(handle_.get(), &out);
+        return out;
     }
 
     /** Current generic-transient reconnect attempt budget (default 30). */
-    int32_t get_reconnect_max_attempts(uint32_t* out) const {
-        return tdx_config_get_reconnect_max_attempts(handle_.get(), out);
+    uint32_t get_reconnect_max_attempts() const {
+        uint32_t out{};
+        tdx_config_get_reconnect_max_attempts(handle_.get(), &out);
+        return out;
     }
 
     /** Current rate-limited reconnect attempt budget (default 100). */
-    int32_t get_reconnect_max_rate_limited_attempts(uint32_t* out) const {
-        return tdx_config_get_reconnect_max_rate_limited_attempts(handle_.get(), out);
+    uint32_t get_reconnect_max_rate_limited_attempts() const {
+        uint32_t out{};
+        tdx_config_get_reconnect_max_rate_limited_attempts(handle_.get(), &out);
+        return out;
     }
 
     /** Set the ServerRestarting reconnect attempt budget. Default 60. */
@@ -650,13 +660,17 @@ public:
     }
 
     /** Current ServerRestarting reconnect attempt budget (default 60). */
-    int32_t get_reconnect_max_server_restart_attempts(uint32_t* out) const {
-        return tdx_config_get_reconnect_max_server_restart_attempts(handle_.get(), out);
+    uint32_t get_reconnect_max_server_restart_attempts() const {
+        uint32_t out{};
+        tdx_config_get_reconnect_max_server_restart_attempts(handle_.get(), &out);
+        return out;
     }
 
     /** Current stable-window reset interval in seconds (default 60). */
-    int32_t get_reconnect_stable_window_secs(uint64_t* out) const {
-        return tdx_config_get_reconnect_stable_window_secs(handle_.get(), out);
+    uint64_t get_reconnect_stable_window_secs() const {
+        uint64_t out{};
+        tdx_config_get_reconnect_stable_window_secs(handle_.get(), &out);
+        return out;
     }
 
     /** Set the wall-clock reconnect envelope (seconds) for the
@@ -668,8 +682,10 @@ public:
 
     /** Current wall-clock reconnect envelope in seconds (default 300;
      *  0 = disabled). */
-    int32_t get_reconnect_max_elapsed_secs(uint64_t* out) const {
-        return tdx_config_get_reconnect_max_elapsed_secs(handle_.get(), out);
+    uint64_t get_reconnect_max_elapsed_secs() const {
+        uint64_t out{};
+        tdx_config_get_reconnect_max_elapsed_secs(handle_.get(), &out);
+        return out;
     }
 
     /** Set the cap (ms) on the exponential generic-transient reconnect
@@ -679,8 +695,10 @@ public:
     }
 
     /** Current reconnect wait_max_ms (default 30_000). */
-    int32_t get_reconnect_wait_max_ms(uint64_t* out_ms) const {
-        return tdx_config_get_reconnect_wait_max_ms(handle_.get(), out_ms);
+    uint64_t get_reconnect_wait_max_ms() const {
+        uint64_t out{};
+        tdx_config_get_reconnect_wait_max_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Set the flat reconnect cadence (ms) for ServerRestarting
@@ -690,8 +708,10 @@ public:
     }
 
     /** Current reconnect wait_server_restart_ms (default 5_000). */
-    int32_t get_reconnect_wait_server_restart_ms(uint64_t* out_ms) const {
-        return tdx_config_get_reconnect_wait_server_restart_ms(handle_.get(), out_ms);
+    uint64_t get_reconnect_wait_server_restart_ms() const {
+        uint64_t out{};
+        tdx_config_get_reconnect_wait_server_restart_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Set the reconnect jitter mode: 0=Full (default), 1=Equal,
@@ -706,8 +726,10 @@ public:
     }
 
     /** Current reconnect jitter mode (same encoding as the setter). */
-    int32_t get_reconnect_jitter(int32_t* out_mode) const {
-        return tdx_config_get_reconnect_jitter(handle_.get(), out_mode);
+    int32_t get_reconnect_jitter() const {
+        int32_t out{};
+        tdx_config_get_reconnect_jitter(handle_.get(), &out);
+        return out;
     }
 
     /** Set the subscription-replay burst size used after an
@@ -717,8 +739,10 @@ public:
     }
 
     /** Current replay_burst_size (default 50). */
-    int32_t get_reconnect_replay_burst_size(uint32_t* out) const {
-        return tdx_config_get_reconnect_replay_burst_size(handle_.get(), out);
+    uint32_t get_reconnect_replay_burst_size() const {
+        uint32_t out{};
+        tdx_config_get_reconnect_replay_burst_size(handle_.get(), &out);
+        return out;
     }
 
     /** Set the pause (ms) between subscription-replay bursts. 0
@@ -728,8 +752,10 @@ public:
     }
 
     /** Current replay_pace_ms (default 5). */
-    int32_t get_reconnect_replay_pace_ms(uint64_t* out_ms) const {
-        return tdx_config_get_reconnect_replay_pace_ms(handle_.get(), out_ms);
+    uint64_t get_reconnect_replay_pace_ms() const {
+        uint64_t out{};
+        tdx_config_get_reconnect_replay_pace_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Install a custom reconnect policy driven by a C callback.
@@ -749,8 +775,10 @@ public:
     }
 
     /** Current fpss timeout_ms (default 3_000). */
-    int32_t get_fpss_timeout_ms(uint64_t* out_ms) const {
-        return tdx_config_get_fpss_timeout_ms(handle_.get(), out_ms);
+    uint64_t get_fpss_timeout_ms() const {
+        uint64_t out{};
+        tdx_config_get_fpss_timeout_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Set the per-server connect timeout (ms) for the streaming
@@ -761,8 +789,10 @@ public:
     }
 
     /** Current fpss connect_timeout_ms (default 2_000). */
-    int32_t get_fpss_connect_timeout_ms(uint64_t* out_ms) const {
-        return tdx_config_get_fpss_connect_timeout_ms(handle_.get(), out_ms);
+    uint64_t get_fpss_connect_timeout_ms() const {
+        uint64_t out{};
+        tdx_config_get_fpss_connect_timeout_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Set the FPSS heartbeat ping interval (ms). Default 250;
@@ -772,8 +802,10 @@ public:
     }
 
     /** Current fpss ping_interval_ms (default 250). */
-    int32_t get_fpss_ping_interval_ms(uint64_t* out_ms) const {
-        return tdx_config_get_fpss_ping_interval_ms(handle_.get(), out_ms);
+    uint64_t get_fpss_ping_interval_ms() const {
+        uint64_t out{};
+        tdx_config_get_fpss_ping_interval_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Set the per-iteration blocking-read slice (ms) for the
@@ -783,8 +815,10 @@ public:
     }
 
     /** Current fpss io_read_slice_ms (default 25). */
-    int32_t get_fpss_io_read_slice_ms(uint64_t* out_ms) const {
-        return tdx_config_get_fpss_io_read_slice_ms(handle_.get(), out_ms);
+    uint64_t get_fpss_io_read_slice_ms() const {
+        uint64_t out{};
+        tdx_config_get_fpss_io_read_slice_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Set the last-frame watchdog (ms); 0 disables. Default 30_000. */
@@ -793,8 +827,10 @@ public:
     }
 
     /** Current fpss data_watchdog_ms (default 30_000; 0 = disabled). */
-    int32_t get_fpss_data_watchdog_ms(uint64_t* out_ms) const {
-        return tdx_config_get_fpss_data_watchdog_ms(handle_.get(), out_ms);
+    uint64_t get_fpss_data_watchdog_ms() const {
+        uint64_t out{};
+        tdx_config_get_fpss_data_watchdog_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Set the TCP keepalive idle time (seconds). Default 5; validated
@@ -804,8 +840,10 @@ public:
     }
 
     /** Current fpss keepalive_idle_secs (default 5). */
-    int32_t get_fpss_keepalive_idle_secs(uint64_t* out) const {
-        return tdx_config_get_fpss_keepalive_idle_secs(handle_.get(), out);
+    uint64_t get_fpss_keepalive_idle_secs() const {
+        uint64_t out{};
+        tdx_config_get_fpss_keepalive_idle_secs(handle_.get(), &out);
+        return out;
     }
 
     /** Set the TCP keepalive probe interval (seconds). Default 2;
@@ -815,8 +853,10 @@ public:
     }
 
     /** Current fpss keepalive_interval_secs (default 2). */
-    int32_t get_fpss_keepalive_interval_secs(uint64_t* out) const {
-        return tdx_config_get_fpss_keepalive_interval_secs(handle_.get(), out);
+    uint64_t get_fpss_keepalive_interval_secs() const {
+        uint64_t out{};
+        tdx_config_get_fpss_keepalive_interval_secs(handle_.get(), &out);
+        return out;
     }
 
     /** Set the TCP keepalive probe count before the kernel declares
@@ -826,8 +866,10 @@ public:
     }
 
     /** Current fpss keepalive_retries (default 2). */
-    int32_t get_fpss_keepalive_retries(uint32_t* out) const {
-        return tdx_config_get_fpss_keepalive_retries(handle_.get(), out);
+    uint32_t get_fpss_keepalive_retries() const {
+        uint32_t out{};
+        tdx_config_get_fpss_keepalive_retries(handle_.get(), &out);
+        return out;
     }
 
     /** Set the FPSS event ring size (slots). Must be a power of two
@@ -838,8 +880,10 @@ public:
     }
 
     /** Current fpss ring_size (default 131_072). */
-    int32_t get_fpss_ring_size(size_t* out) const {
-        return tdx_config_get_fpss_ring_size(handle_.get(), out);
+    size_t get_fpss_ring_size() const {
+        size_t out{};
+        tdx_config_get_fpss_ring_size(handle_.get(), &out);
+        return out;
     }
 
     /** Set the FPSS host-selection policy: 0=Shuffled (default),
@@ -855,8 +899,10 @@ public:
 
     /** Current FPSS host-selection policy (same encoding as the
      *  setter). */
-    int32_t get_fpss_host_selection(int32_t* out_policy) const {
-        return tdx_config_get_fpss_host_selection(handle_.get(), out_policy);
+    int32_t get_fpss_host_selection() const {
+        int32_t out{};
+        tdx_config_get_fpss_host_selection(handle_.get(), &out);
+        return out;
     }
 
     /** Set the FPSS host-shuffle seed using the (has_value, seed)
@@ -866,10 +912,14 @@ public:
         return tdx_config_set_fpss_host_shuffle_seed_explicit(handle_.get(), has_value, seed);
     }
 
-    /** Read the FPSS host-shuffle seed back. *out_has_value=false
-     *  encodes the per-client-entropy sentinel. */
-    int32_t get_fpss_host_shuffle_seed(bool* out_has_value, uint64_t* out_seed) const {
-        return tdx_config_get_fpss_host_shuffle_seed(handle_.get(), out_has_value, out_seed);
+    /** Read the FPSS host-shuffle seed back. Returns @c std::nullopt for
+     *  the per-client-entropy sentinel (no pinned seed); returns the
+     *  wrapped seed when the shuffled order is deterministic. */
+    std::optional<uint64_t> get_fpss_host_shuffle_seed() const {
+        bool has_value = false;
+        uint64_t seed = 0;
+        tdx_config_get_fpss_host_shuffle_seed(handle_.get(), &has_value, &seed);
+        return has_value ? std::optional<uint64_t>{seed} : std::nullopt;
     }
 
     /** Set the wall-clock envelope (seconds) for one
@@ -879,8 +929,10 @@ public:
     }
 
     /** Current retry max_elapsed in seconds (default 300; 0 = disabled). */
-    int32_t get_retry_max_elapsed_secs(uint64_t* out_secs) const {
-        return tdx_config_get_retry_max_elapsed_secs(handle_.get(), out_secs);
+    uint64_t get_retry_max_elapsed_secs() const {
+        uint64_t out{};
+        tdx_config_get_retry_max_elapsed_secs(handle_.get(), &out);
+        return out;
     }
 
     /** Toggle AWS-style full jitter on the flatfile retry ladder.
@@ -890,8 +942,10 @@ public:
     }
 
     /** Current flatfiles jitter setting (default true). */
-    int32_t get_flatfiles_jitter(bool* out_jitter) const {
-        return tdx_config_get_flatfiles_jitter(handle_.get(), out_jitter);
+    bool get_flatfiles_jitter() const {
+        bool out{};
+        tdx_config_get_flatfiles_jitter(handle_.get(), &out);
+        return out;
     }
 
 
@@ -902,10 +956,13 @@ public:
         return tdx_config_set_worker_threads_explicit(handle_.get(), has_value, n);
     }
 
-    /** Read worker_threads back. *out_has_value=false encodes the None
-     *  (auto-size) sentinel. */
-    int32_t get_worker_threads(bool* out_has_value, size_t* out_n) const {
-        return tdx_config_get_worker_threads(handle_.get(), out_has_value, out_n);
+    /** Read worker_threads back. Returns @c std::nullopt for the None
+     *  (auto-size) sentinel; returns the wrapped count when pinned. */
+    std::optional<size_t> get_worker_threads() const {
+        bool has_value = false;
+        size_t n = 0;
+        tdx_config_get_worker_threads(handle_.get(), &has_value, &n);
+        return has_value ? std::optional<size_t>{n} : std::nullopt;
     }
 
     // ── RetryPolicy field setters/getters ──
@@ -914,32 +971,40 @@ public:
     void set_retry_initial_delay_ms(uint64_t ms) {
         tdx_config_set_retry_initial_delay_ms(handle_.get(), ms);
     }
-    int32_t get_retry_initial_delay_ms(uint64_t* out_ms) const {
-        return tdx_config_get_retry_initial_delay_ms(handle_.get(), out_ms);
+    uint64_t get_retry_initial_delay_ms() const {
+        uint64_t out{};
+        tdx_config_get_retry_initial_delay_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Upper-bound backoff delay (ms). Default 30_000 (30 s). */
     void set_retry_max_delay_ms(uint64_t ms) {
         tdx_config_set_retry_max_delay_ms(handle_.get(), ms);
     }
-    int32_t get_retry_max_delay_ms(uint64_t* out_ms) const {
-        return tdx_config_get_retry_max_delay_ms(handle_.get(), out_ms);
+    uint64_t get_retry_max_delay_ms() const {
+        uint64_t out{};
+        tdx_config_get_retry_max_delay_ms(handle_.get(), &out);
+        return out;
     }
 
     /** Total attempt budget. 1 disables retry. Default 5. */
     void set_retry_max_attempts(uint32_t n) {
         tdx_config_set_retry_max_attempts(handle_.get(), n);
     }
-    int32_t get_retry_max_attempts(uint32_t* out_n) const {
-        return tdx_config_get_retry_max_attempts(handle_.get(), out_n);
+    uint32_t get_retry_max_attempts() const {
+        uint32_t out{};
+        tdx_config_get_retry_max_attempts(handle_.get(), &out);
+        return out;
     }
 
     /** AWS-style full jitter toggle. Default true. */
     void set_retry_jitter(bool jitter) {
         tdx_config_set_retry_jitter(handle_.get(), jitter);
     }
-    int32_t get_retry_jitter(bool* out_jitter) const {
-        return tdx_config_get_retry_jitter(handle_.get(), out_jitter);
+    bool get_retry_jitter() const {
+        bool out{};
+        tdx_config_get_retry_jitter(handle_.get(), &out);
+        return out;
     }
 
     // ── FlatFilesConfig field setters/getters ──
@@ -949,8 +1014,10 @@ public:
     void set_flatfiles_max_attempts(uint32_t n) {
         tdx_config_set_flatfiles_max_attempts(handle_.get(), n);
     }
-    int32_t get_flatfiles_max_attempts(uint32_t* out_n) const {
-        return tdx_config_get_flatfiles_max_attempts(handle_.get(), out_n);
+    uint32_t get_flatfiles_max_attempts() const {
+        uint32_t out{};
+        tdx_config_get_flatfiles_max_attempts(handle_.get(), &out);
+        return out;
     }
 
     /** Initial backoff delay (seconds). Doubles per attempt up to
@@ -958,8 +1025,10 @@ public:
     void set_flatfiles_initial_backoff_secs(uint64_t secs) {
         tdx_config_set_flatfiles_initial_backoff_secs(handle_.get(), secs);
     }
-    int32_t get_flatfiles_initial_backoff_secs(uint64_t* out_secs) const {
-        return tdx_config_get_flatfiles_initial_backoff_secs(handle_.get(), out_secs);
+    uint64_t get_flatfiles_initial_backoff_secs() const {
+        uint64_t out{};
+        tdx_config_get_flatfiles_initial_backoff_secs(handle_.get(), &out);
+        return out;
     }
 
     /** Upper-bound backoff delay (seconds). Default 4. Must be >=
@@ -967,8 +1036,10 @@ public:
     void set_flatfiles_max_backoff_secs(uint64_t secs) {
         tdx_config_set_flatfiles_max_backoff_secs(handle_.get(), secs);
     }
-    int32_t get_flatfiles_max_backoff_secs(uint64_t* out_secs) const {
-        return tdx_config_get_flatfiles_max_backoff_secs(handle_.get(), out_secs);
+    uint64_t get_flatfiles_max_backoff_secs() const {
+        uint64_t out{};
+        tdx_config_get_flatfiles_max_backoff_secs(handle_.get(), &out);
+        return out;
     }
 
     // ── AuthConfig field setters/getters ──
@@ -1067,22 +1138,54 @@ public:
      *  @c set_flush_mode: `0` = Batched, `1` = Immediate. Returns `0`
      *  (Batched) on a null handle (matching the C ABI's `-1` failure
      *  mapping at the boundary). */
-    int flush_mode() const {
+    int get_flush_mode() const {
         int32_t mode = 0;
         tdx_config_get_flush_mode(handle_.get(), &mode);
         return mode;
     }
 
     /** Set whether to derive OHLCVC bars locally from trades. */
-    void set_derive_ohlcvc(bool enabled) { tdx_config_set_derive_ohlcvc(handle_.get(), enabled ? 1 : 0); }
+    void set_derive_ohlcvc(bool enabled) { tdx_config_set_derive_ohlcvc(handle_.get(), enabled); }
 
     /** Read the current OHLCVC-derivation flag. Returns `false` on a
      *  null handle (matching the C ABI's `-1` failure mapping at the
      *  boundary). */
-    bool derive_ohlcvc() const {
+    bool get_derive_ohlcvc() const {
         bool enabled = false;
         tdx_config_get_derive_ohlcvc(handle_.get(), &enabled);
         return enabled;
+    }
+
+    // ── MDDS endpoint ──
+
+    /** Set the historical (MDDS) gRPC host. Defaults to the upstream
+     *  production endpoint; redirect the historical channel at a known
+     *  host for testing. Throws a @c tdx::ThetaDataError leaf if the FFI
+     *  rejects the value (null handle or non-UTF-8 input). */
+    void set_mdds_host(const std::string& host) {
+        if (tdx_config_set_mdds_host(handle_.get(), host.c_str()) != 0) {
+            detail::throw_last_ffi_error();
+        }
+    }
+
+    /** Current historical (MDDS) gRPC host. Returns an empty string if
+     *  the FFI getter returns null (null handle or interior-NUL value). */
+    std::string get_mdds_host() const {
+        detail::FfiString s(tdx_config_get_mdds_host(handle_.get()));
+        return s.str();
+    }
+
+    /** Set the historical (MDDS) gRPC port. Companion to
+     *  @c set_mdds_host. */
+    void set_mdds_port(std::uint16_t port) {
+        tdx_config_set_mdds_port(handle_.get(), port);
+    }
+
+    /** Current historical (MDDS) gRPC port. Returns 0 on a null handle. */
+    std::uint16_t get_mdds_port() const {
+        std::uint16_t port = 0;
+        tdx_config_get_mdds_port(handle_.get(), &port);
+        return port;
     }
 
     // ── MDDS pool sizing ──
@@ -1105,7 +1208,7 @@ public:
      * or `0` on a null handle (matching the C ABI's `-1` failure
      * mapping at the boundary).
      */
-    std::uint32_t concurrent_requests() const {
+    std::uint32_t get_concurrent_requests() const {
         std::uint32_t n = 0;
         tdx_config_get_concurrent_requests(handle_.get(), &n);
         return n;
@@ -1131,7 +1234,7 @@ public:
      * Returns the configured byte count, or `0` on a null handle
      * (matching the C ABI's `-1` failure mapping at the boundary).
      */
-    std::size_t warn_on_buffered_threshold_bytes() const {
+    std::size_t get_warn_on_buffered_threshold_bytes() const {
         std::size_t n = 0;
         tdx_config_get_warn_on_buffered_threshold_bytes(handle_.get(), &n);
         return n;
@@ -1564,8 +1667,9 @@ struct UnifiedDeleter {
 /// Full-stream subscription descriptor returned by
 /// `ThetaDataDxClient::active_full_subscriptions`. `sec_type` carries the
 /// security-type discriminant (`"Stock"` / `"Option"` / `"Index"`) the
-/// full-stream subscription is bound to; `kind` is the subscription
-/// kind (`"Trade"` / `"OpenInterest"` / `"Quote"`).
+/// full-stream subscription is bound to; `kind` is the snake_case
+/// full-stream kind label (`"full_trades"` / `"full_open_interest"`),
+/// matching the Python / TypeScript `Subscription.kind` accessor.
 struct FullSubscription {
     std::string kind;
     std::string sec_type;
@@ -1946,15 +2050,43 @@ public:
     const std::string& sec_type() const noexcept { return sec_type_; }
     bool is_option() const noexcept { return is_option_; }
 
+    /// Stable snake_case wire-kind label, identical to the Python /
+    /// TypeScript `Subscription.kind` accessor and the C ABI
+    /// active-subscription `kind` field. Per-contract subscriptions
+    /// return `"quote"` / `"trade"` / `"open_interest"` /
+    /// `"market_value"`; full-stream subscriptions carry the `full_`
+    /// prefix (`"full_trades"` / `"full_open_interest"`) so a full-stream
+    /// open-interest subscription never reads the same as a per-contract
+    /// one.
+    std::string kind_string() const {
+        if (scope_ == Scope::Full) {
+            switch (kind_) {
+                case Kind::Trade:        return "full_trades";
+                case Kind::OpenInterest: return "full_open_interest";
+                case Kind::Quote:        return "full_quote";
+                case Kind::MarketValue:  return "full_market_value";
+            }
+            return "full_quote";
+        }
+        switch (kind_) {
+            case Kind::Quote:        return "quote";
+            case Kind::Trade:        return "trade";
+            case Kind::OpenInterest: return "open_interest";
+            case Kind::MarketValue:  return "market_value";
+        }
+        return "quote";
+    }
+
 private:
     friend class FluentContract;
     friend class FluentSecType;
 
-    static FluentSubscription per_contract_stock(std::string symbol, Kind k) {
+    static FluentSubscription per_contract_stock(std::string symbol, std::string sec_type, Kind k) {
         FluentSubscription s;
         s.scope_ = Scope::Contract;
         s.kind_ = k;
         s.symbol_ = std::move(symbol);
+        s.sec_type_ = std::move(sec_type);
         s.is_option_ = false;
         return s;
     }
@@ -2012,13 +2144,15 @@ class FluentContract {
 public:
     /// Construct a stock contract.
     static FluentContract stock(std::string symbol) {
-        return FluentContract{std::move(symbol), false, "", "", ""};
+        return FluentContract{std::move(symbol), "STOCK", false, "", "", ""};
     }
     /// Construct an index contract. Routes through the stock-shape
     /// wire encoder; the C ABI layer treats them identically (no
-    /// per-index subscribe call exists today).
+    /// per-index subscribe call exists today). The security type is
+    /// retained for rendering so an index contract reads `"INDEX"`
+    /// rather than `"STOCK"`.
     static FluentContract index(std::string symbol) {
-        return FluentContract{std::move(symbol), false, "", "", ""};
+        return FluentContract{std::move(symbol), "INDEX", false, "", "", ""};
     }
     /// Construct an option contract. The expiration / strike / right
     /// travel in a single `OptionLeg` with named members —
@@ -2028,62 +2162,51 @@ public:
     /// silently. `right` accepts `"C"` / `"CALL"` / `"P"` / `"PUT"`
     /// (case-insensitive).
     static FluentContract option(std::string symbol, OptionLeg leg) {
-        return FluentContract{std::move(symbol), true, std::move(leg.expiration),
+        return FluentContract{std::move(symbol), "OPTION", true, std::move(leg.expiration),
                               std::move(leg.strike), std::move(leg.right)};
     }
 
     FluentSubscription quote() const {
-        if (is_option_) {
-            return FluentSubscription::per_contract_option(
-                symbol_, expiration_, strike_, right_,
-                FluentSubscription::Kind::Quote);
-        }
-        return FluentSubscription::per_contract_stock(
-            symbol_, FluentSubscription::Kind::Quote);
+        return make_subscription(FluentSubscription::Kind::Quote);
     }
     FluentSubscription trade() const {
-        if (is_option_) {
-            return FluentSubscription::per_contract_option(
-                symbol_, expiration_, strike_, right_,
-                FluentSubscription::Kind::Trade);
-        }
-        return FluentSubscription::per_contract_stock(
-            symbol_, FluentSubscription::Kind::Trade);
+        return make_subscription(FluentSubscription::Kind::Trade);
     }
     FluentSubscription open_interest() const {
-        if (is_option_) {
-            return FluentSubscription::per_contract_option(
-                symbol_, expiration_, strike_, right_,
-                FluentSubscription::Kind::OpenInterest);
-        }
-        return FluentSubscription::per_contract_stock(
-            symbol_, FluentSubscription::Kind::OpenInterest);
+        return make_subscription(FluentSubscription::Kind::OpenInterest);
     }
     /// Per-contract market-value subscription.
     FluentSubscription market_value() const {
-        if (is_option_) {
-            return FluentSubscription::per_contract_option(
-                symbol_, expiration_, strike_, right_,
-                FluentSubscription::Kind::MarketValue);
-        }
-        return FluentSubscription::per_contract_stock(
-            symbol_, FluentSubscription::Kind::MarketValue);
+        return make_subscription(FluentSubscription::Kind::MarketValue);
     }
 
     const std::string& symbol() const noexcept { return symbol_; }
     bool is_option() const noexcept { return is_option_; }
+    /// Security type as a symbolic name (`"STOCK"` / `"INDEX"` /
+    /// `"OPTION"`), retained so renderings distinguish an index contract
+    /// from a stock one.
+    const std::string& sec_type() const noexcept { return sec_type_; }
     const std::string& expiration() const noexcept { return expiration_; }
     const std::string& strike() const noexcept { return strike_; }
     const std::string& right() const noexcept { return right_; }
 
 private:
-    FluentContract(std::string symbol, bool is_option,
+    FluentContract(std::string symbol, std::string sec_type, bool is_option,
                    std::string expiration, std::string strike, std::string right)
-        : symbol_(std::move(symbol)), is_option_(is_option),
-          expiration_(std::move(expiration)), strike_(std::move(strike)),
-          right_(std::move(right)) {}
+        : symbol_(std::move(symbol)), sec_type_(std::move(sec_type)),
+          is_option_(is_option), expiration_(std::move(expiration)),
+          strike_(std::move(strike)), right_(std::move(right)) {}
+
+    FluentSubscription make_subscription(FluentSubscription::Kind k) const {
+        if (is_option_) {
+            return FluentSubscription::per_contract_option(
+                symbol_, expiration_, strike_, right_, k);
+        }
+        return FluentSubscription::per_contract_stock(symbol_, sec_type_, k);
+    }
 
     std::string symbol_;
+    std::string sec_type_;
     bool is_option_;
     std::string expiration_;
     std::string strike_;
@@ -2096,6 +2219,7 @@ public:
     static FluentSecType stock()  { return FluentSecType{"STOCK"}; }
     static FluentSecType option() { return FluentSecType{"OPTION"}; }
     static FluentSecType index()  { return FluentSecType{"INDEX"}; }
+    static FluentSecType rate()   { return FluentSecType{"RATE"}; }
 
     FluentSubscription full_trades() const {
         return FluentSubscription::full_stream(sec_type_,
@@ -2136,7 +2260,7 @@ inline std::ostream& operator<<(std::ostream& os, const FluentContract& contract
         os << " OPTION " << contract.expiration() << ' ' << contract.right() << ' '
            << contract.strike();
     } else {
-        os << " STOCK";
+        os << ' ' << contract.sec_type();
     }
     return os;
 }
@@ -2162,7 +2286,7 @@ inline std::ostream& operator<<(std::ostream& os, const FluentSubscription& sub)
     if (sub.is_option()) {
         os << " OPTION " << sub.expiration() << ' ' << sub.right() << ' ' << sub.strike();
     } else {
-        os << " STOCK";
+        os << ' ' << sub.sec_type();
     }
     return os << ')';
 }

--- a/sdks/cpp/tests/config_pool_sizing.cpp
+++ b/sdks/cpp/tests/config_pool_sizing.cpp
@@ -1,8 +1,8 @@
 // MDDS pool-sizing setter + getter on tdx::Config.
 //
 // Offline test pinning the contract that `set_concurrent_requests` and
-// the `concurrent_requests()` readback getter on the `tdx::Config` C++
-// wrapper round-trip through the underlying C ABI.
+// the `get_concurrent_requests()` readback getter on the `tdx::Config`
+// C++ wrapper round-trip through the underlying C ABI.
 
 #include <cstdint>
 
@@ -17,11 +17,28 @@ TEST_CASE("Config concurrent_requests setter + getter round-trip", "[config][poo
     // and TypeScript `concurrentRequests` surfaces, so a value set
     // through the C++ wrapper reads back through the same wrapper.
     cfg.set_concurrent_requests(0);
-    REQUIRE(cfg.concurrent_requests() == 0u);
+    REQUIRE(cfg.get_concurrent_requests() == 0u);
     cfg.set_concurrent_requests(1);
-    REQUIRE(cfg.concurrent_requests() == 1u);
+    REQUIRE(cfg.get_concurrent_requests() == 1u);
     cfg.set_concurrent_requests(8);
-    REQUIRE(cfg.concurrent_requests() == 8u);
+    REQUIRE(cfg.get_concurrent_requests() == 8u);
     cfg.set_concurrent_requests(32);
-    REQUIRE(cfg.concurrent_requests() == 32u);
+    REQUIRE(cfg.get_concurrent_requests() == 32u);
+}
+
+TEST_CASE("Config mdds_host / mdds_port setters + getters round-trip",
+          "[config][mdds][offline]") {
+    // The MDDS endpoint overrides mirror the Python `Config.mdds_host` /
+    // `.mdds_port` advanced knobs, so a value set through the C++ wrapper
+    // reads back through the same wrapper.
+    auto cfg = tdx::Config::production();
+
+    // A production config has a non-empty default host.
+    REQUIRE_FALSE(cfg.get_mdds_host().empty());
+
+    cfg.set_mdds_host("127.0.0.1");
+    REQUIRE(cfg.get_mdds_host() == "127.0.0.1");
+
+    cfg.set_mdds_port(50051);
+    REQUIRE(cfg.get_mdds_port() == 50051u);
 }

--- a/sdks/cpp/tests/flatfiles_config.cpp
+++ b/sdks/cpp/tests/flatfiles_config.cpp
@@ -21,14 +21,9 @@
 TEST_CASE("Config exposes FlatFilesConfig production defaults",
           "[config][flatfiles][offline]") {
     auto cfg = tdx::Config::production();
-    std::uint32_t n = 0;
-    std::uint64_t secs = 0;
-    REQUIRE(cfg.get_flatfiles_max_attempts(&n) == 0);
-    REQUIRE(n == 10u);
-    REQUIRE(cfg.get_flatfiles_initial_backoff_secs(&secs) == 0);
-    REQUIRE(secs == 1u);
-    REQUIRE(cfg.get_flatfiles_max_backoff_secs(&secs) == 0);
-    REQUIRE(secs == 30u);
+    REQUIRE(cfg.get_flatfiles_max_attempts() == 10u);
+    REQUIRE(cfg.get_flatfiles_initial_backoff_secs() == 1u);
+    REQUIRE(cfg.get_flatfiles_max_backoff_secs() == 30u);
 }
 
 TEST_CASE("Config::set_flatfiles_max_attempts round-trips via getter",
@@ -36,9 +31,7 @@ TEST_CASE("Config::set_flatfiles_max_attempts round-trips via getter",
     auto cfg = tdx::Config::production();
     for (std::uint32_t n : {0u, 1u, 3u, 5u, 10u, 100u, 1000u}) {
         REQUIRE_NOTHROW(cfg.set_flatfiles_max_attempts(n));
-        std::uint32_t got = 0;
-        REQUIRE(cfg.get_flatfiles_max_attempts(&got) == 0);
-        REQUIRE(got == n);
+        REQUIRE(cfg.get_flatfiles_max_attempts() == n);
     }
 }
 
@@ -50,9 +43,7 @@ TEST_CASE("Config::set_flatfiles_initial_backoff_secs round-trips via getter",
                                std::uint64_t{60}, std::uint64_t{3600},
                                std::uint64_t{86'400}}) {
         REQUIRE_NOTHROW(cfg.set_flatfiles_initial_backoff_secs(secs));
-        std::uint64_t got = 0;
-        REQUIRE(cfg.get_flatfiles_initial_backoff_secs(&got) == 0);
-        REQUIRE(got == secs);
+        REQUIRE(cfg.get_flatfiles_initial_backoff_secs() == secs);
     }
 }
 
@@ -63,9 +54,7 @@ TEST_CASE("Config::set_flatfiles_max_backoff_secs round-trips via getter",
                                std::uint64_t{4}, std::uint64_t{60},
                                std::uint64_t{3600}, std::uint64_t{86'400}}) {
         REQUIRE_NOTHROW(cfg.set_flatfiles_max_backoff_secs(secs));
-        std::uint64_t got = 0;
-        REQUIRE(cfg.get_flatfiles_max_backoff_secs(&got) == 0);
-        REQUIRE(got == secs);
+        REQUIRE(cfg.get_flatfiles_max_backoff_secs() == secs);
     }
 }
 
@@ -79,12 +68,7 @@ TEST_CASE("FlatFiles setters compose with pool-sizing setters",
     REQUIRE_NOTHROW(cfg.set_flatfiles_max_backoff_secs(12));
     REQUIRE_NOTHROW(cfg.set_concurrent_requests(4));
 
-    std::uint32_t n = 0;
-    std::uint64_t secs = 0;
-    REQUIRE(cfg.get_flatfiles_max_attempts(&n) == 0);
-    REQUIRE(n == 7u);
-    REQUIRE(cfg.get_flatfiles_initial_backoff_secs(&secs) == 0);
-    REQUIRE(secs == 3u);
-    REQUIRE(cfg.get_flatfiles_max_backoff_secs(&secs) == 0);
-    REQUIRE(secs == 12u);
+    REQUIRE(cfg.get_flatfiles_max_attempts() == 7u);
+    REQUIRE(cfg.get_flatfiles_initial_backoff_secs() == 3u);
+    REQUIRE(cfg.get_flatfiles_max_backoff_secs() == 12u);
 }

--- a/sdks/cpp/tests/fluent_rendering.cpp
+++ b/sdks/cpp/tests/fluent_rendering.cpp
@@ -34,6 +34,15 @@ TEST_CASE("FluentContract renders symbol and option identity", "[fluent][offline
     const auto option = tdx::Contract::option("SPY", {.expiration = "20260620", .strike = "550", .right = "C"});
     REQUIRE(render(option) == "SPY OPTION 20260620 C 550");
     REQUIRE(tdx::str(option) == "SPY OPTION 20260620 C 550");
+
+    // An index contract renders "INDEX", not "STOCK" — it carries its
+    // own security type rather than borrowing the stock-shape default.
+    const auto index = tdx::Contract::index("VIX");
+    REQUIRE(render(index) == "VIX INDEX");
+    REQUIRE(tdx::str(index) == "VIX INDEX");
+    REQUIRE(index.sec_type() == "INDEX");
+    // The index identity also carries into a per-contract subscription.
+    REQUIRE(tdx::str(index.trade()) == "Subscription(Trade, VIX INDEX)");
 }
 
 TEST_CASE("FluentSecType renders its symbolic name", "[fluent][offline]") {
@@ -41,6 +50,10 @@ TEST_CASE("FluentSecType renders its symbolic name", "[fluent][offline]") {
     os << tdx::SecType::option();
     REQUIRE(os.str() == "OPTION");
     REQUIRE(tdx::str(tdx::SecType::stock()) == "STOCK");
+    REQUIRE(tdx::str(tdx::SecType::index()) == "INDEX");
+    // `rate()` matches the Python `SecType.RATE` / TypeScript
+    // `SecType.rate()` constructor.
+    REQUIRE(tdx::str(tdx::SecType::rate()) == "RATE");
 }
 
 TEST_CASE("FluentSubscription renders scope, kind, and contract", "[fluent][offline]") {
@@ -55,6 +68,23 @@ TEST_CASE("FluentSubscription renders scope, kind, and contract", "[fluent][offl
 
     const auto full = tdx::SecType::option().full_open_interest();
     REQUIRE(tdx::str(full) == "Subscription(full OpenInterest, OPTION)");
+}
+
+TEST_CASE("FluentSubscription::kind_string is snake_case", "[fluent][offline]") {
+    // The snake_case kind label matches the Python / TypeScript
+    // `Subscription.kind` accessor and the C ABI active-subscription
+    // `kind` field — distinct from the PascalCase `operator<<` rendering.
+    REQUIRE(tdx::Contract::stock("AAPL").quote().kind_string() == "quote");
+    REQUIRE(tdx::Contract::stock("AAPL").trade().kind_string() == "trade");
+    REQUIRE(tdx::Contract::stock("AAPL").open_interest().kind_string() == "open_interest");
+    REQUIRE(tdx::Contract::stock("AAPL").market_value().kind_string() == "market_value");
+
+    // Full-stream kinds carry the `full_` prefix, so a full-stream
+    // open-interest never reads the same as a per-contract one.
+    REQUIRE(tdx::SecType::option().full_trades().kind_string() == "full_trades");
+    REQUIRE(tdx::SecType::option().full_open_interest().kind_string() == "full_open_interest");
+    REQUIRE(tdx::Contract::stock("AAPL").open_interest().kind_string()
+            != tdx::SecType::option().full_open_interest().kind_string());
 }
 
 TEST_CASE("tdx_contract_strike_dollars folds the presence flag", "[fluent][offline]") {

--- a/sdks/cpp/tests/lifecycle.cpp
+++ b/sdks/cpp/tests/lifecycle.cpp
@@ -45,14 +45,14 @@ TEST_CASE("Config flush_mode / derive_ohlcvc getters round-trip", "[lifecycle][o
     auto config = tdx::Config::production();
 
     config.set_flush_mode(1);
-    REQUIRE(config.flush_mode() == 1);
+    REQUIRE(config.get_flush_mode() == 1);
     config.set_flush_mode(0);
-    REQUIRE(config.flush_mode() == 0);
+    REQUIRE(config.get_flush_mode() == 0);
 
     config.set_derive_ohlcvc(false);
-    REQUIRE(config.derive_ohlcvc() == false);
+    REQUIRE(config.get_derive_ohlcvc() == false);
     config.set_derive_ohlcvc(true);
-    REQUIRE(config.derive_ohlcvc() == true);
+    REQUIRE(config.get_derive_ohlcvc() == true);
 }
 
 TEST_CASE("MddsClient::connect succeeds against the production server", "[lifecycle][live]") {

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -465,28 +465,28 @@ cpp = true          # `tdx::IndexPriceAtTimeTick` alias over `TdxIndexPriceAtTim
 # tightening) is the umbrella issue under which the cross-binding
 # sweep for these fields would be planned.
 #
-# Two `MddsConfig` advanced overrides (`mdds_host` / `mdds_port`) are
-# exposed on Python alone for structural-test usage (point the
-# historical channel at a refused endpoint to prove the streaming
-# surface never opens it). MDDS is a vendor protocol name, kept
-# verbatim; these knobs are Python-only by design — they are NOT
-# forced onto the other bindings, and the setter-set parity check
-# exempts them with a written reason. The dotted rows below capture
-# the partial-binding state via the `setter = "..."` override on
-# Python.
+# Two `MddsConfig` advanced overrides (`mdds_host` / `mdds_port`):
+# point the historical channel at a known host (e.g. a refused endpoint
+# in structural tests that prove the streaming surface never opens it).
+# MDDS is a vendor protocol name, kept verbatim. Exposed on Python
+# (`Config.mdds_host` / `.mdds_port`) and C++ (`set_mdds_host` /
+# `set_mdds_port` over the FFI `tdx_config_set_mdds_host` /
+# `tdx_config_set_mdds_port`). TypeScript does not carry these advanced
+# knobs. The dotted rows below capture the partial-binding state via the
+# `setter = "..."` override.
 
 [[class]]
 name = "MddsConfig.host"
-python = true       # `Config.mdds_host` advanced override (Python-only)
-typescript = false
-cpp = false
+python = true       # `Config.mdds_host` advanced override
+typescript = false  # advanced historical-endpoint knob not exposed on the napi Config
+cpp = true          # `Config::set_mdds_host` over `tdx_config_set_mdds_host`
 setter = "mdds_host"
 
 [[class]]
 name = "MddsConfig.port"
-python = true       # `Config.mdds_port` advanced override (Python-only)
-typescript = false
-cpp = false
+python = true       # `Config.mdds_port` advanced override
+typescript = false  # advanced historical-endpoint knob not exposed on the napi Config
+cpp = true          # `Config::set_mdds_port` over `tdx_config_set_mdds_port`
 setter = "mdds_port"
 
 [[class]]
@@ -1142,10 +1142,12 @@ cpp = true
 # The `deriveOhlcvc` / `concurrentRequests` readback getters are exposed
 # on every binding: Python (`Config.derive_ohlcvc` / `.concurrent_requests`
 # properties), TypeScript (`Config.deriveOhlcvc` / `.concurrentRequests`
-# getters), C++ (`Config::derive_ohlcvc()` / `::concurrent_requests()`
+# getters), C++ (`Config::get_derive_ohlcvc()` / `::get_concurrent_requests()`
 # over the FFI `tdx_config_get_derive_ohlcvc` / `_concurrent_requests`
-# symbols). The matching setters are tracked by the dotted `[[class]]`
-# rows `FpssConfig.derive_ohlcvc` / `MddsConfig.concurrent_requests`.
+# symbols). C++ readback getters carry a uniform `get_` prefix; the
+# parity gate accepts that per-language convention. The matching setters
+# are tracked by the dotted `[[class]]` rows `FpssConfig.derive_ohlcvc` /
+# `MddsConfig.concurrent_requests`.
 [[method]]
 class = "Config"
 name = "deriveOhlcvc"


### PR DESCRIPTION
Brings the C++ and C-ABI streaming and config surfaces into line with the Python / TypeScript bindings and the Rust core. Breaking, as the C++ `Config` getter names change and the C-ABI `tdx_config_set_derive_ohlcvc` parameter type changes.

## Snake_case active-subscription kind labels

A shared `SubscriptionKind::kind_str` / `FullSubscriptionKind::kind_str` in the fpss core returns the canonical labels (`quote` / `trade` / `open_interest` / `market_value`; full-stream `full_trades` / `full_open_interest`), and `SubscriptionKind::full_kind_str` returns the full-stream label or `None` for kinds with no full-stream form. The C ABI active-subscription projections call these instead of the enum `Debug` spelling. This fixes two defects: a per-contract vs full-stream open-interest label collision (both printed `OpenInterest`), and the PascalCase divergence from the Python / TypeScript `Subscription.kind` accessor. The C++ `FluentSubscription` gains a `kind_string()` accessor returning the same labels; the standalone-FPSS active-subscription projection is fixed alongside the unified one; the stale C ABI and C++ docs are corrected.

## Uniform C++ `Config` getter shape

Every `Config` getter is value-returning `T get_x() const`. The out-parameter `int32_t get_x(T* out)` getters return the value directly, the two `Option`-shaped getters return `std::optional`, and the bare value-returning getters (`flush_mode` / `derive_ohlcvc` / `concurrent_requests` / `warn_on_buffered_threshold_bytes`) gain the `get_` prefix. C++ readback getters carry a uniform `get_` prefix where Python exposes the field-shaped property and TypeScript the camelCase getter; the parity gate accepts that per-language convention.

## MDDS endpoint knob

The historical (MDDS) gRPC host and port are configurable from C++ and the C ABI: `tdx_config_set_mdds_host` / `_get_mdds_host` (+ port) and `Config::set_mdds_host` / `get_mdds_host` (+ port), matching the Python advanced overrides.

## `derive_ohlcvc` parameter type

`tdx_config_set_derive_ohlcvc` takes a `bool` rather than an `i32`, matching its getter and every other binding.

## Fluent surface

`FluentSecType` gains a `rate()` constructor matching the Python `SecType.RATE` / TypeScript `SecType.rate()`. A `FluentContract` retains its security type, so an index contract renders `INDEX` rather than `STOCK`, both standalone and through a per-contract subscription.

## Verification

`cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `generate_sdk_surfaces --check`; `generate_docs_site --check`; `check_binding_parity.py` clean plus its 44 self-tests and 19 companion tests; `cargo build -p thetadatadx-ffi --release` then `check_c_abi_completeness.py` clean (302 symbols, bidirectional); C++ examples and the full test suite build, 45 offline C++ tests pass; a live C++ `MddsClient` historical query returns real data. The live FPSS streaming end-to-end case could not be exercised here (the streaming login times out from this environment, reproduced identically on the base branch — the historical / MDDS path is unaffected); the snake_case kind labels are covered by core unit tests and the offline C++ `kind_string()` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)