### PR TITLE
docs(ffi): name the credentials invariant in the from_file free comments

### DIFF
--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -2260,7 +2260,9 @@ pub unsafe extern "C" fn tdx_mdds_client_connect_from_file(
         // and is owned by this function; `tdx_mdds_client_connect` borrows
         // it and we free it unconditionally below.
         let client = unsafe { tdx_mdds_client_connect(creds, config) };
-        // SAFETY: same fresh, unfreed handle from above.
+        // SAFETY: `creds` is the non-null handle checked above;
+        // `tdx_mdds_client_connect` only borrowed it, so this scope still
+        // owns it and frees it exactly once.
         unsafe { tdx_credentials_free(creds) };
         client
     })

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -462,7 +462,9 @@ pub unsafe extern "C" fn tdx_unified_connect_from_file(
         // and is owned by this function; `tdx_unified_connect` borrows it
         // and we free it unconditionally below.
         let handle = unsafe { tdx_unified_connect(creds, config) };
-        // SAFETY: same fresh, unfreed handle from above.
+        // SAFETY: `creds` is the non-null handle checked above;
+        // `tdx_unified_connect` only borrowed it, so this scope still owns
+        // it and frees it exactly once.
         unsafe { crate::auth::tdx_credentials_free(creds) };
         handle
     })
@@ -1446,7 +1448,9 @@ pub unsafe extern "C" fn tdx_fpss_connect_from_file(
         // and is owned by this function; `tdx_fpss_connect` clones what it
         // needs and we free it unconditionally below.
         let handle = unsafe { tdx_fpss_connect(creds, config) };
-        // SAFETY: same fresh, unfreed handle from above.
+        // SAFETY: `creds` is the non-null handle checked above;
+        // `tdx_fpss_connect` cloned what it needed, so this scope still owns
+        // it and frees it exactly once.
         unsafe { crate::auth::tdx_credentials_free(creds) };
         handle
     })


### PR DESCRIPTION
The three `from_file` connect wrappers added in #749 freed the credentials handle under an identical `// SAFETY: same fresh, unfreed handle from above.` comment. That text names no invariant signal, and at three sites it tripped the SAFETY-comment hygiene gate (the check that guards against copy-pasted unsafe justifications). Each site was fine in isolation; the third pushed the repeat count over the threshold.

Each free comment now states the actual invariant: `creds` is the non-null handle checked above, the connect (`tdx_mdds_client_connect` / `tdx_unified_connect` / `tdx_fpss_connect`) only borrowed or cloned it, so the wrapper scope still owns it and frees it exactly once. Comment-only change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)