### PR TITLE
docs(codegen): derive tick field counts and drop build provenance from generated docs

### DIFF
--- a/crates/thetadatadx/build_support_bin/ticks/tdbe_structs.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/tdbe_structs.rs
@@ -197,12 +197,17 @@ fn pascal_to_snake(name: &str) -> String {
 fn render_one_struct(type_name: &str, def: &TickTypeDef) -> String {
     let mut out = String::new();
 
-    // Doc comment lifted verbatim from the schema. Multi-line docs
-    // (e.g. `GreeksTick`) preserve their per-line `///` shape.
+    // Doc comment derived from the schema. Multi-line docs (e.g.
+    // `GreeksTick`) preserve their per-line `///` shape. The field-count
+    // phrase is recomputed from the actual field set the struct emits
+    // (schema columns plus the `contract_id` tail and `QuoteTick`
+    // midpoint), so the count is correct by construction rather than
+    // hand-maintained in the schema prose.
     let doc = if def.doc.is_empty() {
         format!("`{type_name}` tick.")
     } else {
-        def.doc.clone()
+        let count = struct_field_count(type_name, def);
+        scrub_provenance(&with_field_count(&def.doc, count))
     };
     for line in doc.lines() {
         if line.is_empty() {
@@ -262,6 +267,161 @@ fn render_one_struct(type_name: &str, def: &TickTypeDef) -> String {
 
     out.push_str("}\n");
     out
+}
+
+/// Field count rendered in the `-- N fields` doc phrase: every schema
+/// column plus the `contract_id` tail (`expiration` / `strike` / `right`).
+/// `QuoteTick`'s computed `midpoint` is excluded here because its doc
+/// phrase already names it separately (`-- N fields + midpoint`), so
+/// counting it in `N` would double-count. The total still tracks the field
+/// list by construction — only the named suffix is kept out of `N`.
+fn struct_field_count(_type_name: &str, def: &TickTypeDef) -> usize {
+    def.columns.len() + usize::from(def.contract_id) * 3
+}
+
+/// Rewrite the `-- N fields[ + midpoint]` phrase on the first doc line to
+/// the supplied `count`, preserving any suffix wording (e.g. ` + midpoint`,
+/// trailing summary sentence). When the first line carries no `-- N`
+/// phrase the doc is returned unchanged — the count is informational, not
+/// mandatory, so types that never declared it stay as authored.
+fn with_field_count(doc: &str, count: usize) -> String {
+    let mut lines = doc.lines();
+    let Some(first) = lines.next() else {
+        return doc.to_string();
+    };
+    let rest: Vec<&str> = lines.collect();
+
+    let rewritten_first = rewrite_count_phrase(first, count);
+
+    let mut out = rewritten_first;
+    for line in rest {
+        out.push('\n');
+        out.push_str(line);
+    }
+    out
+}
+
+/// Replace the numeric run immediately after ` -- ` on a single line with
+/// `count`, keeping the surrounding text. `"OHLC tick -- 9 fields. ..."`
+/// with `count = 12` becomes `"OHLC tick -- 12 fields. ..."`;
+/// `"Quote tick -- 10 fields + midpoint. ..."` with `count = 12` becomes
+/// `"Quote tick -- 12 fields + midpoint. ..."`. Lines without a leading
+/// digit after ` -- ` are returned unchanged.
+fn rewrite_count_phrase(line: &str, count: usize) -> String {
+    let Some(dash) = line.find(" -- ") else {
+        return line.to_string();
+    };
+    let after = &line[dash + 4..];
+    let digits_len = after.chars().take_while(char::is_ascii_digit).count();
+    if digits_len == 0 {
+        return line.to_string();
+    }
+    format!("{}{count}{}", &line[..dash + 4], &after[digits_len..])
+}
+
+/// Drop wire-provenance prose from a schema doc so the generated public
+/// surface describes only stable behavior. Two artifact shapes are
+/// removed: prose sentences that record where a layout was checked, and
+/// the wire-column listings (Markdown tables, indented header dumps) those
+/// sentences introduce. Behavioral sentences sharing a paragraph with a
+/// provenance sentence are preserved.
+fn scrub_provenance(doc: &str) -> String {
+    let mut kept: Vec<String> = Vec::new();
+
+    for paragraph in split_paragraphs(doc) {
+        if is_wire_layout_block(&paragraph) {
+            continue;
+        }
+        let cleaned = drop_provenance_sentences(&paragraph);
+        if !cleaned.trim().is_empty() {
+            kept.push(cleaned);
+        }
+    }
+
+    kept.join("\n\n")
+}
+
+/// Split a doc string into paragraphs delimited by blank lines, trimming a
+/// leading blank line (some schema docs open with `"""` on its own line).
+fn split_paragraphs(doc: &str) -> Vec<String> {
+    let mut paragraphs = Vec::new();
+    let mut current: Vec<&str> = Vec::new();
+    for line in doc.lines() {
+        if line.trim().is_empty() {
+            if !current.is_empty() {
+                paragraphs.push(current.join("\n"));
+                current.clear();
+            }
+        } else {
+            current.push(line);
+        }
+    }
+    if !current.is_empty() {
+        paragraphs.push(current.join("\n"));
+    }
+    paragraphs
+}
+
+/// A paragraph that is purely a wire-layout artifact: every non-blank line
+/// is either a Markdown table row (`|`-fenced) or an indented
+/// comma-separated header dump. These exist only as layout evidence and
+/// duplicate the per-field doc comments, so they are dropped wholesale.
+fn is_wire_layout_block(paragraph: &str) -> bool {
+    let lines: Vec<&str> = paragraph.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return false;
+    }
+    lines.iter().all(|line| {
+        let trimmed = line.trim_start();
+        let is_table_row = trimmed.starts_with('|');
+        let is_indented_header_dump = line.starts_with(' ') && trimmed.contains(',');
+        is_table_row || is_indented_header_dump
+    })
+}
+
+/// Remove sentences that record wire-layout provenance from a prose
+/// paragraph, keeping every other sentence. A sentence is a run terminated
+/// by `. ` (or the paragraph end); a sentence is provenance when it names
+/// the verification act or the build it was checked against.
+fn drop_provenance_sentences(paragraph: &str) -> String {
+    let flat = paragraph.split_whitespace().collect::<Vec<_>>().join(" ");
+    let sentences = split_sentences(&flat);
+    // Leave paragraphs without provenance byte-for-byte intact (including
+    // their original line wrapping); only reflow when a sentence is dropped.
+    if !sentences.iter().any(|s| is_provenance_sentence(s)) {
+        return paragraph.to_string();
+    }
+    sentences
+        .into_iter()
+        .filter(|s| !is_provenance_sentence(s))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Split a single-line (whitespace-collapsed) paragraph into sentences on
+/// `. ` boundaries, keeping each sentence's terminating punctuation.
+fn split_sentences(flat: &str) -> Vec<&str> {
+    let mut sentences = Vec::new();
+    let mut start = 0;
+    let bytes = flat.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] == b'.' && (i + 1 == bytes.len() || bytes[i + 1] == b' ') {
+            let end = (i + 1).min(flat.len());
+            sentences.push(flat[start..end].trim());
+            start = (i + 2).min(flat.len());
+        }
+    }
+    if start < flat.len() {
+        sentences.push(flat[start..].trim());
+    }
+    sentences.into_iter().filter(|s| !s.is_empty()).collect()
+}
+
+/// Whether a sentence records where or against what a wire layout was
+/// checked, rather than describing tick behavior.
+fn is_provenance_sentence(sentence: &str) -> bool {
+    let s = sentence.to_ascii_lowercase();
+    s.contains("verified-live") || s.contains("jar build")
 }
 
 /// Map a schema column type to the Rust field type used in the generated

--- a/crates/thetadatadx/src/tdbe/types/generated/tick.rs
+++ b/crates/thetadatadx/src/tdbe/types/generated/tick.rs
@@ -31,7 +31,7 @@ pub struct CalendarDay {
     pub status: crate::tdbe::types::enums::CalendarStatus,
 }
 
-/// End-of-day tick -- 17 fields. Full EOD snapshot with OHLC + quote.
+/// End-of-day tick -- 20 fields. Full EOD snapshot with OHLC + quote.
 ///
 /// The two time columns carry the vendor's v3 field semantics under their
 /// v3 names: `created` is when the EOD report was generated (~17:15 ET,
@@ -221,20 +221,6 @@ impl GreeksAllTick {
 /// 39-column EOD response -- the same data-loss class as the per-trade
 /// Greeks endpoints. `GreeksEodTick` carries the full
 /// EOD wire shape end-to-end across every binding.
-///
-/// Wire layout verified-live against terminal jar build `202605221`
-/// (SPY 2024-06-21 expiration query on 2024-06-14):
-///
-///   symbol, expiration, strike, right,
-///   timestamp, open, high, low, close, volume, count,
-///   bid_size, bid_exchange, bid, bid_condition,
-///   ask_size, ask_exchange, ask, ask_condition,
-///   delta, theta, vega, rho, epsilon, lambda,
-///   gamma, vanna, charm, vomma, veta, vera,
-///   speed, zomma, color, ultima,
-///   d1, d2, dual_delta, dual_gamma,
-///   implied_vol, iv_error,
-///   underlying_timestamp, underlying_price
 ///
 /// The `timestamp` -> `ms_of_day`, `underlying_timestamp` ->
 /// `underlying_ms_of_day`, and `implied_vol` -> `implied_volatility`
@@ -548,10 +534,6 @@ impl GreeksThirdOrderTick {
 /// columns -- `sequence`, `ext_condition1..4`, `condition`, `size`,
 /// `exchange` -- including the SIP-exchange attribution field.
 ///
-/// Wire layout verified-live against terminal jar build `202605221`:
-///
-///   timestamp, sequence, ext_condition1..4, condition, size, exchange, price
-///
 /// The `timestamp` -> `ms_of_day` and `timestamp` -> `date` mappings are
 /// applied through the existing `HEADER_ALIASES` rows in
 /// `crates/thetadatadx/src/mdds/decode/headers.rs`.
@@ -597,14 +579,6 @@ impl IndexPriceAtTimeTick {
 
 /// Interest rate tick -- 2 fields. End-of-day interest rate (percent).
 ///
-/// Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`
-/// and verified-live against terminal jar build `202605221`:
-///
-/// | Schema field | Wire header | Wire type        | Mapping                    |
-/// |--------------|-------------|------------------|----------------------------|
-/// | `date`       | `created`   | Text (ISO date)  | `"2025-04-28"` -> 20250428 |
-/// | `rate`       | `rate`      | Number (percent) | `4.3600` -> 4.36           |
-///
 /// The `date` decode flows through `thetadatadx::decode::row_date`, which
 /// accepts `Number`, `Timestamp`, and `Text` cells uniformly — so this tick
 /// decodes either the documented Text-ISO shape or any future
@@ -619,24 +593,7 @@ pub struct InterestRateTick {
     pub rate: f64,
 }
 
-/// Implied volatility tick -- 11 fields.
-///
-/// Wire layout verified-live against `option_history_greeks_implied_volatility`
-/// (terminal jar build `202605221`):
-///
-/// | Schema field                | Wire header               | Type   |
-/// |-----------------------------|---------------------------|--------|
-/// | `ms_of_day`                 | `timestamp`               | i32    |
-/// | `bid`                       | `bid`                     | price  |
-/// | `bid_implied_volatility`    | `bid_implied_vol`         | f64    |
-/// | `midpoint`                  | `midpoint`                | price  |
-/// | `implied_volatility`        | `implied_vol`             | f64    |
-/// | `ask`                       | `ask`                     | price  |
-/// | `ask_implied_volatility`    | `ask_implied_vol`         | f64    |
-/// | `iv_error`                  | `iv_error`                | f64    |
-/// | `underlying_ms_of_day`      | `underlying_timestamp`    | i32    |
-/// | `underlying_price`          | `underlying_price`        | price  |
-/// | `date`                      | `timestamp`               | i32    |
+/// Implied volatility tick -- 14 fields.
 ///
 /// The snapshot variant (`option_snapshot_greeks_implied_volatility`) emits
 /// a 4-column subset (`ms_of_day, implied_vol, iv_error, date`); the
@@ -732,15 +689,9 @@ impl MarketValueTick {
     }
 }
 
-/// OHLC tick -- 9 fields. Aggregated bar data including SIP-rule VWAP.
+/// OHLC tick -- 12 fields. Aggregated bar data including SIP-rule VWAP.
 ///
-/// Wire layout verified-live (terminal jar build `202605221`) against
-/// `stock_history_ohlc`, `option_history_ohlc`, and `index_history_ohlc`,
-/// which emit the same 8 data columns (`timestamp,open,high,low,close,
-/// volume,count,vwap`). The snapshot variants (`*_snapshot_ohlc`) omit
-/// `vwap`; the generated parser's optional-column path defaults the
-/// field to `0.0` for those endpoints, mirroring how `volume`/`count`
-/// already zero-default on quote-only intraday bars.
+/// The snapshot variants (`*_snapshot_ohlc`) omit `vwap`; the generated parser's optional-column path defaults the field to `0.0` for those endpoints, mirroring how `volume`/`count` already zero-default on quote-only intraday bars.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -783,7 +734,7 @@ impl OhlcTick {
     }
 }
 
-/// Open interest tick -- 3 fields.
+/// Open interest tick -- 6 fields.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -856,7 +807,7 @@ impl PriceTick {
     }
 }
 
