### PR TITLE
docs(config): correct error contracts and fill doc gaps across config, auth, util, and bin

### DIFF
--- a/crates/thetadatadx/src/auth/creds.rs
+++ b/crates/thetadatadx/src/auth/creds.rs
@@ -65,23 +65,18 @@ impl Credentials {
     ///
     /// # Errors
     ///
-    /// Returns an error on network, authentication, or parsing failure.
+    /// Returns [`Error::Config`] if the file cannot be read, and
+    /// [`Error::Auth`] if its contents fail to parse (fewer than two
+    /// lines, or an empty email or password).
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
-        // U12 closure: previously the error message duplicated the
-        // path inside the `(kind)` portion of the `Error::Config`
-        // Display, producing
-        // `configuration error (config file I/O: failed to read
-        // credentials file PATH: ERR): failed to read credentials
-        // file PATH: ERR`.
-        //
-        // The `Error::Config` outer Display is structurally
-        // `"configuration error ({kind}): {message}"`. We keep the
-        // detail on the `kind` side (the typed
-        // `ConfigErrorKind::Io(String)` retains the full diagnostic
-        // for log parsers / retry classifiers) and reduce the outer
-        // `message` to a short label so the parenthesised section is
-        // not duplicated in the human-readable form.
+        // The `Error::Config` Display is structurally
+        // `"configuration error ({kind}): {message}"`. The detail
+        // stays on the `kind` side (the typed `ConfigErrorKind::Io`
+        // retains the full path + os error for log parsers / retry
+        // classifiers) and the outer `message` is a short label, so
+        // the parenthesised section is not duplicated in the
+        // human-readable form.
         let contents = Zeroizing::new(std::fs::read_to_string(path).map_err(|e| {
             // The typed Io variant carries the long form (path + os
             // error) so structural callers can extract it; the
@@ -117,7 +112,9 @@ impl Credentials {
     ///
     /// # Errors
     ///
-    /// Returns an error on network, authentication, or parsing failure.
+    /// Returns [`Error::Auth`] if `contents` has fewer than two lines,
+    /// or if the email (line 1) or password (line 2) is empty after
+    /// trimming.
     pub fn parse(contents: &str) -> Result<Self, Error> {
         let lines: Vec<&str> = contents.lines().collect();
 

--- a/crates/thetadatadx/src/auth/nexus.rs
+++ b/crates/thetadatadx/src/auth/nexus.rs
@@ -230,7 +230,9 @@ fn is_transient_network_error(err: &reqwest::Error) -> bool {
 ///
 /// # Errors
 ///
-/// Returns an error on network, authentication, or parsing failure.
+/// Propagates [`authenticate_at`]'s errors: [`Error::Auth`] for
+/// rejected credentials, network failure, timeout, server error, or an
+/// unparseable / malformed-UUID response.
 ///
 /// Only available when the `__internal` feature is enabled.
 #[cfg(feature = "__internal")]
@@ -284,7 +286,17 @@ fn auth_tls_config() -> Result<rustls::ClientConfig, Error> {
 ///
 /// # Errors
 ///
-/// Returns an error on network, authentication, or parsing failure.
+/// Returns [`Error::Auth`] with [`AuthErrorKind::InvalidCredentials`]
+/// when Nexus returns 401/404, [`AuthErrorKind::Timeout`] or
+/// [`AuthErrorKind::NetworkError`] on transient connection failure after
+/// retries are exhausted, and [`AuthErrorKind::ServerError`] for any
+/// other non-success status, an unparseable body, or a malformed session
+/// UUID.
+///
+/// [`AuthErrorKind::InvalidCredentials`]: crate::error::AuthErrorKind::InvalidCredentials
+/// [`AuthErrorKind::Timeout`]: crate::error::AuthErrorKind::Timeout
+/// [`AuthErrorKind::NetworkError`]: crate::error::AuthErrorKind::NetworkError
+/// [`AuthErrorKind::ServerError`]: crate::error::AuthErrorKind::ServerError
 pub async fn authenticate_at(url: &str, creds: &Credentials) -> Result<AuthResponse, Error> {
     metrics::counter!("thetadatadx.auth.requests").increment(1);
     let auth_start = std::time::Instant::now();
@@ -368,8 +380,10 @@ pub async fn authenticate_at(url: &str, creds: &Credentials) -> Result<AuthRespo
     };
 
     let status = resp.status();
-    // Java special-cases 401 and 404 as "invalid credentials".
-    // Source: AuthenticationManager.authenticateViaCloud() in decompiled terminal.
+    // Nexus returns 401 (rejected) and 404 (unknown account) for the
+    // same caller-facing condition: the supplied email/password pair is
+    // not valid. Both collapse to `InvalidCredentials` so callers do not
+    // retry — a bad password will not become good on a second attempt.
     if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::NOT_FOUND {
         return Err(Error::Auth {
             kind: crate::error::AuthErrorKind::InvalidCredentials,

--- a/crates/thetadatadx/src/auth/session.rs
+++ b/crates/thetadatadx/src/auth/session.rs
@@ -71,7 +71,10 @@ struct Inner {
 /// concurrent refreshes — see [`SessionToken::refresh`].
 #[derive(Clone, Debug)]
 pub struct SessionSnapshot {
+    /// Session UUID observed at snapshot time.
     pub uuid: String,
+    /// Token version observed at snapshot time. [`SessionToken::refresh`]
+    /// re-authenticates only while the live version still equals this.
     pub version: u64,
 }
 

--- a/crates/thetadatadx/src/bin/bench_latency.rs
+++ b/crates/thetadatadx/src/bin/bench_latency.rs
@@ -5,6 +5,13 @@
 //! event-dispatch consumer thread. This is the floor — no Python, no numpy, no
 //! extra FFI hop — so it sets the upper bound on throughput the SDK can
 //! deliver per connection.
+//!
+//! The credentials file path is taken as the first positional argument
+//! (default `creds.txt`). The `DUR` environment variable sets the run length
+//! in seconds (default 30) and `SEC` selects the security type to subscribe to
+//! — `STOCK`, `OPTION`, or `INDEX` (default `OPTION`). On completion it prints
+//! the latency distribution (min/p50/p90/p99/p99.9/max) and the observed event
+//! throughput.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -23,12 +23,13 @@
 //!
 //! # Layout
 //!
-//! [`DirectConfig`] is composed of seven nested sub-configs:
+//! [`DirectConfig`] is composed of eight nested sub-configs:
 //!
 //! | Field           | Type                                                |
 //! |-----------------|-----------------------------------------------------|
 //! | `mdds`          | [`MddsConfig`] — gRPC host/port/TLS/keepalive       |
 //! | `fpss`          | [`FpssConfig`] — TCP hosts, queue/ring, flush mode  |
+//! | `flatfiles`     | [`FlatFilesConfig`] — FLATFILES retry budget        |
 //! | `reconnect`     | [`ReconnectConfig`] — wait cadence + policy         |
 //! | `retry`         | [`RetryPolicy`] — exponential backoff for MDDS |
 //! | `auth`          | [`AuthConfig`] — Nexus URL + `client_type`          |
@@ -70,9 +71,9 @@ pub use crate::backoff::JitterMode;
 ///
 /// # Layout
 ///
-/// Fields are grouped into seven nested sub-configs ([`MddsConfig`],
-/// [`FpssConfig`], [`ReconnectConfig`], [`RetryPolicy`], [`AuthConfig`],
-/// [`MetricsConfig`], [`RuntimeConfig`]). Read accessors on [`DirectConfig`]
+/// Fields are grouped into eight nested sub-configs ([`MddsConfig`],
+/// [`FpssConfig`], [`FlatFilesConfig`], [`ReconnectConfig`], [`RetryPolicy`],
+/// [`AuthConfig`], [`MetricsConfig`], [`RuntimeConfig`]). Read accessors on [`DirectConfig`]
 /// preserve the field-style naming used by older callers; writes go through
 /// the nested struct (e.g. `cfg.fpss.ring_size = N`).
 ///
@@ -133,6 +134,12 @@ impl DirectConfig {
     ///
     /// Environment variables listed on [`DirectConfig`] are layered on
     /// top of these defaults.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the resulting configuration fails [`Self::validate`].
+    /// The hardcoded defaults are always in range, so this fires only
+    /// when an environment override pushes a knob out of bounds.
     #[must_use]
     pub fn production() -> Self {
         let mut config = Self::production_defaults();
@@ -173,6 +180,12 @@ impl DirectConfig {
     /// Note: dev server replays data at max speed, so queue and ring sizes
     /// match production to avoid drops. Some contracts may not exist on
     /// the replayed day.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the preset fails [`Self::validate`] — only reachable
+    /// when an environment override pushes a knob out of bounds, since
+    /// the preset's own values are in range.
     #[must_use]
     pub fn dev() -> Self {
         let mut config = Self::production();
@@ -195,6 +208,12 @@ impl DirectConfig {
     /// MDDS (historical) still uses production servers.
     ///
     /// Source: `config.toml` `fpss_stage_hosts`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the preset fails [`Self::validate`] — only reachable
+    /// when an environment override pushes a knob out of bounds, since
+    /// the preset's own values are in range.
     #[must_use]
     pub fn stage() -> Self {
         let mut config = Self::production();
@@ -386,9 +405,12 @@ impl DirectConfig {
     /// Parse FPSS hosts from a comma-separated `host:port,host:port,...` string.
     ///
     /// This is the format used in `config_0.properties` for `FPSS_NJ_HOSTS`.
+    ///
     /// # Errors
     ///
-    /// Returns an error on network, authentication, or parsing failure.
+    /// Returns [`Error::Config`] when an entry lacks a `host:port` split,
+    /// when a port does not parse as a `u16`, or when the input yields no
+    /// hosts at all.
     pub fn parse_fpss_hosts(hosts_str: &str) -> Result<Vec<(String, u16)>, Error> {
         let mut result = Vec::new();
 
@@ -746,9 +768,12 @@ mod config_file {
         /// connection_window_size_kb = 64
         /// concurrent_requests = 0  # 0 = auto from tier
         /// ```
+        ///
         /// # Errors
         ///
-        /// Returns an error on network, authentication, or parsing failure.
+        /// Returns [`Error::Config`] when the file cannot be read, when its
+        /// contents are not valid TOML, or when the parsed values fail
+        /// [`Self::validate`].
         pub fn from_file(path: impl AsRef<std::path::Path>) -> Result<Self, Error> {
             let contents = std::fs::read_to_string(path.as_ref()).map_err(|e| {
                 Error::config_io(format!(
@@ -762,9 +787,11 @@ mod config_file {
         /// Parse configuration from a TOML string.
         ///
         /// Same semantics as [`from_file`](Self::from_file) but takes a string directly.
+        ///
         /// # Errors
         ///
-        /// Returns an error on network, authentication, or parsing failure.
+        /// Returns [`Error::Config`] when the string is not valid TOML or
+        /// when the parsed values fail [`Self::validate`].
         pub fn from_toml_str(toml_str: &str) -> Result<Self, Error> {
             let cf: ConfigFile =
                 toml::from_str(toml_str).map_err(|e| Error::config_toml(e.to_string()))?;

--- a/crates/thetadatadx/src/util/random_id.rs
+++ b/crates/thetadatadx/src/util/random_id.rs
@@ -21,6 +21,12 @@ pub(crate) fn random_id_hex() -> String {
 /// version or variant nibbles, so v1, v4, and v7 all pass.
 ///
 /// Returns `s` unchanged on success.
+///
+/// # Errors
+///
+/// Returns a static message when `s` is not 36 bytes, when a hyphen is
+/// missing at offset 8, 13, 18, or 23, or when any other position holds
+/// a non-hex byte.
 pub(crate) fn validate_uuid_format(s: &str) -> Result<&str, &'static str> {
     if s.len() != 36 {
         return Err("uuid length must be 36");


### PR DESCRIPTION
Brings the core configuration, authentication, shared-utility, and binary entrypoint modules up to the crate documentation bar. Audit-and-fill only: compliant docs are left untouched, so the diff is confined to genuine gaps and inaccuracies. Comments and docstrings only — no code, signatures, or behavior change.

## What changed

`config/mod.rs` — `DirectConfig` claimed seven nested sub-configs but carries eight; corrected the count and added the missing `flatfiles` row to the layout. Added `# Panics` to `production`/`dev`/`stage`, which expect an in-range configuration. Rewrote three `# Errors` sections that named network and authentication failures these pure parsers and loaders never produce, replacing them with the real conditions (host split, port parse, TOML parse, validation).

`auth/creds.rs` — `from_file` and `parse` had the same inaccurate network/auth boilerplate; replaced with the actual `Error::Config` / `Error::Auth` conditions. Restated the credential-error comment in terms of the structural Display invariant rather than its change history.

`auth/nexus.rs` — `authenticate` and `authenticate_at` now document the precise `AuthErrorKind` mapping with resolving intra-doc links. Restated the 401/404 comment as the caller-facing invariant: both statuses mean invalid credentials, so they collapse to one non-retryable error.

`auth/session.rs` — documented the `SessionSnapshot` public fields, citing the refresh-dedup invariant on `version`.

`util/random_id.rs` — added the `# Errors` contract to `validate_uuid_format`.

`bin/bench_latency.rs` — completed the header with the invocation contract (creds path, `DUR`/`SEC` env vars, output) without quoting any measured numbers.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p thetadatadx -- -D warnings` — clean
- `cargo test -p thetadatadx --doc` — 17 passed, 0 failed
- `generate_docs_site --check` — generated pages match the registries
- `check_public_surface_leak.py` — clean
- Diff verified comments-only in both directions (no code lines added or removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)