### PR TITLE
docs(fpss): fill doc gaps across core, fpss, and frames modules

### DIFF
--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -468,7 +468,7 @@ impl ThetaDataDxClient {
     ///    `Live` (returns [`Self::already_streaming`]); or
     /// 2. an interleaving [`Self::stop_streaming`] bumped the
     ///    [`Self::stop_generation`] counter past `gen_at_entry`
-    ///    (returns [`Self::stopped_during_start`]). This is the H2
+    ///    (returns [`Self::stopped_during_start`]). This is the
     ///    `Stopped → Live` resurrection guard: a caller that started
     ///    connecting BEFORE `stop_streaming` was invoked must NOT see
     ///    its connection installed AFTER stop returned, even though
@@ -703,44 +703,6 @@ impl ThetaDataDxClient {
         }
     }
 
-    /// Wait for the previously-superseded streaming session to
-    /// quiesce, polling its internal drain flag until it observes
-    /// `true` or `timeout` elapses.
-    ///
-    /// Returns `true` when the previous session's I/O thread and
-    /// event-dispatch consumer have both joined, so the previous user
-    /// callback is guaranteed to have stopped firing. Returns `false`
-    /// on timeout, or if no stream has ever been started or stopped on
-    /// this handle (nothing to drain).
-    ///
-    /// # When to call
-    ///
-    /// Call from a thread other than the FPSS consumer thread after
-    /// either [`Self::stop_streaming`] or [`Self::reconnect_streaming`]
-    /// returns, when application code needs to:
-    ///
-    /// - free an FFI callback context that the old callback closure
-    ///   captured by value;
-    /// - drop a captured `Arc` whose contents the old callback was
-    ///   reading;
-    /// - install a fresh callback whose `'static` captures must not
-    ///   alias the old callback's still-running invocations.
-    ///
-    /// # Lifecycle restriction
-    ///
-    /// Because callback-thread stop / reconnect detaches cleanup onto
-    /// a helper thread (see [`Self::start_streaming`] for the full
-    /// rationale), `await_drain` MUST be called from a thread other
-    /// than the FPSS event-dispatch consumer thread. Calling it from
-    /// inside the user callback would block the very thread the
-    /// helper is waiting on and the call would always time out.
-    ///
-    /// # Resolution
-    ///
-    /// Polls every 1 ms; returns as soon as the flag flips. The poll
-    /// loop is intentionally simple (no condvar, no parking) because
-    /// drain is a one-shot, latency-tolerant event — the vast
-    /// majority of calls return on the first or second tick.
     /// Whether a prior streaming session has registered its drain flag
     /// for [`Self::await_drain`] to poll on.
     ///
