### PR TITLE
docs(flatfiles,tdbe): audit and fill doc comments to the crate standard

### DIFF
--- a/crates/thetadatadx/src/flatfiles/framing.rs
+++ b/crates/thetadatadx/src/flatfiles/framing.rs
@@ -45,12 +45,21 @@ pub(crate) mod msg {
 
 /// Single decoded frame.
 pub(crate) struct Frame {
+    /// Wire message code (see [`msg`]).
     pub msg: u16,
+    /// Request id this frame is scoped to, or `-1` for connection-scoped frames.
     pub id: i64,
+    /// Frame body with the 14-byte header stripped.
     pub payload: Vec<u8>,
 }
 
 /// Encode and write a single frame to `out`, then flush.
+///
+/// # Errors
+///
+/// Returns `Error::Config` when `payload` exceeds `u32::MAX` bytes (it
+/// cannot be expressed in the wire `payload_size` field), or `Error::Io`
+/// when the underlying writer fails on the header, payload, or flush.
 pub(crate) async fn write_frame<W>(
     out: &mut W,
     msg: u16,
@@ -76,7 +85,14 @@ where
     Ok(())
 }
 
-/// Read one frame from `src`. Errors propagate the underlying tokio error.
+/// Read one frame from `src`.
+///
+/// # Errors
+///
+/// Returns `Error::Io` when the underlying reader fails or reaches EOF
+/// before a full header or payload is read, and `Error::Config` when the
+/// header declares a payload larger than [`MAX_PAYLOAD`] (rejected to bound
+/// allocation against a hostile or corrupt frame).
 pub(crate) async fn read_frame<R>(src: &mut R) -> Result<Frame, Error>
 where
     R: tokio::io::AsyncRead + Unpin,

--- a/crates/thetadatadx/src/flatfiles/index.rs
+++ b/crates/thetadatadx/src/flatfiles/index.rs
@@ -133,6 +133,8 @@ pub(crate) struct IndexIter<'a> {
 }
 
 impl<'a> IndexIter<'a> {
+    /// Creates an iterator over the INDEX section `index_bytes`, decoding
+    /// each entry's contract key per `sec`.
     pub(crate) fn new(index_bytes: &'a [u8], sec: SecType) -> Self {
         Self {
             cur: Cursor::new(index_bytes),

--- a/crates/thetadatadx/src/flatfiles/mdds_spki.rs
+++ b/crates/thetadatadx/src/flatfiles/mdds_spki.rs
@@ -28,12 +28,19 @@ pub(crate) const ALLOWED_MDDS_HOSTS: &[&str] = &["nj-a.thetadata.us", "nj-b.thet
 /// Production MDDS legacy ports for the `nj-{a,b}` region.
 pub(crate) const MDDS_PORTS: &[u16] = &[12000, 12001];
 
+/// `rustls` certificate verifier that authenticates the MDDS leaf by
+/// pinning its SubjectPublicKeyInfo (SPKI) rather than walking a chain to a
+/// trusted root. The chain is expired, so chain validation is deliberately
+/// bypassed; trust is anchored solely in the pinned SPKI digest and the
+/// hostname allowlist. Handshake-signature verification is still enforced
+/// against the pinned key.
 #[derive(Debug)]
 pub(crate) struct MddsSpkiVerifier {
     algs: WebPkiSupportedAlgorithms,
 }
 
 impl MddsSpkiVerifier {
+    /// Builds a verifier wired to the ring provider's signature algorithms.
     pub(crate) fn new() -> Arc<Self> {
         // Take the signature algorithms straight from the ring provider rather
         // than the process-global default. ring is the sole provider in the dep

--- a/crates/thetadatadx/src/flatfiles/session.rs
+++ b/crates/thetadatadx/src/flatfiles/session.rs
@@ -30,6 +30,8 @@ use crate::fpss::protocol::build_credentials_payload;
 
 /// Established, authenticated MDDS connection.
 pub(crate) struct AuthedSession {
+    /// Authenticated TLS stream, ready to carry FLAT_FILE request/response
+    /// frames.
     pub stream: TlsStream<TcpStream>,
     /// Bundle string from the METADATA frame, e.g.
     /// `"STOCK.STANDARD, OPTION.PRO, INDEX.FREE"`. Useful for surfacing in
@@ -65,15 +67,11 @@ pub(crate) async fn connect_tls(target: MddsHost<'_>) -> Result<TlsStream<TcpStr
     Ok(tls)
 }
 
-/// Build the CREDENTIALS payload.
-///
-/// Layout (verified live):
-/// ```text
 /// Build the VERSION payload — `[u32 BE jsonlen][json_utf8]`.
 ///
 /// The vendor terminal serialises every JVM system property; the server
-/// only inspects the `terminal.version` key. We send a minimal map so the
-/// server's MDC log shows a recognisable client identity without leaking
+/// only inspects the `terminal.version` key. A minimal map keeps the
+/// server's MDC log showing a recognisable client identity without leaking
 /// host details.
 fn build_version_payload() -> Vec<u8> {
     // Hand-rolled to avoid pulling in serde_json for a 1-line constant. The

--- a/crates/thetadatadx/src/flatfiles/types.rs
+++ b/crates/thetadatadx/src/flatfiles/types.rs
@@ -1,12 +1,20 @@
 //! Public enums for the FLATFILES surface.
+//!
+//! Defines the security and request types a caller selects, plus the typed
+//! reason an unavailable FLATFILES response carries. The reason classifier
+//! ([`FlatFilesUnavailableReason::is_transient`]) drives the request
+//! driver's retry-vs-surface decision.
 
 use std::fmt;
 
 /// Security types accepted by the FLATFILES route.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecType {
+    /// Listed options.
     Option,
+    /// Equities.
     Stock,
+    /// Index instruments.
     Index,
 }
 
@@ -38,15 +46,22 @@ impl fmt::Display for SecType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum ReqType {
+    /// End-of-day summary.
     Eod = 1,
+    /// Best bid/offer quotes.
     Quote = 101,
+    /// Open interest.
     OpenInterest = 103,
+    /// Open/high/low/close bars.
     Ohlc = 104,
+    /// Trades.
     Trade = 201,
+    /// Trades interleaved with the prevailing quote.
     TradeQuote = 207,
 }
 
 impl ReqType {
+    /// Returns the V2 server `ReqType.code()` value for the `REQ=` field.
     pub(crate) fn as_wire(self) -> u32 {
         self as u32
     }

--- a/crates/thetadatadx/src/flatfiles/writer.rs
+++ b/crates/thetadatadx/src/flatfiles/writer.rs
@@ -36,8 +36,25 @@ pub(crate) struct RowView<'a> {
 
 /// Polymorphic row writer.
 pub(crate) trait RowSink {
+    /// Emits any once-per-file header. Called before the first row.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Io` when the underlying writer fails.
     fn write_header(&mut self) -> Result<(), Error>;
+    /// Emits one decoded row.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::decode_codec` when a price column carries an
+    /// out-of-range PRICE_TYPE, or `Error::Io` / encode errors from the
+    /// underlying writer.
     fn write_row(&mut self, row: RowView<'_>) -> Result<(), Error>;
+    /// Flushes and finalizes the sink, consuming it.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Io` when the final flush fails.
     fn finish(self: Box<Self>) -> Result<(), Error>;
 }
 
@@ -131,6 +148,7 @@ fn append_csv_prefix(buf: &mut String, entry: &IndexEntry, sec: SecType) {
 // CSV sink — vendor byte format
 // ---------------------------------------------------------------------------
 
+/// [`RowSink`] that writes the vendor CSV byte format.
 pub(crate) struct CsvSink {
     out: BufWriter<File>,
     sec: SecType,
@@ -142,6 +160,11 @@ pub(crate) struct CsvSink {
 }
 
 impl CsvSink {
+    /// Creates a CSV sink writing to `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Io` when `path` cannot be created.
     pub(crate) fn new(
         path: &Path,
         sec: SecType,
@@ -217,6 +240,7 @@ impl RowSink for CsvSink {
 // JSONL sink — one JSON object per line
 // ---------------------------------------------------------------------------
 
+/// [`RowSink`] that writes one JSON object per line (JSONL).
 pub(crate) struct JsonlSink {
     out: BufWriter<File>,
     sec: SecType,
@@ -226,6 +250,11 @@ pub(crate) struct JsonlSink {
 }
 
 impl JsonlSink {
+    /// Creates a JSONL sink writing to `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Io` when `path` cannot be created.
     pub(crate) fn new(
         path: &Path,
         sec: SecType,

--- a/crates/thetadatadx/src/tdbe/conditions/mod.rs
+++ b/crates/thetadatadx/src/tdbe/conditions/mod.rs
@@ -8,8 +8,7 @@
 //!
 //! The public surface — [`TradeCondition`], [`QuoteCondition`],
 //! [`TRADE_CONDITIONS`], [`QUOTE_CONDITIONS`], and the eight lookup
-//! functions — is unchanged from the previous monolithic
-//! `conditions.rs`.
+//! functions — wraps the generated tables with O(1) array-index lookups.
 
 mod tables_generated;
 

--- a/crates/thetadatadx/src/tdbe/flags.rs
+++ b/crates/thetadatadx/src/tdbe/flags.rs
@@ -8,8 +8,9 @@ pub mod trade {
     /// Cancelled trade condition range (40..=44).
     pub const CANCELLED_RANGE: std::ops::RangeInclusive<i32> = 40..=44;
 
-    /// Regular trading hours: 9:30 AM - 4:00 PM ET.
+    /// Regular trading hours open: 9:30 AM ET, in milliseconds-of-day.
     pub const RTH_START_MS: i32 = 34_200_000;
+    /// Regular trading hours close: 4:00 PM ET, in milliseconds-of-day.
     pub const RTH_END_MS: i32 = 57_600_000;
 
     /// Seller-initiated trade (`ext_condition1` == 12).

--- a/crates/thetadatadx/src/tdbe/greeks.rs
+++ b/crates/thetadatadx/src/tdbe/greeks.rs
@@ -1,4 +1,8 @@
-//! Black-Scholes Greeks calculator, ported from `ThetaData`'s Java implementation.
+//! Black-Scholes option pricing and Greeks calculator.
+//!
+//! Computes the theoretical option value, implied volatility, and the full
+//! first- through third-order Greek surface from the Black-Scholes model
+//! with continuous dividend yield.
 //!
 //! Parameters:
 //! - `s`: Spot price (underlying)
@@ -54,8 +58,9 @@ fn is_degenerate(v: f64, t: f64) -> bool {
 /// of 5 separate multiplies + 5 additions + 4 intermediate power variables.
 /// Same Abramowitz & Stegun coefficients, same max error (~1.5e-7), fewer ops.
 ///
-/// For IV solver loops (128 bisection iterations, each calling `norm_cdf` ~4x),
-/// this is the dominant cost — Horner form shaves ~20% off the polynomial eval.
+/// This is the dominant cost in the IV solver's bisection loop, so the
+/// Horner form (fewer floating-point ops) is preferred over the expanded
+/// polynomial.
 fn norm_cdf(x: f64) -> f64 {
     // Coefficients from Abramowitz & Stegun, formula 26.2.17.
     const A: [f64; 5] = [
@@ -81,6 +86,8 @@ fn norm_cdf(x: f64) -> f64 {
     }
 }
 
+/// Returns the Black-Scholes `d1` term. Yields `0.0` for degenerate inputs
+/// (`v <= 0` or `t <= 0`) so downstream Greeks stay finite.
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names)]
 #[must_use]
@@ -91,6 +98,8 @@ pub fn d1(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     ((s / x).ln() + t * (r - q + v * v / 2.0)) / (v * t.sqrt())
 }
 
+/// Returns the Black-Scholes `d2` term (`d1 - v*sqrt(t)`). Yields `0.0`
+/// for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names)]
 #[must_use]
@@ -144,6 +153,8 @@ pub fn value(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> f
     }
 }
 
+/// Returns delta, the option value's sensitivity to spot. Yields `0.0`
+/// for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -159,6 +170,9 @@ pub fn delta(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> f
     }
 }
 
+/// Returns theta, the option value's sensitivity to time, expressed per
+/// calendar day (annual figure divided by 365). Yields `0.0` for
+/// degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -179,6 +193,8 @@ pub fn theta(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> f
     }
 }
 
+/// Returns vega, the option value's sensitivity to volatility. Yields
+/// `0.0` for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -190,6 +206,8 @@ pub fn vega(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     s * (-q * t).exp() * t.sqrt() * ONE_ROOT2PI * e1_from_d1(d1_val)
 }
 
+/// Returns rho, the option value's sensitivity to the risk-free rate.
+/// Yields `0.0` for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -205,6 +223,8 @@ pub fn rho(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> f64
     }
 }
 
+/// Returns epsilon, the option value's sensitivity to the dividend yield.
+/// Yields `0.0` for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -220,6 +240,10 @@ pub fn epsilon(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) ->
     }
 }
 
+/// Returns lambda (elasticity), the percentage change in option value per
+/// percentage change in spot (`delta * s / value`). Yields `0.0` for
+/// degenerate inputs (`v <= 0` or `t <= 0`); Inf/NaN results are realized
+/// to `0.0`.
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -230,6 +254,9 @@ pub fn lambda(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> 
     realize(delta(s, x, v, r, q, t, is_call) * s / value(s, x, v, r, q, t, is_call))
 }
 
+/// Returns gamma, the rate of change of delta with respect to spot.
+/// Independent of `is_call` (identical for both sides). Yields `0.0` for
+/// degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -241,6 +268,9 @@ pub fn gamma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     (-q * t).exp() / (s * v * t.sqrt()) * ONE_ROOT2PI * e1_from_d1(d1_val)
 }
 
+/// Returns vanna, the sensitivity of delta to volatility (equivalently,
+/// of vega to spot). Yields `0.0` for degenerate inputs (`v <= 0` or
+/// `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -252,6 +282,9 @@ pub fn vanna(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     -(-q * t).exp() * f1(d1_val) * d2_val / v
 }
 
+/// Returns charm, the sensitivity of delta to the passage of time
+/// (delta decay). Yields `0.0` for degenerate inputs (`v <= 0` or
+/// `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -268,6 +301,8 @@ pub fn charm(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool) -> f
     }
 }
 
+/// Returns vomma, the sensitivity of vega to volatility (vega convexity).
+/// Yields `0.0` for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -279,6 +314,8 @@ pub fn vomma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     vega(s, x, v, r, q, t) * (d1_val * d2_val / v)
 }
 
+/// Returns veta, the sensitivity of vega to the passage of time. Yields
+/// `0.0` for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -314,6 +351,9 @@ pub fn vera(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     -x * (-r * t).exp() * t * t.sqrt() * f1(d2_val)
 }
 
+/// Returns speed, the rate of change of gamma with respect to spot (third
+/// derivative of value in spot). Yields `0.0` for degenerate inputs
+/// (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -325,6 +365,8 @@ pub fn speed(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     -(-q * t).exp() * f1(d1_val) / (s * s * v * t.sqrt()) * (d1_val / (v * t.sqrt()) + 1.0)
 }
 
+/// Returns zomma, the sensitivity of gamma to volatility. Yields `0.0`
+/// for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -336,6 +378,8 @@ pub fn zomma(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     (-q * t).exp() * f1(d1_val) * (d1_val * d2_val - 1.0) / (s * v * v * t.sqrt())
 }
 