-/// Quote tick -- 10 fields + midpoint. NBBO quote data.
+/// Quote tick -- 13 fields + midpoint. NBBO quote data.
 ///
 /// Wire layout: the full shape is 11 columns (`ms_of_day`,
 /// `bid_size`, `bid_exchange`, `bid`, `bid_condition`, `ask_size`,
@@ -919,17 +870,6 @@ impl QuoteTick {
 /// columns (`sequence`, `ext_condition1..4`, `condition`, `size`,
 /// `exchange`, `price`) that identify which OPRA print each Greek was
 /// calculated against.
-///
-/// Wire layout verified-live against terminal jar build `202605221`:
-///
-///   symbol, expiration, strike, right,
-///   timestamp, sequence, ext_condition1..4, condition, size, exchange, price,
-///   delta, theta, vega, rho, epsilon, lambda,
-///   gamma, vanna, charm, vomma, veta, vera,
-///   speed, zomma, color, ultima,
-///   d1, d2, dual_delta, dual_gamma,
-///   implied_vol, iv_error,
-///   underlying_timestamp, underlying_price
 ///
 /// The `timestamp` -> `ms_of_day`, `underlying_timestamp` ->
 /// `underlying_ms_of_day`, and `implied_vol` -> `implied_volatility`
@@ -1037,10 +977,7 @@ impl TradeGreeksAllTick {
     }
 }
 
