### PR TITLE
docs(ffi,cpp): document FFI error codes and C/C++ public surface

### DIFF
--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -36,18 +36,33 @@ pub const TDX_RETRY_AFTER_NONE: i64 = -1;
 /// substring-match the formatted error string. The mapping mirrors
 /// the Python `to_py_err` hierarchy one-for-one so the leaf set stays
 /// uniform across bindings.
+/// No error: the last call succeeded.
 pub const TDX_ERR_NONE: i32 = 0;
+/// Uncategorized failure that maps to no more specific discriminant.
 pub const TDX_ERR_OTHER: i32 = 1;
+/// Authentication failed (credentials rejected during the auth handshake).
 pub const TDX_ERR_AUTHENTICATION: i32 = 2;
+/// Credentials are malformed or incomplete before any handshake is attempted.
 pub const TDX_ERR_INVALID_CREDENTIALS: i32 = 3;
+/// The account's subscription does not grant access to the requested data.
 pub const TDX_ERR_SUBSCRIPTION: i32 = 4;
+/// The server rate-limited the request; see [`tdx_last_error_retry_after_ms`].
 pub const TDX_ERR_RATE_LIMIT: i32 = 5;
+/// The requested resource (symbol, contract, or endpoint) does not exist.
 pub const TDX_ERR_NOT_FOUND: i32 = 6;
+/// The call exceeded its deadline before the server responded.
 pub const TDX_ERR_DEADLINE_EXCEEDED: i32 = 7;
+/// The service is temporarily unavailable (transient server-side fault).
 pub const TDX_ERR_UNAVAILABLE: i32 = 8;
+/// A transport-layer failure prevented the request from completing.
 pub const TDX_ERR_NETWORK: i32 = 9;
+/// A decoded payload did not match the expected wire schema.
 pub const TDX_ERR_SCHEMA_MISMATCH: i32 = 10;
+/// A streaming session failed mid-flight (drop, partial reconnect, or
+/// stream-level protocol fault).
 pub const TDX_ERR_STREAM: i32 = 11;
+/// An environmental configuration fault (config-file I/O, TOML parse, or an
+/// internal invariant); distinct from [`TDX_ERR_INVALID_PARAMETER`].
 pub const TDX_ERR_CONFIG: i32 = 12;
 /// A client-side parameter was rejected by input validation (a bad
 /// value, an out-of-range number, a missing required field). Distinct

--- a/sdks/cpp/examples/main.cpp
+++ b/sdks/cpp/examples/main.cpp
@@ -1,3 +1,9 @@
+// Minimal end-to-end example for the C++ SDK.
+//
+// Connects an `MddsClient` from a `creds.txt` file, pulls end-of-day
+// history for one symbol, and runs the offline Greeks / implied-volatility
+// calculators that need no server connection.
+
 #include <iostream>
 #include <iomanip>
 #include "thetadx.hpp"

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -61,6 +61,8 @@ typedef struct TdxUnified TdxUnified;
 #define TDX_CALENDAR_STATUS_FULL_CLOSE 2
 #define TDX_CALENDAR_STATUS_WEEKEND 3
 
+/* Per-date trading-calendar entry (list_dates / calendar endpoints):
+ * session open/close times and a TDX_CALENDAR_STATUS_* day-type code. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t date;
     /* C99 bool (1 byte): whether the market trades at all on this date
@@ -74,6 +76,9 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[44];
 } TdxCalendarDay TDX_ALIGN64_END;
 
+/* End-of-day OHLC + closing-quote tick (*_history_eod) -- one row per
+ * trading day fusing the day's open/high/low/close, volume/count, and
+ * the closing bid/ask quote. */
 TDX_ALIGN64_BEGIN typedef struct {
     /* EOD report creation time (NOT a trade time), ms since midnight ET. */
     int32_t created_ms_of_day;
@@ -484,6 +489,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[48];
 } TdxInterestRateTick TDX_ALIGN64_END;
 
+/* Interval-sampled implied-volatility tick (option_*_implied_volatility):
+ * the bid/mid/ask quote with its bid/mid/ask IV triple. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
@@ -507,6 +514,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[28];
 } TdxIvTick TDX_ALIGN64_END;
 
+/* Settlement market-value tick (option_*_market_value): the contract's
+ * bid/ask and reference price used for daily mark-to-market. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
@@ -523,6 +532,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[8];
 } TdxMarketValueTick TDX_ALIGN64_END;
 
+/* OHLCVC bar tick (*_history_ohlc): one aggregated bar with
+ * open/high/low/close, volume/count, and a SIP-rule VWAP. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
@@ -547,6 +558,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[44];
 } TdxOhlcTick TDX_ALIGN64_END;
 
+/* Open-interest tick (option_*_open_interest): the outstanding contract
+ * count reported for the contract. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t open_interest;
@@ -560,6 +573,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[32];
 } TdxOpenInterestTick TDX_ALIGN64_END;
 
+/* Bare index price tick (index_*_price): a single price stamped with
+ * time and date, carrying no trade-side execution columns. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     /* 4 bytes padding before f64 */
@@ -588,6 +603,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[12];
 } TdxIndexPriceAtTimeTick TDX_ALIGN64_END;
 
