### PR TITLE
feat(sdk): from_file client-construction convenience across all bindings

### DIFF
--- a/crates/thetadatadx/build_support_bin/fpss_events/mod.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/mod.rs
@@ -3,8 +3,8 @@
 //! Reads `fpss_event_schema.toml` and emits:
 //!
 //! - `sdks/python/src/_generated/fpss_event_classes.rs` — `#[pyclass]` per Data variant
-//!   + the `fpss_event_to_typed` dispatcher (borrowed `&FpssEvent` →
-//!   pyclass, no intermediate) + `register_fpss_event_classes`.
+//!   plus the `fpss_event_to_typed` dispatcher (borrowed `&FpssEvent` →
+//!   pyclass, no intermediate) plus `register_fpss_event_classes`.
 //! - `sdks/typescript/src/_generated/fpss_event_classes.rs` — `#[napi(object)]` per
 //!   Data variant + a flat `FpssEvent` wrapper struct with optional typed
 //!   payload fields + a `buffered_event_to_typed` dispatcher that converts

--- a/crates/thetadatadx/build_support_bin/sdk_surface/cpp.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/cpp.rs
@@ -66,6 +66,11 @@ fn cpp_fpss_decl(method: &MethodSpec) -> String {
         MethodKind::FpssConnect => {
             out.push_str("    FpssClient(const Credentials& creds, const Config& config);\n");
         }
+        MethodKind::FpssConnectFromFile => {
+            out.push_str(
+                "    static FpssClient from_file(const std::string& path, const Config& config = Config::production());\n",
+            );
+        }
         MethodKind::StockContractCall | MethodKind::FullCall => {
             writeln!(
                 out,
@@ -103,6 +108,9 @@ fn cpp_fpss_def(method: &MethodSpec) -> String {
     match method.kind {
         MethodKind::FpssConnect => {
             include_str!("templates/cpp/fpss_connect_def.cpp.tmpl").to_string()
+        }
+        MethodKind::FpssConnectFromFile => {
+            include_str!("templates/cpp/fpss_connect_from_file_def.cpp.tmpl").to_string()
         }
         MethodKind::StockContractCall | MethodKind::FullCall => format!(
             "int FpssClient::{}({} {}) {{ return tdx_fpss_{}(handle_.get(), {}.c_str()); }}\n",
@@ -202,6 +210,9 @@ fn cpp_lifecycle_def(method: &MethodSpec) -> String {
         }
         MethodKind::ClientConnect => {
             include_str!("templates/cpp/client_connect_def.cpp.tmpl").to_string()
+        }
+        MethodKind::ClientConnectFromFile => {
+            include_str!("templates/cpp/client_connect_from_file_def.cpp.tmpl").to_string()
         }
         other => panic!("unsupported C++ lifecycle kind: {other:?}"),
     }

--- a/crates/thetadatadx/build_support_bin/sdk_surface/spec.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/spec.rs
@@ -51,10 +51,12 @@ pub(super) enum MethodKind {
     AwaitDrain,
     IsAuthenticated,
     FpssConnect,
+    FpssConnectFromFile,
     CredentialsFromFile,
     CredentialsFromEmail,
     ConfigConstructor,
     ClientConnect,
+    ClientConnectFromFile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -270,6 +272,12 @@ fn validate_method_spec(method: &MethodSpec) -> Result<(), Box<dyn std::error::E
                 ("config", ParamType::ConfigRef),
             ],
         ),
+        MethodKind::FpssConnectFromFile => (
+            Some("from_file"),
+            &[CPP],
+            true,
+            &[("path", ParamType::String)],
+        ),
         MethodKind::CredentialsFromFile => (
             Some("credentials_from_file"),
             &[LIFE],
@@ -317,6 +325,12 @@ fn validate_method_spec(method: &MethodSpec) -> Result<(), Box<dyn std::error::E
                 ("creds", ParamType::CredentialsRef),
                 ("config", ParamType::ConfigRef),
             ],
+        ),
+        MethodKind::ClientConnectFromFile => (
+            Some("mdds_client_from_file"),
+            &[LIFE],
+            true,
+            &[("path", ParamType::String)],
         ),
     };
     let (expected_name, allowed_targets, exact_targets, params) = shape;

--- a/crates/thetadatadx/build_support_bin/sdk_surface/templates/cpp/client_connect_from_file_def.cpp.tmpl
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/templates/cpp/client_connect_from_file_def.cpp.tmpl
@@ -1,0 +1,5 @@
+MddsClient MddsClient::from_file(const std::string& path, const Config& config) {
+    auto h = tdx_mdds_client_connect_from_file(path.c_str(), config.get());
+    if (!h) detail::throw_last_ffi_error();
+    return MddsClient(h);
+}

--- a/crates/thetadatadx/build_support_bin/sdk_surface/templates/cpp/fpss_connect_from_file_def.cpp.tmpl
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/templates/cpp/fpss_connect_from_file_def.cpp.tmpl
@@ -1,0 +1,3 @@
+FpssClient FpssClient::from_file(const std::string& path, const Config& config) {
+    return FpssClient(Credentials::from_file(path), config);
+}

--- a/crates/thetadatadx/sdk_surface.toml
+++ b/crates/thetadatadx/sdk_surface.toml
@@ -88,6 +88,13 @@ params = [
 ]
 
 [[methods]]
+name = "from_file"
+kind = "fpss_connect_from_file"
+doc = "Connect to FPSS streaming servers, loading credentials from a file (line 1 = email, line 2 = password), defaulting to the production configuration. Throws on failure."
+targets = ["cpp_fpss"]
+params = [{ name = "path", type = "string", doc = "Path to the credentials file." }]
+
+[[methods]]
 name = "credentials_from_file"
 kind = "credentials_from_file"
 doc = "Load credentials from a file. Throws on failure."
@@ -134,6 +141,13 @@ params = [
   { name = "creds", type = "credentials_ref", doc = "Credentials handle." },
   { name = "config", type = "config_ref", doc = "Configuration handle." },
 ]
+
+[[methods]]
+name = "mdds_client_from_file"
+kind = "client_connect_from_file"
+doc = "Connect the historical (MDDS) client, loading credentials from a file. Throws on failure."
+targets = ["cpp_lifecycle"]
+params = [{ name = "path", type = "string", doc = "Path to the credentials file." }]
 
 [[utilities]]
 name = "auth"

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -2232,6 +2232,40 @@ pub unsafe extern "C" fn tdx_mdds_client_connect(
     })
 }
 
