### PR TITLE
feat(sdk)!: drop the _explicit setter stem, add the mdds endpoint knob and two utility lookups to TypeScript, and realign getter names

### DIFF
--- a/crates/thetadatadx/sdk_surface.toml
+++ b/crates/thetadatadx/sdk_surface.toml
@@ -17,7 +17,7 @@ version = 2
 [[methods]]
 name = "start_streaming"
 kind = "start_streaming"
-doc = "Start FPSS streaming. Events are buffered; poll with next_event()."
+doc = "Start FPSS streaming and register a callback for incoming events. Each typed FPSS event is delivered to the callback off the network thread; the binding owns the dispatcher and the callback runs under a panic boundary."
 targets = ["python_unified", "typescript_napi"]
 
 [[methods]]

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -1225,7 +1225,7 @@ pub unsafe extern "C" fn tdx_config_get_fpss_host_selection(
 /// Ignored under the `FixedOrder` host-selection policy. Returns `0`
 /// on success, `-1` if `config` is null.
 #[no_mangle]
-pub unsafe extern "C" fn tdx_config_set_fpss_host_shuffle_seed_explicit(
+pub unsafe extern "C" fn tdx_config_set_fpss_host_shuffle_seed(
     config: *mut TdxConfig,
     has_value: bool,
     seed: u64,
@@ -1243,7 +1243,7 @@ pub unsafe extern "C" fn tdx_config_set_fpss_host_shuffle_seed_explicit(
 }
 
 /// Read the current FPSS host-shuffle seed. Same `(has_value, seed)`
-/// ABI as `tdx_config_set_fpss_host_shuffle_seed_explicit`:
+/// ABI as `tdx_config_set_fpss_host_shuffle_seed`:
 ///
 /// * `*out_has_value = false` → `None` (per-client entropy). `*out_seed` is left `0`.
 /// * `*out_has_value = true` → `Some(*out_seed)`.
@@ -1443,7 +1443,7 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_callback(
 ///
 /// Returns `0` on success, `-1` if `config` is null.
 #[no_mangle]
-pub unsafe extern "C" fn tdx_config_set_worker_threads_explicit(
+pub unsafe extern "C" fn tdx_config_set_worker_threads(
     config: *mut TdxConfig,
     has_value: bool,
     n: usize,
@@ -2644,7 +2644,7 @@ mod runtime_setter_tests {
     //! do.
 
     #[test]
-    fn worker_threads_explicit_round_trips_via_getter() {
+    fn worker_threads_round_trips_via_getter() {
         let cfg = super::tdx_config_production();
         // SAFETY: handle just returned by tdx_config_production.
         unsafe {
@@ -2660,7 +2660,7 @@ mod runtime_setter_tests {
 
             // Explicit values round-trip including the Some(0) sentinel.
             for n in [0usize, 1, 2, 4, 8, 16, 32, 64] {
-                let rc = super::tdx_config_set_worker_threads_explicit(cfg, true, n);
+                let rc = super::tdx_config_set_worker_threads(cfg, true, n);
                 assert_eq!(rc, 0);
                 assert_eq!((*cfg).inner.runtime.tokio_worker_threads, Some(n));
                 assert_eq!(
@@ -2672,7 +2672,7 @@ mod runtime_setter_tests {
             }
 
             // Reset to None.
-            let rc = super::tdx_config_set_worker_threads_explicit(cfg, false, 999);
+            let rc = super::tdx_config_set_worker_threads(cfg, false, 999);
             assert_eq!(rc, 0);
             assert_eq!((*cfg).inner.runtime.tokio_worker_threads, None);
             super::tdx_config_free(cfg);
@@ -2684,7 +2684,7 @@ mod runtime_setter_tests {
         // SAFETY: passing null to tdx_config_* is the documented FFI
         // contract — getter returns sentinel, setter no-ops.
         unsafe {
-            let rc = super::tdx_config_set_worker_threads_explicit(std::ptr::null_mut(), true, 4);
+            let rc = super::tdx_config_set_worker_threads(std::ptr::null_mut(), true, 4);
             assert_eq!(rc, -1);
             let mut got_has = false;
             let mut got_n: usize = 0;
@@ -3453,7 +3453,7 @@ mod resilience_knob_tests {
             );
             assert_eq!(seed, 0);
             assert_eq!(
-                super::tdx_config_set_fpss_host_shuffle_seed_explicit(cfg, true, 42),
+                super::tdx_config_set_fpss_host_shuffle_seed(cfg, true, 42),
                 0
             );
             assert_eq!(
@@ -3463,7 +3463,7 @@ mod resilience_knob_tests {
             assert!(has_value);
             assert_eq!(seed, 42);
             assert_eq!(
-                super::tdx_config_set_fpss_host_shuffle_seed_explicit(cfg, false, 0),
+                super::tdx_config_set_fpss_host_shuffle_seed(cfg, false, 0),
                 0
             );
             assert_eq!(

--- a/scripts/check_binding_parity.py
+++ b/scripts/check_binding_parity.py
@@ -460,18 +460,12 @@ def _normalize_setter(name: str) -> str:
 # Each entry maps the canonical (normalized) setter name to a written
 # reason. This is the documented per-language-idiom carve-out the gate
 # tolerates — every entry is a reviewed decision, not a silencer.
-SETTER_PARITY_EXEMPT: dict[str, str] = {
-    "mdds_host": (
-        "advanced MDDS endpoint override, Python-only by design "
-        "(structural tests point the historical channel at a refused "
-        "endpoint); mdds is a vendor protocol name, kept verbatim"
-    ),
-    "mdds_port": (
-        "advanced MDDS endpoint override, Python-only by design "
-        "(companion to mdds_host); mdds is a vendor protocol name, "
-        "kept verbatim"
-    ),
-}
+#
+# Empty today: the `mdds_host` / `mdds_port` advanced endpoint overrides
+# are now bound on every binding (Python / TypeScript / C++ / the C
+# ABI), so no carve-out is required. Add an entry here only when a
+# setter is intentionally exposed on a strict subset of bindings.
+SETTER_PARITY_EXEMPT: dict[str, str] = {}
 
 
 def _check_setter_set_parity(
@@ -968,15 +962,22 @@ def _check_method_rows(
             continue
         snake = _camel_to_snake(camel)
 
-        # Python: snake_case method declared on the pyclass.
+        # Python: snake_case method declared on the pyclass. A `#[getter]`
+        # readback accessor carries a `get_` prefix on its Rust fn name
+        # (`fn get_flush_mode`) while pyo3 strips the prefix so the Python
+        # property name stays bare (`config.flush_mode`); accept the
+        # `get_`-prefixed fn name against the bare row, exactly as the C++
+        # branch below accepts `get_<snake>`.
+        py_class_methods = py_methods.get(class_name, set())
         declared_py = row.get("python", False)
-        actual_py = snake in py_methods.get(class_name, set())
+        actual_py = snake in py_class_methods or f"get_{snake}" in py_class_methods
         if declared_py != actual_py:
             verb = "missing" if declared_py and not actual_py else "unexpected"
             errors.append(
                 f"  {class_name}.{camel}.python: declared={declared_py}, "
                 f"actual={actual_py} ({verb} -- expected `fn {snake}` "
-                f"inside `impl {class_name}` on the Python pyclass)"
+                f"or `fn get_{snake}` inside `impl {class_name}` on the "
+                f"Python pyclass)"
             )
 
         # TypeScript: napi-attributed method declared inside the
@@ -2327,6 +2328,32 @@ def _run_selftest() -> int:
             f"C++ `get_`-prefixed getter must satisfy a bare row; got {errors!r}"
         )
 
+    def _case_method_python_get_prefix_resolves() -> None:
+        """Python `#[getter] fn get_<x>` satisfies a bare getter row.
+
+        pyo3 strips the `get_` prefix so the Python property name stays
+        bare (`config.flush_mode`), but the Rust fn name the collector
+        harvests carries the prefix. The gate must accept `get_flush_mode`
+        against the bare `flushMode` row, exactly as it does for C++.
+        """
+        rows = [
+            {
+                "class": "Config",
+                "name": "flushMode",
+                "python": True,
+                "typescript": True,
+                "cpp": True,
+            }
+        ]
+        # Python exposes the readback getter as `fn get_flush_mode`.
+        py_methods = {"Config": {"get_flush_mode"}}
+        ts_methods = {"Config": {"flushMode"}}
+        cpp_methods = {"Config": {"get_flush_mode"}}
+        errors = _check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+        assert errors == [], (
+            f"Python `get_`-prefixed getter must satisfy a bare row; got {errors!r}"
+        )
+
     def _case_method_unexpected_extra() -> None:
         """Declared `false` but method exists on the source — trips."""
         rows = [
@@ -2392,6 +2419,7 @@ def _run_selftest() -> int:
     _case("method negative — declared TS but missing js_name", _case_method_typescript_missing)
     _case("method positive — C++ alias routes Contract -> FluentContract", _case_method_cpp_alias_resolves)
     _case("method positive — C++ `get_` prefix satisfies a bare getter row", _case_method_cpp_get_prefix_resolves)
+    _case("method positive — Python `get_` prefix satisfies a bare getter row", _case_method_python_get_prefix_resolves)
     _case("method negative — stale `false` row with method present", _case_method_unexpected_extra)
     _case("method negative — malformed row missing class or name", _case_method_row_missing_class_or_name)
     _case("method positive — class-scoped TS lookup isolates classes", _case_method_class_scoping_isolates_classes)

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -1225,8 +1225,7 @@ int32_t tdx_config_get_fpss_host_selection(const TdxConfig* config, int32_t* out
  * under the FixedOrder policy. Returns 0 on success, -1 if config is
  * null.
  */
-int32_t tdx_config_set_fpss_host_shuffle_seed_explicit(TdxConfig* config, bool has_value,
-                                                       uint64_t seed);
+int32_t tdx_config_set_fpss_host_shuffle_seed(TdxConfig* config, bool has_value, uint64_t seed);
 
 /**
  * Read the current FPSS host-shuffle seed. *out_has_value=false
@@ -1267,7 +1266,7 @@ int32_t tdx_config_get_flatfiles_jitter(const TdxConfig* config, bool* out_jitte
  *
  * Returns 0 on success, -1 if `config` is NULL.
  */
-int32_t tdx_config_set_worker_threads_explicit(TdxConfig* config, bool has_value, size_t n);
+int32_t tdx_config_set_worker_threads(TdxConfig* config, bool has_value, size_t n);
 
 /**
  * Read the current async worker-thread count. Same widened

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -921,8 +921,8 @@ public:
     /** Set the FPSS host-shuffle seed using the (has_value, seed)
      *  shape. has_value=false derives a fresh per-client seed;
      *  has_value=true makes the shuffled order deterministic. */
-    int32_t set_fpss_host_shuffle_seed_explicit(bool has_value, uint64_t seed) {
-        return tdx_config_set_fpss_host_shuffle_seed_explicit(handle_.get(), has_value, seed);
+    int32_t set_fpss_host_shuffle_seed(bool has_value, uint64_t seed) {
+        return tdx_config_set_fpss_host_shuffle_seed(handle_.get(), has_value, seed);
     }
 
     /** Read the FPSS host-shuffle seed back. Returns @c std::nullopt for
@@ -965,8 +965,8 @@ public:
     /** Set the async worker-thread count using the (has_value, n) shape
      *  that preserves Some(0) across the C boundary. has_value=false
      *  defers to the default sizing. */
-    int32_t set_worker_threads_explicit(bool has_value, size_t n) {
-        return tdx_config_set_worker_threads_explicit(handle_.get(), has_value, n);
+    int32_t set_worker_threads(bool has_value, size_t n) {
+        return tdx_config_set_worker_threads(handle_.get(), has_value, n);
     }
 
     /** Read worker_threads back. Returns @c std::nullopt for the None

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -211,7 +211,7 @@ cpp = true
 #
 # Per-field access on the legacy `FlatFilesConfig` sub-config. Bound on
 # every binding: Python via `Config.flatfiles_*` setters/getters,
-# TypeScript via `Config.setFlatFiles*`, C++ via
+# TypeScript via `Config.setFlatfiles*`, C++ via
 # `tdx::Config::set_flatfiles_*` (which forwards to the FFI
 # `tdx_config_set_flatfiles_*` symbols). `max_attempts` is `u32`, the
 # two `Duration` fields cross the binding boundary as `u64` seconds
@@ -354,11 +354,10 @@ cpp = true
 # Async worker-thread sub-config knob honoured by embedded bindings
 # that own their runtime (FFI / Python / napi). The public setter is
 # `worker_threads` on every binding (Python `Config.worker_threads`,
-# TypeScript `Config.setWorkerThreadsExplicit` / `workerThreads`, C++
-# `set_worker_threads_explicit`, FFI
-# `tdx_config_set_worker_threads_explicit`). The row name carries the
-# public concept; the internal storage field maps to it through the
-# rename table in `check_binding_parity.py`. The widened
+# TypeScript `Config.setWorkerThreads` / `workerThreads`, C++
+# `set_worker_threads`, FFI `tdx_config_set_worker_threads`). The row
+# name carries the public concept; the internal storage field maps to
+# it through the rename table in `check_binding_parity.py`. The widened
 # `(has_value, n)` ABI shape on the C surface lets the `Some(0)`
 # sentinel survive the C boundary.
 
@@ -474,24 +473,24 @@ cpp = true          # `tdx::IndexPriceAtTimeTick` alias over `TdxIndexPriceAtTim
 # Two `MddsConfig` advanced overrides (`mdds_host` / `mdds_port`):
 # point the historical channel at a known host (e.g. a refused endpoint
 # in structural tests that prove the streaming surface never opens it).
-# MDDS is a vendor protocol name, kept verbatim. Exposed on Python
-# (`Config.mdds_host` / `.mdds_port`) and C++ (`set_mdds_host` /
+# MDDS is a vendor protocol name, kept verbatim. Exposed on every
+# binding: Python (`Config.mdds_host` / `.mdds_port`), TypeScript
+# (`Config.setMddsHost` / `.setMddsPort`), and C++ (`set_mdds_host` /
 # `set_mdds_port` over the FFI `tdx_config_set_mdds_host` /
-# `tdx_config_set_mdds_port`). TypeScript does not carry these advanced
-# knobs. The dotted rows below capture the partial-binding state via the
-# `setter = "..."` override.
+# `tdx_config_set_mdds_port`). The dotted rows below capture the
+# binding state via the `setter = "..."` override.
 
 [[class]]
 name = "MddsConfig.host"
 python = true       # `Config.mdds_host` advanced override
-typescript = false  # advanced historical-endpoint knob not exposed on the napi Config
+typescript = true   # `Config.setMddsHost` / `mddsHost` napi setter+getter
 cpp = true          # `Config::set_mdds_host` over `tdx_config_set_mdds_host`
 setter = "mdds_host"
 
 [[class]]
 name = "MddsConfig.port"
 python = true       # `Config.mdds_port` advanced override
-typescript = false  # advanced historical-endpoint knob not exposed on the napi Config
+typescript = true   # `Config.setMddsPort` / `mddsPort` napi setter+getter
 cpp = true          # `Config::set_mdds_port` over `tdx_config_set_mdds_port`
 setter = "mdds_port"
 
@@ -1145,14 +1144,17 @@ python = true
 typescript = true
 cpp = true
 
-# The `deriveOhlcvc` / `concurrentRequests` readback getters are exposed
-# on every binding: Python (`Config.derive_ohlcvc` / `.concurrent_requests`
-# properties), TypeScript (`Config.deriveOhlcvc` / `.concurrentRequests`
-# getters), C++ (`Config::get_derive_ohlcvc()` / `::get_concurrent_requests()`
-# over the FFI `tdx_config_get_derive_ohlcvc` / `_concurrent_requests`
-# symbols). C++ readback getters carry a uniform `get_` prefix; the
-# parity gate accepts that per-language convention. The matching setters
-# are tracked by the dotted `[[class]]` rows `FpssConfig.derive_ohlcvc` /
+# The `flushMode` / `deriveOhlcvc` / `concurrentRequests` readback
+# getters are exposed on every binding: Python (`Config.flush_mode` /
+# `.derive_ohlcvc` / `.concurrent_requests` properties), TypeScript
+# (`Config.flushMode` / `.deriveOhlcvc` / `.concurrentRequests`
+# getters), C++ (`Config::get_flush_mode()` etc. over the FFI
+# `tdx_config_get_*` symbols). Both the Python `#[getter]` accessors and
+# the C++ readback getters carry a uniform `get_` Rust/C++ fn prefix
+# (pyo3 strips it so the Python property name stays bare); the parity
+# gate accepts that per-language convention against the bare row. The
+# matching setters are tracked by the dotted `[[class]]` rows
+# `FpssConfig.flush_mode` / `FpssConfig.derive_ohlcvc` /
 # `MddsConfig.concurrent_requests`.
 [[method]]
 class = "Config"

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -998,7 +998,7 @@ impl Config {
 
     /// Get the current OHLCVC derivation setting.
     #[getter]
-    fn derive_ohlcvc(&self) -> bool {
+    fn get_derive_ohlcvc(&self) -> bool {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         guard.fpss.derive_ohlcvc
     }
@@ -1028,7 +1028,7 @@ impl Config {
     /// Current streaming write-flush policy (``"batched"`` or
     /// ``"immediate"``).
     #[getter]
-    fn flush_mode(&self) -> &'static str {
+    fn get_flush_mode(&self) -> &'static str {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         match guard.fpss.flush_mode {
             config::FpssFlushMode::Batched => "batched",
@@ -1094,7 +1094,7 @@ impl Config {
 
     /// Current `concurrent_requests` setting (``0`` = auto-detect).
     #[getter]
-    fn concurrent_requests(&self) -> usize {
+    fn get_concurrent_requests(&self) -> usize {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         guard.mdds.concurrent_requests
     }

--- a/sdks/python/src/util_helpers.rs
+++ b/sdks/python/src/util_helpers.rs
@@ -8,6 +8,8 @@
 //! util.condition_name(0)            # "REGULAR"
 //! util.exchange_name(3)             # "NewYorkStockExchange"
 //! util.exchange_symbol(3)           # "NYSE"
+//! util.calendar_status_name(1)      # "early_close"
+//! util.timestamp_ms(20240102, 34200000)  # epoch ms, or None if out of domain
 //! util.sequence_signed_to_unsigned(-1)
 //! ```
 //!
@@ -60,6 +62,28 @@ fn is_halted(code: i32) -> bool {
 #[pyfunction]
 fn exchange_name(code: i32) -> &'static str {
     thetadatadx::utils::exchange::exchange_name(code)
+}
+
+/// Vendor vocabulary text for a calendar-day `status` code (`0` ->
+/// `"open"`, `1` -> `"early_close"`, `2` -> `"full_close"`, `3` ->
+/// `"weekend"`). Returns the literal `"UNKNOWN"` for codes outside the
+/// table. Mirrors the C++ `tdx::calendar_status_name` and the C ABI
+/// `tdx_calendar_status_name`.
+#[pyfunction]
+fn calendar_status_name(code: i32) -> &'static str {
+    thetadatadx::CalendarStatus::from_code(code)
+        .map_or("UNKNOWN", thetadatadx::CalendarStatus::as_str)
+}
+
+/// Combine an Eastern-Time `YYYYMMDD` date and milliseconds-of-day into
+/// Unix epoch milliseconds (UTC, DST-aware). Usable with any
+/// `(date, *_ms_of_day)` pair on the tick structs. Returns `None` when
+/// `date` is absent (`0`) or either input is out of domain — the same
+/// `std::nullopt` contract the C++ `tdx::timestamp_ms` returns (the C
+/// ABI `tdx_timestamp_ms` encodes that absence as the `-1` sentinel).
+#[pyfunction]
+fn timestamp_ms(date: i32, ms_of_day: i32) -> Option<i64> {
+    thetadatadx::time::date_ms_to_epoch_ms(date, ms_of_day)
 }
 
 #[pyfunction]
@@ -130,6 +154,8 @@ pub(crate) fn register(parent: &Bound<'_, PyModule>) -> PyResult<()> {
     util.add_function(wrap_pyfunction!(is_halted, &util)?)?;
     util.add_function(wrap_pyfunction!(exchange_name, &util)?)?;
     util.add_function(wrap_pyfunction!(exchange_symbol, &util)?)?;
+    util.add_function(wrap_pyfunction!(calendar_status_name, &util)?)?;
+    util.add_function(wrap_pyfunction!(timestamp_ms, &util)?)?;
     util.add_function(wrap_pyfunction!(sequence_signed_to_unsigned, &util)?)?;
     util.add_function(wrap_pyfunction!(sequence_unsigned_to_signed, &util)?)?;
 

--- a/sdks/python/tests/test_util_helpers.py
+++ b/sdks/python/tests/test_util_helpers.py
@@ -53,6 +53,31 @@ def test_exchange_out_of_range(util):
     assert util.exchange_symbol(9999) == "UNKNOWN"
 
 
+def test_calendar_status_name(util):
+    # Vocabulary from the core CalendarStatus enum / the C ABI
+    # tdx_calendar_status_name. Out-of-table codes return "UNKNOWN".
+    assert util.calendar_status_name(0) == "open"
+    assert util.calendar_status_name(1) == "early_close"
+    assert util.calendar_status_name(2) == "full_close"
+    assert util.calendar_status_name(3) == "weekend"
+    assert util.calendar_status_name(99) == "UNKNOWN"
+    assert util.calendar_status_name(-1) == "UNKNOWN"
+
+
+def test_timestamp_ms(util):
+    # Combines an Eastern-Time YYYYMMDD date + ms-of-day into epoch ms.
+    # 2024-01-02 09:30 ET = 14:30 UTC. Matches the TypeScript
+    # Util.timestampMs and the C++ tdx::timestamp_ms for the same input.
+    assert util.timestamp_ms(20240102, 34_200_000) == 1_704_205_800_000
+
+
+def test_timestamp_ms_out_of_domain_returns_none(util):
+    # Out-of-domain inputs return None (the std::nullopt contract the C++
+    # tdx::timestamp_ms shares), never a coerced sentinel.
+    assert util.timestamp_ms(0, 0) is None
+    assert util.timestamp_ms(20240102, -1) is None
+
+
 def test_quote_condition_lookups(util):
     # quote_condition_name(0) is well-defined in the table; out-of-range
     # falls back to "UNKNOWN".

--- a/sdks/typescript/__tests__/config_reconnect.test.mjs
+++ b/sdks/typescript/__tests__/config_reconnect.test.mjs
@@ -155,7 +155,7 @@ describe('Config.setReconnectWaitMs / setReconnectWaitRateLimitedMs', () => {
   });
 });
 
-describe('Config.setWorkerThreadsExplicit', () => {
+describe('Config.setWorkerThreads', () => {
   it('default workerThreads is the None (auto) sentinel', () => {
     const cfg = Config.production();
     const got = cfg.workerThreads;
@@ -166,13 +166,13 @@ describe('Config.setWorkerThreadsExplicit', () => {
   it('round-trip preserves Some(0) and explicit pinned counts', () => {
     const cfg = Config.production();
     for (const n of [0, 1, 2, 4, 8, 16, 64]) {
-      cfg.setWorkerThreadsExplicit(true, n);
+      cfg.setWorkerThreads(true, n);
       const got = cfg.workerThreads;
       assert.equal(got.hasValue, true);
       assert.equal(got.n, n);
     }
     // Reset to None.
-    cfg.setWorkerThreadsExplicit(false, 999);
+    cfg.setWorkerThreads(false, 999);
     const got = cfg.workerThreads;
     assert.equal(got.hasValue, false);
     assert.equal(got.n, 0);

--- a/sdks/typescript/__tests__/config_resilience.test.mjs
+++ b/sdks/typescript/__tests__/config_resilience.test.mjs
@@ -121,9 +121,9 @@ test("retry envelope defaults and round-trip", () => {
 
 test("flatfiles budget defaults and jitter round-trip", () => {
   const cfg = Config.production();
-  assert.equal(cfg.flatFilesMaxAttempts, 10);
-  assert.equal(cfg.flatFilesMaxBackoffSecs, 30n);
-  assert.equal(cfg.flatFilesJitter, true);
-  cfg.setFlatFilesJitter(false);
-  assert.equal(cfg.flatFilesJitter, false);
+  assert.equal(cfg.flatfilesMaxAttempts, 10);
+  assert.equal(cfg.flatfilesMaxBackoffSecs, 30n);
+  assert.equal(cfg.flatfilesJitter, true);
+  cfg.setFlatfilesJitter(false);
+  assert.equal(cfg.flatfilesJitter, false);
 });

--- a/sdks/typescript/__tests__/flatfiles_config.test.mjs
+++ b/sdks/typescript/__tests__/flatfiles_config.test.mjs
@@ -1,7 +1,7 @@
 // FlatFilesConfig setters on `Config` — TypeScript binding parity
 // with Python / C++ / FFI. Pins the JS surface contract for
-// `setFlatFilesMaxAttempts`, `setFlatFilesInitialBackoffSecs`, and
-// `setFlatFilesMaxBackoffSecs`.
+// `setFlatfilesMaxAttempts`, `setFlatfilesInitialBackoffSecs`, and
+// `setFlatfilesMaxBackoffSecs`.
 //
 // The Rust core enforces the `[1, 10]` range on `max_attempts` and
 // the `max_backoff >= initial_backoff` invariant at
@@ -24,55 +24,55 @@ const { Config } = mod;
 describe('Config.flatFiles* — defaults mirror FlatFilesConfig::production_defaults', () => {
   it('expose the three FlatFilesConfig field defaults', () => {
     const cfg = Config.production();
-    assert.equal(cfg.flatFilesMaxAttempts, 10);
-    assert.equal(cfg.flatFilesInitialBackoffSecs, 1n);
-    assert.equal(cfg.flatFilesMaxBackoffSecs, 30n);
+    assert.equal(cfg.flatfilesMaxAttempts, 10);
+    assert.equal(cfg.flatfilesInitialBackoffSecs, 1n);
+    assert.equal(cfg.flatfilesMaxBackoffSecs, 30n);
   });
 });
 
-describe('Config.setFlatFilesMaxAttempts', () => {
+describe('Config.setFlatfilesMaxAttempts', () => {
   it('round-trips through the setter across the documented u32 range', () => {
     const cfg = Config.production();
     for (const n of [0, 1, 3, 5, 10, 100, 1_000]) {
-      cfg.setFlatFilesMaxAttempts(n);
-      assert.equal(cfg.flatFilesMaxAttempts, n);
+      cfg.setFlatfilesMaxAttempts(n);
+      assert.equal(cfg.flatfilesMaxAttempts, n);
     }
   });
 });
 
-describe('Config.setFlatFilesInitialBackoffSecs', () => {
+describe('Config.setFlatfilesInitialBackoffSecs', () => {
   it('round-trips through the setter across the documented u64 range', () => {
     const cfg = Config.production();
     for (const secs of [0n, 1n, 2n, 4n, 10n, 60n, 3_600n, 86_400n]) {
-      cfg.setFlatFilesInitialBackoffSecs(secs);
-      assert.equal(cfg.flatFilesInitialBackoffSecs, secs);
+      cfg.setFlatfilesInitialBackoffSecs(secs);
+      assert.equal(cfg.flatfilesInitialBackoffSecs, secs);
     }
   });
 
   it('rejects BigInt magnitudes above u64::MAX', () => {
     const cfg = Config.production();
     assert.throws(
-      () => cfg.setFlatFilesInitialBackoffSecs(1n << 65n),
-      /setFlatFilesInitialBackoffSecs/,
+      () => cfg.setFlatfilesInitialBackoffSecs(1n << 65n),
+      /setFlatfilesInitialBackoffSecs/,
       'magnitude above u64::MAX must be rejected at the boundary',
     );
   });
 });
 
-describe('Config.setFlatFilesMaxBackoffSecs', () => {
+describe('Config.setFlatfilesMaxBackoffSecs', () => {
   it('round-trips through the setter across the documented u64 range', () => {
     const cfg = Config.production();
     for (const secs of [0n, 1n, 4n, 10n, 60n, 3_600n, 86_400n]) {
-      cfg.setFlatFilesMaxBackoffSecs(secs);
-      assert.equal(cfg.flatFilesMaxBackoffSecs, secs);
+      cfg.setFlatfilesMaxBackoffSecs(secs);
+      assert.equal(cfg.flatfilesMaxBackoffSecs, secs);
     }
   });
 
   it('rejects BigInt magnitudes above u64::MAX', () => {
     const cfg = Config.production();
     assert.throws(
-      () => cfg.setFlatFilesMaxBackoffSecs(1n << 65n),
-      /setFlatFilesMaxBackoffSecs/,
+      () => cfg.setFlatfilesMaxBackoffSecs(1n << 65n),
+      /setFlatfilesMaxBackoffSecs/,
       'magnitude above u64::MAX must be rejected at the boundary',
     );
   });
@@ -81,13 +81,13 @@ describe('Config.setFlatFilesMaxBackoffSecs', () => {
 describe('FlatFiles setter state survives interleaved pool-sizing calls', () => {
   it('FlatFiles setter mutations land independently of pool-sizing mutations', () => {
     const cfg = Config.production();
-    cfg.setFlatFilesMaxAttempts(7);
-    cfg.setFlatFilesInitialBackoffSecs(3n);
-    cfg.setFlatFilesMaxBackoffSecs(12n);
+    cfg.setFlatfilesMaxAttempts(7);
+    cfg.setFlatfilesInitialBackoffSecs(3n);
+    cfg.setFlatfilesMaxBackoffSecs(12n);
     cfg.setConcurrentRequests(4);
-    assert.equal(cfg.flatFilesMaxAttempts, 7);
-    assert.equal(cfg.flatFilesInitialBackoffSecs, 3n);
-    assert.equal(cfg.flatFilesMaxBackoffSecs, 12n);
+    assert.equal(cfg.flatfilesMaxAttempts, 7);
+    assert.equal(cfg.flatfilesInitialBackoffSecs, 3n);
+    assert.equal(cfg.flatfilesMaxBackoffSecs, 12n);
     assert.equal(cfg.concurrentRequests, 4);
   });
 });

--- a/sdks/typescript/__tests__/util_helpers.test.mjs
+++ b/sdks/typescript/__tests__/util_helpers.test.mjs
@@ -47,6 +47,28 @@ describe('Util cross-language helpers (#424)', () => {
     }
   });
 
+  it('exposes calendarStatusName and timestampMs with the cross-binding sentinels', () => {
+    // Calendar status — vocabulary from the C ABI tdx_calendar_status_name
+    // / the core CalendarStatus enum. Out-of-table codes return "UNKNOWN".
+    assert.equal(mod.Util.calendarStatusName(0), 'open');
+    assert.equal(mod.Util.calendarStatusName(1), 'early_close');
+    assert.equal(mod.Util.calendarStatusName(2), 'full_close');
+    assert.equal(mod.Util.calendarStatusName(3), 'weekend');
+    assert.equal(mod.Util.calendarStatusName(99), 'UNKNOWN');
+    assert.equal(mod.Util.calendarStatusName(-1), 'UNKNOWN');
+
+    // timestamp_ms combines an Eastern-Time YYYYMMDD date + ms-of-day
+    // into epoch ms as a BigInt. 2024-01-02 09:30 ET = 14:30 UTC.
+    const epoch = mod.Util.timestampMs(20240102, 34200000);
+    assert.equal(typeof epoch, 'bigint');
+    assert.equal(epoch, 1704205800000n);
+
+    // Out-of-domain inputs return null (the std::nullopt contract the
+    // C++ tdx::timestamp_ms shares), never a coerced sentinel value.
+    assert.equal(mod.Util.timestampMs(0, 0), null);
+    assert.equal(mod.Util.timestampMs(20240102, -1), null);
+  });
+
   it('rejects BigInt inputs outside the wire range instead of silent coercion', () => {
     // i32::MAX + 1 — out of wire range.
     assert.throws(

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -5,9 +5,9 @@
  *
  * Build a config via one of the three static factories
  * ([`Config::production`] / [`Config::dev`] / [`Config::stage`]), tune
- * it with the setters below, then pass it to
- * `ThetaDataDxClient.connectWithConfig` /
- * `ThetaDataDxClient.connectFromFileWithConfig`.
+ * it with the setters below, then pass it as the optional second
+ * argument to `ThetaDataDxClient.connect(creds, config)` /
+ * `ThetaDataDxClient.connectFromFile(path, config)`.
  *
  * Mutating methods follow JS convention and
  * return `void` (chain by calling `cfg.method(...)` then passing
@@ -288,9 +288,9 @@ export declare class Config {
    * Default `true`; `false` gives the deterministic schedule,
    * useful for tests that assert exact timings.
    */
-  setFlatFilesJitter(jitter: boolean): void
+  setFlatfilesJitter(jitter: boolean): void
   /** Current `flatfiles.jitter` value (default `true`). */
-  get flatFilesJitter(): boolean
+  get flatfilesJitter(): boolean
   /**
    * Set the async worker-thread count for embedded runtimes.
    * `hasValue=false` defers to the default sizing; `hasValue=true`
@@ -298,7 +298,7 @@ export declare class Config {
    * sentinel, matching the widened-`Option` setter shape across the
    * binding matrix).
    */
-  setWorkerThreadsExplicit(hasValue: boolean, n: number): void
+  setWorkerThreads(hasValue: boolean, n: number): void
   /**
    * Current `workerThreads` setting as `{ hasValue, n }`.
    * `hasValue=false` encodes the `None` (auto) sentinel.
@@ -342,33 +342,33 @@ export declare class Config {
    * permit retries up to `maxAttempts - 1` after the initial call.
    * Default `3`. Validated to the range `[1, 10]` at connect time.
    */
-  setFlatFilesMaxAttempts(n: number): void
+  setFlatfilesMaxAttempts(n: number): void
   /** Current `flatfiles.max_attempts` value. */
-  get flatFilesMaxAttempts(): number
+  get flatfilesMaxAttempts(): number
   /**
    * Set the initial backoff delay (seconds) for the flatfile
    * driver retry loop. Doubles per attempt up to
-   * `flatFilesMaxBackoffSecs`. Default `1n`.
+   * `flatfilesMaxBackoffSecs`. Default `1n`.
    *
    * Accepts a `bigint` for parity with the Python / C++ / FFI
    * surface (`u64`).
    */
-  setFlatFilesInitialBackoffSecs(secs: bigint): void
+  setFlatfilesInitialBackoffSecs(secs: bigint): void
   /** Current `flatfiles.initial_backoff` value (seconds, returned as BigInt). */
-  get flatFilesInitialBackoffSecs(): bigint
+  get flatfilesInitialBackoffSecs(): bigint
   /**
    * Set the upper-bound backoff delay (seconds) for the flatfile
    * driver retry loop. The doubling schedule never exceeds this
    * value regardless of attempt number. Default `4n`. Must be
-   * greater than or equal to `flatFilesInitialBackoffSecs`
+   * greater than or equal to `flatfilesInitialBackoffSecs`
    * (rejected at connect-time validate otherwise).
    *
    * Accepts a `bigint` for parity with the Python / C++ / FFI
    * surface (`u64`).
    */
-  setFlatFilesMaxBackoffSecs(secs: bigint): void
+  setFlatfilesMaxBackoffSecs(secs: bigint): void
   /** Current `flatfiles.max_backoff` value (seconds, returned as BigInt). */
-  get flatFilesMaxBackoffSecs(): bigint
+  get flatfilesMaxBackoffSecs(): bigint
   /**
    * Set the Nexus auth URL. Default matches the upstream
    * production endpoint; override to redirect at a staging
@@ -385,6 +385,18 @@ export declare class Config {
   setClientType(clientType: string): void
   /** Current `auth.client_type` value. */
   get clientType(): string
+  /** Override the historical gRPC host. Companion to `setMddsPort`. */
+  setMddsHost(host: string): void
+  /** Current historical gRPC host. */
+  get mddsHost(): string
+  /**
+   * Override the historical gRPC port. Companion to `setMddsHost` —
+   * same test-only rationale. Rejects values outside the `u16` range
+   * (`0..=65535`).
+   */
+  setMddsPort(port: number): void
+  /** Current historical gRPC port. */
+  get mddsPort(): number
   /**
    * Set the Prometheus exporter port. Pass `null` or `undefined`
    * to leave the exporter disabled (the `None` default); pass a
@@ -2717,6 +2729,25 @@ export declare class Util {
   static isHalted(code: number): boolean
   static exchangeName(code: number): string
   static exchangeSymbol(code: number): string
+  /**
+   * Vendor vocabulary text for a calendar-day `status` code (`0` ->
+   * `"open"`, `1` -> `"early_close"`, `2` -> `"full_close"`, `3` ->
+   * `"weekend"`). Returns the literal `"UNKNOWN"` for codes outside
+   * the table. Mirrors the C++ `tdx::calendar_status_name` and the C
+   * ABI `tdx_calendar_status_name`.
+   */
+  static calendarStatusName(code: number): string
+  /**
+   * Combine an Eastern-Time `YYYYMMDD` date and milliseconds-of-day
+   * into Unix epoch milliseconds (UTC, DST-aware) as a JS BigInt.
+   * Usable with any `(date, *_ms_of_day)` pair on the tick structs.
+   * Returns `null` when `date` is absent (`0`) or either input is out
+   * of domain — the same `std::nullopt` contract the C++
+   * `tdx::timestamp_ms` returns (the C ABI `tdx_timestamp_ms` encodes
+   * that absence as the `-1` sentinel). BigInt matches the
+   * `*TimestampMs` tick accessors so the epoch domain is uniform.
+   */
+  static timestampMs(date: number, msOfDay: number): bigint | null
   /**
    * Convert a signed wire-encoded trade-sequence value to its unsigned
    * monotonic form. Mirrors `thetadatadx::utils::sequences::signed_to_unsigned`.

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -1001,8 +1001,8 @@ impl Config {
     /// Toggle AWS-style full jitter on the flatfile retry ladder.
     /// Default `true`; `false` gives the deterministic schedule,
     /// useful for tests that assert exact timings.
-    #[napi(js_name = "setFlatFilesJitter")]
-    pub fn set_flat_files_jitter(&self, jitter: bool) -> napi::Result<()> {
+    #[napi(js_name = "setFlatfilesJitter")]
+    pub fn set_flatfiles_jitter(&self, jitter: bool) -> napi::Result<()> {
         let mut guard = self
             .inner
             .lock()
@@ -1012,8 +1012,8 @@ impl Config {
     }
 
     /// Current `flatfiles.jitter` value (default `true`).
-    #[napi(getter, js_name = "flatFilesJitter")]
-    pub fn flat_files_jitter(&self) -> napi::Result<bool> {
+    #[napi(getter, js_name = "flatfilesJitter")]
+    pub fn flatfiles_jitter(&self) -> napi::Result<bool> {
         let guard = self
             .inner
             .lock()
@@ -1026,8 +1026,8 @@ impl Config {
     /// pins worker count to `n` (with `n=0` preserved as the `Some(0)`
     /// sentinel, matching the widened-`Option` setter shape across the
     /// binding matrix).
-    #[napi(js_name = "setWorkerThreadsExplicit")]
-    pub fn set_worker_threads_explicit(&self, has_value: bool, n: u32) -> napi::Result<()> {
+    #[napi(js_name = "setWorkerThreads")]
+    pub fn set_worker_threads(&self, has_value: bool, n: u32) -> napi::Result<()> {
         let mut guard = self
             .inner
             .lock()
@@ -1173,8 +1173,8 @@ impl Config {
     /// loop. `1` disables retry (single call only); higher values
     /// permit retries up to `maxAttempts - 1` after the initial call.
     /// Default `3`. Validated to the range `[1, 10]` at connect time.
-    #[napi(js_name = "setFlatFilesMaxAttempts")]
-    pub fn set_flat_files_max_attempts(&self, n: u32) -> napi::Result<()> {
+    #[napi(js_name = "setFlatfilesMaxAttempts")]
+    pub fn set_flatfiles_max_attempts(&self, n: u32) -> napi::Result<()> {
         let mut guard = self
             .inner
             .lock()
@@ -1184,8 +1184,8 @@ impl Config {
     }
 
     /// Current `flatfiles.max_attempts` value.
-    #[napi(getter, js_name = "flatFilesMaxAttempts")]
-    pub fn flat_files_max_attempts(&self) -> napi::Result<u32> {
+    #[napi(getter, js_name = "flatfilesMaxAttempts")]
+    pub fn flatfiles_max_attempts(&self) -> napi::Result<u32> {
         let guard = self
             .inner
             .lock()
@@ -1195,19 +1195,19 @@ impl Config {
 
     /// Set the initial backoff delay (seconds) for the flatfile
     /// driver retry loop. Doubles per attempt up to
-    /// `flatFilesMaxBackoffSecs`. Default `1n`.
+    /// `flatfilesMaxBackoffSecs`. Default `1n`.
     ///
     /// Accepts a `bigint` for parity with the Python / C++ / FFI
     /// surface (`u64`).
-    #[napi(js_name = "setFlatFilesInitialBackoffSecs")]
-    pub fn set_flat_files_initial_backoff_secs(
+    #[napi(js_name = "setFlatfilesInitialBackoffSecs")]
+    pub fn set_flatfiles_initial_backoff_secs(
         &self,
         secs: napi::bindgen_prelude::BigInt,
     ) -> napi::Result<()> {
         let (_signed, value, lossless) = secs.get_u64();
         if !lossless {
             return Err(napi::Error::from_reason(
-                "setFlatFilesInitialBackoffSecs: BigInt magnitude must fit in u64",
+                "setFlatfilesInitialBackoffSecs: BigInt magnitude must fit in u64",
             ));
         }
         let mut guard = self
@@ -1219,8 +1219,8 @@ impl Config {
     }
 
     /// Current `flatfiles.initial_backoff` value (seconds, returned as BigInt).
-    #[napi(getter, js_name = "flatFilesInitialBackoffSecs")]
-    pub fn flat_files_initial_backoff_secs(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
+    #[napi(getter, js_name = "flatfilesInitialBackoffSecs")]
+    pub fn flatfiles_initial_backoff_secs(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
         let guard = self
             .inner
             .lock()
@@ -1233,20 +1233,20 @@ impl Config {
     /// Set the upper-bound backoff delay (seconds) for the flatfile
     /// driver retry loop. The doubling schedule never exceeds this
     /// value regardless of attempt number. Default `4n`. Must be
-    /// greater than or equal to `flatFilesInitialBackoffSecs`
+    /// greater than or equal to `flatfilesInitialBackoffSecs`
     /// (rejected at connect-time validate otherwise).
     ///
     /// Accepts a `bigint` for parity with the Python / C++ / FFI
     /// surface (`u64`).
-    #[napi(js_name = "setFlatFilesMaxBackoffSecs")]
-    pub fn set_flat_files_max_backoff_secs(
+    #[napi(js_name = "setFlatfilesMaxBackoffSecs")]
+    pub fn set_flatfiles_max_backoff_secs(
         &self,
         secs: napi::bindgen_prelude::BigInt,
     ) -> napi::Result<()> {
         let (_signed, value, lossless) = secs.get_u64();
         if !lossless {
             return Err(napi::Error::from_reason(
-                "setFlatFilesMaxBackoffSecs: BigInt magnitude must fit in u64",
+                "setFlatfilesMaxBackoffSecs: BigInt magnitude must fit in u64",
             ));
         }
         let mut guard = self
@@ -1258,8 +1258,8 @@ impl Config {
     }
 
     /// Current `flatfiles.max_backoff` value (seconds, returned as BigInt).
-    #[napi(getter, js_name = "flatFilesMaxBackoffSecs")]
-    pub fn flat_files_max_backoff_secs(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
+    #[napi(getter, js_name = "flatfilesMaxBackoffSecs")]
+    pub fn flatfiles_max_backoff_secs(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
         let guard = self
             .inner
             .lock()
@@ -1315,6 +1315,66 @@ impl Config {
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
         Ok(guard.auth.client_type.clone())
+    }
+
+    // ── MddsConfig advanced endpoint overrides ────────────────────
+    //
+    // `mdds_host` / `mdds_port` point the historical gRPC channel at an
+    // explicit endpoint. Used by structural tests that need to aim the
+    // historical channel at a known-refused endpoint to prove the
+    // streaming-only surface never opens it; production code paths keep
+    // the `Config.production()` default. Mirrors the Python
+    // `Config.mdds_host` / `.mdds_port`, the C++ `set_mdds_host` /
+    // `set_mdds_port`, and the C ABI `tdx_config_set_mdds_host` /
+    // `tdx_config_set_mdds_port`.
+
+    /// Override the historical gRPC host. Companion to `setMddsPort`.
+    #[napi(js_name = "setMddsHost")]
+    pub fn set_mdds_host(&self, host: String) -> napi::Result<()> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.mdds.host = host;
+        Ok(())
+    }
+
+    /// Current historical gRPC host.
+    #[napi(getter, js_name = "mddsHost")]
+    pub fn mdds_host(&self) -> napi::Result<String> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.mdds.host.clone())
+    }
+
+    /// Override the historical gRPC port. Companion to `setMddsHost` —
+    /// same test-only rationale. Rejects values outside the `u16` range
+    /// (`0..=65535`).
+    #[napi(js_name = "setMddsPort")]
+    pub fn set_mdds_port(&self, port: u32) -> napi::Result<()> {
+        let resolved = u16::try_from(port).map_err(|_| {
+            crate::invalid_parameter_err(format!(
+                "setMddsPort: port must be in the u16 range 0..=65535; got {port}"
+            ))
+        })?;
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        guard.mdds.port = resolved;
+        Ok(())
+    }
+
+    /// Current historical gRPC port.
+    #[napi(getter, js_name = "mddsPort")]
+    pub fn mdds_port(&self) -> napi::Result<u32> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(u32::from(guard.mdds.port))
     }
 
     // ── MetricsConfig field setter/getter ─────────────────────────

--- a/sdks/typescript/src/util_helpers.rs
+++ b/sdks/typescript/src/util_helpers.rs
@@ -8,6 +8,8 @@
 //! Util.conditionName(0);          // "REGULAR"
 //! Util.exchangeName(3);           // "NewYorkStockExchange"
 //! Util.exchangeSymbol(3);         // "NYSE"
+//! Util.calendarStatusName(1);     // "early_close"
+//! Util.timestampMs(20240102, 34200000);  // epoch ms BigInt, or null
 //! Util.sequenceSignedToUnsigned(BigInt(-1));
 //! ```
 //!
@@ -71,6 +73,31 @@ impl Util {
     #[napi(js_name = "exchangeSymbol")]
     pub fn exchange_symbol(code: i32) -> String {
         thetadatadx::utils::exchange::exchange_symbol(code).to_string()
+    }
+
+    /// Vendor vocabulary text for a calendar-day `status` code (`0` ->
+    /// `"open"`, `1` -> `"early_close"`, `2` -> `"full_close"`, `3` ->
+    /// `"weekend"`). Returns the literal `"UNKNOWN"` for codes outside
+    /// the table. Mirrors the C++ `tdx::calendar_status_name` and the C
+    /// ABI `tdx_calendar_status_name`.
+    #[napi(js_name = "calendarStatusName")]
+    pub fn calendar_status_name(code: i32) -> String {
+        thetadatadx::CalendarStatus::from_code(code)
+            .map_or("UNKNOWN", thetadatadx::CalendarStatus::as_str)
+            .to_string()
+    }
+
+    /// Combine an Eastern-Time `YYYYMMDD` date and milliseconds-of-day
+    /// into Unix epoch milliseconds (UTC, DST-aware) as a JS BigInt.
+    /// Usable with any `(date, *_ms_of_day)` pair on the tick structs.
+    /// Returns `null` when `date` is absent (`0`) or either input is out
+    /// of domain — the same `std::nullopt` contract the C++
+    /// `tdx::timestamp_ms` returns (the C ABI `tdx_timestamp_ms` encodes
+    /// that absence as the `-1` sentinel). BigInt matches the
+    /// `*TimestampMs` tick accessors so the epoch domain is uniform.
+    #[napi(js_name = "timestampMs")]
+    pub fn timestamp_ms(date: i32, ms_of_day: i32) -> Option<BigInt> {
+        thetadatadx::time::date_ms_to_epoch_ms(date, ms_of_day).map(BigInt::from)
     }
 
     /// Convert a signed wire-encoded trade-sequence value to its unsigned


### PR DESCRIPTION
Six cross-binding config and utility symmetry gaps closed so the setter names, the historical-endpoint knobs, and the utility lookups read and behave the same in every binding.

The `_explicit` stem is dropped from the widened-`Option` setter names across the C ABI, C++, and TypeScript. `tdx_config_set_worker_threads_explicit` becomes `tdx_config_set_worker_threads`, `tdx_config_set_fpss_host_shuffle_seed_explicit` becomes `tdx_config_set_fpss_host_shuffle_seed`, and the C++ `set_worker_threads` / `set_fpss_host_shuffle_seed` and TypeScript `setWorkerThreads` forwarders follow. The `(has_value, n)` / `(has_value, seed)` signature is unchanged — it already encodes the optional distinction; only the redundant suffix goes. Python already used the bare names.

The TypeScript `Config` gains the `mdds_host` / `mdds_port` advanced endpoint overrides (`setMddsHost` / `mddsHost` / `setMddsPort` / `mddsPort`), the last binding missing them after Python, C++, and the C ABI gained them. They point the historical gRPC channel at an explicit endpoint, matching the Python and C++ surface one-for-one.

`calendarStatusName(code)` and `timestampMs(date, msOfDay)` join the Python `util` submodule and the TypeScript `Util` namespace; both existed only on the C ABI and C++. `calendarStatusName` returns the status text (`"open"` / `"early_close"` / `"full_close"` / `"weekend"`, `"UNKNOWN"` out of table). `timestampMs` returns epoch milliseconds or the absent value (`None` on Python, `null` on TypeScript) for an out-of-domain date or ms-of-day, matching the `std::optional<int64_t>` the C++ helper returns.

The TypeScript flatfile-retry setters move from the two-word `setFlatFiles*` stem to the single-word `setFlatfiles*` (`setFlatfilesJitter`, `setFlatfilesMaxAttempts`, ...) so the JS surface matches the single-token `flatfiles` the Python, C++, and C ABI bindings already use.

The Python `Config` readback fns regain the `get_` prefix (`get_derive_ohlcvc` / `get_flush_mode` / `get_concurrent_requests`). pyo3 strips the prefix, so the Python property names stay bare (`config.flush_mode`) and user code is unchanged; the Rust fn names now match the majority `get_` convention and the C ABI / C++ spelling. The parity gate's method-row check accepts the `get_`-prefixed Python fn against a bare getter row, the same allowance it already makes for C++.

The stale `start_streaming` doc in `sdk_surface.toml` is rewritten to describe callback registration; the previous text claimed events are polled with a `next_event()` the callback-driven binding surface does not expose. The generated docstrings are emitted from a kind-specific template and were already correct, so the regenerated output is byte-identical.

Breaking: the C ABI / C++ / TypeScript worker-thread and host-shuffle-seed setter names change, and the TypeScript flatfile setters change stem.

The parity matrix flips `MddsConfig.host` / `MddsConfig.port` to bound on TypeScript and updates the setter and getter row notes; the now-uniformly-bound `mdds_host` / `mdds_port` carve-outs are dropped from the parity script's exemption map, and a selftest case pins the Python `get_`-prefix acceptance.

Verification: `cargo fmt --all -- --check` and the napi/py crates clean; `cargo clippy -- -D warnings` clean on the FFI, napi, and py crates; `generate_sdk_surfaces --check` and `generate_docs_site --check` byte-identical; `check_binding_parity.py` clean with 44 setters aligned across all four bindings (45/45 selftest, 19/19 pytest); `check_c_abi_completeness.py` clean (bidirectional rust<->header parity on the renamed symbols); `check_docs_consistency.py` clean; the workspace `cargo test` green including the renamed FFI setter round-trips; the full Python pytest suite (381 passed) and the full TypeScript suite (138 passed). Functional checks: `setWorkerThreads` present and `setWorkerThreadsExplicit` gone, `setMddsHost` / `mddsHost`, `setFlatfilesJitter`, `Util.calendarStatusName` and `Util.timestampMs` with matching epoch values across Python and TypeScript, and the Python property names unchanged after the `get_` re-add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)