+/* NBBO quote tick (*_history_quote): the bid/ask quote with sizes,
+ * exchanges, conditions, and a derived midpoint. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t bid_size;
@@ -613,6 +630,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[40];
 } TdxQuoteTick TDX_ALIGN64_END;
 
+/* Trade-with-quote tick (*_history_trade_quote): each trade print fused
+ * with the bid/ask quote prevailing at execution time. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t sequence;
@@ -651,6 +670,8 @@ TDX_ALIGN64_BEGIN typedef struct {
     uint8_t _tail_padding[48];
 } TdxTradeQuoteTick TDX_ALIGN64_END;
 
+/* Single trade-print tick (*_history_trade): one OPRA/SIP execution with
+ * price, size, exchange, sequence, and condition codes. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t sequence;
@@ -681,6 +702,9 @@ TDX_ALIGN64_BEGIN typedef struct {
 /*  Typed array return types                                              */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
+/* Owned tick-array views: { const T* data; size_t len; }. Returned by the
+ * matching tdx_* data call; each MUST be freed with its tdx_*_array_free
+ * (below). An empty result is data=NULL, len=0. */
 typedef struct { const TdxEodTick* data; size_t len; } TdxEodTickArray;
 typedef struct { const TdxOhlcTick* data; size_t len; } TdxOhlcTickArray;
 typedef struct { const TdxTradeTick* data; size_t len; } TdxTradeTickArray;