+/// Connect a historical (MDDS) client, loading credentials from a file
+/// (line 1 = email, line 2 = password) instead of a credentials handle.
+///
+/// One-call equivalent of `tdx_credentials_from_file` followed by
+/// `tdx_mdds_client_connect`: the credentials are opened from `path`,
+/// consumed for the connect, and freed internally. The returned handle
+/// and its ownership / free convention are identical to
+/// `tdx_mdds_client_connect` (free with `tdx_mdds_client_free`).
+///
+/// Returns null on argument validation or connection/auth failure
+/// (check `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_mdds_client_connect_from_file(
+    path: *const c_char,
+    config: *const TdxConfig,
+) -> *mut TdxMddsClient {
+    ffi_boundary!(ptr::null_mut(), {
+        // SAFETY: `path` is a NUL-terminated C string valid for the call;
+        // `tdx_credentials_from_file` validates non-null + UTF-8 and sets
+        // `tdx_last_error()` on failure.
+        let creds = unsafe { tdx_credentials_from_file(path) };
+        if creds.is_null() {
+            return ptr::null_mut();
+        }
+        // SAFETY: `creds` was just allocated by `tdx_credentials_from_file`
+        // and is owned by this function; `tdx_mdds_client_connect` borrows
+        // it and we free it unconditionally below.
+        let client = unsafe { tdx_mdds_client_connect(creds, config) };
+        // SAFETY: same fresh, unfreed handle from above.
+        unsafe { tdx_credentials_free(creds) };
+        client
+    })
+}
+
 /// Free a historical (MDDS) client handle.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_mdds_client_free(client: *mut TdxMddsClient) {

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -434,6 +434,40 @@ pub unsafe extern "C" fn tdx_unified_connect(
     })
 }
 
+/// Connect a unified client, loading credentials from a file
+/// (line 1 = email, line 2 = password) instead of a credentials handle.
+///
+/// One-call equivalent of `tdx_credentials_from_file` followed by
+/// `tdx_unified_connect`: the credentials are opened from `path`,
+/// consumed for the connect, and freed internally. The returned handle
+/// and its ownership / free convention are identical to
+/// `tdx_unified_connect` (free with `tdx_unified_free`).
+///
+/// Returns null on argument validation or connection/auth failure
+/// (check `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_unified_connect_from_file(
+    path: *const c_char,
+    config: *const TdxConfig,
+) -> *mut TdxUnified {
+    ffi_boundary!(ptr::null_mut(), {
+        // SAFETY: `path` is a NUL-terminated C string valid for the call;
+        // `tdx_credentials_from_file` validates non-null + UTF-8 and sets
+        // `tdx_last_error()` on failure.
+        let creds = unsafe { crate::auth::tdx_credentials_from_file(path) };
+        if creds.is_null() {
+            return ptr::null_mut();
+        }
+        // SAFETY: `creds` was just allocated by `tdx_credentials_from_file`
+        // and is owned by this function; `tdx_unified_connect` borrows it
+        // and we free it unconditionally below.
+        let handle = unsafe { tdx_unified_connect(creds, config) };
+        // SAFETY: same fresh, unfreed handle from above.
+        unsafe { crate::auth::tdx_credentials_free(creds) };
+        handle
+    })
+}
+
 /// Register a queued FPSS callback on the unified client and start streaming.
 ///
 /// `callback` is invoked from the LMAX event-dispatch consumer thread for
@@ -1380,6 +1414,41 @@ pub unsafe extern "C" fn tdx_fpss_connect(
             prev_drained: Mutex::new(Vec::new()),
             dispatcher: Mutex::new(FfpssDispatcherSession::Idle),
         }))