-/// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon
-/// / lambda) paired with the trade-side execution columns identifying the
-/// OPRA print each Greek was calculated against. Wire layout verified-live
-/// against terminal jar build `202605221`.
+/// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon / lambda) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -1116,11 +1053,7 @@ impl TradeGreeksFirstOrderTick {
     }
 }
 
-/// Per-trade implied-volatility tick (single `implied_volatility` +
-/// `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled
-/// `IvTick`) paired with the trade-side execution columns identifying the
-/// OPRA print the IV was calculated against. Wire layout verified-live
-/// against terminal jar build `202605221`.
+/// Per-trade implied-volatility tick (single `implied_volatility` + `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled `IvTick`) paired with the trade-side execution columns identifying the OPRA print the IV was calculated against.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -1184,10 +1117,7 @@ impl TradeGreeksImpliedVolatilityTick {
     }
 }
 
-/// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma /
-/// veta) paired with the trade-side execution columns identifying the OPRA
-/// print each Greek was calculated against. Wire layout verified-live
-/// against terminal jar build `202605221`.
+/// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma / veta) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -1261,11 +1191,7 @@ impl TradeGreeksSecondOrderTick {
     }
 }
 
-/// Per-trade third-order Greeks tick (speed / zomma / color / ultima)
-/// paired with the trade-side execution columns identifying the OPRA print
-/// each Greek was calculated against. The vendor's third-order schema does
-/// not publish `vera`. Wire layout verified-live against terminal jar build
-/// `202605221`.
+/// Per-trade third-order Greeks tick (speed / zomma / color / ultima) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against. The vendor's third-order schema does not publish `vera`.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -1337,7 +1263,7 @@ impl TradeGreeksThirdOrderTick {
     }
 }
 