+/// Returns color, the sensitivity of gamma to the passage of time (gamma
+/// decay). Yields `0.0` for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -350,6 +394,10 @@ pub fn color(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
             + (2.0 * (r - q) * t - d2_val * v * t.sqrt()) / (v * t.sqrt()) * d1_val)
 }
 
+/// Returns ultima, the sensitivity of vomma to volatility (third-order
+/// volatility Greek). The result is clamped to `[-100.0, 100.0]` to bound
+/// the numerically unstable tails. Yields `0.0` for degenerate inputs
+/// (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -363,6 +411,9 @@ pub fn ultima(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64) -> f64 {
     out.clamp(-100.0, 100.0)
 }
 
+/// Returns dual delta, the option value's sensitivity to the strike (the
+/// risk-neutral probability of finishing in the money, signed by side).
+/// Yields `0.0` for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -378,6 +429,8 @@ pub fn dual_delta(s: f64, x: f64, v: f64, r: f64, q: f64, t: f64, is_call: bool)
     }
 }
 
+/// Returns dual gamma, the rate of change of dual delta with respect to
+/// the strike. Yields `0.0` for degenerate inputs (`v <= 0` or `t <= 0`).
 // Reason: s, x, v, r, q, t are standard Black-Scholes parameter names.
 #[allow(clippy::many_single_char_names, clippy::similar_names)]
 #[must_use]