+    })
+}
+
+/// Allocate an FPSS handle, loading credentials from a file
+/// (line 1 = email, line 2 = password) instead of a credentials handle.
+///
+/// One-call equivalent of `tdx_credentials_from_file` followed by
+/// `tdx_fpss_connect`: the credentials are opened from `path`, consumed
+/// for the connect, and freed internally. As with `tdx_fpss_connect`
+/// this does NOT open the FPSS TLS connection — connection is deferred
+/// until `tdx_fpss_set_callback`. The returned handle and its ownership
+/// / free convention are identical to `tdx_fpss_connect` (free with
+/// `tdx_fpss_free`).
+///
+/// Returns null on argument validation failure (check `tdx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn tdx_fpss_connect_from_file(
+    path: *const c_char,
+    config: *const TdxConfig,
+) -> *mut TdxFpssHandle {
+    ffi_boundary!(std::ptr::null_mut(), {
+        // SAFETY: `path` is a NUL-terminated C string valid for the call;
+        // `tdx_credentials_from_file` validates non-null + UTF-8 and sets
+        // `tdx_last_error()` on failure.
+        let creds = unsafe { crate::auth::tdx_credentials_from_file(path) };
+        if creds.is_null() {
+            return std::ptr::null_mut();
+        }
+        // SAFETY: `creds` was just allocated by `tdx_credentials_from_file`
+        // and is owned by this function; `tdx_fpss_connect` clones what it
+        // needs and we free it unconditionally below.
+        let handle = unsafe { tdx_fpss_connect(creds, config) };
+        // SAFETY: same fresh, unfreed handle from above.
+        unsafe { crate::auth::tdx_credentials_free(creds) };
+        handle
     })
 }
 