-/// Combined trade + quote tick -- 24 fields.
+/// Combined trade + quote tick -- 27 fields.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -1419,7 +1345,7 @@ impl TradeQuoteTick {
     }
 }
 
-/// Trade tick -- 15 fields. Core unit of trade data.
+/// Trade tick -- 18 fields. Core unit of trade data.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]


### PR DESCRIPTION
The tick-struct emitter copied each per-struct doc comment verbatim from the schema, so two accuracy issues reached the generated public surface in `crates/thetadatadx/src/tdbe/types/generated/tick.rs`.

The `-- N fields` phrase was hand-maintained and had drifted from the real field set. Every struct that gains the contract-id tail or the quote midpoint under-counted: EodTick 17 to 20, IvTick 11 to 14, OhlcTick 9 to 12, OpenInterestTick 3 to 6, TradeQuoteTick 24 to 27, TradeTick 15 to 18, QuoteTick 10 to 13 + midpoint. The emitter already iterates the column list and appends the contract-id triple, so it now derives the count and the phrase is correct by construction. QuoteTick keeps its `+ midpoint` suffix and excludes the midpoint from `N` so it is not double-counted.

The same verbatim copy carried wire-layout provenance prose into the public docs. The emitter now keeps only the stable behavioral description: provenance sentences and the wire-column listings they introduce are dropped, while behavioral sentences sharing a paragraph are preserved untouched.

Both the emitter change and its regenerated output are committed together. Gates: drift `--check` clean (tick + docs site), `cargo fmt --all -- --check` clean, `cargo clippy -p thetadatadx --all-features -- -D warnings` clean, `cargo test -p thetadatadx --doc` 17 passed, `check_public_surface_leak.py` clean. Every per-struct doc count now matches its real field count and zero provenance strings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)