### PR TITLE
docs(mdds): bring MDDS and gRPC modules to the documentation bar

### DIFF
--- a/crates/thetadatadx/src/grpc/channel.rs
+++ b/crates/thetadatadx/src/grpc/channel.rs
@@ -11,7 +11,8 @@
 //! [`Channel::server_streaming`] sends a single server-streaming RPC and
 //! returns a [`ServerStreaming`] that yields decoded response messages.
 //! Per-chunk payload decode (zstd + prost `DataTable`) runs inline on
-//! the request task — the measured-fastest shape for this workload.
+//! the request task, keeping each chunk on its producing connection and
+//! avoiding a cross-thread hand-off for this workload.
 //!
 //! # Connector
 //!
@@ -71,8 +72,7 @@ impl Default for ChannelTuning {
     fn default() -> Self {
         Self {
             // HTTP/2 spec initial windows (64 KiB) — the same wire
-            // shape the production config defaults to and the shape
-            // the transport comparison was measured at.
+            // shape the production config defaults to.
             initial_stream_window_size: 64 * 1024,
             initial_connection_window_size: 64 * 1024,
             keepalive_interval: Duration::from_secs(30),
@@ -629,8 +629,8 @@ fn deadline_error(d: Duration) -> ChannelError {
 /// statuses the decode layer synthesizes locally for protocol-shape
 /// violations (over-limit frames map to the canonical `OutOfRange`,
 /// malformed framing to `Internal`), which carry no source either —
-/// both are terminal for the retry shell, matching the previous
-/// transport's codec-error classification.
+/// a protocol-shape violation is deterministic, so both are terminal
+/// for the retry shell rather than transient.
 ///
 /// A status WITH a source chain is a locally-synthesized wrapper
 /// around a transport fault; the chain is walked for the precise
@@ -640,16 +640,16 @@ fn deadline_error(d: Duration) -> ChannelError {
 ///   surfaces as [`ChannelError::DeadlineExceeded`].
 /// - `tonic::ConnectError` — the lazy reconnect path failed to dial;
 ///   connection-level, surfaces as [`ChannelError::ConnectionClosed`].
-/// - [`h2::Error`] — scoped by the same rules the previous transport
-///   used: `GOAWAY` / IO failure / "inactive stream" are
-///   connection-level ([`ChannelError::ConnectionClosed`]); per-stream
-///   `RST_STREAM` (any reason code) and library-detected per-stream
-///   protocol errors are stream-level ([`ChannelError::H2Stream`]).
-///   HTTP/2 spec § 7 (Error Codes) is the canonical scope list.
+/// - [`h2::Error`] — scoped by HTTP/2 error semantics: `GOAWAY` / IO
+///   failure / "inactive stream" are connection-level
+///   ([`ChannelError::ConnectionClosed`]); per-stream `RST_STREAM`
+///   (any reason code) and library-detected per-stream protocol errors
+///   are stream-level ([`ChannelError::H2Stream`]). HTTP/2 spec § 7
+///   (Error Codes) is the canonical scope list.
 /// - [`std::io::Error`] — transport gone; connection-level.
 /// - An exhausted chain falls back to connection-level: an unknown
-///   local transport fault is retried on a fresh pick, mirroring the
-///   previous transport's open-phase classification.
+///   local transport fault is treated as transient and retried on a
+///   fresh pick.
 pub(crate) fn classify_status(status: tonic::Status, deadline_ms: Option<u64>) -> ChannelError {
     use std::error::Error as _;
     if status.source().is_none() {

--- a/crates/thetadatadx/src/grpc/mod.rs
+++ b/crates/thetadatadx/src/grpc/mod.rs
@@ -25,8 +25,9 @@
 //! - [`endpoints`] — a hand-written example RPC plus bench helpers.
 //!
 //! Per-chunk decode (zstd decompress + prost `DataTable` decode) runs
-//! inline on the request task — measured faster than handing chunks to
-//! a dedicated decoder pool at every production-reachable concurrency.
+//! inline on the request task rather than on a dedicated decoder pool,
+//! keeping each chunk on the connection that produced it and avoiding
+//! cross-thread hand-off at every production-reachable concurrency.
 //!
 //! # Surface hygiene
 //!

--- a/crates/thetadatadx/src/grpc/pool.rs
+++ b/crates/thetadatadx/src/grpc/pool.rs
@@ -5,11 +5,10 @@
 //! window and `MAX_CONCURRENT_STREAMS` is finite. [`ChannelPool`] keeps
 //! `N` parallel channels — one HTTP/2 connection each — and hands them
 //! out via [`ChannelPool::next`], picking the channel with the fewest
-//! in-flight streams. Measured against a single multiplexed connection
-//! carrying the same workload, the per-worker connection fan-out
-//! delivers roughly 1.8x the small-frame throughput and 2.3x the
-//! large-frame throughput at the 16-concurrent account ceiling, so the
-//! pool survives the transport swap unchanged.
+//! in-flight streams. Spreading concurrent work across several
+//! connections gives each its own flow-control window and stream
+//! budget, so a saturated stream count on one connection does not
+//! throttle the others the way a single multiplexed connection would.
 //!
 //! The pool is `Arc`-clone-cheap and `Send + Sync`; callers can clone
 //! it freely across tasks. Each [`ChannelPool::next`] returns a lease

--- a/crates/thetadatadx/src/mdds/client.rs
+++ b/crates/thetadatadx/src/mdds/client.rs
@@ -93,7 +93,7 @@ impl MddsClient {
     /// 2. Opens a gRPC channel (TLS) to the MDDS server.
     ///
     /// The FPSS (real-time streaming) connection is not established here;
-    /// it will be added in a future release.
+    /// this constructor covers only the MDDS historical-data channel.
     /// # Errors
     ///
     /// Returns an error on network, authentication, or parsing failure.
@@ -323,10 +323,10 @@ impl MddsClient {
 ///
 /// ThetaData enforces a hard server-side cap on concurrent in-flight
 /// gRPC requests per tier (Free=1 / Value=2 / Standard=4 / Pro=8).
-/// A caller asking for `concurrent_requests = 32` on a Pro tier
-/// previously got 32 channels opened; the (Pro_cap + 1)-th RPC then
-/// failed with an upstream `ResourceExhausted` per-stream rejection,
-/// which the SDK retried on a different channel, producing a confusing
+/// Without the clamp, a caller asking for `concurrent_requests = 32`
+/// on a Pro tier opens 32 channels; the (Pro_cap + 1)-th RPC then
+/// fails with an upstream `ResourceExhausted` per-stream rejection,
+/// which the SDK retries on a different channel, producing a confusing
 /// "everything fails intermittently" symptom. Clamping locally
 /// surfaces the misconfiguration as a `tracing::warn!` on connect and
 /// keeps the live pool inside the tier's headroom.
@@ -388,9 +388,10 @@ fn effective_pool_size(
 /// layer rather than buffered past the configured bound.
 ///
 /// Per-chunk payload decode (zstd + protobuf) runs inline on each
-/// request's task — measured faster than a dedicated decode pool at
-/// every production-reachable concurrency, including multi-chunk
-/// fan-in.
+/// request's task rather than a dedicated decode pool, keeping each
+/// chunk on its producing connection and avoiding cross-thread
+/// hand-off at every production-reachable concurrency, including
+/// multi-chunk fan-in.
 async fn open_channel_pool(
     host: &str,
     port: u16,

--- a/crates/thetadatadx/src/mdds/decode/error.rs
+++ b/crates/thetadatadx/src/mdds/decode/error.rs
@@ -62,11 +62,10 @@ pub enum DecodeError {
         available: String,
     },
     /// A mid-stream gRPC chunk carries a header set that does not match the
-    /// header set established by the first chunk. The stream accumulator
-    /// used to silently retain the first header set and accumulate rows
-    /// from every chunk underneath it, which would transparently corrupt
-    /// a row set if the server's wire schema changed mid-response. This
-    /// variant surfaces the drift instead of hiding it.
+    /// header set established by the first chunk. Retaining the first chunk's
+    /// header set while accumulating rows from a diverging chunk would
+    /// transparently corrupt the row set, so the accumulator surfaces the
+    /// drift as this error rather than hiding it.
     #[error(
         "chunk {chunk_index} headers drifted from first-chunk schema; \
          first: [{first}]; chunk: [{chunk}]"
@@ -79,11 +78,10 @@ pub enum DecodeError {
     /// A `Text` cell in a date-typed column did not match the documented
     /// ISO `YYYY-MM-DD` or compact `YYYYMMDD` shapes. The v3 wire path
     /// publishes some date columns (notably `interest_rate_history_eod.created`,
-    /// `calendar_day.date`, and `OptionContract.expiration`) as text;
-    /// previously a malformed value coalesced silently to `0`. Surfacing
-    /// this as an error mirrors the strict-decode policy on every other
-    /// column type and prevents silent corruption of downstream
-    /// timestamps.
+    /// `calendar_day.date`, and `OptionContract.expiration`) as text.
+    /// Surfacing a malformed value as an error rather than coalescing it to
+    /// `0` mirrors the strict-decode policy on every other column type and
+    /// prevents silent corruption of downstream timestamps.
     #[error("invalid date text {raw:?} (expected YYYY-MM-DD or YYYYMMDD)")]
     InvalidDate {
         /// The exact text that failed to parse, captured verbatim from
@@ -92,8 +90,8 @@ pub enum DecodeError {
     },
     /// A `Text` cell in a time-typed column did not match the documented
     /// `HH:MM:SS` shape. Used on the v3 calendar `open` / `close`
-    /// columns. Previously a malformed value coalesced silently to `0`;
-    /// surfacing this prevents silent corruption of trading-session
+    /// columns. Surfacing a malformed value as an error rather than
+    /// coalescing it to `0` prevents silent corruption of trading-session
     /// timestamps in downstream consumers.
     #[error("invalid time text {raw:?} (expected HH:MM:SS)")]
     InvalidTime {
@@ -104,10 +102,10 @@ pub enum DecodeError {
     /// A `Text` cell in an enum-typed column carried a value outside the
     /// documented vendor vocabulary. Used on the v3 `right` (option
     /// CALL/PUT) and calendar `type` (open / early_close / full_close /
-    /// weekend) columns. Previously an unknown variant fell through to
-    /// `0` (right) or `CALENDAR_STATUS_UNKNOWN` (calendar), masking
-    /// schema drift from upstream. Surfacing this as an error matches
-    /// the strict-decode policy on every other typed column.
+    /// weekend) columns. Surfacing an unknown variant as an error rather
+    /// than folding it to a default (`0` for `right`, an unknown-status
+    /// sentinel for calendar) keeps upstream schema drift visible and
+    /// matches the strict-decode policy on every other typed column.
     #[error("unknown enum variant {raw:?} on field `{field}`")]
     UnknownEnumVariant {
         /// Static name of the wire column (`right`, `calendar.type`,

--- a/crates/thetadatadx/src/mdds/decode/mod.rs
+++ b/crates/thetadatadx/src/mdds/decode/mod.rs
@@ -13,9 +13,8 @@
 //! | [`dual_type_columns`] | Hand-written parsers for columns that arrive as either `Number` or `Text` on the v3 wire (`parse_option_contracts_v3`, …) |
 //!
 //! Public API surface is preserved at `thetadatadx::decode::*` via the
-//! crate-root re-export of this module. Eastern-time / DST primitives
-//! previously living here have moved to [`crate::tdbe::time`] and are reused by
-//! the FPSS latency path.
+//! crate-root re-export of this module. Eastern-time / DST primitives live in
+//! [`crate::tdbe::time`] and are reused by the FPSS latency path.
 
 pub mod cell;
 pub(crate) mod column;

--- a/crates/thetadatadx/src/mdds/decode/tests.rs
+++ b/crates/thetadatadx/src/mdds/decode/tests.rs
@@ -681,8 +681,8 @@ fn parse_trade_ticks_propagates_type_mismatch() {
 // A `DataValue` with its `data_type` oneof unset is a wire-protocol
 // anomaly (the upstream parser's default arm throws on it). The
 // helpers `row_number` / `row_date` /
-// etc. already surface it as `TypeMismatch { observed: "Unset" }`. These
-// tests pin the same behaviour on the call-sites that used to coalesce
+// etc. surface it as `TypeMismatch { observed: "Unset" }`. These
+// tests pin that behaviour on the call-sites that must not coalesce
 // `NullValue | None` to zero: `parse_option_contracts_v3`,
 // `parse_calendar_days_v3`, the generator-emitted EOD helpers, and the
 // generator-emitted contract-id injected `expiration` / `right` fields.
@@ -782,8 +782,8 @@ fn parse_eod_ticks_errors_on_unset_cell() {
 fn parse_trade_ticks_errors_on_unset_injected_expiration() {
     // `parse_trade_ticks` is generator-emitted with `contract_id = true`;
     // an `expiration` header in the server payload triggers the injected
-    // `expiration` / `strike` / `right` decode. An unset cell there used
-    // to coalesce to 0; now it must fail loud.
+    // `expiration` / `strike` / `right` decode. An unset cell there must
+    // fail loud rather than coalesce to 0.
     let table = proto::DataTable {
         headers: vec!["ms_of_day".into(), "price".into(), "expiration".into()],
         data_table: vec![row_of(vec![
@@ -964,7 +964,7 @@ fn parse_greeks_all_ticks_decodes_first_order_subset_with_silent_gaps() {
     // Wire-absent columns: zero-defaulted. These are the columns the
     // server does NOT publish for `_greeks_first_order` — `find_header`
     // returning `None` for each must NOT yield an error and must NOT
-    // warn (the pre-fix behaviour spammed eight warn lines per row).
+    // warn (an unguarded lookup would emit eight warn lines per row).
     assert_eq!(t.gamma, 0.0);
     assert_eq!(t.vanna, 0.0);
     assert_eq!(t.charm, 0.0);
@@ -1030,12 +1030,12 @@ fn parse_greeks_all_ticks_decodes_second_order_subset_with_silent_gaps() {
 }
 
 /// Vendor wire shape for `option_*_greeks_third_order`: speed / zomma /
-/// color / ultima plus IV pair. This is the exact endpoint the Issue
-/// #472 reporter was hitting — `option_snapshot_greeks_third_order`
-/// previously emitted eight warn lines per row for the absent
-/// first-order / second-order / `_all`-only columns. The test pins the
-/// silent-gap behaviour so a future regression of `find_header` back
-/// to `tracing::warn!` would surface here as a behavioural change.
+/// color / ultima plus IV pair. `option_snapshot_greeks_third_order`
+/// omits the first-order / second-order / `_all`-only columns, so an
+/// unguarded `find_header` would emit eight warn lines per row for the
+/// absent columns. The test pins the silent-gap behaviour so a
+/// regression of `find_header` back to `tracing::warn!` would surface
+/// here as a behavioural change.
 /// Column layout pinned to upstream OpenAPI schema
 /// `items_option_snapshot_greeks_third_order` (notably `vera` is NOT
 /// in the third-order subset; it only ships in `_greeks_all`).

--- a/crates/thetadatadx/src/mdds/decode/transport.rs
+++ b/crates/thetadatadx/src/mdds/decode/transport.rs
@@ -211,8 +211,9 @@ mod r1_tests {
     /// Proof: a hostile `ResponseData.original_size`
     /// larger than `max_message_size` returns a typed
     /// `MessageTooLarge` error BEFORE any allocation runs. Pinned at
-    /// 2 GiB advertised vs 4 MiB ceiling — historically this triggered
-    /// the runaway allocation; the fix returns a clean error.
+    /// 2 GiB advertised vs 4 MiB ceiling — the size guard must reject
+    /// the advertised expansion rather than letting it drive a runaway
+    /// `Vec::resize`.
     #[test]
     fn hostile_original_size_rejected_before_alloc() {
         let mut response = proto::ResponseData {
@@ -220,9 +221,9 @@ mod r1_tests {
                 algo: proto::CompressionAlgo::Zstd as i32,
                 level: 0,
             }),
-            // 2 GiB advertised expansion — would have triggered a
-            // `Vec::resize(usize::try_from(i32::MAX), 0)` before R1.
-            // `original_size` is a wire-protocol `i32`; the v9 hostile
+            // 2 GiB advertised expansion — an unguarded path would feed
+            // this straight into `Vec::resize(usize::try_from(i32::MAX), 0)`.
+            // `original_size` is a wire-protocol `i32`; the hostile
             // value `i32::MAX` is the upper bound a peer can set.
             original_size: i32::MAX,
             // Empty payload — never reached because original_size

--- a/crates/thetadatadx/src/mdds/endpoint_args.rs
+++ b/crates/thetadatadx/src/mdds/endpoint_args.rs
@@ -117,6 +117,11 @@ impl EndpointArgs {
     }
 
     /// Parse a raw string according to registry metadata and insert it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EndpointError::InvalidParams`] when `raw` does not parse as
+    /// the type `param_type` requires.
     pub fn insert_raw(
         &mut self,
         key: &str,
@@ -511,6 +516,13 @@ pub enum EndpointOutput {
 /// returns `EndpointError::Server(Error::Timeout { duration_ms })`.
 /// Subsequent calls on the same `MddsClient` succeed.
 ///
+/// # Errors
+///
+/// Returns [`EndpointError::UnknownEndpoint`] for an unrecognized `name`,
+/// [`EndpointError::InvalidParams`] for malformed `args`, and
+/// [`EndpointError::Server`] for transport, auth, or deadline failures
+/// (including `Error::Timeout` when `args.timeout_ms()` expires).
+///
 /// Only present when the `__internal` feature is enabled.
 #[cfg(feature = "__internal")]
 pub async fn invoke_endpoint(
@@ -549,6 +561,13 @@ pub async fn invoke_endpoint(
 /// `EndpointError::Server(Error::Timeout { duration_ms })`. The handler is
 /// guaranteed not to be invoked again once the deadline fires.
 ///
+/// # Errors
+///
+/// Same error surface as [`invoke_endpoint`]:
+/// [`EndpointError::UnknownEndpoint`] for an unrecognized `name`,
+/// [`EndpointError::InvalidParams`] for malformed `args`, and
+/// [`EndpointError::Server`] for transport, auth, or deadline failures.
+///
 /// Only present when the `__internal` feature is enabled.
 #[cfg(feature = "__internal")]
 pub async fn invoke_endpoint_stream(
@@ -570,6 +589,11 @@ pub async fn invoke_endpoint_stream(
 }
 
 /// Parse a raw string value according to registry metadata into a typed endpoint arg.
+///
+/// # Errors
+///
+/// Returns [`EndpointError::InvalidParams`] when `raw` cannot be parsed as the
+/// numeric or boolean shape `param_type` demands; string-typed params never error.
 ///
 /// Only present when the `__internal` feature is enabled.
 #[cfg(feature = "__internal")]
@@ -749,7 +773,7 @@ mod tests {
 
     #[test]
     fn required_expiration_rejects_invalid_formats() {
-        // ISO-dashed `YYYY-MM-DD` is now valid; assert on an actually-invalid form.
+        // ISO-dashed `YYYY-MM-DD` is accepted; assert on an actually-invalid form.
         let mut args = EndpointArgs::new();
         args.insert(
             "expiration".into(),

--- a/crates/thetadatadx/src/mdds/endpoints.rs
+++ b/crates/thetadatadx/src/mdds/endpoints.rs
@@ -118,12 +118,10 @@ impl From<&[String]> for SymbolInput {
 /// rather than forwarding a string the upstream cannot serve. Daily
 /// bars come from the `*_history_eod` endpoints.
 ///
-/// The historical SDK accepted `"0"` and silently mapped it to
-/// `"100ms"`. That contradicted the previously-documented behaviour
-/// (`"0"` was advertised as "every quote change"), so `"0"` now snaps
-/// to `"tick"` — which is the upstream every-event vocabulary. Calls
-/// that depended on the silent-100ms behaviour should switch to an
-/// explicit preset.
+/// The `"0"` sentinel snaps to `"tick"` — the upstream every-event
+/// vocabulary — so the zero input maps to every-event sampling rather
+/// than a silent fixed-bar default. Callers wanting a fixed bar should
+/// pass an explicit preset.
 fn normalize_interval(interval: &str) -> String {
     if interval.ends_with('s') || interval.ends_with('m') || interval.ends_with('h') {
         return interval.to_string();
@@ -158,10 +156,9 @@ fn normalize_interval(interval: &str) -> String {
 /// Convert `time_of_day` values into the canonical `HH:MM:SS.SSS` format.
 ///
 /// ThetaData's v3 at-time endpoints expect a formatted ET wall-clock time
-/// such as `"09:30:00.000"`. Older ThetaDataDxClient docs and examples used
-/// millisecond strings like `"34200000"`. To preserve compatibility while
-/// aligning the public contract, this helper accepts either form and
-/// normalizes to `HH:MM:SS.SSS`.
+/// such as `"09:30:00.000"`. This helper also accepts a millisecond-of-day
+/// string like `"34200000"` and normalizes either form to `HH:MM:SS.SSS`,
+/// so both the formatted and millisecond inputs reach the server canonical.
 ///
 /// Invalid or out-of-range values are passed through unchanged so the
 /// server can return the canonical validation error.
@@ -313,17 +310,17 @@ mod tests {
 
     #[test]
     fn normalize_interval_snaps_zero_to_tick() {
-        // The historical mapping was `0 -> 100ms`, which contradicted
-        // the previously-documented every-event semantics. The upstream
-        // `tick` keyword is the every-event vocabulary, so the zero
-        // sentinel snaps to it instead.
+        // The upstream `tick` keyword is the every-event vocabulary, so
+        // the zero sentinel snaps to it (every-event sampling) rather
+        // than a fixed sub-second bar.
         assert_eq!(normalize_interval("0"), "tick");
     }
 
     #[test]
     fn normalize_interval_snaps_small_milliseconds_to_documented_presets() {
-        // 10ms-and-under -> 10ms; 11-100ms -> 100ms. The earlier
-        // 0..=100 -> 100ms mapping skipped the 10ms preset entirely.
+        // 10ms-and-under -> 10ms; 11-100ms -> 100ms. Each sub-100ms
+        // input snaps to the nearest documented preset, including the
+        // 10ms bar.
         assert_eq!(normalize_interval("10"), "10ms");
         assert_eq!(normalize_interval("11"), "100ms");
         assert_eq!(normalize_interval("100"), "100ms");

--- a/crates/thetadatadx/src/mdds/macros.rs
+++ b/crates/thetadatadx/src/mdds/macros.rs
@@ -26,6 +26,11 @@
 /// the future is wrapped in [`tokio::time::timeout`]; on elapsed the future
 /// is dropped and `Error::Timeout { duration_ms }` is returned. Local state
 /// captured by the future (`_permit`, `tonic::Streaming`) drops with it.
+///
+/// # Errors
+///
+/// Returns `Error::Timeout` when the deadline elapses; otherwise propagates
+/// whatever error the wrapped future resolves to.
 pub(crate) async fn run_with_optional_deadline<F, T>(
     deadline: Option<std::time::Duration>,
     fut: F,
@@ -76,8 +81,8 @@ enum StatusClass {
 ///
 /// Exists as a free function so the macros can call it with a plain
 /// `Result` produced by their owned request + stream + collect chain,
-/// avoiding the higher-ranked trait bounds that broke the previous
-/// closure-based helper.
+/// avoiding the higher-ranked trait bounds a closure-based helper
+/// would impose.
 pub(crate) async fn classify_attempt<T>(
     session: &crate::auth::SessionToken,
     snap: &crate::auth::session::SessionSnapshot,
@@ -253,8 +258,8 @@ pub(crate) async fn classify_streaming_attempt(
 
 /// Drive the unary endpoint retry / refresh loop.
 ///
-/// Single source of truth for the control flow previously open-coded
-/// in three macro arms. The closure receives the current session
+/// Single source of truth for the retry / refresh control flow shared
+/// by the endpoint macro arms. The closure receives the current session
 /// snapshot and returns the per-attempt result; the helper handles
 /// snapshotting, classification, refresh, backoff, and the
 /// post-refresh re-attempt budget.
@@ -264,6 +269,12 @@ pub(crate) async fn classify_streaming_attempt(
 /// (budget = 1), a single `Unauthenticated` triggers refresh + one
 /// post-refresh re-attempt. Subsequent failures surface to the
 /// caller.
+///
+/// # Errors
+///
+/// Returns the last attempt's [`crate::error::Error`] once the retry
+/// budget or wall-clock envelope is exhausted, or a terminal error
+/// (including a failed session refresh) surfaced unchanged.
 pub(crate) async fn run_unary_retry_loop<T, F, Fut>(
     session: &crate::auth::SessionToken,
     policy: &crate::config::RetryPolicy,
@@ -324,6 +335,12 @@ where
 /// `Unauthenticated` triggers refresh + restart from chunk zero
 /// (MDDS has no resume token); the closure is invoked again with
 /// the post-refresh snapshot.
+///
+/// # Errors
+///
+/// Returns the last attempt's [`crate::error::Error`] once the retry
+/// budget or wall-clock envelope is exhausted, or a terminal error
+/// (including a failed session refresh) surfaced unchanged.
 pub(crate) async fn run_streaming_retry_loop<F, Fut>(
     session: &crate::auth::SessionToken,
     policy: &crate::config::RetryPolicy,
@@ -526,11 +543,10 @@ macro_rules! list_endpoint {
                     };
                     // Bind the lease to a local so it lives across
                     // the await — the pre-dispatch reservation
-                    // must outlive `server_streaming` for the
-                    // picker fix (Finding 4) to count pending
-                    // opens correctly under burst contention.
-                    // Deref coercion from `&ChannelLease` to
-                    // `&Channel` satisfies the generated stub
+                    // must outlive `server_streaming` so the picker
+                    // counts pending opens correctly under burst
+                    // contention. Deref coercion from `&ChannelLease`
+                    // to `&Channel` satisfies the generated stub
                     // signature.
                     let lease = self.channel();
                     let stream = $crate::proto::beta_theta_terminal::$grpc(
@@ -825,10 +841,10 @@ macro_rules! parsed_endpoint {
                         // Strict decode: type mismatch in any cell propagates
                         // as Error::Decode via `From<DecodeError>`.
                         let parsed = $parser(&table).map_err(Error::from)?;
-                        // Issue #576: surface the wrong-API-for-this-workload
+                        // Surface the wrong-API-for-this-workload
                         // signal exactly once per request, after the buffered
-                        // `Vec` materialized — before this point we don't yet
-                        // know the row count, after this point the caller has
+                        // `Vec` materialized — before this point the row count
+                        // is unknown, after this point the caller has
                         // already paid the buffered cost. `row_count` is the
                         // length the caller is about to receive; `row_size`
                         // is the wire-shape lower bound (`size_of::<Item>`).
@@ -1542,7 +1558,7 @@ mod refresh_retry_disabled_tests {
 
 #[cfg(test)]
 mod warn_buffered_tests {
-    //! Coverage for the issue #576 large-buffered-response warn helper.
+    //! Coverage for the large-buffered-response warn helper.
     //!
     //! Two layers of tests:
     //!

--- a/crates/thetadatadx/src/mdds/registry.rs
+++ b/crates/thetadatadx/src/mdds/registry.rs
@@ -33,9 +33,13 @@
 #[cfg(feature = "__internal")]
 #[derive(Debug, Clone)]
 pub struct ParamMeta {
+    /// Parameter name as accepted on the call (e.g. `"symbol"`).
     pub name: &'static str,
+    /// Human-readable description surfaced in CLI/MCP help.
     pub description: &'static str,
+    /// Scalar type the value is parsed into.
     pub param_type: ParamType,
+    /// Whether the parameter must be supplied by the caller.
     pub required: bool,
 }
 

--- a/crates/thetadatadx/src/mdds/stream.rs
+++ b/crates/thetadatadx/src/mdds/stream.rs
@@ -36,6 +36,13 @@ impl MddsClient {
     /// which processes each chunk without materializing all rows in memory.
     ///
     /// [`for_each_chunk`]: Self::for_each_chunk
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] when a chunk fails to decompress or decode, when a
+    /// chunk exceeds the channel's `max_message_size` ceiling, or when
+    /// mid-stream headers drift from the first chunk's schema
+    /// ([`decode::DecodeError::ChunkHeaderDrift`]).
     pub(crate) async fn collect_stream(
         &self,
         mut stream: ServerStreaming<proto::ResponseData>,
@@ -53,7 +60,7 @@ impl MddsClient {
             // Each DataValueList row is ~64 bytes on average (header-dependent),
             // so original_size / 64 gives a reasonable row-count estimate.
             //
-            // R1 bound: cap the hint at `max_message_size` so a hostile
+            // Cap the hint at `max_message_size` so a hostile
             // `original_size = i32::MAX` cannot inflate `all_rows`'
             // capacity past the channel's configured ceiling before the
             // decompression layer rejects the payload.
@@ -66,10 +73,10 @@ impl MddsClient {
             if headers.is_empty() {
                 headers = table.headers;
             } else if !table.headers.is_empty() && table.headers != headers {
-                // Mid-stream schema drift. The old accumulator silently kept
-                // the first chunk's headers and piled rows under them; surface
-                // the mismatch instead so downstream decoders do not read
-                // columns under the wrong names.
+                // Mid-stream schema drift: surface the mismatch so
+                // downstream decoders do not read columns under the wrong
+                // names. Silently keeping the first chunk's headers and
+                // piling later rows under them would mislabel the data.
                 return Err(decode::DecodeError::ChunkHeaderDrift {
                     chunk_index,
                     first: headers.join(","),
@@ -133,9 +140,9 @@ impl MddsClient {
     {
         // Preserve first-chunk headers across all chunks, matching
         // collect_stream behavior. Reject any mid-stream chunk whose
-        // non-empty headers disagree with the first-chunk schema: accepting
-        // them silently would let the callback read columns under the wrong
-        // names, which is the exact failure mode P13 asked to close.
+        // non-empty headers disagree with the first-chunk schema:
+        // accepting them silently would let the callback read columns
+        // under the wrong names.
         let mut saved_headers: Option<Vec<String>> = None;
         let mut chunk_index: usize = 0;
         let max_message_size = stream.max_message_size();
@@ -167,9 +174,9 @@ impl MddsClient {
 }
 
 /// Decode a single `ResponseData` chunk (zstd decompress + `DataTable`
-/// decode) inline on the caller's task — the measured-fastest shape
-/// for this workload at every production-reachable concurrency,
-/// including multi-chunk streams.
+/// decode) inline on the caller's task, keeping the chunk on its
+/// producing connection and avoiding cross-thread hand-off at every
+/// production-reachable concurrency, including multi-chunk streams.
 fn decode_chunk(
     response: proto::ResponseData,
     max_message_size: usize,
@@ -180,8 +187,8 @@ fn decode_chunk(
 
 #[cfg(test)]
 mod streaming_decode_contract {
-    //! Issue #565 contract pin: the chunk-by-chunk decode primitive that
-    //! the generated `.stream(handler)` method on every parsed builder
+    //! Contract pin: the chunk-by-chunk decode primitive that the
+    //! generated `.stream(handler)` method on every parsed builder
     //! routes through must surface chunks ONE AT A TIME and never carry
     //! a per-chunk `proto::DataTable` past its handler invocation.
     //!

--- a/crates/thetadatadx/src/mdds/validate.rs
+++ b/crates/thetadatadx/src/mdds/validate.rs
@@ -10,10 +10,9 @@
 //! TOML surface spec and proto schema — a fundamentally different
 //! domain — so they remain separate.
 //!
-//! This module merges the previous top-level `crate::validate` and the
-//! single-arg `crate::mdds::validate` adapter. The two-argument
-//! canonical validators sit at the top; the single-arg adapters used
-//! by the generated builder macros sit below.
+//! The two-argument canonical validators (which take a parameter name
+//! for diagnostics) sit at the top; the single-arg adapters used by
+//! the generated builder macros sit below.
 
 use crate::error::Error;
 use crate::mdds::endpoint_args::EndpointError;
@@ -91,6 +90,12 @@ fn parse_iso_date_components(value: &str) -> Option<(i32, u32, u32)> {
 /// shape the caller used. ISO-dashed input is canonicalized to the
 /// compact wire form by [`crate::mdds::wire_semantics::normalize_date`]
 /// at request-construction time, mirroring `normalize_expiration`.
+///
+/// # Errors
+///
+/// Returns [`EndpointError::InvalidParams`] when `value` matches neither
+/// accepted shape or names a calendar-impossible date (e.g. `20260230`,
+/// the `00000000` sentinel, a year outside 1900-2100).
 pub(crate) fn validate_date(value: &str, param_name: &str) -> Result<(), EndpointError> {
     // ISO-dashed shape (`YYYY-MM-DD`): parse components and run the
     // same calendar check the compact path uses. Date-typed formatters
@@ -107,7 +112,7 @@ pub(crate) fn validate_date(value: &str, param_name: &str) -> Result<(), Endpoin
     }
     // Shape passed; now apply the calendar check. Rejects the
     // `00000000` sentinel and impossible dates like `20260230` or
-    // `19990431` that the shape-only check used to silently accept.
+    // `19990431` that a shape-only check would silently accept.
     let yyyymmdd: i32 = value.parse().map_err(|_| {
         EndpointError::InvalidParams(format!(
             "'{param_name}' must be 8 digits (YYYYMMDD), got: '{value}'"
@@ -126,6 +131,12 @@ pub(crate) fn validate_date(value: &str, param_name: &str) -> Result<(), Endpoin
 /// Both dated forms are calendar-checked — `2026-02-30`,
 /// `2026-13-01`, and `2026-04-31` are rejected on every public input
 /// regardless of which textual shape the caller used.
+///
+/// # Errors
+///
+/// Returns [`EndpointError::InvalidParams`] when `value` is neither a
+/// wildcard (`*` / `0`) nor a calendar-valid date in either accepted
+/// shape.
 ///
 /// Only compiled under `__internal` — called from `EndpointArgs` methods.
 #[cfg(feature = "__internal")]
@@ -156,6 +167,11 @@ pub(crate) fn validate_expiration(value: &str, param_name: &str) -> Result<(), E
 /// [`crate::mdds::wire_semantics::wire_strike_opt`] so the server applies
 /// its documented default.
 ///
+/// # Errors
+///
+/// Returns [`EndpointError::InvalidParams`] when `value` is neither a
+/// wildcard form (`""` / `*` / `0`) nor a finite positive decimal.
+///
 /// Only compiled under `__internal` — called from `EndpointArgs` methods.
 #[cfg(feature = "__internal")]
 pub(crate) fn validate_strike(value: &str, param_name: &str) -> Result<(), EndpointError> {
@@ -170,6 +186,12 @@ pub(crate) fn validate_strike(value: &str, param_name: &str) -> Result<(), Endpo
     }
 }
 
+/// Validate a `symbol` parameter: accepts any non-empty string.
+///
+/// # Errors
+///
+/// Returns [`EndpointError::InvalidParams`] when `value` is empty.
+///
 /// Only compiled under `__internal` — called from `EndpointArgs` methods.
 #[cfg(feature = "__internal")]
 pub(crate) fn validate_symbol(value: &str, param_name: &str) -> Result<(), EndpointError> {
@@ -204,6 +226,19 @@ const VALID_INTERVAL_PRESETS: &[&str] = &[
     "30m", "1h",
 ];
 
+/// Validate an `interval` parameter against the upstream enum and the
+/// millisecond-shorthand shape.
+///
+/// Accepts any preset in [`VALID_INTERVAL_PRESETS`] or a positive integer
+/// of milliseconds (snapped to the nearest preset downstream).
+///
+/// # Errors
+///
+/// Returns [`EndpointError::InvalidParams`] when `value` is empty, names
+/// a bar size beyond the `1h` ceiling, or matches no accepted shape. The
+/// beyond-`1h` case carries a diagnostic pointing at `1h` / the
+/// `*_history_eod` endpoints.
+///
 /// Only compiled under `__internal` — called from `EndpointArgs` methods.
 #[cfg(feature = "__internal")]
 pub(crate) fn validate_interval(value: &str, param_name: &str) -> Result<(), EndpointError> {
@@ -249,6 +284,14 @@ fn is_beyond_hour_shorthand(value: &str) -> bool {
         .is_some_and(|digits| !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()))
 }
 
+/// Validate a `right` parameter: accepts any form the canonical
+/// `parse_right` parser recognises.
+///
+/// # Errors
+///
+/// Returns [`EndpointError::InvalidParams`] when `value` is not one of
+/// `call` / `put` / `both` / `C` / `P` / `*` (case-insensitive).
+///
 /// Only compiled under `__internal` — called from `EndpointArgs` methods.
 #[cfg(feature = "__internal")]
 pub(crate) fn validate_right(value: &str, param_name: &str) -> Result<(), EndpointError> {
@@ -264,6 +307,13 @@ pub(crate) fn validate_right(value: &str, param_name: &str) -> Result<(), Endpoi
     })
 }
 
+/// Validate a `year` parameter: requires exactly four ASCII digits.
+///
+/// # Errors
+///
+/// Returns [`EndpointError::InvalidParams`] when `value` is not exactly
+/// four digits (`YYYY`).
+///
 /// Only compiled under `__internal` — called from `EndpointArgs` methods.
 #[cfg(feature = "__internal")]
 pub(crate) fn validate_year(value: &str, param_name: &str) -> Result<(), EndpointError> {
@@ -275,6 +325,8 @@ pub(crate) fn validate_year(value: &str, param_name: &str) -> Result<(), Endpoin
     Ok(())
 }
 
+/// Split a comma-separated `value` into trimmed, non-empty symbols.
+///
 /// Only compiled under `__internal` — called from `EndpointArgs` methods.
 #[cfg(feature = "__internal")]
 pub(crate) fn parse_symbols(value: &str) -> Vec<String> {
@@ -286,6 +338,14 @@ pub(crate) fn parse_symbols(value: &str) -> Vec<String> {
         .collect()
 }
 
+/// Parse a boolean from the accepted textual forms (`true` / `false` /
+/// `1` / `0`, case-insensitive for the words).
+///
+/// # Errors
+///
+/// Returns a static message describing the accepted values when `value`
+/// matches none of them.
+///
 /// Only compiled under `__internal` — called from `parse_raw_arg_value` in
 /// `endpoint_args.rs` which is itself gated on `__internal`.
 #[cfg(feature = "__internal")]
@@ -312,6 +372,11 @@ pub(crate) fn parse_bool(value: &str) -> Result<bool, &'static str> {
 /// Wraps the two-arg canonical [`validate_date`] in the single-arg
 /// signature the `parsed_endpoint!` and streaming-builder macros
 /// expect (the param name is implicit at the call site).
+///
+/// # Errors
+///
+/// Returns [`Error`] (the converted [`EndpointError`]) when `date` fails
+/// the canonical date validation.
 pub(super) fn validate_date_required(date: &str) -> Result<(), Error> {
     validate_date(date, "date").map_err(Error::from)
 }
@@ -332,8 +397,8 @@ mod tests {
 
     #[test]
     fn validate_date_required_rejects_impossible_calendar_dates() {
-        // The exact garbage shapes that shape-only validation used to
-        // silently accept:
+        // The exact garbage shapes a shape-only check would silently
+        // accept:
         assert!(validate_date_required("00000000").is_err());
         assert!(validate_date_required("20260230").is_err()); // Feb 30
         assert!(validate_date_required("19990431").is_err()); // Apr 31
@@ -470,10 +535,9 @@ mod internal_tests {
 
     #[test]
     fn expiration_iso_dashed_form_enforces_calendar_bounds() {
-        // The previous code path checked only the textual shape of
-        // `YYYY-MM-DD` and accepted calendar-impossible inputs. Both
-        // forms now flow through the same Gregorian validator, so
-        // these inputs are rejected.
+        // Both textual forms flow through the same Gregorian validator,
+        // so calendar-impossible `YYYY-MM-DD` inputs are rejected — a
+        // shape-only check would accept them.
         for bad in [
             "2026-02-30", // Feb 30 — no such day
             "2026-13-01", // month 13 — out of range

--- a/crates/thetadatadx/src/mdds/wire_semantics.rs
+++ b/crates/thetadatadx/src/mdds/wire_semantics.rs
@@ -5,11 +5,11 @@
 //! - build-time mode collapsing in `build_support/endpoints/modes.rs` (via
 //!   `#[path]` reuse of this file)
 
-// The `venue=nqb` default used to live here as a runtime constant applied
-// at query-assembly time. The default now lives in the SSOT
+// The `venue=nqb` default lives in the SSOT
 // (`endpoint_surface.toml` -> `stock_venue_filter.default = "nqb"`) so it
 // flows through every emitted SDK builder uniformly. `modes.rs` reads
-// `param.default` directly; no runtime bridge needed.
+// `param.default` directly; no runtime constant is applied at
+// query-assembly time here.
 
 /// Canonicalize the `expiration` parameter for the MDDS server.
 ///


### PR DESCRIPTION
Audit-and-fill documentation pass over the MDDS and gRPC source modules. Every file in the partition carries a present-tense module header, every public item documents its one-line purpose, and Result-returning public functions document their error conditions; unsafe blocks and panicking paths carry the matching safety/panic notes where applicable.

The decode-placement rationale in the gRPC and MDDS module headers and the inline-decode helpers now cites the architectural invariant (each chunk stays on its producing connection, avoiding cross-thread hand-off) rather than an unsourced throughput claim. Change-history phrasing in the decode and validation docs is replaced with the invariant each check upholds.

The change is comments and docstrings only — no code, signatures, or behavior changed.

Gates run locally on the branch:

- `cargo fmt --all -- --check` clean
- `cargo clippy -p thetadatadx -- -D warnings` clean
- `cargo test -p thetadatadx --doc` 17 passed, 0 failed
- `generate_docs_site --check` generated pages match the registries
- `check_public_surface_leak.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)