### PR TITLE
feat(sdk)!: ConfigError leaf, stream-fault routing, and a creds-first TypeScript connect

### DIFF
--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -333,6 +333,18 @@ public:
     using ThetaDataError::ThetaDataError;
 };
 
+/// Environmental configuration fault — a config-file read failure, a
+/// TOML parse error, or an internal config invariant. Distinct from
+/// `InvalidParameterError` (a rejected user-supplied argument): a
+/// `ConfigError` is the environment, not the call site. Pinned to the
+/// reserved `TDX_ERR_CONFIG` discriminant so a `catch (const
+/// ConfigError&)` clause catches the same conditions the Python
+/// `ConfigError` and the C ABI config code surface.
+class ConfigError : public ThetaDataError {
+public:
+    using ThetaDataError::ThetaDataError;
+};
+
 // Generated request-options bag. Included after the exception hierarchy
 // so its `with_deadline` setter can throw the complete
 // `InvalidParameterError` type when handed a negative deadline.
@@ -383,8 +395,9 @@ inline std::optional<double> last_ffi_retry_after_seconds() {
             throw InvalidParameterError("thetadatadx: " + message);
         case TDX_ERR_STREAM:
             throw StreamError("thetadatadx: " + message);
-        case TDX_ERR_OTHER:
         case TDX_ERR_CONFIG:
+            throw ConfigError("thetadatadx: " + message);
+        case TDX_ERR_OTHER:
         case TDX_ERR_NONE:
         default:
             throw ThetaDataError("thetadatadx: " + message);

--- a/sdks/cpp/tests/error_taxonomy.cpp
+++ b/sdks/cpp/tests/error_taxonomy.cpp
@@ -38,16 +38,17 @@ TEST_CASE("ThetaDataError is the root of the SDK exception hierarchy",
     STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::SchemaMismatchError>);
     STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::InvalidParameterError>);
     STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::StreamError>);
+    STATIC_REQUIRE(std::is_base_of_v<tdx::ThetaDataError, tdx::ConfigError>);
     // InvalidCredentialsError narrows AuthenticationError.
     STATIC_REQUIRE(std::is_base_of_v<tdx::AuthenticationError, tdx::InvalidCredentialsError>);
 }
 
