### PR TITLE
docs(cli,mcp,server): bring tool crate docs to the documentation standard

### DIFF
--- a/tools/cli/src/flatfile_commands.rs
+++ b/tools/cli/src/flatfile_commands.rs
@@ -1,14 +1,14 @@
-// Hand-written FLATFILES subcommand surface (issue #433).
-//
-// Wires `tdx flatfile {quotes,trades,trade_quote,ohlc,open_interest,eod,request}`
-// to `thetadatadx::ThetaDataDxClient::flatfile_request`. Output goes to the
-// path supplied with `-o` / `--output`; if absent, the CSV/JSONL bytes
-// are streamed to stdout via `std::io::copy` from the file we just wrote
-// (the SDK's primary entry point writes to disk; we reroute on demand).
-//
-// Flat files are whole-universe daily blobs — they take a single
-// `YYYYMMDD` date, NOT a (start, end, symbol) tuple. The high-level
-// SDK methods reflect that contract; the CLI mirrors it 1:1.
+//! Hand-written `tdx flatfile` subcommand surface.
+//!
+//! Wires `tdx flatfile {quotes,trades,trade_quote,ohlc,open_interest,eod,request}`
+//! to `thetadatadx::ThetaDataDxClient::flatfile_request`. Output goes to the
+//! path supplied with `-o` / `--output`; if absent, the CSV/JSONL bytes
+//! are streamed to stdout via `std::io::copy` from the file just written
+//! (the SDK's primary entry point writes to disk; the CLI reroutes on demand).
+//!
+//! Flat files are whole-universe daily blobs — they take a single
+//! `YYYYMMDD` date, not a (start, end, symbol) tuple. The high-level
+//! SDK methods reflect that contract; the CLI mirrors it 1:1.
 
 use clap::{Arg, ArgMatches, Command};
 use thetadatadx::flatfiles::{FlatFileFormat, ReqType, SecType};