@@ -921,7 +883,7 @@ impl ThetaDataDxClient {
     /// Get all active per-contract subscriptions.
     /// # Errors
     ///
-    /// Returns an error on network, authentication, or parsing failure.
+    /// Returns [`Error::Fpss`] when streaming has not been started.
     pub fn active_subscriptions(&self) -> Result<Vec<(SubscriptionKind, Contract)>, Error> {
         self.with_streaming(|s| Ok(s.active_subscriptions()))
     }
@@ -929,7 +891,7 @@ impl ThetaDataDxClient {
     /// Get all active full-type (full-stream) subscriptions.
     /// # Errors
     ///
-    /// Returns an error on network, authentication, or parsing failure.
+    /// Returns [`Error::Fpss`] when streaming has not been started.
     pub fn active_full_subscriptions(&self) -> Result<Vec<(SubscriptionKind, SecType)>, Error> {
         self.with_streaming(|s| Ok(s.active_full_subscriptions()))
     }
@@ -1320,6 +1282,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: option open-interest flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_option_open_interest(
         &self,
         date: &str,
@@ -1337,6 +1302,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: option trade-quote flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_option_trade_quote(
         &self,
         date: &str,
@@ -1354,6 +1322,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: option trade flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_option_trade(
         &self,
         date: &str,
@@ -1371,6 +1342,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: option quote flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_option_quote(
         &self,
         date: &str,
@@ -1388,6 +1362,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: option end-of-day flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_option_eod(
         &self,
         date: &str,
@@ -1405,6 +1382,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: stock trade-quote flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_stock_trade_quote(
         &self,
         date: &str,
@@ -1422,6 +1402,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: stock trade flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_stock_trade(
         &self,
         date: &str,
@@ -1439,6 +1422,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: stock quote flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_stock_quote(
         &self,
         date: &str,
@@ -1456,6 +1442,9 @@ impl ThetaDataDxClient {
     }
 
     /// Convenience: stock end-of-day flat file for `date`.
+    ///
+    /// # Errors
+    /// Same conditions as [`Self::flatfile_request`].
     pub async fn flatfile_stock_eod(
         &self,
         date: &str,
@@ -1805,8 +1794,7 @@ mod tests {
     }
 
     /// `reconnect_streaming` returns `Error::PartialReconnect` carrying the
-    /// failed list when subscriptions cannot be restored — the regression
-    /// test for issue #461. The variant payload is asserted by pattern-
+    /// failed list when subscriptions cannot be restored. The variant payload is asserted by pattern-
     /// match, not just `is_err()`, so a future refactor that changes the
     /// payload shape breaks this test loudly.
     #[test]
@@ -1846,8 +1834,8 @@ mod tests {
         }
     }
 
-    /// H2 regression: an in-flight `start_streaming*` that snapshotted
-    /// `stop_generation = N` at entry must NOT install `Live` when an
+    /// Resurrection-race regression: an in-flight `start_streaming*` that
+    /// snapshotted `stop_generation = N` at entry must NOT install `Live` when an
     /// interleaving `stop_streaming` has bumped `stop_generation` to
     /// `N+1` by the time the install runs. This is the
     /// `Stopped → Live` resurrection race the generation token closes.
@@ -1928,9 +1916,8 @@ mod tests {
     /// free paths use this to disambiguate the two `false` returns from
     /// `await_drain` (timeout vs. nothing-to-wait-on).
     ///
-    /// Post PR514 audit: the slot is now a `Vec` so stacked
-    /// stop/start/stop cycles cannot lose an earlier still-draining
-    /// generation when a later one retires.
+    /// The slot is a `Vec` so stacked stop/start/stop cycles cannot lose
+    /// an earlier still-draining generation when a later one retires.
     #[test]
     fn prev_drained_is_set_tracks_vec_of_generations() {
         let slot: Mutex<Vec<Arc<AtomicBool>>> = Mutex::new(Vec::new());
@@ -1966,10 +1953,10 @@ mod tests {
         assert!(g.is_empty(), "all retired generations drained");
     }
 
-    /// HIGH-001 regression — multi-generation `await_drain` must wait
-    /// for ALL retired sessions, not just the most-recent. The pre-fix
-    /// single-slot tracker would have returned `true` as soon as the
-    /// last-pushed flag flipped, even with earlier flags still pending.
+    /// Multi-generation `await_drain` must wait for ALL retired sessions,
+    /// not just the most-recent. A single-slot tracker would return `true`
+    /// as soon as the last-pushed flag flipped, even with earlier flags
+    /// still pending.
     #[test]
     fn await_drain_waits_for_all_retired_generations() {
         // We exercise the predicate logic directly through a `Vec` to
@@ -2091,9 +2078,9 @@ mod tests {
 
     #[test]
     fn theta_data_client_alias_resolves_to_theta_data_dx() {
-        // Phase 3a: `ThetaDataDxClient` is the new public name; the old
-        // `ThetaDataDxClient` is kept as a compatibility alias. Both must
-        // refer to the same type so existing call sites keep compiling.
+        // `ThetaDataDxClient` is the canonical public client type; this
+        // guards that the name continues to resolve to the same type so
+        // existing call sites keep compiling.
         fn _alias_check(c: ThetaDataDxClient) -> ThetaDataDxClient {
             c
         }

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -1,3 +1,11 @@
+//! The crate's public [`Error`] type and its category enums.
+//!
+//! [`Error`] is the single error surface returned across the SDK. Every
+//! variant carries a typed category (`kind`) alongside a human-readable
+//! message so callers can pattern-match on the failure class without
+//! parsing `Display` strings, and the `Display` shapes stay stable for
+//! bindings that read `to_string()`.
+
 use thiserror::Error;
 
 /// Classification of authentication failures.

--- a/crates/thetadatadx/src/fpss/events.rs
+++ b/crates/thetadatadx/src/fpss/events.rs
@@ -229,15 +229,13 @@ pub enum FpssControl {
     UnknownFrame { code: u8, payload: Vec<u8> },
     /// Server connection ack (code 4, `StreamMsgType::Connected`).
     ///
-    /// Decoded from the server→client CONNECTED frame. Previously fell
-    /// through to [`FpssControl::UnknownFrame`].
+    /// Decoded from the server→client CONNECTED frame.
     Connected,
     /// Server heartbeat (code 10, `StreamMsgType::Ping`).
     ///
     /// The server emits PING frames (observed 1-byte payload `[0]`) that
     /// client heartbeat logic does not have to answer. Payload preserved
-    /// for diagnostics — previously every heartbeat surfaced as
-    /// `UnknownFrame { code: 10, payload: [0] }`.
+    /// for diagnostics.
     Ping { payload: Vec<u8> },
     /// Server-side reconnect ack (code 13).
     ///
@@ -308,9 +306,9 @@ pub(crate) const FPSS_EVENT_TAG_EMPTY: u8 = 3;
 ///   for soak-test introspection without leaking raw bytes through the
 ///   public API.
 /// * [`FpssEventInternal::Empty`] — pre-allocation placeholder for
-///   ring-buffer slots that have never been written; the previous
-///   `Option<FpssEvent>` slot wrapper is collapsed into this variant
-///   so the consumer closure can avoid the `Option` discriminant test.
+///   ring-buffer slots that have never been written; folding the empty
+///   case into a variant lets the consumer closure avoid an
+///   `Option<FpssEvent>` discriminant test.
 ///
 /// The I/O thread builds `FpssEventInternal` directly from the wire
 /// decoder; the event-dispatch consumer reborrows the slot reference to a
@@ -329,7 +327,8 @@ pub enum FpssEventInternal {
     /// `thetadatadx.fpss.decode_failures` metric counter and visible
     /// to soak tests that assert on the internal stream shape.
     Unparseable = FPSS_EVENT_TAG_UNPARSEABLE,
-    /// Ring-buffer slot placeholder. Filtered before user callbacks.
+    /// Ring-buffer slot placeholder for an unwritten / drained slot.
+    /// Filtered before user callbacks.
     Empty = FPSS_EVENT_TAG_EMPTY,
 }
 
@@ -470,9 +469,9 @@ mod tests {
     use super::*;
     use crate::tdbe::types::price::Price;
 
-    /// `FpssEventInternal::as_public` relies on. Any future change that
-    /// breaks size, alignment, or discriminant equality between
-    /// `FpssEvent` and the public-facing variants of
+    /// Pins the layout compatibility `FpssEventInternal::as_public`
+    /// relies on. Any change that breaks size, alignment, or discriminant
+    /// equality between `FpssEvent` and the public-facing variants of
     /// `FpssEventInternal` must trip this test before it can corrupt a
     /// reborrow.
     ///

--- a/crates/thetadatadx/src/fpss/io_loop/login.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/login.rs
@@ -36,10 +36,9 @@ pub(in crate::fpss) enum LoginResult {
 /// the wire delivered them. The caller flushes this buffer onto the
 /// event bus once the Disruptor producer is live, so user callbacks
 /// observe handshake-time control frames on the same channel the
-/// post-login `decode_frame` dispatch uses. Prior to this, every typed
-/// control frame that preceded `METADATA` was silently dropped because
-/// the handshake loop consumed it before the main dispatch could turn
-/// it into a typed event.
+/// post-login `decode_frame` dispatch uses — a typed control frame that
+/// precedes `METADATA` would otherwise be lost, since the handshake loop
+/// consumes it before the main dispatch can turn it into a typed event.
 pub(in crate::fpss) fn wait_for_login(
     stream: &mut connection::FpssStream,
     pending_control: &mut Vec<FpssControl>,
@@ -138,10 +137,9 @@ mod tests {
 
     /// A CONNECTED frame arriving BEFORE METADATA must be captured in
     /// `pending_control` so the io_loop can forward the buffered
-    /// `FpssControl::Connected` to the event bus. Before the v8
-    /// handshake work, the handshake loop silently dropped the frame
-    /// because only the post-login `decode_frame` dispatch knew how to
-    /// turn it into a typed event.
+    /// `FpssControl::Connected` to the event bus. Without this capture
+    /// the frame would be lost, since only the post-login `decode_frame`
+    /// dispatch knows how to turn it into a typed event.
     #[test]
     fn wait_for_login_captures_connected_frame_before_metadata() {
         let mut buf = Vec::new();
@@ -254,11 +252,10 @@ mod tests {
         ));
     }
 
-    /// Finding #1 coverage: a PING frame arriving BEFORE METADATA must
-    /// be captured in `pending_control` as `FpssControl::Ping` with
-    /// the exact payload bytes. Before this fix, the handshake's
-    /// trace-and-drop branch silently swallowed every heartbeat that
-    /// the server emitted between CONNECT and METADATA.
+    /// A PING frame arriving BEFORE METADATA must be captured in
+    /// `pending_control` as `FpssControl::Ping` with the exact payload
+    /// bytes, so the handshake's trace-and-drop branch does not swallow a
+    /// heartbeat the server emits between CONNECT and METADATA.
     #[test]
     fn wait_for_login_captures_ping_frame_before_metadata() {
         let mut buf = Vec::new();
@@ -284,8 +281,8 @@ mod tests {
         }
     }
 
-    /// Finding #1 coverage: a RECONNECTED frame (code 13) arriving
-    /// BEFORE METADATA must be captured as
+    /// A RECONNECTED frame (code 13) arriving BEFORE METADATA must be
+    /// captured as
     /// `FpssControl::ReconnectedServer`. The distinction from the
     /// client-emitted `FpssControl::Reconnected` is preserved.
     #[test]
@@ -303,8 +300,8 @@ mod tests {
         assert!(matches!(pending[0], FpssControl::ReconnectedServer));
     }
 
-    /// Finding #1 coverage: a RESTART frame (code 31) arriving BEFORE
-    /// METADATA must be captured as `FpssControl::Restart`.
+    /// A RESTART frame (code 31) arriving BEFORE METADATA must be
+    /// captured as `FpssControl::Restart`.
     #[test]
     fn wait_for_login_captures_restart_frame_before_metadata() {
         let mut buf = Vec::new();
@@ -320,9 +317,8 @@ mod tests {
         assert!(matches!(pending[0], FpssControl::Restart));
     }
 
-    /// Finding #1 coverage: multiple typed control frames arriving
-    /// BEFORE METADATA must all be captured, in the exact wire order
-    /// the server delivered them.
+    /// Multiple typed control frames arriving BEFORE METADATA must all
+    /// be captured, in the exact wire order the server delivered them.
     #[test]
     fn wait_for_login_captures_multiple_control_frames_in_wire_order() {
         let mut buf = Vec::new();

--- a/crates/thetadatadx/src/fpss/io_loop/mod.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/mod.rs
@@ -485,8 +485,8 @@ where
                     // Otherwise, fall through to drain commands.
                 }
                 Err(ref e) if is_drain_yield(e) => {
-                    // Finding #3: mid-frame reader yielded so the
-                    // command drain can keep up. `frame_state` has
+                    // Mid-frame reader yielded so the command drain can
+                    // keep up. `frame_state` has
                     // been updated with the exact byte offset in the
                     // header / payload, so the next `read_frame_into`
                     // call resumes without desync. Do NOT count this
@@ -1736,8 +1736,8 @@ mod tests {
         assert_eq!(wire_req_id((1_i64 << 32) + 7), 7);
     }
 
-    /// Finding #2 coverage: transient disconnect reasons must NOT
-    /// short-circuit -- they should produce a retry delay so the
+    /// Transient disconnect reasons must NOT short-circuit -- they
+    /// should produce a retry delay so the
     /// reconnect loop proceeds. Paired with the permanent-reasons
     /// test above, this pins the exact set that triggers the
     /// shutdown-store-break path versus the continue'session path.

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -1439,7 +1439,7 @@ impl FpssClient {
     /// was full.
     ///
     /// This is the user-facing "events dropped due to slow callback"
-    /// metric on the post-SSOT pipeline. Operators should poll on a
+    /// metric. Operators should poll on a
     /// periodic timer (e.g. every second) and emit a `warn` log on any
     /// non-zero delta — a per-drop log would amplify under sustained
     /// overflow.

--- a/crates/thetadatadx/src/fpss/protocol/contract.rs
+++ b/crates/thetadatadx/src/fpss/protocol/contract.rs
@@ -168,7 +168,7 @@ impl Contract {
                 format!("invalid expiration date {expiration:?}: {e}"),
             )
         })?;
-        // H4: reject impossible expirations (00000000, 20260230,
+        // Reject impossible expirations (00000000, 20260230,
         // 19990431, …) on every public option-builder input. Uses the
         // same canonical Gregorian validator the MDDS validator calls
         // (`crate::tdbe::time::is_valid_yyyymmdd`) so the two surfaces agree
@@ -308,10 +308,10 @@ impl Contract {
     /// (`Contract::to_bytes` / `Contract::from_bytes`). The parser
     /// matches this upper bound so `from_str` / `to_bytes` / `from_bytes`
     /// round-trip symmetrically -- the wire format is the ground truth
-    /// for what the terminal can see. Widening from the previous 6-char
-    /// cap admits upstream sources that ship longer roots (14+ char
-    /// instrument identifiers observed on some non-equity feeds) without
-    /// requiring parser-side special-casing.
+    /// for what the terminal can see. The 16-byte ceiling admits upstream
+    /// sources that ship longer roots (14+ char instrument identifiers
+    /// observed on some non-equity feeds) without requiring parser-side
+    /// special-casing.
     pub(crate) const MAX_ROOT_LEN: usize = 16;
     /// Validate that a candidate root ticker is 1..=`MAX_ROOT_LEN` ASCII
     /// uppercase letters optionally containing a single `.` (e.g.
@@ -322,10 +322,9 @@ impl Contract {
     /// symbols that fail downstream exchange lookups.
     ///
     /// The length ceiling matches `Contract::to_bytes`, which accepts
-    /// roots up to 16 bytes; widening the parser to the wire limit
-    /// keeps `from_str` / `to_bytes` / `from_bytes` round-trip
-    /// symmetric. Returns an `Error::Config` with the offending input
-    /// on failure.
+    /// roots up to 16 bytes, so `from_str` / `to_bytes` / `from_bytes`
+    /// round-trip symmetrically. Returns an `Error::Config` with the
+    /// offending input on failure.
     fn validate_root(input: &str, root: &str) -> Result<(), Error> {
         if root.is_empty() || root.len() > Self::MAX_ROOT_LEN {
             return Err(Error::config_invalid(
@@ -434,10 +433,10 @@ impl Contract {
         // ships contracts with future expirations, so pre-2000 OCC
         // symbols cannot reach this parser over the wire.
         let expiration: i32 = 20_000_000 + yymmdd;
-        // H4: reject impossible OCC-21 expirations (e.g. `260230`
+        // Reject impossible OCC-21 expirations (e.g. `260230`
         // (Feb 30) or `260431` (Apr 31)) using the same canonical
-        // Gregorian validator as MDDS + `Contract::option`. Previously
-        // any 6-digit numeric string was accepted silently.
+        // Gregorian validator as MDDS + `Contract::option`, so a
+        // shape-valid-but-impossible date never decodes to a contract.
         if !crate::tdbe::time::is_valid_yyyymmdd(expiration) {
             return Err(Error::config_invalid(
                 "contract.expiration",
@@ -825,9 +824,14 @@ impl std::str::FromStr for Contract {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ContractParseError {
+    /// The buffer ended before a full contract record could be read.
     TooShort,
+    /// The leading `total_size` byte is below the structural minimum or
+    /// inconsistent with the declared root length.
     InvalidSize(usize),
+    /// The root field bytes are not valid UTF-8.
     InvalidUtf8,
+    /// The security-type byte does not map to a known [`SecType`].
     UnknownSecType(u8),
 }
 
@@ -1024,9 +1028,9 @@ mod tests {
 
     #[test]
     fn option_rejects_impossible_calendar_dates() {
-        // H4 regression: shape-only validation used to silently accept
-        // these. Both `Contract::option` and OCC-21 parsing now defer
-        // to the canonical Gregorian validator.
+        // Both `Contract::option` and OCC-21 parsing defer to the
+        // canonical Gregorian validator, so shape-valid-but-impossible
+        // dates are rejected.
         for bad in ["00000000", "20260230", "19990431", "21010101", "18991231"] {
             assert!(
                 Contract::option(
@@ -1252,14 +1256,13 @@ mod tests {
         );
     }
 
-    // -- Finding #4: Contract::from_str wire-codec parity ---------------------
+    // -- Contract::from_str wire-codec parity ---------------------------------
     //
     // `to_bytes()` accepts roots up to 16 bytes (Java
     // `Contract.toBytes()` matches); `from_bytes()` round-trips
     // whatever the wire delivers. The bare-root parser must accept the
     // same 1..=16 range so `from_str` / `to_bytes` / `from_bytes`
-    // round-trip symmetrically. Widening keeps 1..=6 behaviour
-    // unchanged (existing tests still pass) and adds 7..=16 as valid.
+    // round-trip symmetrically.
 
     #[test]
     fn from_str_accepts_seven_char_root() {
@@ -1337,9 +1340,9 @@ mod tests {
         let c21 = Contract::from_str(twentyone).expect("21-char OCC-21 must parse");
 
         // Both strings MUST produce the same Contract. This pins the
-        // repair behaviour — previously the 20-char form was padded
-        // with a trailing space, which shifted the right-byte into a
-        // digit slot and either errored or decoded a different contract.
+        // repair behaviour: peeling the fixed 15-char suffix and
+        // re-padding the root keeps the right-byte aligned, rather than
+        // a trailing-space pad that would shift it into a digit slot.
         assert_eq!(c20, c21, "20-char and 21-char forms must parse identically");
         assert_eq!(&*c20.symbol, "SPY");
         assert_eq!(c20.expiration, Some(20_260_417));

--- a/crates/thetadatadx/src/fpss/ring.rs
+++ b/crates/thetadatadx/src/fpss/ring.rs
@@ -138,8 +138,7 @@ pub struct RingEvent {
     pub(crate) event: FpssEventInternal,
 }
 
-// SAFETY: Required-invariant restate per audit MINOR sweep --
-// `FpssEventInternal` is `Send` + holds no thread-affine state
+// SAFETY: `FpssEventInternal` is `Send` + holds no thread-affine state
 // (only `Arc<Contract>` + owned `Vec<u8>` + POD primitives). Concurrent
 // shared access is gated by the disruptor's sequencing protocol:
 // exactly one publisher writes a slot before publishing the sequence,
@@ -579,8 +578,8 @@ mod tests {
 
         let count = 1000usize;
         // One Arc<Contract>, reused across all published events so the
-        // throughput test doesn't allocate per event (matches real
-        // hot-path behaviour after v8).
+        // throughput test doesn't allocate per event (matches the
+        // hot-path behaviour where the contract is shared).
         let throughput_contract = std::sync::Arc::new(crate::fpss::protocol::Contract::stock(""));
         for _ in 0..count {
             let contract_clone = std::sync::Arc::clone(&throughput_contract);

--- a/crates/thetadatadx/src/frames/mod.rs
+++ b/crates/thetadatadx/src/frames/mod.rs
@@ -30,6 +30,11 @@ pub trait TicksPolarsExt {
     /// names match the Arrow schema produced by [`TicksArrowExt::to_arrow`]
     /// and the Python `.to_polars()` terminal on the matching
     /// `<TickName>List` wrapper.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`polars::prelude::PolarsError`] when polars rejects the
+    /// assembled columns (e.g. a length mismatch while building the frame).
     fn to_polars(&self) -> polars::prelude::PolarsResult<polars::prelude::DataFrame>;
 }
 
@@ -44,6 +49,11 @@ pub trait TicksArrowExt {
     /// Materialise `self` as an Arrow `RecordBatch`. Column order,
     /// names, and dtypes match the schema emitted by the Python
     /// slice_arrow path in `sdks/python/src/tick_arrow.rs`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`arrow_schema::ArrowError`] when the column arrays
+    /// cannot be assembled into a `RecordBatch` against the schema.
     fn to_arrow(
         &self,
     ) -> ::core::result::Result<arrow_array::RecordBatch, arrow_schema::ArrowError>;


### PR DESCRIPTION
Audit-and-fill documentation pass over the crate top-level files, the `fpss` subtree, and the `frames` module. This corrects gaps and substandard or non-documentary comments while leaving already-compliant docs untouched, so the diff is comments and docstrings only.

What changed:

- Added the missing module header to `error.rs` and per-variant docs to `ContractParseError`.
- Added `# Errors` to the polars and arrow tick conversions in `frames/mod.rs` and to the flatfile convenience methods on the client.
- Corrected an inaccurate `# Errors` description on the active-subscription accessors and repaired two docstrings that had unrelated text concatenated in front of them.
- Removed non-documentary vocabulary (process and version markers, change-announcing banners, internal finding tags) from comments and docstrings, replacing each with a present-tense statement of the invariant it describes.

Every public item now carries a doc comment, every `Result`-returning public function documents its error conditions, and each `unsafe` site names the invariant the caller must uphold. No code, signature, or behavior changes.

Gates: `cargo fmt --all -- --check`, `cargo clippy -p thetadatadx -- -D warnings`, `cargo test -p thetadatadx --doc`, the docs-site `--check`, and `scripts/check_public_surface_leak.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)