-TEST_CASE("throw_for_code routes the invalid-parameter discriminant to InvalidParameterError",
+TEST_CASE("throw_for_code routes config discriminants to their leaf classes",
           "[errors][offline]") {
     // A rejected client parameter (`TDX_ERR_INVALID_PARAMETER`) must
     // surface as `InvalidParameterError`, distinguishable by catch type
-    // from the generic `ThetaDataError` that the environmental config
-    // code (`TDX_ERR_CONFIG`) still produces.
+    // from the environmental config fault (`TDX_ERR_CONFIG`) that
+    // surfaces as `ConfigError`.
     try {
         tdx::detail::throw_for_code(TDX_ERR_INVALID_PARAMETER, "bad date");
         FAIL("throw_for_code must throw");
@@ -57,14 +58,17 @@ TEST_CASE("throw_for_code routes the invalid-parameter discriminant to InvalidPa
         FAIL("expected InvalidParameterError, got generic ThetaDataError: " << e.what());
     }
 
-    // The generic config code stays on the root class.
+    // The environmental config code routes to the dedicated
+    // `ConfigError` leaf, not `InvalidParameterError` and not the root.
     try {
         tdx::detail::throw_for_code(TDX_ERR_CONFIG, "toml parse");
         FAIL("throw_for_code must throw");
     } catch (const tdx::InvalidParameterError& e) {
         FAIL("TDX_ERR_CONFIG must not surface as InvalidParameterError: " << e.what());
-    } catch (const tdx::ThetaDataError&) {
-        // expected — generic config fault
+    } catch (const tdx::ConfigError&) {
+        // expected — environmental config fault
+    } catch (const tdx::ThetaDataError& e) {
+        FAIL("expected ConfigError, got generic ThetaDataError: " << e.what());
     }
 }
 

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -15,7 +15,7 @@
 [[class]]
 name = "Credentials"
 python = true
-typescript = false  # JS takes credentials as constructor args, not a class
+typescript = true   # `Credentials` napi class: `new Credentials(email, password)` / `Credentials.fromFile(path)`, passed to `connect(creds, config?)`
 cpp = true
 
 [[class]]
@@ -197,6 +197,12 @@ cpp = true
 
 [[class]]
 name = "StreamError"
+python = true
+typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+cpp = true
+
+[[class]]
+name = "ConfigError"
 python = true
 typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
 cpp = true
@@ -1088,7 +1094,7 @@ cpp = true
 class = "Credentials"
 name = "fromFile"
 python = true
-typescript = false
+typescript = true   # `Credentials.fromFile(path)` napi factory
 cpp = true
 
 [[method]]

--- a/sdks/python/src/errors.rs
+++ b/sdks/python/src/errors.rs
@@ -68,10 +68,11 @@ create_exception!(thetadatadx, SubscriptionError, ThetaDataError);
 create_exception!(thetadatadx, RateLimitError, ThetaDataError);
 
 // Client-side input validation rejected a parameter (a bad value, an
-// out-of-range number, a missing required field). Distinct from the root
-// `ThetaDataError` so a malformed-but-rejected argument is distinguishable
-// by class from an unrelated configuration fault (config-file I/O, TOML
-// parse, internal invariant) which stays on the root class.
+// out-of-range number, a missing required field). Distinct from
+// `ConfigError` so a malformed-but-rejected argument is distinguishable
+// by class from an unrelated environmental configuration fault
+// (config-file I/O, TOML parse, internal invariant), which raises
+// `ConfigError`.
 create_exception!(thetadatadx, InvalidParameterError, ThetaDataError);
 
 // Decoder schema mismatch — surfaces `Error::Decode` + `DecodeError`
@@ -102,6 +103,15 @@ create_exception!(thetadatadx, NotFoundError, ThetaDataError);
 
 // FPSS streaming protocol / state-machine failures.
 create_exception!(thetadatadx, StreamError, ThetaDataError);
+
+// Environmental configuration fault — a config-file read failure, a
+// TOML parse error, or an internal config invariant. Distinct from
+// `InvalidParameterError` (a rejected user-supplied argument): a
+// `ConfigError` is the environment, not the call site. Pinned to the
+// reserved `TDX_ERR_CONFIG` discriminant so a `except
+// thetadatadx.ConfigError` clause catches the same conditions the C++
+// `ConfigError` and the C ABI config code surface.
+create_exception!(thetadatadx, ConfigError, ThetaDataError);
 
 // ── Back-compatibility aliases ────────────────────────────────────────
 //
@@ -151,6 +161,7 @@ pub fn register_exceptions(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<
     )?;
     m.add("NotFoundError", py.get_type::<NotFoundError>())?;
     m.add("StreamError", py.get_type::<StreamError>())?;
+    m.add("ConfigError", py.get_type::<ConfigError>())?;
     // Back-compatibility aliases: same type object under the legacy name.
     m.add("NoDataFoundError", py.get_type::<NotFoundError>())?;
     m.add("TimeoutError", py.get_type::<DeadlineExceededError>())?;
@@ -218,12 +229,12 @@ pub fn to_py_err(e: thetadatadx::Error) -> PyErr {
         thetadatadx::Error::Decompress { .. } => SchemaMismatchError::new_err(e.to_string()),
         // User-input validation failures route to the dedicated
         // invalid-parameter class; environmental config faults
-        // (`Io` / `TomlParse` / `Internal`) stay on the root class.
+        // (`Io` / `TomlParse` / `Internal`) route to `ConfigError`.
         thetadatadx::Error::Config { kind, .. } => {
             if kind.is_invalid_parameter() {
                 InvalidParameterError::new_err(e.to_string())
             } else {
-                ThetaDataError::new_err(e.to_string())
+                ConfigError::new_err(e.to_string())
             }
         }
         thetadatadx::Error::Fpss { kind, .. } => match kind {
@@ -235,6 +246,12 @@ pub fn to_py_err(e: thetadatadx::Error) -> PyErr {
             FpssErrorKind::ProtocolError => StreamError::new_err(e.to_string()),
             _ => StreamError::new_err(e.to_string()),
         },
+        // FlatFiles availability + partial-reconnect failures are
+        // streaming-surface faults; route them to `StreamError` so a
+        // `except StreamError` clause behaves identically to the C++
+        // and C ABI mapping (both pin these to the stream discriminant).
+        thetadatadx::Error::FlatFilesUnavailable(_)
+        | thetadatadx::Error::PartialReconnect { .. } => StreamError::new_err(e.to_string()),
         // Catch-all for future `#[non_exhaustive]` variants added on the
         // Rust side. We keep the build green and route to the root class
         // so the caller still sees a branded exception rather than an
@@ -467,17 +484,43 @@ mod tests {
     }
 
     #[test]
-    fn config_environmental_fault_maps_to_root_class() {
+    fn config_environmental_fault_maps_to_config_error() {
         // A non-input config fault (file I/O, TOML parse, internal
-        // invariant) is not a user-parameter error and stays on the
-        // root class.
+        // invariant) is not a user-parameter error; it routes to the
+        // dedicated `ConfigError` leaf, matching the C++ `ConfigError`
+        // and the C ABI `TDX_ERR_CONFIG` discriminant.
         Python::initialize();
         Python::attach(|py| {
             let io = to_py_err(thetadatadx::Error::config_io("file not found"));
-            assert_exception_class(py, &io, "ThetaDataError");
+            assert_exception_class(py, &io, "ConfigError");
 
             let toml = to_py_err(thetadatadx::Error::config_toml("expected `]`"));
-            assert_exception_class(py, &toml, "ThetaDataError");
+            assert_exception_class(py, &toml, "ConfigError");
+        });
+    }
+
+    #[test]
+    fn flatfiles_unavailable_maps_to_stream_error() {
+        // FlatFiles availability failures are a streaming-surface fault;
+        // they route to `StreamError` so the class matches the C++ / C
+        // ABI mapping (both pin this to the stream discriminant).
+        Python::initialize();
+        Python::attach(|py| {
+            let err = to_py_err(thetadatadx::Error::FlatFilesUnavailable(
+                thetadatadx::flatfiles::FlatFilesUnavailableReason::RequestRejected {
+                    server_message: "no subscription".into(),
+                },
+            ));
+            assert_exception_class(py, &err, "StreamError");
+        });
+    }
+
+    #[test]
+    fn partial_reconnect_maps_to_stream_error() {
+        Python::initialize();
+        Python::attach(|py| {
+            let err = to_py_err(thetadatadx::Error::PartialReconnect { failed: Vec::new() });
+            assert_exception_class(py, &err, "StreamError");
         });
     }
 
@@ -511,6 +554,7 @@ mod tests {
                 ),
                 ("NotFoundError", py.get_type::<NotFoundError>()),
                 ("StreamError", py.get_type::<StreamError>()),
+                ("ConfigError", py.get_type::<ConfigError>()),
             ] {
                 let is_sub = cls_ty
                     .is_subclass(&root)

--- a/sdks/python/tests/test_error_parity.py
+++ b/sdks/python/tests/test_error_parity.py
@@ -41,6 +41,7 @@ CANONICAL_CLASSES = [
     "DeadlineExceededError",
     "NotFoundError",
     "StreamError",
+    "ConfigError",
 ]
 
 

--- a/sdks/typescript/__tests__/fpss_client.test.mjs
+++ b/sdks/typescript/__tests__/fpss_client.test.mjs
@@ -39,14 +39,9 @@ function methodNames(block) {
 }
 
 describe('FpssClient native addon surface', () => {
-  it('exports the FpssClient class with all four connect factories', () => {
+  it('exports the FpssClient class with the creds-first connect factories', () => {
     assert.ok(mod.FpssClient, 'FpssClient should be exported');
-    for (const factory of [
-      'connect',
-      'connectFromFile',
-      'connectWithConfig',
-      'connectFromFileWithConfig',
-    ]) {
+    for (const factory of ['connect', 'connectFromFile']) {
       assert.equal(
         typeof mod.FpssClient[factory],
         'function',

--- a/sdks/typescript/__tests__/mdds_client.test.mjs
+++ b/sdks/typescript/__tests__/mdds_client.test.mjs
@@ -45,14 +45,9 @@ function methodNames(block) {
 }
 
 describe('MddsClient native addon surface', () => {
-  it('exports the MddsClient class with all four connect factories', () => {
+  it('exports the MddsClient class with the creds-first connect factories', () => {
     assert.ok(mod.MddsClient, 'MddsClient should be exported');
-    for (const factory of [
-      'connect',
-      'connectFromFile',
-      'connectWithConfig',
-      'connectFromFileWithConfig',
-    ]) {
+    for (const factory of ['connect', 'connectFromFile']) {
       assert.equal(
         typeof mod.MddsClient[factory],
         'function',

--- a/sdks/typescript/__tests__/typed-errors.test.mjs
+++ b/sdks/typescript/__tests__/typed-errors.test.mjs
@@ -41,6 +41,7 @@ describe('typed error hierarchy', () => {
       'NetworkError',
       'SchemaMismatchError',
       'StreamError',
+      'ConfigError',
     ];
 
     for (const name of expected) {

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -480,6 +480,34 @@ export declare class ContractRef {
 }
 
 /**
+ * ThetaData login credentials.
+ *
+ * Build from an email + password pair (`new Credentials(email,
+ * password)`) or load from a credentials file (`Credentials.fromFile`,
+ * line 1 = email, line 2 = password), then pass the handle to a client
+ * `connect(creds, config?)`. Mirrors the Python `Credentials` and the
+ * C++ `tdx::Credentials`.
+ *
+ * ```js
+ * const { Credentials, ThetaDataDxClient } = require("@thetadatadx/sdk");
+ * const creds = Credentials.fromFile("creds.txt");
+ * const tdx = ThetaDataDxClient.connect(creds);
+ * ```
+ */
+export declare class Credentials {
+  /** Create credentials from an email and password. */
+  constructor(email: string, password: string)
+  /** Load credentials from a file (line 1 = email, line 2 = password). */
+  static fromFile(path: string): Credentials
+  /**
+   * Redacted string form — never exposes the email or password. Matches
+   * the redacted `Debug` impl on the Rust `auth::Credentials` and the
+   * Python `Credentials.__repr__`.
+   */
+  toString(): string
+}
+
+/**
  * JS class wrapping a decoded flat-file row vector. Created by every
  * method on [`FlatFilesNamespace`]; carries the typed
  * `Vec<FlatFileRow>` until the user picks a terminal.
@@ -549,33 +577,24 @@ export declare class FlatFilesNamespace {
  */
 export declare class FpssClient {
   /**
-   * Allocate a standalone FPSS handle against the production endpoint.
+   * Allocate a standalone FPSS handle with a [`Credentials`] handle.
    * Streaming only — opens no MDDS channel and issues no Nexus request.
-   * The FPSS TLS connection opens on the first `startStreaming` call.
+   * Pass an optional [`Config`] (`dev` / `stage` / `production`, plus
+   * any tuned FPSS / reconnect setters) to override the
+   * production-default endpoint. The FPSS TLS connection opens on the
+   * first `startStreaming` call.
+   *
+   * The config is snapshot at construction time: the `Config` handle
+   * may be reused or mutated afterward without affecting this client.
    */
-  static connect(email: string, password: string): FpssClient
+  static connect(creds: Credentials, config?: Config | undefined | null): FpssClient
   /**
    * Allocate a standalone FPSS handle with a credentials file (line 1 =
-   * email, line 2 = password) against the production endpoint.
+   * email, line 2 = password). Convenience wrapper over
+   * `Credentials.fromFile` + `connect`. Pass an optional [`Config`] to
+   * override the production-default endpoint.
    */
-  static connectFromFile(path: string): FpssClient
-  /**
-   * Allocate a standalone FPSS handle against an explicit [`Config`]
-   * (`dev` / `stage` / `production`, plus any tuned FPSS / reconnect
-   * setters). Use `connect` for the production-default endpoint.
-   *
-   * The config is snapshot at construction time: the `Config` handle may
-   * be reused or mutated afterward without affecting this client.
-   */
-  static connectWithConfig(email: string, password: string, config: Config): FpssClient
-  /**
-   * Allocate a standalone FPSS handle with a credentials file against an
-   * explicit [`Config`]. Use `connectFromFile` for the
-   * production-default endpoint.
-   *
-   * The config is snapshot at construction time.
-   */
-  static connectFromFileWithConfig(path: string, config: Config): FpssClient
+  static connectFromFile(path: string, config?: Config | undefined | null): FpssClient
   /**
    * Start FPSS streaming and register a JS callback for incoming events.
    *
@@ -754,35 +773,23 @@ export declare class FpssClient {
  */
 export declare class MddsClient {
   /**
-   * Connect to ThetaData and open the MDDS channel. Historical
-   * (MDDS/gRPC) only — this client never opens the FPSS streaming
-   * transport. Use [`FpssClient`] for real-time data.
+   * Connect to ThetaData with a [`Credentials`] handle and open the
+   * MDDS channel. Historical (MDDS/gRPC) only — this client never
+   * opens the FPSS streaming transport. Pass an optional [`Config`] to
+   * override the production-default endpoint. Use [`FpssClient`] for
+   * real-time data.
+   *
+   * The config is snapshot at connect time: the `Config` handle may be
+   * reused or mutated afterward without affecting this client.
    */
-  static connect(email: string, password: string): MddsClient
+  static connect(creds: Credentials, config?: Config | undefined | null): MddsClient
   /**
    * Connect with a credentials file (line 1 = email, line 2 =
-   * password). Historical (MDDS/gRPC) only.
+   * password). Convenience wrapper over `Credentials.fromFile` +
+   * `connect`. Historical (MDDS/gRPC) only. Pass an optional
+   * [`Config`] to override the production-default endpoint.
    */
-  static connectFromFile(path: string): MddsClient
-  /**
-   * Connect to ThetaData against an explicit [`Config`] (`dev` /
-   * `stage` / `production`, plus any tuned setters). Historical
-   * (MDDS/gRPC) only. Use `connect` for the production-default
-   * endpoint.
-   *
-   * The config is snapshot at connect time: the `Config` handle may
-   * be reused or mutated afterward without affecting this client.
-   */
-  static connectWithConfig(email: string, password: string, config: Config): MddsClient
-  /**
-   * Connect with a credentials file (line 1 = email, line 2 =
-   * password) against an explicit [`Config`]. Historical (MDDS/gRPC)
-   * only. Use `connectFromFile` for the production-default endpoint.
-   *
-   * The config is snapshot at connect time: the `Config` handle may
-   * be reused or mutated afterward without affecting this client.
-   */
-  static connectFromFileWithConfig(path: string, config: Config): MddsClient
+  static connectFromFile(path: string, config?: Config | undefined | null): MddsClient
   /**
    * List all available stock ticker symbols.
    *
@@ -1666,32 +1673,28 @@ export declare class Subscription {
 
 export declare class ThetaDataDxClient {
   /**
-   * Connect to ThetaData. Historical (MDDS/gRPC) only; call startStreaming()
-   * to begin FPSS real-time data.
-   */
-  static connect(email: string, password: string): ThetaDataDxClient
-  /** Connect with a credentials file (line 1 = email, line 2 = password). */
-  static connectFromFile(path: string): ThetaDataDxClient
-  /**
-   * Connect to ThetaData against an explicit [`Config`] (`dev` /
-   * `stage` / `production`, plus any tuned setters). Historical
-   * (MDDS/gRPC) only; call startStreaming() to begin FPSS real-time
-   * data. Use `connect` for the production-default endpoint.
+   * Connect to ThetaData with a [`Credentials`] handle. Pass an
+   * optional [`Config`] (`dev` / `stage` / `production`, plus any
+   * tuned setters) to override the production-default endpoint.
+   * Historical (MDDS/gRPC) only; call startStreaming() to begin FPSS
+   * real-time data.
    *
-   * The config is snapshot at connect time: the `Config` handle may
-   * be reused or mutated afterward without affecting this client.
+   * The config is snapshot at connect time: the `Config` handle may be
+   * reused or mutated afterward without affecting this client.
+   *
+   * ```js
+   * const creds = Credentials.fromFile("creds.txt");
+   * const tdx = ThetaDataDxClient.connect(creds);
+   * ```
    */
-  static connectWithConfig(email: string, password: string, config: Config): ThetaDataDxClient
+  static connect(creds: Credentials, config?: Config | undefined | null): ThetaDataDxClient
   /**
    * Connect with a credentials file (line 1 = email, line 2 =
-   * password) against an explicit [`Config`] (`dev` / `stage` /
-   * `production`, plus any tuned setters). Use `connectFromFile` for
-   * the production-default endpoint.
-   *
-   * The config is snapshot at connect time: the `Config` handle may
-   * be reused or mutated afterward without affecting this client.
+   * password). Convenience wrapper over `Credentials.fromFile` +
+   * `connect`. Pass an optional [`Config`] to override the
+   * production-default endpoint.
    */
-  static connectFromFileWithConfig(path: string, config: Config): ThetaDataDxClient
+  static connectFromFile(path: string, config?: Config | undefined | null): ThetaDataDxClient
   /**
    * Cumulative count of FPSS events the TLS reader could not
    * publish into the event ring because the event-dispatch consumer

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -592,6 +592,7 @@ module.exports.ContractRef = nativeBinding.ContractRef
 // napi-emitted `ContractRef` constructor. Without this, `require
 // ('thetadatadx').Contract.stock(...)` is undefined at runtime.
 module.exports.Contract = nativeBinding.ContractRef;
+module.exports.Credentials = nativeBinding.Credentials
 module.exports.FlatFileRowList = nativeBinding.FlatFileRowList
 module.exports.FlatFilesNamespace = nativeBinding.FlatFilesNamespace
 module.exports.FpssClient = nativeBinding.FpssClient

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -42,9 +42,9 @@ fn bigint_to_u64(name: &str, v: &napi::bindgen_prelude::BigInt) -> napi::Result<
 ///
 /// Build a config via one of the three static factories
 /// ([`Config::production`] / [`Config::dev`] / [`Config::stage`]), tune
-/// it with the setters below, then pass it to
-/// `ThetaDataDxClient.connectWithConfig` /
-/// `ThetaDataDxClient.connectFromFileWithConfig`.
+/// it with the setters below, then pass it as the optional second
+/// argument to `ThetaDataDxClient.connect(creds, config)` /
+/// `ThetaDataDxClient.connectFromFile(path, config)`.
 ///
 /// Mutating methods follow JS convention and
 /// return `void` (chain by calling `cfg.method(...)` then passing

--- a/sdks/typescript/src/fpss_client.rs
+++ b/sdks/typescript/src/fpss_client.rs
@@ -47,14 +47,15 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use thetadatadx::auth::{self, Credentials as RustCredentials};
-use thetadatadx::config::{self, DirectConfig};
+use thetadatadx::config::DirectConfig;
 use thetadatadx::fpss::protocol::SubscriptionKind;
 use thetadatadx::fpss::{self, FpssClient as RustFpssClient};
 use thetadatadx::DispatcherSession;
 
 use crate::fluent::Subscription;
 use crate::{
-    buffered_event_to_typed, fpss_event_to_buffered, runtime, to_napi_err, Config, TsfnCallback,
+    buffered_event_to_typed, config_or_production, fpss_event_to_buffered, runtime, to_napi_err,
+    Config, Credentials, TsfnCallback,
 };
 
 /// Snapshot of the parameters required to open an FPSS TLS connection.
@@ -314,57 +315,30 @@ impl FpssClient {
     // observable behaviour applies across every binding. No MDDS channel is
     // opened and no Nexus request is issued by any factory.
 
-    /// Allocate a standalone FPSS handle against the production endpoint.
+    /// Allocate a standalone FPSS handle with a [`Credentials`] handle.
     /// Streaming only — opens no MDDS channel and issues no Nexus request.
-    /// The FPSS TLS connection opens on the first `startStreaming` call.
+    /// Pass an optional [`Config`] (`dev` / `stage` / `production`, plus
+    /// any tuned FPSS / reconnect setters) to override the
+    /// production-default endpoint. The FPSS TLS connection opens on the
+    /// first `startStreaming` call.
+    ///
+    /// The config is snapshot at construction time: the `Config` handle
+    /// may be reused or mutated afterward without affecting this client.
     #[napi(factory)]
-    pub fn connect(email: String, password: String) -> napi::Result<FpssClient> {
-        let creds = auth::Credentials::new(email, password);
-        let direct = config::DirectConfig::production();
-        let params = params_from_direct(&creds, &direct)?;
+    pub fn connect(creds: &Credentials, config: Option<&Config>) -> napi::Result<FpssClient> {
+        let direct = config_or_production(config);
+        let params = params_from_direct(&creds.inner, &direct)?;
         Ok(FpssClient::from_params(params))
     }
 
     /// Allocate a standalone FPSS handle with a credentials file (line 1 =
-    /// email, line 2 = password) against the production endpoint.
-    #[napi(factory)]
-    pub fn connect_from_file(path: String) -> napi::Result<FpssClient> {
+    /// email, line 2 = password). Convenience wrapper over
+    /// `Credentials.fromFile` + `connect`. Pass an optional [`Config`] to
+    /// override the production-default endpoint.
+    #[napi(factory, js_name = "connectFromFile")]
+    pub fn connect_from_file(path: String, config: Option<&Config>) -> napi::Result<FpssClient> {
         let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-        let direct = config::DirectConfig::production();
-        let params = params_from_direct(&creds, &direct)?;
-        Ok(FpssClient::from_params(params))
-    }
-
-    /// Allocate a standalone FPSS handle against an explicit [`Config`]
-    /// (`dev` / `stage` / `production`, plus any tuned FPSS / reconnect
-    /// setters). Use `connect` for the production-default endpoint.
-    ///
-    /// The config is snapshot at construction time: the `Config` handle may
-    /// be reused or mutated afterward without affecting this client.
-    #[napi(factory)]
-    pub fn connect_with_config(
-        email: String,
-        password: String,
-        config: &Config,
-    ) -> napi::Result<FpssClient> {
-        let creds = auth::Credentials::new(email, password);
-        let direct = config.snapshot();
-        let params = params_from_direct(&creds, &direct)?;
-        Ok(FpssClient::from_params(params))
-    }
-
-    /// Allocate a standalone FPSS handle with a credentials file against an
-    /// explicit [`Config`]. Use `connectFromFile` for the
-    /// production-default endpoint.
-    ///
-    /// The config is snapshot at construction time.
-    #[napi(factory)]
-    pub fn connect_from_file_with_config(
-        path: String,
-        config: &Config,
-    ) -> napi::Result<FpssClient> {
-        let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-        let direct = config.snapshot();
+        let direct = config_or_production(config);
         let params = params_from_direct(&creds, &direct)?;
         Ok(FpssClient::from_params(params))
     }

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -61,6 +61,73 @@ pub(crate) fn invalid_parameter_err(message: impl std::fmt::Display) -> napi::Er
     napi::Error::from_reason(format!("[InvalidParameterError] {message}"))
 }
 
+// ── Credentials ──
+//
+// A first-class credentials handle mirroring the Python `Credentials`
+// pyclass (`sdks/python/src/lib.rs`), the C++ `tdx::Credentials`, and the
+// C ABI `TdxCredentials` handle. Every binding builds credentials the
+// same way — `new Credentials(email, password)` or
+// `Credentials.fromFile(path)` — then hands the handle to `connect`, so
+// the connect surface is `connect(creds, config?)` across the board
+// rather than each binding spreading raw `email`/`password` strings.
+
+/// ThetaData login credentials.
+///
+/// Build from an email + password pair (`new Credentials(email,
+/// password)`) or load from a credentials file (`Credentials.fromFile`,
+/// line 1 = email, line 2 = password), then pass the handle to a client
+/// `connect(creds, config?)`. Mirrors the Python `Credentials` and the
+/// C++ `tdx::Credentials`.
+///
+/// ```js
+/// const { Credentials, ThetaDataDxClient } = require("@thetadatadx/sdk");
+/// const creds = Credentials.fromFile("creds.txt");
+/// const tdx = ThetaDataDxClient.connect(creds);
+/// ```
+#[napi]
+#[derive(Clone)]
+pub struct Credentials {
+    pub(crate) inner: auth::Credentials,
+}
+
+#[napi]
+impl Credentials {
+    /// Create credentials from an email and password.
+    #[napi(constructor)]
+    pub fn new(email: String, password: String) -> Credentials {
+        Credentials {
+            inner: auth::Credentials::new(email, password),
+        }
+    }
+
+    /// Load credentials from a file (line 1 = email, line 2 = password).
+    #[napi(factory, js_name = "fromFile")]
+    pub fn from_file(path: String) -> napi::Result<Credentials> {
+        let inner = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
+        Ok(Credentials { inner })
+    }
+
+    /// Redacted string form — never exposes the email or password. Matches
+    /// the redacted `Debug` impl on the Rust `auth::Credentials` and the
+    /// Python `Credentials.__repr__`.
+    #[napi(js_name = "toString")]
+    pub fn to_string_js(&self) -> String {
+        "Credentials(email=<redacted>)".to_string()
+    }
+}
+
+/// Snapshot an optional [`Config`] handle into an owned [`DirectConfig`],
+/// falling back to the production default when none is supplied. The
+/// snapshot decouples the client from later mutations of the `Config`
+/// handle, matching the connect-time snapshot semantics every binding
+/// shares.
+pub(crate) fn config_or_production(config: Option<&Config>) -> config::DirectConfig {
+    match config {
+        Some(c) => c.snapshot(),
+        None => config::DirectConfig::production(),
+    }
+}
+
 /// Validate a JavaScript `timeoutMs` deadline and convert it to the
 /// integer millisecond domain the Python, C++, and C ABI bindings take.
 ///
@@ -160,13 +227,13 @@ fn leaf_class_for(e: &thetadatadx::Error) -> &'static str {
             "SchemaMismatchError"
         }
         // User-input validation failures route to the dedicated
-        // invalid-parameter class; environmental config faults stay on
-        // the root class.
+        // invalid-parameter class; environmental config faults route to
+        // the dedicated `ConfigError` class.
         thetadatadx::Error::Config { kind, .. } => {
             if kind.is_invalid_parameter() {
                 "InvalidParameterError"
             } else {
-                "ThetaDataError"
+                "ConfigError"
             }
         }
         thetadatadx::Error::Fpss { kind, .. } => match kind {
@@ -175,6 +242,13 @@ fn leaf_class_for(e: &thetadatadx::Error) -> &'static str {
             FpssErrorKind::ConnectionRefused | FpssErrorKind::Disconnected => "NetworkError",
             _ => "StreamError",
         },
+        // FlatFiles availability + partial-reconnect failures are
+        // streaming-surface faults; pin them to `StreamError` so a
+        // `catch (e instanceof StreamError)` clause behaves identically
+        // to the C++ and C ABI mapping (both route these to the stream
+        // discriminant).
+        thetadatadx::Error::FlatFilesUnavailable(_)
+        | thetadatadx::Error::PartialReconnect { .. } => "StreamError",
         _ => "ThetaDataError",
     }
 }
@@ -312,60 +386,30 @@ pub struct ThetaDataDxClient {
 impl ThetaDataDxClient {
     // Lifecycle: intentionally hand-written (language-specific constructor semantics).
 
-    /// Connect to ThetaData. Historical (MDDS/gRPC) only; call startStreaming()
-    /// to begin FPSS real-time data.
-    #[napi(factory)]
-    pub fn connect(email: String, password: String) -> napi::Result<ThetaDataDxClient> {
-        let creds = auth::Credentials::new(email, password);
-        let config = config::DirectConfig::production();
-        let tdx = runtime()
-            .block_on(thetadatadx::ThetaDataDxClient::connect(
-                // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
-                &creds, config,
-            ))
-            .map_err(to_napi_err)?;
-        Ok(ThetaDataDxClient {
-            tdx: Arc::new(tdx),
-            callback: Mutex::new(None),
-        })
-    }
-
-    /// Connect with a credentials file (line 1 = email, line 2 = password).
-    #[napi(factory)]
-    pub fn connect_from_file(path: String) -> napi::Result<ThetaDataDxClient> {
-        let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-        let config = config::DirectConfig::production();
-        let tdx = runtime()
-            .block_on(thetadatadx::ThetaDataDxClient::connect(
-                // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
-                &creds, config,
-            ))
-            .map_err(to_napi_err)?;
-        Ok(ThetaDataDxClient {
-            tdx: Arc::new(tdx),
-            callback: Mutex::new(None),
-        })
-    }
-
-    /// Connect to ThetaData against an explicit [`Config`] (`dev` /
-    /// `stage` / `production`, plus any tuned setters). Historical
-    /// (MDDS/gRPC) only; call startStreaming() to begin FPSS real-time
-    /// data. Use `connect` for the production-default endpoint.
+    /// Connect to ThetaData with a [`Credentials`] handle. Pass an
+    /// optional [`Config`] (`dev` / `stage` / `production`, plus any
+    /// tuned setters) to override the production-default endpoint.
+    /// Historical (MDDS/gRPC) only; call startStreaming() to begin FPSS
+    /// real-time data.
     ///
-    /// The config is snapshot at connect time: the `Config` handle may
-    /// be reused or mutated afterward without affecting this client.
+    /// The config is snapshot at connect time: the `Config` handle may be
+    /// reused or mutated afterward without affecting this client.
+    ///
+    /// ```js
+    /// const creds = Credentials.fromFile("creds.txt");
+    /// const tdx = ThetaDataDxClient.connect(creds);
+    /// ```
     #[napi(factory)]
-    pub fn connect_with_config(
-        email: String,
-        password: String,
-        config: &Config,
+    pub fn connect(
+        creds: &Credentials,
+        config: Option<&Config>,
     ) -> napi::Result<ThetaDataDxClient> {
-        let creds = auth::Credentials::new(email, password);
-        let cfg = config.snapshot();
+        let cfg = config_or_production(config);
         let tdx = runtime()
             .block_on(thetadatadx::ThetaDataDxClient::connect(
                 // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
-                &creds, cfg,
+                &creds.inner,
+                cfg,
             ))
             .map_err(to_napi_err)?;
         Ok(ThetaDataDxClient {
@@ -375,19 +419,16 @@ impl ThetaDataDxClient {
     }
 
     /// Connect with a credentials file (line 1 = email, line 2 =
-    /// password) against an explicit [`Config`] (`dev` / `stage` /
-    /// `production`, plus any tuned setters). Use `connectFromFile` for
-    /// the production-default endpoint.
-    ///
-    /// The config is snapshot at connect time: the `Config` handle may
-    /// be reused or mutated afterward without affecting this client.
-    #[napi(factory)]
-    pub fn connect_from_file_with_config(
+    /// password). Convenience wrapper over `Credentials.fromFile` +
+    /// `connect`. Pass an optional [`Config`] to override the
+    /// production-default endpoint.
+    #[napi(factory, js_name = "connectFromFile")]
+    pub fn connect_from_file(
         path: String,
-        config: &Config,
+        config: Option<&Config>,
     ) -> napi::Result<ThetaDataDxClient> {
         let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-        let cfg = config.snapshot();
+        let cfg = config_or_production(config);
         let tdx = runtime()
             .block_on(thetadatadx::ThetaDataDxClient::connect(
                 // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
@@ -596,74 +637,35 @@ impl MddsClient {
     // opens MDDS + Nexus and never opens FPSS until a streaming method is
     // called, which this class does not surface.
 
-    /// Connect to ThetaData and open the MDDS channel. Historical
-    /// (MDDS/gRPC) only — this client never opens the FPSS streaming
-    /// transport. Use [`FpssClient`] for real-time data.
+    /// Connect to ThetaData with a [`Credentials`] handle and open the
+    /// MDDS channel. Historical (MDDS/gRPC) only — this client never
+    /// opens the FPSS streaming transport. Pass an optional [`Config`] to
+    /// override the production-default endpoint. Use [`FpssClient`] for
+    /// real-time data.
+    ///
+    /// The config is snapshot at connect time: the `Config` handle may be
+    /// reused or mutated afterward without affecting this client.
     #[napi(factory)]
-    pub fn connect(email: String, password: String) -> napi::Result<MddsClient> {
-        let creds = auth::Credentials::new(email, password);
-        let config = config::DirectConfig::production();
+    pub fn connect(creds: &Credentials, config: Option<&Config>) -> napi::Result<MddsClient> {
+        let cfg = config_or_production(config);
         let tdx = runtime()
             .block_on(thetadatadx::ThetaDataDxClient::connect(
                 // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
-                &creds, config,
+                &creds.inner,
+                cfg,
             ))
             .map_err(to_napi_err)?;
         Ok(MddsClient { tdx: Arc::new(tdx) })
     }
 
     /// Connect with a credentials file (line 1 = email, line 2 =
-    /// password). Historical (MDDS/gRPC) only.
-    #[napi(factory)]
-    pub fn connect_from_file(path: String) -> napi::Result<MddsClient> {
+    /// password). Convenience wrapper over `Credentials.fromFile` +
+    /// `connect`. Historical (MDDS/gRPC) only. Pass an optional
+    /// [`Config`] to override the production-default endpoint.
+    #[napi(factory, js_name = "connectFromFile")]
+    pub fn connect_from_file(path: String, config: Option<&Config>) -> napi::Result<MddsClient> {
         let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-        let config = config::DirectConfig::production();
-        let tdx = runtime()
-            .block_on(thetadatadx::ThetaDataDxClient::connect(
-                // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
-                &creds, config,
-            ))
-            .map_err(to_napi_err)?;
-        Ok(MddsClient { tdx: Arc::new(tdx) })
-    }
-
-    /// Connect to ThetaData against an explicit [`Config`] (`dev` /
-    /// `stage` / `production`, plus any tuned setters). Historical
-    /// (MDDS/gRPC) only. Use `connect` for the production-default
-    /// endpoint.
-    ///
-    /// The config is snapshot at connect time: the `Config` handle may
-    /// be reused or mutated afterward without affecting this client.
-    #[napi(factory)]
-    pub fn connect_with_config(
-        email: String,
-        password: String,
-        config: &Config,
-    ) -> napi::Result<MddsClient> {
-        let creds = auth::Credentials::new(email, password);
-        let cfg = config.snapshot();
-        let tdx = runtime()
-            .block_on(thetadatadx::ThetaDataDxClient::connect(
-                // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
-                &creds, cfg,
-            ))
-            .map_err(to_napi_err)?;
-        Ok(MddsClient { tdx: Arc::new(tdx) })
-    }
-
-    /// Connect with a credentials file (line 1 = email, line 2 =
-    /// password) against an explicit [`Config`]. Historical (MDDS/gRPC)
-    /// only. Use `connectFromFile` for the production-default endpoint.
-    ///
-    /// The config is snapshot at connect time: the `Config` handle may
-    /// be reused or mutated afterward without affecting this client.
-    #[napi(factory)]
-    pub fn connect_from_file_with_config(
-        path: String,
-        config: &Config,
-    ) -> napi::Result<MddsClient> {
-        let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
-        let cfg = config.snapshot();
+        let cfg = config_or_production(config);
         let tdx = runtime()
             .block_on(thetadatadx::ThetaDataDxClient::connect(
                 // VOCAB-OK: tokio Runtime::block_on in NAPI bridge

--- a/sdks/typescript/streaming-session.d.ts
+++ b/sdks/typescript/streaming-session.d.ts
@@ -56,6 +56,7 @@ export class UnavailableError extends ThetaDataError {}
 export class NetworkError extends ThetaDataError {}
 export class SchemaMismatchError extends ThetaDataError {}
 export class StreamError extends ThetaDataError {}
+export class ConfigError extends ThetaDataError {}
 
 /** Callback signature mirrored from the napi-generated
  * `startStreaming(callback)` declaration in `index.d.ts`. */

--- a/sdks/typescript/streaming-session.js
+++ b/sdks/typescript/streaming-session.js
@@ -120,6 +120,12 @@ class StreamError extends ThetaDataError {
     this.name = 'StreamError';
   }
 }
+class ConfigError extends ThetaDataError {
+  constructor(message) {
+    super(message);
+    this.name = 'ConfigError';
+  }
+}
 
 const CLASS_BY_NAME = {
   ThetaDataError,
@@ -134,6 +140,7 @@ const CLASS_BY_NAME = {
   NetworkError,
   SchemaMismatchError,
   StreamError,
+  ConfigError,
 };
 
 // `[ClassName] message` or `[ClassName retry_after_ms=N] message`. The
@@ -449,4 +456,5 @@ module.exports = Object.assign({}, native, exportedClasses, exportedFreeFns, {
   NetworkError,
   SchemaMismatchError,
   StreamError,
+  ConfigError,
 });


### PR DESCRIPTION
Three cross-binding symmetry gaps closed on the Python and TypeScript surfaces so the typed-exception vocabulary and the connect shape are identical in every binding.

A new `ConfigError` leaf joins the exception hierarchy on Python, TypeScript, and C++. An environmental configuration fault — a config-file read failure, a TOML parse error, or an internal config invariant — was routing to the root `ThetaDataError` on Python and TypeScript, and the C++ wrapper folded the reserved `TDX_ERR_CONFIG` discriminant into the root. All three now raise `ConfigError`, matching the discriminant the C ABI already reserves, so a rejected call-site argument (`InvalidParameterError`) stays distinguishable by catch type from an environment fault.

`FlatFilesUnavailable` and `PartialReconnect` now route to `StreamError` on Python and TypeScript. The C++ and C ABI already mapped both to the stream discriminant; the higher-level bindings let them fall through to the root, so a `catch (StreamError)` / `except StreamError` clause now behaves identically across every binding.

The TypeScript SDK gains a first-class `Credentials` class — `new Credentials(email, password)` and `Credentials.fromFile(path)`, with a redacted `toString` — mirroring the Python `Credentials` pyclass and the C++ `tdx::Credentials`. The unified `ThetaDataDxClient`, the standalone `MddsClient`, and the standalone `FpssClient` now connect with `connect(creds, config?)` / `connectFromFile(path, config?)`, replacing the raw `email, password` factories and folding the separate `connectWithConfig` / `connectFromFileWithConfig` variants into the optional second argument.

Breaking: the TypeScript `connect` / `connectFromFile` signatures change shape (creds-first, config optional) and the `*WithConfig` factories are removed.

The parity matrix flips `Credentials` and `Credentials.fromFile` to bound on TypeScript and adds a `ConfigError` class row. The Python error-parity test and the TypeScript typed-error test add `ConfigError` to their canonical leaf sets, and the C++ error-taxonomy test asserts `TDX_ERR_CONFIG` surfaces as `ConfigError`.

Verification: `cargo fmt --all -- --check` and the napi/py crates clean; `cargo clippy -- -D warnings` clean on both SDK crates; `generate_sdk_surfaces --check` and `generate_docs_site --check` byte-identical; `check_binding_parity.py` clean (44/44 selftest); `test_error_parity.py` green with `ConfigError`; the Python error-dispatch unit tests, the TypeScript typed-error and client-surface tests, and a compiled C++ `throw_for_code(TDX_ERR_CONFIG)` check all pass. Functional checks: Python `raise ConfigError`, TypeScript `new Credentials(...)` + `connect(creds)` accepting a handle and rejecting a raw string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)