@@ -769,6 +793,9 @@ typedef struct {
 /*  Free functions for typed arrays                                       */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
+/* Each frees the array returned by its matching tdx_* data call and
+ * releases the backing allocation. No-op on a NULL/empty (data=NULL,
+ * len=0) array. Call exactly once per returned array. */
 void tdx_eod_tick_array_free(TdxEodTickArray arr);
 void tdx_ohlc_tick_array_free(TdxOhlcTickArray arr);
 void tdx_trade_tick_array_free(TdxTradeTickArray arr);

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -47,6 +47,9 @@ namespace tdx {
 template <typename T>
 using Span = std::span<T>;
 #else
+/// C++17 fallback for `std::span`: a non-owning pointer + length view over a
+/// contiguous run of `T`, exposing the `data()` / `size()` / iteration subset
+/// the streaming callbacks rely on.
 template <typename T>
 class Span {
 public:
@@ -164,6 +167,9 @@ struct Subscription {
 
 // ── Greeks result (from standalone tdx_all_greeks) ──
 
+/// Full set of option Greeks and Black-Scholes intermediates returned by the
+/// standalone `tdx_all_greeks` computation, alongside the implied volatility
+/// solve result (`iv`, `iv_error`).
 struct GreeksResult {
     double value;
     double delta;
@@ -238,6 +244,9 @@ enum class GrpcStatusKind : uint32_t {
     Unauthenticated = 16,
 };
 
+/// Root of the typed exception hierarchy; every FFI failure surfaces as this
+/// class or one of its leaves. Derives from `std::runtime_error` so generic
+/// `catch (const std::runtime_error&)` handlers still observe every failure.
 class ThetaDataError : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
@@ -543,24 +552,30 @@ struct FfiString {
 
 // ── RAII deleters ──
 
+/// `unique_ptr` deleter that releases a `TdxCredentials*` via `tdx_credentials_free`.
 struct CredentialsDeleter {
     void operator()(TdxCredentials* p) const { if (p) tdx_credentials_free(p); }
 };
 
+/// `unique_ptr` deleter that releases a `TdxConfig*` via `tdx_config_free`.
 struct ConfigDeleter {
     void operator()(TdxConfig* p) const { if (p) tdx_config_free(p); }
 };
 
+/// `unique_ptr` deleter that releases a `TdxMddsClient*` via `tdx_mdds_client_free`.
 struct MddsClientDeleter {
     void operator()(TdxMddsClient* p) const { if (p) tdx_mdds_client_free(p); }
 };
 
+/// `unique_ptr` deleter that releases a `TdxFpssHandle*` via `tdx_fpss_free`.
 struct FpssHandleDeleter {
     void operator()(TdxFpssHandle* p) const { if (p) tdx_fpss_free(p); }
 };
 
 // ── Credentials ──
 
+/// RAII holder for a ThetaData credentials handle (`TdxCredentials*`), freed
+/// automatically on destruction. Constructed via `from_file` or `from_email`.
 class Credentials {
 public:
     /** Load credentials from a file (line 1 = email, line 2 = password). */
@@ -579,6 +594,10 @@ private:
 
 // ── Config ──
 
+/// RAII holder for a client configuration handle (`TdxConfig*`), freed
+/// automatically on destruction. Built from a named preset (`production` /
+/// `dev` / `stage`) and tuned through the reconnect, FPSS, retry, MDDS, and
+/// metrics setters below.
 class Config {
 public:
     /** Production config (ThetaData NJ datacenter). */
@@ -1263,6 +1282,10 @@ private:
 
 // ── MddsClient ──
 
+/// RAII wrapper around a historical (MDDS) gRPC client handle
+/// (`TdxMddsClient*`), freed automatically on destruction. The recommended
+/// entry point for pure-historical access; the generated historical query
+/// methods are mixed in from `historical.hpp.inc`.
 class MddsClient {
 public:
     /** Connect a historical (MDDS) client to ThetaData servers. Throws on
@@ -1558,6 +1581,8 @@ private:
 // `FlatFileRowList::to_arrow_ipc()`. Pair with arrow-cpp on the
 // consumer side to materialise an `arrow::Table`.
 
+/// `unique_ptr` deleter that releases a `TdxFlatFileRowList*` via
+/// `tdx_flatfile_rowlist_free`.
 struct FlatFileRowListDeleter {
     void operator()(TdxFlatFileRowList* p) const {
         if (p) tdx_flatfile_rowlist_free(p);
@@ -1678,6 +1703,7 @@ private:
     const TdxUnified* handle_;
 };
 
+/// `unique_ptr` deleter that releases a `TdxUnified*` via `tdx_unified_free`.
 struct UnifiedDeleter {
     void operator()(TdxUnified* p) const {
         if (p) tdx_unified_free(p);
@@ -2061,8 +2087,11 @@ private:
 // new C ABI symbols — the value type just routes the existing call
 // dispatch by stored kind + payload.
 
+/// Forward declaration of the fluent stock / option contract identifier.
 class FluentContract;
+/// Forward declaration of the typed market-data subscription value type.
 class FluentSubscription;
+/// Forward declaration of the fluent security-type accessor for full-stream subscriptions.
 class FluentSecType;
 
 /// Typed market-data subscription. Returned by `Contract::quote` /
@@ -2072,7 +2101,10 @@ class FluentSecType;
 /// `ThetaDataDxClient::subscribe(sub)` or `subscribe_many(...)`.
 class FluentSubscription {
 public:
+    /// Whether the subscription targets a single contract or the full
+    /// per-sec-type universe.
     enum class Scope { Contract, Full };
+    /// The market-data feed kind the subscription carries.
     enum class Kind { Quote, Trade, OpenInterest, MarketValue };
 
     Scope scope() const noexcept { return scope_; }

--- a/sdks/cpp/tests/error_taxonomy.cpp
+++ b/sdks/cpp/tests/error_taxonomy.cpp
@@ -1,12 +1,11 @@
 // Typed-error hierarchy tests for the C++ SDK.
 //
-// Before B4, every FFI error surfaced as a generic
-// `std::runtime_error` carrying the formatted reason string —
-// callers had to substring-match to distinguish auth failures from
-// rate limits. B4 introduces a `ThetaDataError` base + a leaf class
-// per `GrpcStatusKind` + `AuthErrorKind` discriminator that callers
-// can `catch` on directly. The hierarchy mirrors the Python /
-// TypeScript leaf set so the cross-binding contract stays uniform.
+// The C++ surface exposes a `ThetaDataError` base plus a leaf class
+// per `GrpcStatusKind` + `AuthErrorKind` discriminator, so callers
+// `catch` a typed exception instead of substring-matching a generic
+// `std::runtime_error` reason string. The hierarchy mirrors the
+// Python / TypeScript leaf set so the cross-binding contract stays
+// uniform.
 
 #include <chrono>
 #include <stdexcept>

--- a/sdks/cpp/tests/interest_rate.cpp
+++ b/sdks/cpp/tests/interest_rate.cpp
@@ -1,16 +1,14 @@
-// Regression coverage for the `InterestRateTick` schema fix.
+// Schema coverage for the `InterestRateTick` C ABI / C++ wrapper.
 //
-// The upstream v3 server emits 2 columns (`created` as ISO date Text,
-// `rate` as percent Number). The earlier SDK declared 3 fields
-// (`ms_of_day`, `rate`, `date`) and decoded every live response into
-// `column 0: expected Number|Timestamp, got Text`. The fix removed
-// the fictitious `ms_of_day` field and rewired `date` to flow through
-// `parse_iso_date`.
+// The upstream interest-rate response carries 2 columns (`created` as
+// an ISO date Text, `rate` as a percent Number). `TdxInterestRateTick`
+// must mirror that 2-field shape: a `rate` value and a `date` parsed
+// through `parse_iso_date`. A third field would force the live decode
+// to reject column 0 as `expected Number|Timestamp, got Text`.
 //
-// This file pins the C ABI / C++ wrapper surface for the new
-// 2-field shape so a future schema regression cannot ship a header
-// whose `TdxInterestRateTick` struct still carries the removed field.
-// Live decode coverage lives in
+// This file pins the struct layout so a header whose
+// `TdxInterestRateTick` drifts from the 2-field schema fails to
+// compile. Live decode coverage lives in
 // `crates/thetadatadx/tests/test_interest_rate_schema.rs`.
 
 #include <cstddef>

--- a/sdks/cpp/tests/thetadatadx_client.cpp
+++ b/sdks/cpp/tests/thetadatadx_client.cpp
@@ -1,7 +1,8 @@
-// ThetaDataDxClient FPSS surface — closes the prior coverage gap
-// where the C++ wrapper exposed only the raw `tdx_unified_*` C ABI
-// for push-callback streaming. Every method listed below is now
-// reachable on the typed wrapper without dropping to the C handle.
+// ThetaDataDxClient FPSS surface tests.
+//
+// The typed `ThetaDataDxClient` wrapper exposes the full push-callback
+// streaming surface, so callers reach every method below without
+// dropping to the raw `tdx_unified_*` C ABI handle.
 //
 // Offline tests confirm:
 //   * `is_streaming` returns false on a moved-from / never-connected
@@ -9,8 +10,8 @@
 //   * `dropped_event_count` returns 0 on the same.
 //   * Move-construct + move-assign hold the callback-storage
 //     ordering invariant (no UAF in the destructor).
-//   * The wrapper compiles with each new method bound — that's the
-//     real proof; absence of these symbols was the bug.
+//   * The wrapper compiles with each method bound — symbol presence
+//     is the surface contract this file pins.
 //
 // Live tests (gated on `THETADX_LIVE_CREDS`) drive the full
 // set_callback -> stop_streaming -> reconnect -> await_drain ->


### PR DESCRIPTION
Audit-and-fill of the documentation on the C-ABI crate and the hand-written C/C++ SDK surface. Comments and docstrings only — no code, signatures, or behavior change.

## FFI crate (`ffi/src`)

Each `TDX_ERR_*` discriminant in `error.rs` now carries a one-line doc stating the condition it represents, so callers reading `tdx_last_error_code()` no longer have to infer meaning from the shared group banner alone.

The remaining hand-written modules (`lib.rs`, `panic.rs`, `endpoints.rs`, `auth.rs`, `flatfiles.rs`, `streaming.rs`, `types.rs`, `utility.rs`) already met the bar — module headers, per-item docs, and precise `# Safety` sections on the unsafe boundary — and were left untouched to avoid churn.

## C header (`sdks/cpp/include/thetadx.h`)

Every tick struct now opens with a one-line purpose banner naming its source endpoint and column semantics. The repetitive tick-array typedef family and the matching array-free family each get a single group banner stating the owned `{ data, len }` view shape, the empty-result convention, and the free-exactly-once ownership contract.

## C++ header (`sdks/cpp/include/thetadx.hpp`)

Documented the previously-undocumented public declarations: the `Span` C++17 view, the `ThetaDataError` hierarchy root, every `unique_ptr` deleter, the RAII holder classes, the fluent forward declarations, and the `Scope` / `Kind` enums.

## C++ tests

Reframed three test banners (`error_taxonomy.cpp`, `interest_rate.cpp`, `thetadatadx_client.cpp`) to state the surface invariant each file pins rather than the change history, and added the missing file banner to `examples/main.cpp`.

## Generated files (not edited — flagged for an emitter pass)

The `@generated` Rust includes (`endpoint_request_options.rs`, `endpoint_with_options.rs`, `endpoint_stream.rs`, `fpss_event_converter.rs`, `fpss_event_structs.rs`), every `sdks/cpp/include/*.inc` and `sdks/cpp/src/*.inc`, and `examples/validate.cpp` were left untouched; any doc gaps there belong to their emitter templates.

## Gates

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p thetadatadx-ffi -- -D warnings`: clean
- `cargo build -p thetadatadx-ffi --release` + `check_c_abi_completeness.py`: clean (305 symbols, bidirectional rust↔header parity)
- `check_public_surface_leak.py`: clean
- C++ examples + test suite build: clean; offline tests 207/207 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)