--- a/scripts/check_binding_parity.py
+++ b/scripts/check_binding_parity.py
@@ -2251,6 +2251,198 @@ def _check_historical_streaming_rows(
     return errors
 
 
+# ─── Client construction-from-file surface ([[from_file]]) ────────────
+#
+# Every standalone client class exposes a one-call file-construction
+# convenience that loads credentials from a two-line file and connects.
+# The entry point is not a data method the `[[method]]` rows cover, and
+# its spelling differs per binding (`from_file` on Python / C++,
+# `connectFromFile` on TypeScript, `tdx_<stem>_connect_from_file` on the
+# C ABI), so a single `[[method]]` row cannot express it. These
+# collectors harvest each binding's file-construction surface so the
+# `[[from_file]]` rows can pin the cross-binding roster.
+#
+# `name` is the cross-binding client class identifier. The C ABI symbol
+# stem differs from the class name (`tdx_unified_connect_from_file` for
+# `ThetaDataDxClient`, `tdx_mdds_client_connect_from_file` for
+# `MddsClient`, `tdx_fpss_connect_from_file` for `FpssClient`); the stem
+# table below bridges the two.
+#
+# The family governs exactly the standalone clients that connect to the
+# servers via a `tdx_<stem>_connect_from_file` C ABI symbol. It does NOT
+# govern `Credentials.from_file` (a credentials factory that returns a
+# `Credentials`, not a connected client, surfaced over the distinct
+# `tdx_credentials_from_file` symbol) nor the Python-only
+# `AsyncThetaDataDxClient.from_file` (no C ABI / managed-binding twin —
+# its presence is tracked by the `AsyncThetaDataDxClient` `[[class]]`
+# row). Scoping the collectors to the governed roster keeps those
+# unrelated `from_file` entry points out of this family while still
+# tripping on a new governed client that forgets a row.
+
+
+# Parity class name → C ABI symbol stem for the
+# `tdx_<stem>_connect_from_file` extern "C" symbol. The keys are the
+# governed client roster: every class this family tracks, and the only
+# classes the collectors below consider.
+FROM_FILE_FFI_STEMS: dict[str, str] = {
+    "ThetaDataDxClient": "unified",
+    "MddsClient": "mdds_client",
+    "FpssClient": "fpss",
+}
+
+# The governed client roster (the C++ class spelling of each, so the
+# C++ collector can match the harvested class name before folding it
+# back to the cross-binding identifier).
+_FROM_FILE_GOVERNED: frozenset[str] = frozenset(FROM_FILE_FFI_STEMS)
+
+
+def _collect_python_from_file_classes(py_methods: dict[str, set[str]]) -> set[str]:
+    """Governed client classes whose Python pyclass exposes a `from_file`
+    staticmethod.
+
+    Reuses the already-collected `{pyclass: {method, ...}}` map; a
+    governed class carrying `from_file` exposes the file-construction
+    convenience. Scoped to `_FROM_FILE_GOVERNED` so the credentials
+    factory (`Credentials.from_file`) and the Python-only async twin are
+    not mistaken for governed clients.
+    """
+    return {
+        cls
+        for cls, methods in py_methods.items()
+        if cls in _FROM_FILE_GOVERNED and "from_file" in methods
+    }
+
+
+def _collect_typescript_from_file_classes(ts_methods: dict[str, set[str]]) -> set[str]:
+    """Governed client classes whose TypeScript napi class exposes a
+    `connectFromFile` factory.
+
+    Reuses the already-collected `{class: {method, ...}}` map; the napi
+    factory's `js_name` is the camelCase `connectFromFile`. Scoped to the
+    governed roster (the `Credentials.fromFile` factory is excluded).
+    """
+    return {
+        cls
+        for cls, methods in ts_methods.items()
+        if cls in _FROM_FILE_GOVERNED and "connectFromFile" in methods
+    }
+
+
+def _collect_cpp_from_file_classes(cpp_methods: dict[str, set[str]]) -> set[str]:
+    """Governed client classes whose C++ wrapper exposes a `from_file`
+    static member.
+
+    Reuses the already-collected `{class: {method, ...}}` map (which
+    inlines the generator-emitted `*.inc` member declarations), folds the
+    C++ alias names back to the cross-binding class identifier, and scopes
+    to the governed roster so `Credentials::from_file` is not counted.
+    """
+    reverse_alias = {v: k for k, v in CPP_ALIASES.items()}
+    out: set[str] = set()
+    for cls, methods in cpp_methods.items():
+        if "from_file" in methods:
+            canonical = reverse_alias.get(cls, cls)
+            if canonical in _FROM_FILE_GOVERNED:
+                out.add(canonical)
+    return out
+
+
+def _collect_ffi_from_file_stems(ffi_src: pathlib.Path) -> set[str]:
+    """C ABI symbol stems whose `tdx_<stem>_connect_from_file` extern "C"
+    symbol exists in `ffi/src/`.
+
+    Returns the bare stems (`unified` / `mdds_client` / `fpss`); the
+    checker maps each parity class name to its stem via
+    `FROM_FILE_FFI_STEMS`.
+    """
+    out: set[str] = set()
+    if not ffi_src.is_dir():
+        return out
+    fn_re = re.compile(r"\bfn\s+tdx_(\w+)_connect_from_file\s*\(")
+    for rs in ffi_src.rglob("*.rs"):
+        text = rs.read_text(encoding="utf-8")
+        for m in fn_re.finditer(text):
+            out.add(m.group(1))
+    return out
+
+
+def _check_from_file_rows(
+    rows: list[dict[str, Any]],
+    py_from_file: set[str],
+    ts_from_file: set[str],
+    cpp_from_file: set[str],
+    ffi_stems: set[str],
+) -> list[str]:
+    """Per-client-class cross-binding gate for `[[from_file]]` rows.
+
+    Each row declares a client class `name` plus the expected
+    file-construction presence in Python / TypeScript / C++ / the C ABI.
+    The checker verifies the actual binding state against the declared
+    state and returns a list of mismatch strings (empty when every row
+    matches).
+
+    Beyond the per-row check, the collected sets are reconciled against
+    the union of declared row names: a client that exposes
+    file-construction on ANY binding but has no row at all trips the
+    gate, so a newly-added `from_file` cannot slip in untracked.
+    """
+    errors: list[str] = []
+    declared_names = {row.get("name") for row in rows if row.get("name")}
+    for row in rows:
+        name = row.get("name")
+        if not name:
+            errors.append(f"  [[from_file]] row missing `name`: {row!r}")
+            continue
+        stem = FROM_FILE_FFI_STEMS.get(name)
+        if stem is None:
+            errors.append(
+                f"  [[from_file]] row `{name}` has no C ABI stem mapping; "
+                f"add it to FROM_FILE_FFI_STEMS."
+            )
+            continue
+        ffi_present = stem in ffi_stems
+        for lang, actual, hint in (
+            ("python", name in py_from_file, f"`from_file` staticmethod on the `{name}` pyclass"),
+            (
+                "typescript",
+                name in ts_from_file,
+                f"`connectFromFile` napi factory on the `{name}` class",
+            ),
+            ("cpp", name in cpp_from_file, f"`from_file(` static member on the `{name}` C++ class"),
+            ("ffi", ffi_present, f"`tdx_{stem}_connect_from_file` extern \"C\" symbol"),
+        ):
+            declared = row.get(lang, False)
+            if declared != actual:
+                verb = "missing" if declared and not actual else "unexpected"
+                errors.append(
+                    f"  {name}.{lang}: declared={declared}, actual={actual} "
+                    f"({verb} -- expected {hint})"
+                )
+    # Reverse-direction orphan check: any client exposing file
+    # construction on a binding but lacking a row is undocumented drift.
+    ffi_classes = {
+        cls for cls, stem in FROM_FILE_FFI_STEMS.items() if stem in ffi_stems
+    }
+    seen = py_from_file | ts_from_file | cpp_from_file | ffi_classes
+    for client in sorted(seen - declared_names):
+        on = sorted(
+            lang
+            for lang, s in (
+                ("python", py_from_file),
+                ("typescript", ts_from_file),
+                ("cpp", cpp_from_file),
+                ("ffi", ffi_classes),
+            )
+            if client in s
+        )
+        errors.append(
+            f"  {client}: exposes file construction on {on} but has no "
+            f"[[from_file]] row. Add one declaring its per-binding "
+            f"presence so the surface stays tracked."
+        )
+    return errors
+
+
 # ─── Main gate ──────────────────────────────────────────────────────
 
 
@@ -2496,6 +2688,7 @@ def main(argv: list[str] | None = None) -> int:
     historical_streaming_rows: list[dict[str, Any]] = data.get(
         "historical_streaming", []
     )
+    from_file_rows: list[dict[str, Any]] = data.get("from_file", [])
     if not rows:
         print("parity.toml has no [[class]] rows", file=sys.stderr)
         return 1
@@ -2591,6 +2784,19 @@ def main(argv: list[str] | None = None) -> int:
     ffi_stream = _collect_ffi_streaming_endpoints(FFI_SRC)
     historical_streaming_errors = _check_historical_streaming_rows(
         historical_streaming_rows, py_stream, ts_stream, cpp_stream, ffi_stream
+    )
+
+    # Client construction-from-file surface ([[from_file]] rows) — the
+    # one-call `from_file` / `connectFromFile` / `tdx_*_connect_from_file`
+    # convenience per standalone client class. Its spelling differs per
+    # binding, so it cannot ride a `[[method]]` row; this family pins it
+    # across Python / TypeScript / C++ / the C ABI.
+    py_from_file = _collect_python_from_file_classes(py_class_methods)
+    ts_from_file = _collect_typescript_from_file_classes(ts_class_methods)
+    cpp_from_file = _collect_cpp_from_file_classes(cpp_class_methods)
+    ffi_from_file_stems = _collect_ffi_from_file_stems(FFI_SRC)
+    from_file_errors = _check_from_file_rows(
+        from_file_rows, py_from_file, ts_from_file, cpp_from_file, ffi_from_file_stems
     )
 
     # Public-surface vocabulary: no public client identifier may embed
@@ -2763,6 +2969,17 @@ def main(argv: list[str] | None = None) -> int:
             print(e)
         print()
 
+    if from_file_errors:
+        had_errors = True
+        print(
+            f"check_binding_parity: {len(from_file_errors)} "
+            f"client construction-from-file mismatch(es) (per-client "
+            f"`[[from_file]]` granularity):"
+        )
+        for e in from_file_errors:
+            print(e)
+        print()
+
     if surface_vocab_errors:
         had_errors = True
         print(
@@ -2838,12 +3055,14 @@ def main(argv: list[str] | None = None) -> int:
     n_value_fields = len(value_field_rows)
     n_utilities = len(utility_rows)
     n_hist_stream = len(historical_streaming_rows)
+    n_from_file = len(from_file_rows)
     print(
         f"check_binding_parity: clean "
         f"({n_class} class rows + {n_dotted} field rows + "
         f"{n_methods} method rows + {n_value_fields} value-field rows + "
         f"{n_utilities} utility rows + "
         f"{n_hist_stream} historical-streaming rows + "
+        f"{n_from_file} from-file rows + "
         f"{n_fields} rust pub fields checked; "
         f"py_classes={len(py_classes)} ts_classes={len(ts_classes)} "
         f"cpp_classes={len(cpp_classes)} "
@@ -3595,6 +3814,114 @@ def _run_selftest() -> int:
     _case("hist-stream positive — TS-first ship state is silent", _case_hist_stream_ts_only_state_is_silent)
     _case("hist-stream negative — untracked streaming endpoint trips", _case_hist_stream_untracked_orphan_trips)
     _case("hist-stream — initialism-aware inverse agrees across bindings", _case_hist_stream_initialism_inverse)
+
+    # ── Client construction-from-file surface selftests ───────────
+
+    def _case_from_file_positive_all_bound() -> None:
+        """A client exposing file construction on every declared binding
+        (with the idiomatic per-binding spelling) is silent."""
+        rows = [
+            {
+                "name": "MddsClient",
+                "python": True,
+                "typescript": True,
+                "cpp": True,
+                "ffi": True,
+            }
+        ]
+        errors = _check_from_file_rows(
+            rows,
+            {"MddsClient"},
+            {"MddsClient"},
+            {"MddsClient"},
+            {"mdds_client"},
+        )
+        assert errors == [], f"all-bound row must be silent; got {errors!r}"
+
+    def _case_from_file_missing_on_ffi_trips() -> None:
+        """Row claims the C ABI exposes file construction but the
+        `tdx_<stem>_connect_from_file` symbol is absent — trips."""
+        rows = [
+            {
+                "name": "FpssClient",
+                "python": True,
+                "typescript": True,
+                "cpp": True,
+                "ffi": True,
+            }
+        ]
+        errors = _check_from_file_rows(
+            rows,
+            {"FpssClient"},
+            {"FpssClient"},
+            {"FpssClient"},
+            set(),
+        )
+        assert any("ffi" in e and "missing" in e for e in errors), (
+            f"missing C ABI symbol must trip; got {errors!r}"
+        )
+
+    def _case_from_file_untracked_orphan_trips() -> None:
+        """A client exposing file construction on a binding with no row
+        at all trips the reverse-direction orphan check."""
+        errors = _check_from_file_rows(
+            [], {"ThetaDataDxClient"}, set(), set(), set()
+        )
+        assert any(
+            "ThetaDataDxClient" in e and "no [[from_file]] row" in e
+            for e in errors
+        ), f"untracked file-construction client must trip; got {errors!r}"
+
+    def _case_from_file_ffi_stem_maps_class_name() -> None:
+        """The FFI stem table bridges the class name to its C ABI symbol
+        stem: `ThetaDataDxClient` resolves via `unified`, not its own
+        name. A row declaring ffi=true is silent only when the matching
+        stem symbol exists."""
+        rows = [
+            {
+                "name": "ThetaDataDxClient",
+                "python": False,
+                "typescript": False,
+                "cpp": False,
+                "ffi": True,
+            }
+        ]
+        # The class name itself in the stem set must NOT satisfy the row;
+        # only the mapped `unified` stem does.
+        errors_wrong = _check_from_file_rows(
+            rows, set(), set(), set(), {"theta_data_dx_client"}
+        )
+        assert any("ffi" in e for e in errors_wrong), (
+            f"class-name stem must not satisfy the row; got {errors_wrong!r}"
+        )
+        errors_right = _check_from_file_rows(rows, set(), set(), set(), {"unified"})
+        assert errors_right == [], (
+            f"mapped `unified` stem must satisfy the row; got {errors_right!r}"
+        )
+
+    def _case_from_file_live_sources_clean() -> None:
+        """The shipped bindings expose `from_file` (idiomatic spelling) on
+        every client the live `[[from_file]]` rows declare."""
+        data = tomllib.loads(PARITY_TOML.read_text(encoding="utf-8"))
+        rows = data.get("from_file", [])
+        assert rows, "live parity.toml must declare [[from_file]] rows"
+        py_methods = _collect_python_class_methods(PY_SRC)
+        ts_methods = _collect_typescript_class_methods(TS_SRC)
+        cpp_methods = _collect_cpp_class_methods(CPP_HPP)
+        errors = _check_from_file_rows(
+            rows,
+            _collect_python_from_file_classes(py_methods),
+            _collect_typescript_from_file_classes(ts_methods),
+            _collect_cpp_from_file_classes(cpp_methods),
+            _collect_ffi_from_file_stems(FFI_SRC),
+        )
+        assert errors == [], f"live from_file sources must be clean; got {errors!r}"
+
+    _case("from-file positive — all four bindings construct", _case_from_file_positive_all_bound)
+    _case("from-file negative — missing C ABI symbol trips", _case_from_file_missing_on_ffi_trips)
+    _case("from-file negative — untracked client trips", _case_from_file_untracked_orphan_trips)
+    _case("from-file — FFI stem table maps class name", _case_from_file_ffi_stem_maps_class_name)
+    _case("from-file — live sources clean", _case_from_file_live_sources_clean)
 
     # ── Public-surface vocabulary guard selftests ──────────────────
 

--- a/scripts/test_check_binding_parity.py
+++ b/scripts/test_check_binding_parity.py
@@ -661,6 +661,90 @@ def test_utility_roster_live_complete() -> None:
     assert errors == [], f"live utility roster must be complete; got {errors!r}"
 
 
+def test_from_file_parity_all_bound_passes() -> None:
+    rows = [
+        {
+            "name": "MddsClient",
+            "python": True,
+            "typescript": True,
+            "cpp": True,
+            "ffi": True,
+        }
+    ]
+    errors = cbp._check_from_file_rows(
+        rows, {"MddsClient"}, {"MddsClient"}, {"MddsClient"}, {"mdds_client"}
+    )
+    assert errors == [], f"all-bound from_file row must be silent; got {errors!r}"
+
+
+def test_from_file_missing_on_ffi_trips() -> None:
+    rows = [
+        {
+            "name": "FpssClient",
+            "python": True,
+            "typescript": True,
+            "cpp": True,
+            "ffi": True,
+        }
+    ]
+    errors = cbp._check_from_file_rows(
+        rows, {"FpssClient"}, {"FpssClient"}, {"FpssClient"}, set()
+    )
+    assert any("ffi" in e and "missing" in e for e in errors), (
+        f"missing C ABI from_file symbol must trip; got {errors!r}"
+    )
+
+
+def test_from_file_untracked_client_trips() -> None:
+    errors = cbp._check_from_file_rows(
+        [], {"ThetaDataDxClient"}, set(), set(), set()
+    )
+    assert any(
+        "ThetaDataDxClient" in e and "no [[from_file]] row" in e for e in errors
+    ), f"untracked file-construction client must trip; got {errors!r}"
+
+
+def test_from_file_ffi_stem_maps_class_name() -> None:
+    rows = [
+        {
+            "name": "ThetaDataDxClient",
+            "python": False,
+            "typescript": False,
+            "cpp": False,
+            "ffi": True,
+        }
+    ]
+    # The class name itself must not satisfy the row; only the mapped stem.
+    wrong = cbp._check_from_file_rows(rows, set(), set(), set(), {"theta_data_dx_client"})
+    assert any("ffi" in e for e in wrong), (
+        f"class-name stem must not satisfy the row; got {wrong!r}"
+    )
+    right = cbp._check_from_file_rows(rows, set(), set(), set(), {"unified"})
+    assert right == [], f"mapped `unified` stem must satisfy the row; got {right!r}"
+
+
+def test_from_file_parity_live_sources_clean() -> None:
+    """Every client the live `[[from_file]]` rows declare exposes the
+    idiomatic file-construction entry point on the claimed bindings.
+    """
+    import tomllib
+
+    data = tomllib.loads(cbp.PARITY_TOML.read_text(encoding="utf-8"))
+    rows = data.get("from_file", [])
+    assert rows, "live parity.toml must declare [[from_file]] rows"
+    py_methods = cbp._collect_python_class_methods(cbp.PY_SRC)
+    ts_methods = cbp._collect_typescript_class_methods(cbp.TS_SRC)
+    cpp_methods = cbp._collect_cpp_class_methods(cbp.CPP_HPP)
+    errors = cbp._check_from_file_rows(
+        rows,
+        cbp._collect_python_from_file_classes(py_methods),
+        cbp._collect_typescript_from_file_classes(ts_methods),
+        cbp._collect_cpp_from_file_classes(cpp_methods),
+        cbp._collect_ffi_from_file_stems(cbp.FFI_SRC),
+    )
+    assert errors == [], f"live from_file sources must be clean; got {errors!r}"
+
+
 # ─── Driver ────────────────────────────────────────────────────────
 
 
@@ -688,6 +772,11 @@ def main() -> int:
     _check("setter-set missing-on-TS trips", test_setter_set_parity_missing_on_ts_trips)
     _check("setter-set exemption honoured", test_setter_set_parity_exemption_honoured)
     _check("setter-set live sources clean", test_setter_set_parity_live_sources_clean)
+    _check("from-file all-bound passes", test_from_file_parity_all_bound_passes)
+    _check("from-file missing-on-FFI trips", test_from_file_missing_on_ffi_trips)
+    _check("from-file untracked client trips", test_from_file_untracked_client_trips)
+    _check("from-file FFI stem maps class name", test_from_file_ffi_stem_maps_class_name)
+    _check("from-file live sources clean", test_from_file_parity_live_sources_clean)
 
     if _fails:
         print(f"test_check_binding_parity: {len(_fails)} failure(s)")

--- a/sdks/cpp/include/fpss.hpp.inc
+++ b/sdks/cpp/include/fpss.hpp.inc
@@ -14,3 +14,5 @@
     bool is_authenticated() const;
     /** Connect to FPSS streaming servers. Throws on failure. */
     FpssClient(const Credentials& creds, const Config& config);
+    /** Connect to FPSS streaming servers, loading credentials from a file (line 1 = email, line 2 = password), defaulting to the production configuration. Throws on failure. */
+    static FpssClient from_file(const std::string& path, const Config& config = Config::production());

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -1510,6 +1510,12 @@ int32_t tdx_config_get_warn_on_buffered_threshold_bytes(const TdxConfig* config,
  *  connection/auth failure. */
 TdxMddsClient* tdx_mdds_client_connect(const TdxCredentials* creds, const TdxConfig* config);
 
+/** Connect a historical (MDDS) client, loading credentials from a file
+ *  (line 1 = email, line 2 = password). One-call equivalent of
+ *  tdx_credentials_from_file + tdx_mdds_client_connect. Free with
+ *  tdx_mdds_client_free. Returns NULL on argument or connection/auth failure. */
+TdxMddsClient* tdx_mdds_client_connect_from_file(const char* path, const TdxConfig* config);
+
 /** Free a historical (MDDS) client handle. */
 void tdx_mdds_client_free(TdxMddsClient* client);
 
@@ -1665,6 +1671,12 @@ bool tdx_contract_strike_dollars(const TdxContract* contract, double* out_dollar
 /** Connect to the real-time streaming servers. Returns NULL on failure. */
 TdxFpssHandle* tdx_fpss_connect(const TdxCredentials* creds, const TdxConfig* config);
 
+/** Connect to the real-time streaming servers, loading credentials from a file
+ *  (line 1 = email, line 2 = password). One-call equivalent of
+ *  tdx_credentials_from_file + tdx_fpss_connect. Free with tdx_fpss_free.
+ *  Returns NULL on failure. */
+TdxFpssHandle* tdx_fpss_connect_from_file(const char* path, const TdxConfig* config);
+
 /** Polymorphic subscribe / unsubscribe — see TdxSubscriptionRequest below. */
 
 /** Check if authenticated. Returns 1 if true, 0 if false. */
@@ -1816,6 +1828,12 @@ void tdx_fpss_free(TdxFpssHandle* h);
 /** Connect to ThetaData (historical only -- real-time streaming is NOT started).
  *  Returns NULL on connection/auth failure (check tdx_last_error()). */
 TdxUnified* tdx_unified_connect(const TdxCredentials* creds, const TdxConfig* config);
+
+/** Connect a unified client, loading credentials from a file (line 1 = email,
+ *  line 2 = password). One-call equivalent of tdx_credentials_from_file +
+ *  tdx_unified_connect. Free with tdx_unified_free. Returns NULL on argument
+ *  or connection/auth failure (check tdx_last_error()). */
+TdxUnified* tdx_unified_connect_from_file(const char* path, const TdxConfig* config);
 
 /** Register a streaming callback and start streaming on the unified client.
  *

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -1269,6 +1269,13 @@ public:
      *  failure. */
     static MddsClient connect(const Credentials& creds, const Config& config);
 
+    /** Connect a historical (MDDS) client, loading credentials from a file
+     *  (line 1 = email, line 2 = password). One-call equivalent of
+     *  `Credentials::from_file(path)` followed by `connect`, defaulting to
+     *  the production configuration. Throws on failure or an unreadable
+     *  credentials file. */
+    static MddsClient from_file(const std::string& path, const Config& config = Config::production());
+
     #include "historical.hpp.inc"
 
 private:
@@ -1704,6 +1711,20 @@ public:
     /// Connect a unified client. Throws on auth / handshake failure.
     static ThetaDataDxClient connect(const Credentials& creds, const Config& config) {
         TdxUnified* h = tdx_unified_connect(creds.get(), config.get());
+        if (h == nullptr) {
+            detail::throw_last_ffi_error();
+        }
+        return ThetaDataDxClient(h);
+    }
+
+    /// Connect a unified client, loading credentials from a file (line 1 =
+    /// email, line 2 = password). One-call equivalent of
+    /// `Credentials::from_file(path)` followed by `connect`, defaulting to
+    /// the production configuration. Throws on auth / handshake failure or
+    /// an unreadable credentials file.
+    static ThetaDataDxClient from_file(const std::string& path,
+                                       const Config& config = Config::production()) {
+        TdxUnified* h = tdx_unified_connect_from_file(path.c_str(), config.get());
         if (h == nullptr) {
             detail::throw_last_ffi_error();
         }

--- a/sdks/cpp/src/fpss.cpp.inc
+++ b/sdks/cpp/src/fpss.cpp.inc
@@ -19,3 +19,7 @@ FpssClient::FpssClient(const Credentials& creds, const Config& config) {
     handle_.reset(h);
 }
 
+FpssClient FpssClient::from_file(const std::string& path, const Config& config) {
+    return FpssClient(Credentials::from_file(path), config);
+}
+

--- a/sdks/cpp/src/lifecycle.cpp.inc
+++ b/sdks/cpp/src/lifecycle.cpp.inc
@@ -24,3 +24,9 @@ MddsClient MddsClient::connect(const Credentials& creds, const Config& config) {
     return MddsClient(h);
 }
 
+MddsClient MddsClient::from_file(const std::string& path, const Config& config) {
+    auto h = tdx_mdds_client_connect_from_file(path.c_str(), config.get());
+    if (!h) detail::throw_last_ffi_error();
+    return MddsClient(h);
+}
+

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1934,3 +1934,49 @@ python = true
 typescript = true
 cpp = true
 ffi = true
+
+# ─── Client construction-from-file convenience ([[from_file]]) ────────
+#
+# Every standalone client class exposes a one-call file-construction
+# convenience: load credentials from a two-line file (line 1 = email,
+# line 2 = password) and connect, defaulting to the production
+# configuration. It composes `Credentials::from_file(path)` with the
+# class's `connect`, named per language idiom:
+#
+#   python      — `<Class>.from_file(path, config=None)` staticmethod on
+#                 the pyclass.
+#   typescript  — `<Class>.connectFromFile(path, config?)` napi factory.
+#   cpp         — `<Class>::from_file(path, config = Config::production())`
+#                 static member on the C++ wrapper.
+#   ffi         — the `tdx_<stem>_connect_from_file(path, config)`
+#                 extern "C" symbol (`unified` / `mdds_client` / `fpss`).
+#
+# The construction entry point is not a data method the `[[method]]`
+# rows cover, and its spelling differs per binding, so without this
+# family a binding could grow `from_file` on one client and silently
+# omit it on another. The collector set is reconciled against these
+# rows in both directions: a declared row that does not match the
+# binding state fails, and a client that exposes file-construction on
+# any binding without a row fails. `name` is the cross-binding client
+# class identifier (the same name used by the `[[class]]` rows).
+
+[[from_file]]
+name = "ThetaDataDxClient"
+python = true
+typescript = true
+cpp = true
+ffi = true
+
+[[from_file]]
+name = "MddsClient"
+python = true
+typescript = true
+cpp = true
+ffi = true
+
+[[from_file]]
+name = "FpssClient"
+python = true
+typescript = true
+cpp = true
+ffi = true

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -616,6 +616,11 @@ class ThetaDataDxClient:
     """
 
     def __init__(self, creds: Credentials, config: Config) -> None: ...
+    @staticmethod
+    def from_file(
+        path: str,
+        config: Optional[Config] = None,
+    ) -> ThetaDataDxClient: ...
 
     # Streaming lifecycle.
     def start_streaming(self, callback: EventCallback) -> None: ...

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1251,6 +1251,32 @@ impl ThetaDataDxClient {
         })
     }
 
+    /// Convenience constructor: `ThetaDataDxClient.from_file("creds.txt")`.
+    /// Loads credentials from a two-line file and connects with the
+    /// supplied `config`, defaulting to `Config.production()`.
+    ///
+    /// The `config` kwarg is optional. The historical behaviour
+    /// (no kwarg = production endpoint) is preserved; tests and
+    /// dev / stage environments reach a single-arg constructor shape
+    /// via `ThetaDataDxClient.from_file("creds.txt", config=Config.dev())`.
+    /// Parity with `AsyncThetaDataDxClient.from_file()`,
+    /// `MddsClient.from_file()`, and `FpssClient.from_file()` — every
+    /// Python client exposes the same one-call file-construction shape.
+    #[staticmethod]
+    #[pyo3(signature = (path, config=None))]
+    fn from_file(py: Python<'_>, path: &str, config: Option<&Config>) -> PyResult<Self> {
+        let creds = Credentials::from_file(path)?;
+        let owned_default;
+        let cfg = match config {
+            Some(c) => c,
+            None => {
+                owned_default = Config::production();
+                &owned_default
+            }
+        };
+        Self::new(py, &creds, cfg)
+    }
+
     // No per-endpoint `_df` / `_arrow` / `_polars` convenience wrappers.
     // Every historical endpoint returns `Py<<TickName>List>` (or
     // `Py<StringList>` for list endpoints); chain `.to_polars()` /


### PR DESCRIPTION
Every standalone client now exposes a one-call file-construction entry point that loads credentials from a two-line file and connects, defaulting to the production configuration: Python `ThetaDataDxClient.from_file(path, config=None)`, C++ `ThetaDataDxClient::from_file` / `MddsClient::from_file` / `FpssClient::from_file`, and the C ABI `tdx_unified_connect_from_file` / `tdx_mdds_client_connect_from_file` / `tdx_fpss_connect_from_file` symbols. This brings Python, C++, and the C ABI to the shape TypeScript already shipped via `connectFromFile`.

The C++ wrappers compose `Credentials::from_file(path)` with the existing connect, calling the C ABI directly where a private handle constructor makes that cleaner. The lifecycle and FPSS definitions are emitted from `sdk_surface.toml` so the per-binding cost stays in the generator, not in hand-written sidecar files.

A `[[from_file]]` parity family pins the convenience across Python, TypeScript, C++, and the C ABI: each binding's idiomatic entry point is harvested and reconciled in both directions, so a client that grows file construction on one binding but not another fails the gate. The selftest and companion test cover the positive, missing-symbol, untracked-client, and stem-mapping axes.

Verified green locally: `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings` plus the Python and napi crates, `generate_sdk_surfaces --check`, `generate_docs_site --check`, `check_binding_parity.py` plus its companion test and `--selftest`, `check_docs_consistency.py`, `check_c_abi_completeness.py` (305 symbols, bidirectional parity), and `cargo test --workspace --features thetadatadx/__test-helpers`. The C++ examples build against the release FFI library; the Python wheel builds via maturin. Live check: Python `ThetaDataDxClient.from_file` returned rows from a historical query, and C++ `MddsClient::from_file` (which calls `tdx_mdds_client_connect_from_file`) returned EOD rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)