@@ -474,45 +527,73 @@ fn iv_bisection(s: f64, x: f64, r: f64, q: f64, t: f64, o: f64, is_call: bool, o
     out[1] = ((v - o) / o).clamp(-100.0, 100.0);
 }
 
-/// All Greeks computed in a single struct.
+/// Full Greek surface computed in a single pass, with shared intermediates.
+///
+/// Each field carries the same quantity as the like-named free function in
+/// this module; see those for the per-Greek definitions and degenerate-input
+/// behaviour.
 #[derive(Debug, Clone, Copy)]
 pub struct GreeksResult {
+    /// Black-Scholes theoretical option value.
     pub value: f64,
+    /// First derivative of value in spot.
     pub delta: f64,
+    /// Second derivative of value in spot.
     pub gamma: f64,
+    /// Sensitivity to time, per calendar day.
     pub theta: f64,
+    /// Sensitivity to volatility.
     pub vega: f64,
+    /// Sensitivity to the risk-free rate.
     pub rho: f64,
+    /// Implied volatility recovered from the option price.
     pub iv: f64,
+    /// Relative residual of the IV solve (`(value - price) / price`), clamped
+    /// to `[-100.0, 100.0]`.
     pub iv_error: f64,
     // Second order
+    /// Sensitivity of delta to volatility.
     pub vanna: f64,
+    /// Sensitivity of delta to time.
     pub charm: f64,
+    /// Sensitivity of vega to volatility.
     pub vomma: f64,
+    /// Sensitivity of vega to time.
     pub veta: f64,
     /// DvegaDr: `-K * exp(-r*T) * T * sqrt(T) * phi(d2)`. Sensitivity of
     /// vega to the risk-free rate.
     pub vera: f64,
     // Third order
+    /// Sensitivity of gamma to spot.
     pub speed: f64,
+    /// Sensitivity of gamma to volatility.
     pub zomma: f64,
+    /// Sensitivity of gamma to time.
     pub color: f64,
+    /// Sensitivity of vomma to volatility.
     pub ultima: f64,
     // Auxiliary
+    /// Black-Scholes `d1` term.
     pub d1: f64,
+    /// Black-Scholes `d2` term.
     pub d2: f64,
+    /// Sensitivity of value to the strike.
     pub dual_delta: f64,
+    /// Sensitivity of dual delta to the strike.
     pub dual_gamma: f64,
+    /// Sensitivity of value to the dividend yield.
     pub epsilon: f64,
+    /// Elasticity: percentage change in value per percentage change in spot.
     pub lambda: f64,
 }
 