@@ -186,6 +186,12 @@ fn parse_req_type(s: &str) -> Result<ReqType, thetadatadx::Error> {
 /// when the subcommand was a `flatfile` subcommand (handled here);
 /// `Ok(false)` lets the caller fall through to the registry-driven
 /// dispatch in `main::run`.
+///
+/// # Errors
+/// Returns an error when the flatfile sub-subcommand is missing or unknown,
+/// when `--sec-type` / `--req-type` fail to parse, when credentials cannot be
+/// loaded, when the underlying flat-file request fails, or when streaming the
+/// result to stdout hits an I/O error.
 pub(crate) async fn try_dispatch(
     matches: &ArgMatches,
     creds_path: &str,

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -1,3 +1,18 @@
+//! `tdx` -- native command-line client for ThetaData market data.
+//!
+//! Builds its command tree dynamically from the shared endpoint registry, so
+//! every category and endpoint the SDK exposes is reachable as
+//! `tdx <category> <endpoint> [args...]` with no per-command wiring. A
+//! hand-written `flatfile` group covers the whole-universe flat-file surface.
+//!
+//! ## Invocation contract
+//! - Credentials resolve from `--creds <path>` (default `creds.txt`: email on
+//!   line 1, password on line 2). `--config {production,dev}` selects the
+//!   server preset and `--format {table,json,json-raw,csv}` selects the output
+//!   encoding; results go to stdout and diagnostics to stderr.
+//! - The process exits non-zero with a message on stderr when an endpoint
+//!   call, credential load, or argument parse fails.
+
 use std::process;
 
 use clap::{Arg, ArgMatches, Command};

--- a/tools/mcp/src/flatfile_tools.rs
+++ b/tools/mcp/src/flatfile_tools.rs
@@ -1,30 +1,30 @@
-// Hand-written FLATFILES tool surface for the MCP server (issue #431).
-//
-// Mirrors the Python / TypeScript flatfile API. Tools return the
-// on-disk path of the written CSV / JSONL blob — MCP transports
-// JSON-RPC, not raw bytes, and whole-universe flat files routinely
-// exceed 100 MB. Returning a path is the same convention the existing
-// MCP utility tools use for any file-producing operation.
-//
-// Tool naming (matches the Rust `flatfile_*` helper methods on
-// `ThetaDataDxClient`):
-//
-//   tdx_flatfile_request                     (generic)
-//   tdx_flatfile_option_quote
-//   tdx_flatfile_option_trade
-//   tdx_flatfile_option_trade_quote
-//   tdx_flatfile_option_ohlc
-//   tdx_flatfile_option_open_interest
-//   tdx_flatfile_option_eod
-//   tdx_flatfile_stock_quote
-//   tdx_flatfile_stock_trade
-//   tdx_flatfile_stock_trade_quote
-//   tdx_flatfile_stock_eod
-//
-// All ten convenience tools take `(date, output_path?, format?)`. The
-// generic tool takes `(sec_type, req_type, date, output_path, format)`
-// with case-insensitive enum strings. A missing `output_path` writes
-// to a deterministic temp path and surfaces it in the response.
+//! Hand-written flat-file tool surface for the MCP server.
+//!
+//! Mirrors the Python / TypeScript flatfile API. Tools return the
+//! on-disk path of the written CSV / JSONL blob — MCP transports
+//! JSON-RPC, not raw bytes, and whole-universe flat files are large.
+//! Returning a path is the same convention the other MCP utility tools
+//! use for any file-producing operation.
+//!
+//! Tool naming (matches the Rust `flatfile_*` helper methods on
+//! `ThetaDataDxClient`):
+//!
+//!   tdx_flatfile_request                     (generic)
+//!   tdx_flatfile_option_quote
+//!   tdx_flatfile_option_trade
+//!   tdx_flatfile_option_trade_quote
+//!   tdx_flatfile_option_ohlc
+//!   tdx_flatfile_option_open_interest
+//!   tdx_flatfile_option_eod
+//!   tdx_flatfile_stock_quote
+//!   tdx_flatfile_stock_trade
+//!   tdx_flatfile_stock_trade_quote
+//!   tdx_flatfile_stock_eod
+//!
+//! All ten convenience tools take `(date, output_path?, format?)`. The
+//! generic tool takes `(sec_type, req_type, date, output_path, format)`
+//! with case-insensitive enum strings. A missing `output_path` writes
+//! to a deterministic temp path and surfaces it in the response.
 
 use sonic_rs::{json, JsonValueTrait, Value};
 use thetadatadx::flatfiles::{FlatFileFormat, ReqType, SecType};
@@ -203,6 +203,12 @@ fn convenience_pair(tool_name: &str) -> Option<(SecType, ReqType)> {
 /// Try to execute a flatfile tool. Returns `Some(result)` if `name`
 /// matches a flatfile tool; `None` otherwise (caller falls through
 /// to the registry-driven dispatch).
+///
+/// # Errors
+/// The inner `Result` is `Err` when a required argument is missing, when an
+/// enum string (`sec_type`, `req_type`, `format`) fails to parse, when no
+/// `ThetaDataDxClient` is connected, or when the underlying flat-file request
+/// fails.
 pub(crate) async fn try_execute_flatfile_tool(
     client: Option<&ThetaDataDxClient>,
     name: &str,

--- a/tools/mcp/src/main.rs
+++ b/tools/mcp/src/main.rs
@@ -1013,6 +1013,8 @@ fn convert_endpoint_args(args: &Value) -> Result<EndpointArgs, String> {
 //  Tool execution — registry-driven dispatch
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Failure of a tool invocation, mapped to a JSON-RPC error code at the
+/// dispatch boundary.
 pub(crate) enum ToolError {
     /// -32602: Invalid params
     InvalidParams(String),
@@ -1140,9 +1142,9 @@ async fn handle_request(
 /// Canonicalises non-finite f64 leaves to JSON `null` (cross-language SDK
 /// agreement, see `json_canon`) and surfaces any residual serialisation
 /// failure as a JSON-RPC `-32603` Internal Error so the LLM client never
-/// receives a successful but empty `tools/call` result. Lifted out of the
-/// `tools/call` arm so the regression test for issue #459 can exercise the
-/// canonicalisation path without spinning up a live `ThetaDataDxClient` client.
+/// receives a successful but empty `tools/call` result. Kept separate from the
+/// `tools/call` arm so a test can exercise the canonicalisation path without
+/// spinning up a live `ThetaDataDxClient` client.
 fn build_tool_call_response(id: Value, result: &mut Value) -> JsonRpcResponse {
     match thetadatadx::json_canon::canonicalize_and_serialize(result) {
         Ok(text) => JsonRpcResponse::success(
@@ -1770,8 +1772,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    //  Issue #459 regression — tools/call must not return a successful but
-    //  empty result when the tool output carries a non-finite f64 cell.
+    //  tools/call must not return a successful but empty result when the
+    //  tool output carries a non-finite f64 cell.
     // -----------------------------------------------------------------------
 
     #[test]

--- a/tools/server/src/flatfile_routes.rs
+++ b/tools/server/src/flatfile_routes.rs
@@ -1,4 +1,4 @@
-//! Hand-written FLATFILES route surface for the REST server (issue #432).
+//! Hand-written flat-file route surface for the REST server.
 //!
 //! Flat files are server-pre-built whole-universe daily blobs (CSV /
 //! JSONL). They are a one-shot batch download — NOT a WebSocket
@@ -41,6 +41,8 @@ use tokio_util::io::ReaderStream;
 use crate::format;
 use crate::state::AppState;
 
+/// Query parameters for the convenience flat-file route
+/// (`GET /v3/flatfile/{sec_type}/{req_type}`).
 #[derive(Debug, Deserialize)]
 pub(crate) struct FlatfileQuery {
     /// Trading date in `YYYYMMDD` form.
@@ -50,11 +52,17 @@ pub(crate) struct FlatfileQuery {
     pub format: Option<String>,
 }
 
+/// JSON request body for the generic flat-file route
+/// (`POST /v3/flatfile/request`).
 #[derive(Debug, Deserialize)]
 pub(crate) struct FlatfileRequestBody {
+    /// Security type, parsed case-insensitively (`OPTION`, `STOCK`, `INDEX`).
     pub sec_type: String,
+    /// Request type, parsed case-insensitively (`QUOTE`, `TRADE`, `EOD`, ...).
     pub req_type: String,
+    /// Trading date in `YYYYMMDD` form.
     pub date: String,
+    /// On-disk format: `csv` (default) or `jsonl`.
     #[serde(default)]
     pub format: Option<String>,
 }

--- a/tools/server/src/handler.rs
+++ b/tools/server/src/handler.rs
@@ -888,7 +888,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    //  Issue #459 regression — non-finite f64 must not collapse to empty body
+    //  non-finite f64 must not collapse to an empty body
     // -----------------------------------------------------------------------
 
     /// Read the body of an axum `Response` to a `String` synchronously inside
@@ -1176,9 +1176,9 @@ mod tests {
     #[tokio::test]
     async fn json_response_emits_non_empty_body_for_nan_payload() {
         // Construct a payload that mimics a Greeks-style row where one cell
-        // came back non-finite from the upstream solver. Before issue #459
-        // this would round-trip through `sonic_rs::to_string(...).unwrap_or_default()`
-        // and hand the client a 200 OK with an empty body.
+        // came back non-finite from the upstream solver. A naive
+        // `sonic_rs::to_string(...).unwrap_or_default()` round-trip would hand
+        // the client a 200 OK with an empty body; canonicalisation must not.
         let mut row = sonic_rs::json!({
             "symbol": "AAPL",
             "delta": 0.5_f64,

--- a/tools/server/src/router.rs
+++ b/tools/server/src/router.rs
@@ -221,7 +221,7 @@ pub fn build(state: AppState, rate_limit_general: bool) -> Router {
             ),
         );
 
-    // FLATFILES routes — issue #432. Whole-universe daily blobs over
+    // Flat-file routes — whole-universe daily blobs over
     // HTTP. Not a WebSocket subscription stream; flat files are batch
     // downloads and the bytes ride a streaming response body so the
     // server doesn't pin multi-hundred-MB blobs in RAM.

--- a/tools/server/src/validation.rs
+++ b/tools/server/src/validation.rs
@@ -125,6 +125,10 @@ impl std::error::Error for ValidationError {}
 /// flows into any downstream allocator or JSON builder. Legitimate
 /// ThetaData inputs are pure ASCII alphanumerics plus `.,-_*`; none of
 /// those are classified as control characters by `char::is_control`.
+///
+/// # Errors
+/// Returns `ValidationError::invalid_content` when `value` contains any
+/// character for which `char::is_control` is true.
 pub fn ensure_no_control_chars(value: &str, field: &'static str) -> Result<(), ValidationError> {
     if value.chars().any(|c| c.is_control()) {
         return Err(ValidationError::invalid_content(
@@ -143,6 +147,10 @@ pub fn ensure_no_control_chars(value: &str, field: &'static str) -> Result<(), V
 ///
 /// Only checks bounded size. Format validity (alphanumeric, non-empty) is
 /// enforced downstream by `thetadatadx::validate::validate_symbol`.
+///
+/// # Errors
+/// Returns a `ValidationError` when `value` is empty, exceeds
+/// [`MAX_SYMBOL_LEN`], or contains control characters.
 pub fn validate_symbol(value: &str, field: &'static str) -> Result<(), ValidationError> {
     if value.is_empty() {
         return Err(ValidationError::invalid_content(field, "must be non-empty"));
@@ -159,6 +167,10 @@ pub fn validate_symbol(value: &str, field: &'static str) -> Result<(), Validatio
 }
 
 /// Validate a comma-separated symbols list (`?roots=AAPL,MSFT,...`).
+///
+/// # Errors
+/// Returns a `ValidationError` when `value` exceeds [`MAX_SYMBOLS_LEN`] or
+/// contains control characters.
 pub fn validate_symbols_list(value: &str, field: &'static str) -> Result<(), ValidationError> {
     if value.len() > MAX_SYMBOLS_LEN {
         return Err(ValidationError::too_long(
@@ -174,6 +186,10 @@ pub fn validate_symbols_list(value: &str, field: &'static str) -> Result<(), Val
 /// Validate a date or expiration string. Accepts both `YYYYMMDD` (8 chars)
 /// and `YYYY-MM-DD` (10 chars); stricter format validation happens in
 /// `thetadatadx::validate::validate_date` / `validate_expiration`.
+///
+/// # Errors
+/// Returns a `ValidationError` when `value` exceeds [`MAX_DATE_LEN`] or
+/// contains control characters.
 pub fn validate_date(value: &str, field: &'static str) -> Result<(), ValidationError> {
     if value.len() > MAX_DATE_LEN {
         return Err(ValidationError::too_long(field, value.len(), MAX_DATE_LEN));
@@ -183,6 +199,10 @@ pub fn validate_date(value: &str, field: &'static str) -> Result<(), ValidationE
 }
 
 /// Validate a strike-price string (decimal or `*`).
+///
+/// # Errors
+/// Returns a `ValidationError` when `value` exceeds [`MAX_STRIKE_LEN`] or
+/// contains control characters.
 pub fn validate_strike(value: &str, field: &'static str) -> Result<(), ValidationError> {
     if value.len() > MAX_STRIKE_LEN {
         return Err(ValidationError::too_long(
@@ -196,6 +216,10 @@ pub fn validate_strike(value: &str, field: &'static str) -> Result<(), Validatio
 }
 
 /// Validate an option `right` string.
+///
+/// # Errors
+/// Returns a `ValidationError` when `value` is empty, exceeds
+/// [`MAX_RIGHT_LEN`], or contains control characters.
 pub fn validate_right(value: &str, field: &'static str) -> Result<(), ValidationError> {
     if value.is_empty() {
         return Err(ValidationError::invalid_content(field, "must be non-empty"));
@@ -208,6 +232,10 @@ pub fn validate_right(value: &str, field: &'static str) -> Result<(), Validation
 }
 
 /// Validate an interval string (e.g. `"60000"` or `"1m"`).
+///
+/// # Errors
+/// Returns a `ValidationError` when `value` exceeds [`MAX_INTERVAL_LEN`] or
+/// contains control characters.
 pub fn validate_interval(value: &str, field: &'static str) -> Result<(), ValidationError> {
     if value.len() > MAX_INTERVAL_LEN {
         return Err(ValidationError::too_long(
@@ -221,6 +249,10 @@ pub fn validate_interval(value: &str, field: &'static str) -> Result<(), Validat
 }
 
 /// Validate a venue / exchange code.
+///
+/// # Errors
+/// Returns a `ValidationError` when `value` exceeds [`MAX_VENUE_LEN`] or
+/// contains control characters.
 pub fn validate_venue(value: &str, field: &'static str) -> Result<(), ValidationError> {
     if value.len() > MAX_VENUE_LEN {
         return Err(ValidationError::too_long(field, value.len(), MAX_VENUE_LEN));
@@ -245,6 +277,10 @@ pub fn validate_venue(value: &str, field: &'static str) -> Result<(), Validation
 /// attacker-controlled bytes into operator terminals or aggregated logs.
 /// A legitimate query-parameter name is already a C-identifier-shaped
 /// string; filtering is a no-op for valid inputs.
+///
+/// # Errors
+/// Returns a `ValidationError` (carrying the sanitized parameter name) when
+/// `value` exceeds [`MAX_GENERIC_LEN`] or contains control characters.
 pub fn validate_generic_named(value: &str, param_name: &str) -> Result<(), ValidationError> {
     if value.len() > MAX_GENERIC_LEN {
         let safe_name: String = sanitize_param_name(param_name);
@@ -295,6 +331,10 @@ fn sanitize_param_name(param_name: &str) -> String {
 /// every multi-symbol snapshot list past 16 bytes.
 ///
 /// `ParamMeta.name` is `&'static str` so the error label costs nothing.
+///
+/// # Errors
+/// Propagates the `ValidationError` from whichever type-specific validator
+/// the param routes to (length-cap or control-character rejection).
 pub fn validate_param_value(param: &ParamMeta, value: &str) -> Result<(), ValidationError> {
     match param.param_type {
         ParamType::Symbol => validate_symbol(value, param.name),
@@ -323,6 +363,10 @@ pub fn validate_param_value(param: &ParamMeta, value: &str) -> Result<(), Valida
 /// This is called from `handler::build_endpoint_args` BEFORE the raw value
 /// is parsed into an `EndpointArgValue` so we bound memory + CPU before
 /// anything expensive happens.
+///
+/// # Errors
+/// Propagates the `ValidationError` from whichever name-specific validator
+/// the param routes to (length-cap or control-character rejection).
 pub fn validate_query_param(name: &str, value: &str) -> Result<(), ValidationError> {
     match name {
         "root" | "symbol" | "ticker" => validate_symbol(value, static_name(name)),

--- a/tools/server/src/ws/broadcast.rs
+++ b/tools/server/src/ws/broadcast.rs
@@ -48,15 +48,18 @@ const WARN_EVERY_N: u64 = 1024;
 ///
 /// # Contract identity
 ///
-/// Every `FpssData::*` variant now carries `contract: Arc<Contract>`
+/// Every `FpssData::*` variant carries `contract: Arc<Contract>`
 /// directly — the SDK's I/O thread populates it from its internal
-/// contract cache at decode time. The bridge no longer maintains its
-/// own `contract_id -> Arc<Contract>` map: the contract reference
+/// contract cache at decode time. The bridge keeps no
+/// `contract_id -> Arc<Contract>` map of its own: the contract reference
 /// rides on the event itself, so a concurrent reconnect or
-/// market-close cannot race in between callback-time and
-/// serialisation-time the way the previous map-and-relookup pattern
-/// allowed. `Arc::clone` is still a refcount bump, so the per-event
-/// hot-path cost is unchanged.
+/// market-close cannot race between callback time and serialisation
+/// time. `Arc::clone` is a refcount bump, so the per-event hot-path
+/// cost stays minimal.
+///
+/// # Errors
+/// Returns an error when `ThetaDataDxClient::start_streaming` fails to
+/// establish the FPSS stream.
 pub fn start_fpss_bridge(state: AppState) -> Result<(), thetadatadx::Error> {
     let state_for_cb = state.clone();
     let state_for_task = state.clone();

--- a/tools/server/src/ws/contract_map.rs
+++ b/tools/server/src/ws/contract_map.rs
@@ -7,11 +7,11 @@ use thetadatadx::fpss::{FpssData, FpssEvent};
 
 /// Return the parsed contract attached to a data event, if any.
 ///
-/// Every `FpssData::*` variant now carries `contract: Arc<Contract>`
+/// Every `FpssData::*` variant carries `contract: Arc<Contract>`
 /// directly — the I/O thread populates it from its internal contract
-/// cache at decode time. The WebSocket bridge no longer maintains its
-/// own `contract_id -> Contract` map; cloning the `Arc` is a refcount
-/// bump, not a heap allocation on the contract symbol.
+/// cache at decode time. The WebSocket bridge keeps no
+/// `contract_id -> Contract` map of its own; cloning the `Arc` is a
+/// refcount bump, not a heap allocation on the contract symbol.
 pub(super) fn lookup_event_contract(event: &FpssEvent) -> Option<Arc<Contract>> {
     match event {
         FpssEvent::Data(FpssData::Quote { contract, .. })


### PR DESCRIPTION
Audit-and-fill pass over the three tool crates (`thetadatadx-cli`, `thetadatadx-mcp`, `thetadatadx-server`) to bring every non-generated Rust file up to the documentation standard. Comments and docstrings only — no code, signature, or behavior change. Files whose docs already met the bar were left untouched.

## What changed
- `tdx` CLI entrypoint gains a `//!` module header stating purpose and the invocation contract (credentials, config preset, output format/streams, exit behavior).
- Flatfile command and tool surfaces (CLI, MCP, REST routes) get proper `//!` module headers.
- `# Errors` added to the Result-returning query validators in `validation.rs`, the flatfile dispatchers, and `start_fpss_bridge`.
- Documented the previously bare flatfile request structs and the MCP `ToolError` enum.
- Restated the WebSocket contract-identity notes in present-tense invariant form and stripped process/temporal vocab (issue references, change-announcing phrasing) from comments.

## Generated files (not edited)
- `tools/cli/src/raw_headers_generated.rs`, `tools/cli/src/utilities.rs`, `tools/mcp/src/utilities.rs` carry `@generated DO NOT EDIT` and are produced by `build.rs`; left untouched per the standard.

## Gates
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --manifest-path tools/{cli,mcp,server}/Cargo.toml -- -D warnings`: clean for all three.
- `python3 scripts/check_public_surface_leak.py`: clean.
- Diff verified comments-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)