-/// Compute all 23 Greeks at once with maximally shared intermediates.
+/// Computes the full [`GreeksResult`] surface at once with maximally shared
+/// intermediates.
 ///
 /// Precomputes `d1`, `d2`, and all shared sub-expressions (exponentials,
 /// CDF values, products) once, then evaluates Greeks in dependency tiers:
 ///
-/// **Tier 0 — Shared intermediates** (8 precomputed values):
+/// **Tier 0 — Shared intermediates** (precomputed once):
 ///   `sqrt_t`, `v_sqrt_t`, `d1`, `d2`, `exp(-qt)`, `exp(-rt)`, `N(d1)`, `N(d2)`,
 ///   `f1(d1)`, `f1(d2)`, `e1`, `d1*d2`
 ///
@@ -528,8 +609,8 @@ pub struct GreeksResult {
 /// **Auxiliary** (lambda, `dual_delta`, `dual_gamma)`:
 ///   Depend on Tier 1 values.
 ///
-/// This avoids ~20 redundant `d1`/`d2` recalculations and ~40 redundant
-/// `exp()`/`norm_cdf()` calls compared to calling each Greek individually.
+/// This avoids the redundant `d1`/`d2` recalculations and repeated
+/// `exp()`/`norm_cdf()` calls incurred by computing each Greek individually.
 ///
 /// `right` accepts `"C"`/`"P"`/`"call"`/`"put"` case-insensitively (see
 /// [`crate::tdbe::right::parse_right_strict`]).
@@ -595,8 +676,8 @@ pub fn all_greeks(
 /// Use this when the caller already has a recent IV and just wants
 /// the full bundle re-evaluated at new `(s, x, ...)` inputs — the
 /// typical IV-cache hot path. One Tier-0 intermediates pass is
-/// shared across every Greek in the bundle, so this is roughly 2×
-/// faster than issuing 17+ separate per-Greek calls.
+/// shared across every Greek in the bundle, avoiding the repeated
+/// `d1`/`d2`/`exp`/`norm_cdf` work of separate per-Greek calls.
 ///
 /// # Returned `iv_error`
 ///

--- a/crates/thetadatadx/src/tdbe/mod.rs
+++ b/crates/thetadatadx/src/tdbe/mod.rs
@@ -10,7 +10,7 @@
 //! - **Price** -- fixed-point price encoding used by `ThetaData`
 //! - **Enums** -- [`SecType`], [`DataType`], [`StreamMsgType`](types::enums::StreamMsgType), etc.
 //! - **FIT/FIE codecs** -- 4-bit nibble encoding for FPSS tick compression
-//! - **Greeks** -- Black-Scholes option pricing (23 Greeks + IV solver)
+//! - **Greeks** -- Black-Scholes option pricing, Greek surface, and IV solver
 //! - **Error** -- encoding-layer error types
 //! - **Flags** -- bit flags and condition codes for market data records
 //!

--- a/crates/thetadatadx/src/tdbe/types/enums.rs
+++ b/crates/thetadatadx/src/tdbe/types/enums.rs
@@ -1,3 +1,11 @@
+//! Wire enum taxonomy for the FPSS data layer.
+//!
+//! Each enum mirrors a numeric (or short-text) code carried on the wire and
+//! pairs a `from_code` resolver with an `as_str` symbolic form for the dynamic
+//! bindings. `from_code` constructors stay strict — unknown codes return
+//! `None` (or a documented sentinel) so the decoder fails loudly on schema
+//! drift rather than mis-classifying.
+
 /// Security type identifier.
 ///
 /// `Unknown` is a sentinel for contracts whose shape has not yet been resolved.
@@ -19,6 +27,8 @@ pub enum SecType {
 }
 
 impl SecType {
+    /// Resolve a wire security-type code to its variant; `None` for unknown
+    /// codes (including the `Unknown` sentinel, which has no wire form).
     #[must_use]
     pub fn from_code(code: i32) -> Option<Self> {
         match code {
@@ -33,6 +43,7 @@ impl SecType {
         }
     }
 
+    /// Upper-case symbolic name (`"STOCK"`, `"OPTION"`, …) for binding surfaces.
     #[must_use]
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -158,9 +169,10 @@ pub enum DataType {
 }
 
 impl DataType {
+    /// Resolve a wire field-type code to its variant; `None` for codes outside
+    /// the known taxonomy.
     #[must_use]
     pub fn from_code(code: i32) -> Option<Self> {
-        // Generated from the Java enum
         match code {
             0 => Some(Self::Date),
             1 => Some(Self::MsOfDay),
@@ -372,6 +384,8 @@ pub enum ReqType {
 }
 
 impl ReqType {
+    /// Upper-snake symbolic name for the request type (`"QUOTE"`, `"TRADE"`,
+    /// …), falling back to `"DEFAULT"` for unmapped variants.
     #[must_use]
     #[allow(dead_code)] // Reason: paired with the reference `ReqType` enum above; no in-crate caller today.
     pub fn as_str(&self) -> &'static str {
@@ -423,6 +437,8 @@ pub enum StreamMsgType {
 }
 
 impl StreamMsgType {
+    /// Resolve a wire stream-message code to its variant; `None` for unknown
+    /// codes.
     #[inline]
     #[must_use]
     pub fn from_code(code: u8) -> Option<Self> {

--- a/crates/thetadatadx/src/tdbe/types/mod.rs
+++ b/crates/thetadatadx/src/tdbe/types/mod.rs
@@ -1,3 +1,11 @@
+//! Wire data types for the FPSS data layer: tick structs, protocol enums, and
+//! the fixed-point [`price::Price`].
+//!
+//! Splits into three leaves — [`enums`] (wire enum taxonomy), [`price`]
+//! (variable-precision fixed-point price), and [`tick`] (per-tick
+//! `#[repr(C)]` structs) — and re-exports each as a flat facade so callers
+//! reach the leaf types directly off `types`.
+
 pub mod enums;
 pub mod price;
 pub mod tick;

--- a/crates/thetadatadx/src/tdbe/types/price.rs
+++ b/crates/thetadatadx/src/tdbe/types/price.rs
@@ -1,3 +1,12 @@
+//! Variable-precision fixed-point price.
+//!
+//! `ThetaData` encodes a price as a `(value, price_type)` pair where the real
+//! price is `value * 10^(price_type - 10)`. [`Price`] stores that pair and
+//! compares values by scaling to a common base via integer powers of ten,
+//! falling back to f64 only when the exponent gap would overflow `i64`. The
+//! `price_type` invariant (`0..=MAX_PRICE_TYPE`) keeps every `POW10_*` table
+//! index in bounds.
+
 use std::cmp::Ordering;
 use std::fmt;
 

--- a/crates/thetadatadx/src/tdbe/types/tick.rs
+++ b/crates/thetadatadx/src/tdbe/types/tick.rs
@@ -68,32 +68,38 @@ impl_contract_id!(TradeGreeksImpliedVolatilityTick);
 use crate::tdbe::flags;
 
 impl TradeTick {
+    /// `true` when the trade condition falls in the cancellation range.
     #[must_use]
     pub fn is_cancelled(&self) -> bool {
         flags::trade::CANCELLED_RANGE.contains(&self.condition)
     }
 
+    /// `true` when the condition flags carry the "do not update last" bit.
     #[must_use]
     pub fn trade_condition_no_last(&self) -> bool {
         self.condition_flags & flags::condition_flags::NO_LAST == flags::condition_flags::NO_LAST
     }
 
+    /// `true` when the price flags carry the "sets last" bit.
     #[must_use]
     pub fn price_condition_set_last(&self) -> bool {
         self.price_flags & flags::price_flags::SET_LAST == flags::price_flags::SET_LAST
     }
 
+    /// `true` when `volume_type` marks this trade as incremental volume.
     #[must_use]
     pub fn is_incremental_volume(&self) -> bool {
         self.volume_type == flags::volume::INCREMENTAL
     }
 
-    /// Regular trading hours: 9:30 AM - 4:00 PM ET.
+    /// `true` when `ms_of_day` falls within regular trading hours
+    /// (9:30 AM - 4:00 PM ET).
     #[must_use]
     pub fn regular_trading_hours(&self) -> bool {
         (flags::trade::RTH_START_MS..=flags::trade::RTH_END_MS).contains(&self.ms_of_day)
     }
 
+    /// `true` when the extended condition marks this trade as seller-initiated.
     #[must_use]
     pub fn is_seller(&self) -> bool {
         self.ext_condition1 == flags::trade::SELLER_CONDITION


### PR DESCRIPTION
Audit-and-fill documentation pass over the hand-written flatfiles and tdbe modules, bringing each file to the crate documentation standard: a module header on every file, a one-line purpose on every public item, and `# Errors` / `# Panics` notes wherever a public function can fail or panic. Already-compliant docs were left untouched to avoid churn.

Flatfiles: documented the `Frame` fields and the `# Errors` conditions on `write_frame` / `read_frame`, stated the SPKI-pinning trust invariant on `MddsSpkiVerifier`, repaired a malformed version-payload doc comment, and documented the `SecType` / `ReqType` variants and the `RowSink` / `CsvSink` / `JsonlSink` surface.

tdbe: added the missing module headers on the wire-enum, fixed-point price, and types facade modules, documented the wire-enum constructors and accessors, documented the Greeks per-primitive functions and their degenerate-input behavior, and documented the remaining `TradeTick` condition accessors. Dropped unverifiable Greek counts in favor of the actual surface and rephrased historical and source-derivation framing into factual statements of what the code computes.

The generated outputs under `tdbe/types/generated/**` and `tdbe/conditions/tables_generated.rs` were left to the emitter pass and not touched here.

Comments and docstrings only; the diff contains no code, signature, or behavior changes. Verified: `cargo fmt --all -- --check`, `cargo clippy -p thetadatadx -- -D warnings`, `cargo test -p thetadatadx --doc` (17 passed), `generate_docs_site --check`, and `check_public_surface_leak.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)