### PR TITLE
docs(cpp): finish Doxygen coverage and remove implementation vocabulary from the public headers

### DIFF
--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -1,13 +1,13 @@
 /**
  * thetadatadx C FFI header.
  *
- * This header declares the C interface to the thetadatadx Rust SDK.
+ * This header declares the C interface to the thetadatadx SDK.
  * Used by both the C++ wrapper and any other C-compatible language.
  *
  * Memory model:
  * - Opaque handles (TdxCredentials*, TdxMddsClient*, TdxConfig*) are heap-allocated
- *   by the Rust side and MUST be freed with the corresponding tdx_*_free function.
- * - Tick data is returned as #[repr(C)] struct arrays. Each array type has a
+ *   by the library and MUST be freed with the corresponding tdx_*_free function.
+ * - Tick data is returned as fixed-layout struct arrays. Each array type has a
  *   corresponding tdx_*_array_free function that MUST be called.
  * - String arrays (TdxStringArray) must be freed with tdx_string_array_free.
  * - Functions that can fail return empty arrays (data=NULL, len=0) and set a
@@ -42,16 +42,16 @@ typedef struct TdxConfig TdxConfig;
 typedef struct TdxFpssHandle TdxFpssHandle;
 typedef struct TdxUnified TdxUnified;
 
-/* Generated request-options bridge shared with Rust FFI. */
+/* Generated request-options bridge shared with the FFI surface. */
 #include "endpoint_request_options.h.inc"
 
 /* ═══════════════════════════════════════════════════════════════════════ */
-/*  #[repr(C)] tick types — layout-compatible with Rust tick structs      */
+/*  Fixed-layout tick types                                               */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
-/* All tick structs are 64-byte aligned to match Rust's #[repr(C, align(64))].
- * Explicit tail padding is part of that ABI contract so C/C++ array stepping
- * stays byte-for-byte compatible with Rust. Price fields are f64 (double). */
+/* All tick structs are 64-byte aligned and carry explicit tail padding as
+ * part of the ABI contract, so C/C++ array stepping stays byte-for-byte
+ * compatible with the wire layout. Price fields are 64-bit doubles. */
 
 /* Calendar day-type codes carried by TdxCalendarDay.status — the
  * vendor's own vocabulary. Resolve the text form with
@@ -99,12 +99,12 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t bid_condition;
     int32_t ask_size;
     int32_t ask_exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double ask;
     int32_t ask_condition;
     int32_t date;
     int32_t expiration;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double strike;
     /* Unicode scalar value of the right character: 'C' (67) for a call,
      * 'P' (80) for a put, 0 when contract identity is absent
@@ -116,7 +116,7 @@ TDX_ALIGN64_BEGIN typedef struct {
 /* Full-union Greeks tick (option_*_greeks_all, interval-sampled). */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double bid;
     double ask;
     double implied_volatility;
@@ -142,7 +142,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double lambda;
     double vera;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -161,7 +161,7 @@ TDX_ALIGN64_BEGIN typedef struct {
  * GreeksAllTick. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double open;
     double high;
     double low;
@@ -176,7 +176,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t ask_exchange;
     double ask;
     int32_t ask_condition;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double delta;
     double theta;
     double vega;
@@ -200,7 +200,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -215,7 +215,7 @@ TDX_ALIGN64_BEGIN typedef struct {
 /* First-order Greeks subset tick (option_*_greeks_first_order). */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double bid;
     double ask;
     double delta;
@@ -227,7 +227,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -242,7 +242,7 @@ TDX_ALIGN64_BEGIN typedef struct {
 /* Second-order Greeks subset tick (option_*_greeks_second_order). */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double bid;
     double ask;
     double gamma;
@@ -253,7 +253,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -269,7 +269,7 @@ TDX_ALIGN64_BEGIN typedef struct {
  * vendor's third-order schema does not publish `vera`. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double bid;
     double ask;
     double speed;
@@ -279,7 +279,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -305,7 +305,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     double delta;
     double theta;
@@ -330,7 +330,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -354,7 +354,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     double delta;
     double theta;
@@ -365,7 +365,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -389,7 +389,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     double gamma;
     double vanna;
@@ -399,7 +399,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -424,7 +424,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     double speed;
     double zomma;
@@ -433,7 +433,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -459,12 +459,12 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     double implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -478,12 +478,12 @@ TDX_ALIGN64_BEGIN typedef struct {
 
 /* InterestRateTick (2 fields). End-of-day interest rate (percent).
  * Wire shape per docs.thetadata.us/operations/interest_rate_history_eod.html:
- *   date  <- Text "YYYY-MM-DD" header `created`, parsed to YYYYMMDD i32
+ *   date  <- Text "YYYY-MM-DD" header `created`, parsed to a YYYYMMDD int32
  *   rate  <- Number percent (e.g. 4.36 for SOFR 2025-04-28)
  */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t date;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double rate;
     uint8_t _tail_padding[48];
 } TdxInterestRateTick TDX_ALIGN64_END;
@@ -492,7 +492,7 @@ TDX_ALIGN64_BEGIN typedef struct {
  * the bid/mid/ask quote with its bid/mid/ask IV triple. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double bid;
     double bid_implied_volatility;
     double midpoint;
@@ -501,7 +501,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     double ask_implied_volatility;
     double iv_error;
     int32_t underlying_ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double underlying_price;
     int32_t date;
     int32_t expiration;
@@ -517,7 +517,7 @@ TDX_ALIGN64_BEGIN typedef struct {
  * bid/ask and reference price used for daily mark-to-market. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double market_bid;
     double market_ask;
     double market_price;
@@ -535,7 +535,7 @@ TDX_ALIGN64_BEGIN typedef struct {
  * open/high/low/close, volume/count, and a SIP-rule VWAP. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double open;
     double high;
     double low;
@@ -576,7 +576,7 @@ TDX_ALIGN64_BEGIN typedef struct {
  * time and date, carrying no trade-side execution columns. */
 TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     int32_t date;
     uint8_t _tail_padding[40];
@@ -596,7 +596,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     int32_t date;
     uint8_t _tail_padding[12];
@@ -608,23 +608,23 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t ms_of_day;
     int32_t bid_size;
     int32_t bid_exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double bid;
     int32_t bid_condition;
     int32_t ask_size;
     int32_t ask_exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double ask;
     int32_t ask_condition;
     int32_t date;
     int32_t expiration;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double strike;
     /* Unicode scalar value of the right character: 'C' (67) for a call,
      * 'P' (80) for a put, 0 when contract identity is absent
      * (single-contract queries). Cast to char for display. */
     uint32_t right;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double midpoint;
     uint8_t _tail_padding[40];
 } TdxQuoteTick TDX_ALIGN64_END;
@@ -641,7 +641,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     int32_t condition_flags;
     int32_t price_flags;
@@ -650,17 +650,17 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t quote_ms_of_day;
     int32_t bid_size;
     int32_t bid_exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double bid;
     int32_t bid_condition;
     int32_t ask_size;
     int32_t ask_exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double ask;
     int32_t ask_condition;
     int32_t date;
     int32_t expiration;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double strike;
     /* Unicode scalar value of the right character: 'C' (67) for a call,
      * 'P' (80) for a put, 0 when contract identity is absent
@@ -681,7 +681,7 @@ TDX_ALIGN64_BEGIN typedef struct {
     int32_t condition;
     int32_t size;
     int32_t exchange;
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double price;
     int32_t condition_flags;
     int32_t price_flags;
@@ -732,7 +732,7 @@ typedef struct { const TdxTradeQuoteTick* data; size_t len; } TdxTradeQuoteTickA
 typedef struct {
     const char* symbol;     /* heap-allocated, freed with tdx_option_contract_array_free */
     int32_t expiration;     /* YYYYMMDD */
-    /* 4 bytes padding before f64 */
+    /* 4 bytes padding before the double field */
     double strike;          /* dollars */
     /* Unicode scalar value of the right character: 'C' (67) for a call,
      * 'P' (80) for a put. Cast to char for display. */
@@ -792,9 +792,11 @@ typedef struct {
 /*  Free functions for typed arrays                                       */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
-/* Each frees the array returned by its matching tdx_* data call and
- * releases the backing allocation. No-op on a NULL/empty (data=NULL,
- * len=0) array. Call exactly once per returned array. */
+/** Each frees the array returned by its matching tdx_* data call and
+ *  releases the backing allocation.
+ *  @param arr The array returned by the matching data call; a NULL/empty
+ *             (data=NULL, len=0) array is a no-op.
+ *  @note Call exactly once per returned array. */
 void tdx_eod_tick_array_free(TdxEodTickArray arr);
 void tdx_ohlc_tick_array_free(TdxOhlcTickArray arr);
 void tdx_trade_tick_array_free(TdxTradeTickArray arr);
@@ -819,7 +821,12 @@ void tdx_interest_rate_tick_array_free(TdxInterestRateTickArray arr);
 void tdx_trade_quote_tick_array_free(TdxTradeQuoteTickArray arr);
 void tdx_option_contract_array_free(TdxOptionContractArray arr);
 void tdx_string_array_free(TdxStringArray arr);
+/** Free a result handle returned by tdx_all_greeks.
+ *  @param result Handle from tdx_all_greeks; no-op when NULL. Call exactly once. */
 void tdx_greeks_result_free(TdxGreeksResult* result);
+/** Free a subscription array returned by an active-subscriptions query.
+ *  @param arr Array from tdx_*_active_subscriptions; no-op when NULL.
+ *             Call exactly once. */
 void tdx_subscription_array_free(TdxSubscriptionArray* arr);
 
 /* ── Arrow IPC terminal for history tick rows ── */
@@ -832,12 +839,16 @@ typedef struct TdxArrowBytes {
     size_t len;
 } TdxArrowBytes;
 
-/* Serialise a span of history tick rows as an Arrow IPC stream — the same
- * columnar exit Python exposes via <TickName>List.to_arrow(). `rows` may be
- * NULL only when `len` is 0 (a valid zero-row stream). Returns (data=NULL,
- * len=0) on error with tdx_last_error() set; on success the caller MUST free
- * the bytes with tdx_arrow_bytes_free. The element type is the layout-pinned
- * tick struct the matching history endpoint returns. */
+/** Serialise a span of history tick rows as an Arrow IPC stream — the same
+ *  columnar exit Python exposes via <TickName>List.to_arrow(). The element
+ *  type is the layout-pinned tick struct the matching history endpoint
+ *  returns.
+ *  @param rows Pointer to the tick rows to serialise; may be NULL only when
+ *              len is 0 (a valid zero-row stream).
+ *  @param len Number of rows referenced by rows.
+ *  @return An Arrow IPC byte buffer on success that the caller MUST free with
+ *          tdx_arrow_bytes_free, or (data=NULL, len=0) on error with
+ *          tdx_last_error() set. */
 TdxArrowBytes tdx_eod_ticks_to_arrow_ipc(const TdxEodTick* rows, size_t len);
 TdxArrowBytes tdx_ohlc_ticks_to_arrow_ipc(const TdxOhlcTick* rows, size_t len);
 TdxArrowBytes tdx_trade_ticks_to_arrow_ipc(const TdxTradeTick* rows, size_t len);
@@ -861,43 +872,45 @@ TdxArrowBytes tdx_calendar_days_to_arrow_ipc(const TdxCalendarDay* rows, size_t 
 TdxArrowBytes tdx_interest_rate_ticks_to_arrow_ipc(const TdxInterestRateTick* rows, size_t len);
 TdxArrowBytes tdx_trade_quote_ticks_to_arrow_ipc(const TdxTradeQuoteTick* rows, size_t len);
 
-/** Free a byte buffer returned by any tdx_*_to_arrow_ipc terminal. */
+/** Free a byte buffer returned by any tdx_*_to_arrow_ipc terminal.
+ *  @param bytes Buffer from a tdx_*_to_arrow_ipc call; a (data=NULL, len=0)
+ *               buffer is a no-op. Call exactly once. */
 void tdx_arrow_bytes_free(TdxArrowBytes bytes);
 
 /* ── Error ── */
 
-/** Retrieve the last error message (or NULL if no error).
- *  The returned pointer is valid until the next FFI call on the same thread.
- *  Do NOT free this pointer. */
+/** Retrieve the last error message for the current thread.
+ *  @return The error string, or NULL when no error is set. The pointer is
+ *          valid only until the next FFI call on the same thread; do NOT
+ *          free it.
+ *  @note Thread-local: each thread observes only its own last error. */
 const char* tdx_last_error(void);
 
 /** Clear the thread-local error string.
- *  Higher-level wrappers should call this before issuing an FFI call so
- *  they can distinguish "the call set a new error" from "the previous
- *  call left a stale error in the slot" when an empty value (e.g. zero
- *  rows) is also a valid success outcome. */
+ *  @note Higher-level wrappers should call this before issuing an FFI call
+ *        so they can distinguish "the call set a new error" from "the
+ *        previous call left a stale error in the slot" when an empty value
+ *        (e.g. zero rows) is also a valid success outcome. */
 void tdx_clear_error(void);
 
-/** Typed discriminant of the last FFI error on this thread. Higher-
- *  level bindings (the C++ exception hierarchy below, the typed napi
- *  error subclasses in the TypeScript SDK) dispatch on this to pick
- *  the right exception / error subclass without substring-matching
- *  the formatted error string. Codes match the constants below; the
- *  string from `tdx_last_error()` carries the diagnostic.
- *
- *  Returns `TDX_ERR_NONE` when no error is set or after
- *  `tdx_clear_error()`. */
+/** Typed discriminant of the last FFI error on the current thread. Higher-
+ *  level bindings (the C++ exception hierarchy below, the typed error
+ *  subclasses in the TypeScript SDK) dispatch on this to pick the right
+ *  exception / error subclass without substring-matching the formatted
+ *  error string. The string from tdx_last_error() carries the diagnostic.
+ *  @return One of the TDX_ERR_* discriminants below; TDX_ERR_NONE when no
+ *          error is set or after tdx_clear_error(). */
 int32_t tdx_last_error_code(void);
 
-/** Server-supplied rate-limit back-off of the last FFI error on this
- *  thread, in milliseconds, or `-1` when the error carries no
- *  `RetryInfo` hint. Set only for a rate-limit error whose upstream
- *  status attached the hint; every other error reads `-1`. The C++
- *  `RateLimitError::retry_after()` surfaces this as a typed value. */
+/** Server-supplied rate-limit back-off of the last FFI error on the current
+ *  thread, in milliseconds. Set only for a rate-limit error whose upstream
+ *  status attached the hint. The C++ RateLimitError::retry_after() surfaces
+ *  this as a typed value.
+ *  @return The back-off in milliseconds, or -1 when the error carries no
+ *          retry hint (every non-rate-limit error reads -1). */
 int64_t tdx_last_error_retry_after_ms(void);
 
-/* Error-code discriminants returned by `tdx_last_error_code()`.
- * Kept in sync with the `TDX_ERR_*` constants in `ffi/src/error.rs`. */
+/* Error-code discriminants returned by `tdx_last_error_code()`. */
 #define TDX_ERR_NONE 0
 #define TDX_ERR_OTHER 1
 #define TDX_ERR_AUTHENTICATION 2
@@ -915,27 +928,45 @@ int64_t tdx_last_error_retry_after_ms(void);
 
 /* ── Credentials ── */
 
-/** Create credentials from email and password. Returns NULL on error. */
+/** Create a credentials handle from an email and password.
+ *  @param email Account email; must be non-NULL.
+ *  @param password Account password; must be non-NULL.
+ *  @return Heap-owned TdxCredentials the caller must release with
+ *          tdx_credentials_free, or NULL on error (check tdx_last_error()). */
 TdxCredentials* tdx_credentials_from_email(const char* email, const char* password);
 
-/** Load credentials from a file (line 1 = email, line 2 = password). Returns NULL on error. */
+/** Create a credentials handle by reading a file (line 1 = email,
+ *  line 2 = password).
+ *  @param path Filesystem path to the credentials file; must be non-NULL.
+ *  @return Heap-owned TdxCredentials the caller must release with
+ *          tdx_credentials_free, or NULL on error (check tdx_last_error()). */
 TdxCredentials* tdx_credentials_from_file(const char* path);
 
-/** Free a credentials handle. */
+/** Release a credentials handle.
+ *  @param creds Handle from tdx_credentials_from_email /
+ *               tdx_credentials_from_file; no-op when NULL. Call exactly once. */
 void tdx_credentials_free(TdxCredentials* creds);
 
 /* ── Config ── */
 
-/** Create a production config (ThetaData NJ datacenter). */
+/** Create a production config (ThetaData NJ datacenter).
+ *  @return Heap-owned TdxConfig the caller must release with
+ *          tdx_config_free. */
 TdxConfig* tdx_config_production(void);
 
-/** Create a dev streaming config (port 20200, infinite historical replay). */
+/** Create a dev streaming config (port 20200, infinite historical replay).
+ *  @return Heap-owned TdxConfig the caller must release with
+ *          tdx_config_free. */
 TdxConfig* tdx_config_dev(void);
 
-/** Create a stage streaming config (port 20100, testing, unstable). */
+/** Create a stage streaming config (port 20100, testing, unstable).
+ *  @return Heap-owned TdxConfig the caller must release with
+ *          tdx_config_free. */
 TdxConfig* tdx_config_stage(void);
 
-/** Free a config handle. */
+/** Release a config handle.
+ *  @param config Handle from a config factory; no-op when NULL.
+ *                Call exactly once. */
 void tdx_config_free(TdxConfig* config);
 
 /**
@@ -949,11 +980,13 @@ void tdx_config_free(TdxConfig* config);
  *             reset after a continuous data-flow window configured via
  *             `tdx_config_set_reconnect_stable_window_secs`.
  *   policy=1: Manual -- no auto-reconnect.
- * Returns 0 on success, -1 on an invalid policy (outside {0, 1}) or null
- * config. A rejected policy sets tdx_last_error_code to
- * TDX_ERR_INVALID_PARAMETER so an unknown value is rejected with the
- * same typed class the Python / TypeScript bindings raise, never
- * silently coerced to Auto.
+ * @param config Config handle to mutate.
+ * @param policy Reconnect policy selector (0 = Auto, 1 = Manual).
+ * @return 0 on success, -1 on an invalid policy (outside {0, 1}) or null
+ *         config. A rejected policy sets tdx_last_error_code to
+ *         TDX_ERR_INVALID_PARAMETER so an unknown value is rejected with the
+ *         same typed class the Python / TypeScript bindings raise, never
+ *         silently coerced to Auto.
  */
 int32_t tdx_config_set_reconnect_policy(TdxConfig* config, int policy);
 
@@ -961,6 +994,8 @@ int32_t tdx_config_set_reconnect_policy(TdxConfig* config, int policy);
  * Set the per-class transient-failure attempt budget for the
  * auto-reconnect path. Default 30. No effect unless the reconnect
  * policy is Auto.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param max_attempts Per-class transient-failure attempt budget.
  */
 void tdx_config_set_reconnect_max_attempts(TdxConfig* config,
                                            uint32_t max_attempts);
@@ -969,6 +1004,8 @@ void tdx_config_set_reconnect_max_attempts(TdxConfig* config,
  * Set the per-class rate-limited (`TooManyRequests`) attempt budget for
  * the auto-reconnect path. Default 100. No effect unless the reconnect
  * policy is Auto.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param max_rate_limited_attempts Per-class rate-limited attempt budget.
  */
 void tdx_config_set_reconnect_max_rate_limited_attempts(
     TdxConfig* config, uint32_t max_rate_limited_attempts);
@@ -977,21 +1014,26 @@ void tdx_config_set_reconnect_max_rate_limited_attempts(
  * Set the continuous successful-data-flow window (in seconds) after
  * which the auto-reconnect attempt counters reset. Default 60. No
  * effect unless the reconnect policy is Auto.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param secs Stable-window length in seconds.
  */
 void tdx_config_set_reconnect_stable_window_secs(TdxConfig* config,
                                                  uint64_t secs);
 
 /**
  * Set the reconnect delay (ms) honoured for generic transient
- * disconnects (TimedOut, ServerRestarting, Unspecified, ...). Plumbed
- * through to the streaming I/O loop at connect time. Default 250.
+ * disconnects (TimedOut, ServerRestarting, Unspecified, ...). Applied
+ * to the streaming session at connect time. Default 250.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param ms Reconnect delay in milliseconds.
  */
 void tdx_config_set_reconnect_wait_ms(TdxConfig* config, uint64_t ms);
 
 /**
- * Read the current reconnect wait_ms setting. Writes the configured
- * millisecond delay into *out_ms. Returns 0 on success, -1 if either
- * pointer is null.
+ * Read the current reconnect wait_ms setting.
+ * @param config Config handle to read.
+ * @param out_ms Receives the configured millisecond delay on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_wait_ms(const TdxConfig* config, uint64_t* out_ms);
 
@@ -999,33 +1041,42 @@ int32_t tdx_config_get_reconnect_wait_ms(const TdxConfig* config, uint64_t* out_
  * Set the reconnect delay (ms) honoured for `TooManyRequests`
  * rate-limited disconnects. Default 130_000 (the upstream-instructed
  * 130 s rate-limit cooldown).
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param ms Reconnect delay in milliseconds.
  */
 void tdx_config_set_reconnect_wait_rate_limited_ms(TdxConfig* config, uint64_t ms);
 
 /**
- * Read the current reconnect wait_rate_limited_ms setting. Same shape
- * as tdx_config_get_reconnect_wait_ms.
+ * Read the current reconnect wait_rate_limited_ms setting.
+ * @param config Config handle to read.
+ * @param out_ms Receives the configured millisecond delay on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_wait_rate_limited_ms(const TdxConfig* config, uint64_t* out_ms);
 
 
 /**
- * Read the configured reconnect policy selector. Writes 0 (Auto),
- * 1 (Manual), or 2 (Custom) into *out_policy. Returns 0 on success,
- * -1 if either pointer is null.
+ * Read the configured reconnect policy selector.
+ * @param config Config handle to read.
+ * @param out_policy Receives 0 (Auto), 1 (Manual), or 2 (Custom) on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_policy(const TdxConfig* config, int32_t* out_policy);
 
 /**
  * Read the generic-transient reconnect attempt budget (default 30).
  * When the policy is not Auto, writes the default-limits value.
- * Returns 0 on success, -1 if either pointer is null.
+ * @param config Config handle to read.
+ * @param out Receives the attempt budget on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_max_attempts(const TdxConfig* config, uint32_t* out);
 
 /**
- * Read the rate-limited reconnect attempt budget (default 100). Same
- * shape as tdx_config_get_reconnect_max_attempts.
+ * Read the rate-limited reconnect attempt budget (default 100).
+ * @param config Config handle to read.
+ * @param out Receives the attempt budget on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_max_rate_limited_attempts(const TdxConfig* config,
                                                            uint32_t* out);
@@ -1033,19 +1084,25 @@ int32_t tdx_config_get_reconnect_max_rate_limited_attempts(const TdxConfig* conf
 /**
  * Set the ServerRestarting reconnect attempt budget. Default 60. No
  * effect unless the reconnect policy is Auto.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param n ServerRestarting attempt budget.
  */
 void tdx_config_set_reconnect_max_server_restart_attempts(TdxConfig* config, uint32_t n);
 
 /**
  * Read the ServerRestarting reconnect attempt budget (default 60).
- * Same shape as tdx_config_get_reconnect_max_attempts.
+ * @param config Config handle to read.
+ * @param out Receives the attempt budget on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_max_server_restart_attempts(const TdxConfig* config,
                                                              uint32_t* out);
 
 /**
- * Read the stable-window reset interval in seconds (default 60). Same
- * shape as tdx_config_get_reconnect_max_attempts.
+ * Read the stable-window reset interval in seconds (default 60).
+ * @param config Config handle to read.
+ * @param out Receives the stable-window length in seconds on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_stable_window_secs(const TdxConfig* config, uint64_t* out);
 
@@ -1055,12 +1112,17 @@ int32_t tdx_config_get_reconnect_stable_window_secs(const TdxConfig* config, uin
  * first attempt of a consecutive-reconnect sequence. 0 disables the
  * envelope (attempt budgets only). Default 300. No effect unless the
  * reconnect policy is Auto.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param secs Reconnect envelope in seconds (0 disables).
  */
 void tdx_config_set_reconnect_max_elapsed_secs(TdxConfig* config, uint64_t secs);
 
 /**
  * Read the wall-clock reconnect envelope in seconds (default 300;
- * 0 = disabled). Same shape as tdx_config_get_reconnect_max_attempts.
+ * 0 = disabled).
+ * @param config Config handle to read.
+ * @param out Receives the envelope in seconds on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_max_elapsed_secs(const TdxConfig* config, uint64_t* out);
 
@@ -1068,19 +1130,33 @@ int32_t tdx_config_get_reconnect_max_elapsed_secs(const TdxConfig* config, uint6
  * Set the cap (ms) on the exponential generic-transient reconnect
  * ladder. The ladder starts at reconnect_wait_ms and doubles per
  * consecutive attempt up to this value. Default 30_000.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Ladder cap in milliseconds.
  */
 void tdx_config_set_reconnect_wait_max_ms(TdxConfig* config, uint64_t v);
 
-/** Read the current reconnect wait_max_ms setting (default 30_000). */
+/**
+ * Read the current reconnect wait_max_ms setting (default 30_000).
+ * @param config Config handle to read.
+ * @param out Receives the ladder cap in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_reconnect_wait_max_ms(const TdxConfig* config, uint64_t* out);
 
 /**
  * Set the flat reconnect cadence (ms) for ServerRestarting
  * disconnects. Default 5_000.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Reconnect cadence in milliseconds.
  */
 void tdx_config_set_reconnect_wait_server_restart_ms(TdxConfig* config, uint64_t v);
 
-/** Read the current reconnect wait_server_restart_ms setting (default 5_000). */
+/**
+ * Read the current reconnect wait_server_restart_ms setting (default 5_000).
+ * @param config Config handle to read.
+ * @param out Receives the cadence in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_reconnect_wait_server_restart_ms(const TdxConfig* config, uint64_t* out);
 
 /**
@@ -1089,14 +1165,18 @@ int32_t tdx_config_get_reconnect_wait_server_restart_ms(const TdxConfig* config,
  *   mode=1: Equal -- delay/2 + uniform(0, delay/2).
  *   mode=2: Decorrelated -- walk relative to the previous delay.
  *   mode=3: None -- deterministic delays (tests only).
- * Returns 0 on success, -1 on an invalid mode or null config.
+ * @param config Config handle to mutate.
+ * @param mode Jitter strategy selector (0-3 per the list above).
+ * @return 0 on success, -1 on an invalid mode or null config.
  */
 int32_t tdx_config_set_reconnect_jitter(TdxConfig* config, int32_t mode);
 
 /**
  * Read the configured reconnect jitter mode. Same encoding as
- * tdx_config_set_reconnect_jitter. Returns 0 on success, -1 if either
- * pointer is null.
+ * tdx_config_set_reconnect_jitter.
+ * @param config Config handle to read.
+ * @param out_mode Receives the jitter mode on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_reconnect_jitter(const TdxConfig* config, int32_t* out_mode);
 
@@ -1105,125 +1185,209 @@ int32_t tdx_config_get_reconnect_jitter(const TdxConfig* config, int32_t* out_mo
  * frames are written in bursts of this many, each burst flushed and
  * followed by a jittered replay_pace_ms pause. Minimum 1 (validated at
  * connect). Default 50.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param n Replay burst size in frames (minimum 1).
  */
 void tdx_config_set_reconnect_replay_burst_size(TdxConfig* config, uint32_t n);
 
-/** Read the current replay_burst_size setting (default 50). */
+/**
+ * Read the current replay_burst_size setting (default 50).
+ * @param config Config handle to read.
+ * @param out Receives the burst size on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_reconnect_replay_burst_size(const TdxConfig* config, uint32_t* out);
 
 /**
  * Set the pause (ms) between subscription-replay bursts after an
  * auto-reconnect. 0 removes the pause. Default 5.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Inter-burst pause in milliseconds (0 disables).
  */
 void tdx_config_set_reconnect_replay_pace_ms(TdxConfig* config, uint64_t v);
 
-/** Read the current replay_pace_ms setting (default 5). */
+/**
+ * Read the current replay_pace_ms setting (default 5).
+ * @param config Config handle to read.
+ * @param out Receives the pause in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_reconnect_replay_pace_ms(const TdxConfig* config, uint64_t* out);
 
 /**
  * Reconnect-decision callback for tdx_config_set_reconnect_callback.
  * Invoked on the streaming I/O thread after each retriable involuntary
- * disconnect. reason is the RemoveReason discriminant; attempt is the
- * 1-based consecutive-reconnect counter. Return the reconnect delay in
- * milliseconds, or any negative value to stop reconnecting.
+ * disconnect.
+ * @param reason The disconnect-reason discriminant.
+ * @param attempt The 1-based consecutive-reconnect counter.
+ * @param user_data The opaque pointer registered alongside the callback.
+ * @return The reconnect delay in milliseconds, or any negative value to
+ *         stop reconnecting.
  */
 typedef int64_t (*TdxReconnectCallback)(int32_t reason, uint32_t attempt, void* user_data);
 
 /**
  * Install a custom reconnect policy driven by a C callback. Permanent
- * disconnect reasons never reach the callback. The callback runs on
- * the SDK's streaming I/O thread: cb and user_data must be safe to use
- * from another thread for as long as any client built from this config
- * is alive. Passing cb=NULL restores the default Auto policy. Returns
- * 0 on success, -1 if config is null.
+ * disconnect reasons never reach the callback.
+ * @param config Config handle to mutate.
+ * @param cb The reconnect-decision callback; NULL restores the default Auto
+ *           policy.
+ * @param user_data Opaque pointer passed back to cb unchanged.
+ * @return 0 on success, -1 if config is null.
+ * @note cb runs on the streaming I/O thread: cb and user_data must be safe
+ *       to use from another thread for as long as any client built from
+ *       this config is alive.
  */
 int32_t tdx_config_set_reconnect_callback(TdxConfig* config, TdxReconnectCallback cb,
                                           void* user_data);
 
 /**
  * Set the FPSS read timeout (ms): the no-frames deadline after which
- * the streaming I/O loop declares the session dead and reconnects.
- * Default 3_000; validated to [100, 60_000] at connect.
+ * the streaming session is declared dead and reconnects. Default 3_000;
+ * validated to [100, 60_000] at connect.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Read timeout in milliseconds.
  */
 void tdx_config_set_fpss_timeout_ms(TdxConfig* config, uint64_t v);
 
-/** Read the current fpss timeout_ms setting (default 3_000). */
+/**
+ * Read the current fpss timeout_ms setting (default 3_000).
+ * @param config Config handle to read.
+ * @param out Receives the timeout in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_timeout_ms(const TdxConfig* config, uint64_t* out);
 
 /**
  * Set the per-server connect timeout (ms) for the streaming
  * connection. Default 2_000; validated to [1_000, 60_000] at connect.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Connect timeout in milliseconds.
  */
 void tdx_config_set_fpss_connect_timeout_ms(TdxConfig* config, uint64_t v);
 
-/** Read the current fpss connect_timeout_ms setting (default 2_000). */
+/**
+ * Read the current fpss connect_timeout_ms setting (default 2_000).
+ * @param config Config handle to read.
+ * @param out Receives the timeout in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_connect_timeout_ms(const TdxConfig* config, uint64_t* out);
 
 /**
  * Set the FPSS heartbeat ping interval (ms). Default 250; validated to
  * [100, 300_000] at connect.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Ping interval in milliseconds.
  */
 void tdx_config_set_fpss_ping_interval_ms(TdxConfig* config, uint64_t v);
 
-/** Read the current fpss ping_interval_ms setting (default 250). */
+/**
+ * Read the current fpss ping_interval_ms setting (default 250).
+ * @param config Config handle to read.
+ * @param out Receives the interval in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_ping_interval_ms(const TdxConfig* config, uint64_t* out);
 
 /**
- * Set the per-iteration blocking-read slice (ms) for the streaming I/O
- * loop. Default 25; validated to [10, 500] at connect.
+ * Set the per-iteration blocking-read slice (ms) for the streaming
+ * session. Default 25; validated to [10, 500] at connect.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Read slice in milliseconds.
  */
 void tdx_config_set_fpss_io_read_slice_ms(TdxConfig* config, uint64_t v);
 
-/** Read the current fpss io_read_slice_ms setting (default 25). */
+/**
+ * Read the current fpss io_read_slice_ms setting (default 25).
+ * @param config Config handle to read.
+ * @param out Receives the read slice in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_io_read_slice_ms(const TdxConfig* config, uint64_t* out);
 
 /**
  * Set the last-frame watchdog (ms): when no frame of any kind has
- * arrived for this long the I/O loop force-reconnects. 0 disables.
+ * arrived for this long the session force-reconnects. 0 disables.
  * Default 30_000.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Watchdog interval in milliseconds (0 disables).
  */
 void tdx_config_set_fpss_data_watchdog_ms(TdxConfig* config, uint64_t v);
 
-/** Read the current fpss data_watchdog_ms setting (default 30_000; 0 = disabled). */
+/**
+ * Read the current fpss data_watchdog_ms setting (default 30_000; 0 = disabled).
+ * @param config Config handle to read.
+ * @param out Receives the watchdog interval in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_data_watchdog_ms(const TdxConfig* config, uint64_t* out);
 
 /**
  * Set the TCP keepalive idle time (seconds) before the first kernel
  * probe on a silent FPSS socket. Default 5; validated to [1, 7_200]
  * at connect.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Keepalive idle time in seconds.
  */
 void tdx_config_set_fpss_keepalive_idle_secs(TdxConfig* config, uint64_t v);
 
-/** Read the current fpss keepalive_idle_secs setting (default 5). */
+/**
+ * Read the current fpss keepalive_idle_secs setting (default 5).
+ * @param config Config handle to read.
+ * @param out Receives the idle time in seconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_keepalive_idle_secs(const TdxConfig* config, uint64_t* out);
 
 /**
  * Set the interval (seconds) between TCP keepalive probes. Default 2;
  * validated to [1, 75] at connect.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Keepalive probe interval in seconds.
  */
 void tdx_config_set_fpss_keepalive_interval_secs(TdxConfig* config, uint64_t v);
 
-/** Read the current fpss keepalive_interval_secs setting (default 2). */
+/**
+ * Read the current fpss keepalive_interval_secs setting (default 2).
+ * @param config Config handle to read.
+ * @param out Receives the probe interval in seconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_keepalive_interval_secs(const TdxConfig* config, uint64_t* out);
 
 /**
  * Set the number of unanswered TCP keepalive probes after which the
  * kernel declares the FPSS connection dead (where the platform exposes
  * the knob). Default 2; validated to [1, 10] at connect.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param v Keepalive probe-failure count.
  */
 void tdx_config_set_fpss_keepalive_retries(TdxConfig* config, uint32_t v);
 
-/** Read the current fpss keepalive_retries setting (default 2). */
+/**
+ * Read the current fpss keepalive_retries setting (default 2).
+ * @param config Config handle to read.
+ * @param out Receives the probe-failure count on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_keepalive_retries(const TdxConfig* config, uint32_t* out);
 
 /**
  * Set the FPSS event ring buffer size (slots). Must be a power of two
  * >= 64; invalid values are rejected at the setter (tdx_last_error).
  * Default 131_072.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param n Ring buffer size in slots (power of two, >= 64).
  */
 void tdx_config_set_fpss_ring_size(TdxConfig* config, size_t n);
 
-/** Read the current fpss ring_size setting (default 131_072). */
+/**
+ * Read the current fpss ring_size setting (default 131_072).
+ * @param config Config handle to read.
+ * @param out Receives the ring buffer size in slots on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_fpss_ring_size(const TdxConfig* config, size_t* out);
 
 /**
@@ -1232,31 +1396,40 @@ int32_t tdx_config_get_fpss_ring_size(const TdxConfig* config, size_t* out);
  *             shuffle; a fleet spreads across hosts and consecutive
  *             failover attempts cross physical machines.
  *   policy=1: FixedOrder -- use the declared host order verbatim.
- * Returns 0 on success, -1 on an invalid policy or null config.
+ * @param config Config handle to mutate.
+ * @param policy Host-selection policy selector (0 = Shuffled, 1 = FixedOrder).
+ * @return 0 on success, -1 on an invalid policy or null config.
  */
 int32_t tdx_config_set_fpss_host_selection(TdxConfig* config, int32_t policy);
 
 /**
  * Read the configured FPSS host-selection policy. Same encoding as
- * tdx_config_set_fpss_host_selection. Returns 0 on success, -1 if
- * either pointer is null.
+ * tdx_config_set_fpss_host_selection.
+ * @param config Config handle to read.
+ * @param out_policy Receives the host-selection policy on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_fpss_host_selection(const TdxConfig* config, int32_t* out_policy);
 
 /**
  * Set the FPSS host-shuffle seed using the (has_value, seed) widened
- * shape. has_value=false (default) derives a fresh per-client seed so
- * a fleet shuffles independently; has_value=true makes the shuffled
- * order deterministic -- useful for fleet sharding and tests. Ignored
- * under the FixedOrder policy. Returns 0 on success, -1 if config is
- * null.
+ * shape. Ignored under the FixedOrder policy.
+ * @param config Config handle to mutate.
+ * @param has_value false (default) derives a fresh per-client seed so a
+ *                  fleet shuffles independently; true makes the shuffled
+ *                  order deterministic, useful for fleet sharding and tests.
+ * @param seed The deterministic seed, honoured only when has_value is true.
+ * @return 0 on success, -1 if config is null.
  */
 int32_t tdx_config_set_fpss_host_shuffle_seed(TdxConfig* config, bool has_value, uint64_t seed);
 
 /**
- * Read the current FPSS host-shuffle seed. *out_has_value=false
- * encodes the per-client-entropy sentinel. Returns 0 on success, -1
- * if any pointer is null.
+ * Read the current FPSS host-shuffle seed.
+ * @param config Config handle to read.
+ * @param out_has_value Receives false for the per-client-entropy sentinel,
+ *                      true when an explicit seed is set.
+ * @param out_seed Receives the seed when out_has_value is true.
+ * @return 0 on success, -1 if any pointer is null.
  */
 int32_t tdx_config_get_fpss_host_shuffle_seed(const TdxConfig* config, bool* out_has_value,
                                               uint64_t* out_seed);
@@ -1265,43 +1438,57 @@ int32_t tdx_config_get_fpss_host_shuffle_seed(const TdxConfig* config, bool* out
  * Set the wall-clock envelope (seconds) for one historical-channel
  * retry sequence, measured from the first attempt. 0 disables the
  * envelope (attempt budget only). Default 300.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param secs Retry envelope in seconds (0 disables).
  */
 void tdx_config_set_retry_max_elapsed_secs(TdxConfig* config, uint64_t secs);
 
-/** Read the current retry max_elapsed value in seconds (default 300; 0 = disabled). */
+/**
+ * Read the current retry max_elapsed value in seconds (default 300; 0 = disabled).
+ * @param config Config handle to read.
+ * @param out_secs Receives the envelope in seconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_retry_max_elapsed_secs(const TdxConfig* config, uint64_t* out_secs);
 
 /**
  * Toggle AWS-style full jitter on the flatfile retry ladder. Default
  * true; false gives the deterministic schedule, useful for tests.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param jitter true enables full jitter, false uses the deterministic schedule.
  */
 void tdx_config_set_flatfiles_jitter(TdxConfig* config, bool jitter);
 
-/** Read the current flatfiles jitter setting (default true). */
+/**
+ * Read the current flatfiles jitter setting (default true).
+ * @param config Config handle to read.
+ * @param out_jitter Receives the jitter flag on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_flatfiles_jitter(const TdxConfig* config, bool* out_jitter);
 
 /**
- * Set the async worker-thread count for embedded runtimes.
- *
- *   has_value=false: encodes the auto-size sentinel (`None`); `n`
- *     is ignored. Defers to the default sizing.
- *   has_value=true: encodes `Some(n)`. The builder clamps `n=0` to
- *     `1`, but the explicit `Some(0)` is preserved across the C
- *     boundary matching the widened Option shape so Python / TS / C++
- *     bindings agree.
- *
- * Returns 0 on success, -1 if `config` is NULL.
+ * Set the async worker-thread count for embedded runtimes, using the
+ * widened (has_value, n) shape so an unset value is distinct from any
+ * explicit count across the Python / TypeScript / C++ bindings.
+ * @param config Config handle to mutate.
+ * @param has_value false leaves the count unset (auto-sized) and ignores n;
+ *                  true sets an explicit count. An explicit 0 is preserved
+ *                  across the boundary; the connection clamps it to 1.
+ * @param n The explicit worker-thread count, honoured only when has_value
+ *          is true.
+ * @return 0 on success, -1 if config is NULL.
  */
 int32_t tdx_config_set_worker_threads(TdxConfig* config, bool has_value, size_t n);
 
 /**
- * Read the current async worker-thread count. Same widened
- * (has_value, n) shape:
- *
- *   *out_has_value=false: config holds `None` (auto-size). *out_n=0.
- *   *out_has_value=true:  config holds `Some(*out_n)`.
- *
- * Returns 0 on success, -1 if any pointer is null.
+ * Read the current async worker-thread count, using the same widened
+ * (has_value, n) shape.
+ * @param config Config handle to read.
+ * @param out_has_value Receives false when the count is unset (auto-sized),
+ *                      true when an explicit count is set.
+ * @param out_n Receives the count (0 when unset, the explicit count otherwise).
+ * @return 0 on success, -1 if any pointer is null.
  */
 int32_t tdx_config_get_worker_threads(const TdxConfig* config, bool* out_has_value, size_t* out_n);
 
@@ -1311,128 +1498,184 @@ int32_t tdx_config_get_worker_threads(const TdxConfig* config, bool* out_has_val
  * Set the initial backoff delay (ms) for the historical-channel retry policy.
  * Default 250. Subsequent retries double from here, capped at
  * tdx_config_set_retry_max_delay_ms.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param ms Initial backoff delay in milliseconds.
  */
 void tdx_config_set_retry_initial_delay_ms(TdxConfig* config, uint64_t ms);
 
-/** Read retry.initial_delay (ms). */
+/**
+ * Read the historical-channel retry initial-delay setting (ms).
+ * @param config Config handle to read.
+ * @param out_ms Receives the initial delay in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_retry_initial_delay_ms(const TdxConfig* config, uint64_t* out_ms);
 
 /**
  * Set the upper-bound backoff delay (ms) for the historical-channel retry policy.
  * Default 30_000 (30 s).
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param ms Upper-bound backoff delay in milliseconds.
  */
 void tdx_config_set_retry_max_delay_ms(TdxConfig* config, uint64_t ms);
 
-/** Read retry.max_delay (ms). */
+/**
+ * Read the historical-channel retry max-delay setting (ms).
+ * @param config Config handle to read.
+ * @param out_ms Receives the max delay in milliseconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_retry_max_delay_ms(const TdxConfig* config, uint64_t* out_ms);
 
 /**
  * Set the total attempt budget for the historical-channel retry policy. 1 disables
  * retry (single call only); higher values permit retries up to
  * max_attempts - 1 after the initial call. Default 20.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param n Total attempt budget.
  */
 void tdx_config_set_retry_max_attempts(TdxConfig* config, uint32_t n);
 
-/** Read retry.max_attempts. */
+/**
+ * Read the historical-channel retry max-attempts setting.
+ * @param config Config handle to read.
+ * @param out_n Receives the attempt budget on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_retry_max_attempts(const TdxConfig* config, uint32_t* out_n);
 
 /**
  * Toggle AWS-style full-jitter on the historical-channel retry policy. Default
  * true. false gives the deterministic backoff schedule
  * min(max_delay, initial * 2^attempt), useful for tests.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param jitter true enables full jitter, false uses the deterministic schedule.
  */
 void tdx_config_set_retry_jitter(TdxConfig* config, bool jitter);
 
-/** Read retry.jitter. */
+/**
+ * Read the historical-channel retry jitter setting.
+ * @param config Config handle to read.
+ * @param out_jitter Receives the jitter flag on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_retry_jitter(const TdxConfig* config, bool* out_jitter);
 
 /* ── FlatFilesConfig field setters/getters ── */
 
 /**
- * Set the total attempt budget for the flatfile driver retry loop.
+ * Set the total attempt budget for the flatfile retry loop.
  * 1 disables retry (single call only); higher values permit retries
  * up to max_attempts - 1 after the initial call. Default 10.
  * Validated to the range [1, 100] at connect time.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param n Total attempt budget.
  */
 void tdx_config_set_flatfiles_max_attempts(TdxConfig* config, uint32_t n);
 
-/** Read flatfiles.max_attempts. */
+/**
+ * Read the flatfile retry max-attempts setting.
+ * @param config Config handle to read.
+ * @param out_n Receives the attempt budget on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_flatfiles_max_attempts(const TdxConfig* config, uint32_t* out_n);
 
 /**
- * Set the initial backoff delay (seconds) for the flatfile driver
- * retry loop. Doubles per attempt up to max_backoff_secs. Default 1.
+ * Set the initial backoff delay (seconds) for the flatfile retry loop.
+ * Doubles per attempt up to max_backoff_secs. Default 1.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param secs Initial backoff delay in seconds.
  */
 void tdx_config_set_flatfiles_initial_backoff_secs(TdxConfig* config, uint64_t secs);
 
-/** Read flatfiles.initial_backoff (seconds). */
+/**
+ * Read the flatfile retry initial-backoff setting (seconds).
+ * @param config Config handle to read.
+ * @param out_secs Receives the initial backoff in seconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_flatfiles_initial_backoff_secs(const TdxConfig* config, uint64_t* out_secs);
 
 /**
- * Set the upper-bound backoff delay (seconds) for the flatfile
- * driver retry loop. The doubling schedule never exceeds this value
- * regardless of attempt number. Default 30. Must be >= initial_backoff
- * (rejected at connect-time validate otherwise).
+ * Set the upper-bound backoff delay (seconds) for the flatfile retry
+ * loop. The doubling schedule never exceeds this value regardless of
+ * attempt number. Default 30. Must be >= initial_backoff (rejected at
+ * connect-time validation otherwise).
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param secs Upper-bound backoff delay in seconds.
  */
 void tdx_config_set_flatfiles_max_backoff_secs(TdxConfig* config, uint64_t secs);
 
-/** Read flatfiles.max_backoff (seconds). */
+/**
+ * Read the flatfile retry max-backoff setting (seconds).
+ * @param config Config handle to read.
+ * @param out_secs Receives the max backoff in seconds on success.
+ * @return 0 on success, -1 if either pointer is null.
+ */
 int32_t tdx_config_get_flatfiles_max_backoff_secs(const TdxConfig* config, uint64_t* out_secs);
 
 /* ── AuthConfig field setters/getters ── */
 
 /**
- * Set the Nexus auth URL on a config handle. `url` must be a non-null,
- * NUL-terminated, valid-UTF-8 C string. Returns 0 on success, -1 if
- * `config` is null or `url` is null / not valid UTF-8 (check
- * tdx_last_error()).
+ * Set the Nexus auth URL on a config handle.
+ * @param config Config handle to mutate.
+ * @param url Non-null, NUL-terminated, valid-UTF-8 C string.
+ * @return 0 on success, -1 if config is null or url is null / not valid
+ *         UTF-8 (check tdx_last_error()).
  */
 int32_t tdx_config_set_nexus_url(TdxConfig* config, const char* url);
 
 /**
- * Read auth.nexus_url. Returns a heap-owned NUL-terminated C string
- * the caller MUST release with tdx_string_free, or null on a null
- * handle / interior-NUL value (check tdx_last_error()).
+ * Read the configured Nexus auth URL.
+ * @param config Config handle to read.
+ * @return A heap-owned NUL-terminated C string the caller MUST release with
+ *         tdx_string_free, or NULL on a null handle / interior-NUL value
+ *         (check tdx_last_error()).
  */
 char* tdx_config_get_nexus_url(const TdxConfig* config);
 
 /**
- * Set the QueryInfo.client_type identifier on a config handle.
- * `client_type` must be a non-null, NUL-terminated, valid-UTF-8 C
- * string. Returns 0 on success, -1 if `config` is null or
- * `client_type` is null / not valid UTF-8 (check tdx_last_error()).
+ * Set the client_type query identifier on a config handle.
+ * @param config Config handle to mutate.
+ * @param client_type Non-null, NUL-terminated, valid-UTF-8 C string.
+ * @return 0 on success, -1 if config is null or client_type is null / not
+ *         valid UTF-8 (check tdx_last_error()).
  */
 int32_t tdx_config_set_client_type(TdxConfig* config, const char* client_type);
 
 /**
- * Read auth.client_type. Returns a heap-owned NUL-terminated C string
- * the caller MUST release with tdx_string_free, or null on a null
- * handle / interior-NUL value (check tdx_last_error()).
+ * Read the configured client_type query identifier.
+ * @param config Config handle to read.
+ * @return A heap-owned NUL-terminated C string the caller MUST release with
+ *         tdx_string_free, or NULL on a null handle / interior-NUL value
+ *         (check tdx_last_error()).
  */
 char* tdx_config_get_client_type(const TdxConfig* config);
 
 /* ── MetricsConfig field setter/getter ── */
 
 /**
- * Set the Prometheus exporter port on a config handle. Uses the
- * widened (has_value, port) shape:
- *
- *   has_value=false: encodes `None` (exporter disabled). `port` ignored.
- *   has_value=true:  encodes `Some(port)`. The exporter binds an HTTP
- *     listener on 0.0.0.0:<port> when the metrics-prometheus feature
- *     is compiled in.
- *
- * Returns 0 on success, -1 if `config` is null.
+ * Set the Prometheus exporter port on a config handle, using the widened
+ * (has_value, port) shape.
+ * @param config Config handle to mutate.
+ * @param has_value false leaves the exporter disabled and ignores port;
+ *                  true enables it. When enabled and the metrics-prometheus
+ *                  feature is compiled in, the exporter binds an HTTP
+ *                  listener on 0.0.0.0:<port>.
+ * @param port The exporter port, honoured only when has_value is true.
+ * @return 0 on success, -1 if config is null.
  */
 int32_t tdx_config_set_metrics_port(TdxConfig* config, bool has_value, uint16_t port);
 
 /**
- * Read metrics.port. Same (has_value, port) shape:
- *
- *   *out_has_value=false: config holds `None` (disabled). *out_port=0.
- *   *out_has_value=true:  config holds `Some(*out_port)`.
- *
- * Returns 0 on success, -1 if any pointer is null.
+ * Read the configured Prometheus exporter port, using the same widened
+ * (has_value, port) shape.
+ * @param config Config handle to read.
+ * @param out_has_value Receives false when the exporter is disabled, true
+ *                      when a port is set.
+ * @param out_port Receives the port (0 when disabled, the set port otherwise).
+ * @return 0 on success, -1 if any pointer is null.
  */
 int32_t tdx_config_get_metrics_port(const TdxConfig* config, bool* out_has_value, uint16_t* out_port);
 
@@ -1440,114 +1683,142 @@ int32_t tdx_config_get_metrics_port(const TdxConfig* config, bool* out_has_value
  * Set streaming flush mode on a config handle.
  *   mode=0: Batched (default) -- flush only on PING every 100ms.
  *   mode=1: Immediate -- flush after every frame write.
- *
- * Returns 0 on success. Returns -1 and sets `tdx_last_error` /
- * `tdx_last_error_code = TDX_ERR_CONFIG` when `mode` is outside the
- * documented `{0, 1}` set or when `config` is null.
+ * @param config Config handle to mutate.
+ * @param mode Flush mode selector (0 = Batched, 1 = Immediate).
+ * @return 0 on success. -1 with tdx_last_error set and tdx_last_error_code =
+ *         TDX_ERR_CONFIG when mode is outside {0, 1} or config is null.
  */
 int tdx_config_set_flush_mode(TdxConfig* config, int mode);
 
 /**
  * Read the current streaming flush mode. Same encoding as
- * tdx_config_set_flush_mode: writes 0 (Batched) or 1 (Immediate) into
- * *out_mode. Returns 0 on success, -1 if either pointer is null.
+ * tdx_config_set_flush_mode.
+ * @param config Config handle to read.
+ * @param out_mode Receives 0 (Batched) or 1 (Immediate) on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_flush_mode(const TdxConfig* config, int32_t* out_mode);
 
 /**
  * Set streaming OHLCVC derivation on a config handle.
- *   enabled=true (default): derive OHLCVC bars locally from trade events.
- *   enabled=false: only emit server-sent OHLCVC frames (lower overhead).
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param enabled true (default) derives OHLCVC bars locally from trade
+ *                events; false emits only server-sent OHLCVC frames
+ *                (lower overhead).
  */
 void tdx_config_set_derive_ohlcvc(TdxConfig* config, bool enabled);
 
 /**
- * Read the current OHLCVC-derivation flag. Writes true/false into
- * *out_enabled. Returns 0 on success, -1 if either pointer is null.
+ * Read the current OHLCVC-derivation flag.
+ * @param config Config handle to read.
+ * @param out_enabled Receives the derivation flag on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_derive_ohlcvc(const TdxConfig* config, bool* out_enabled);
 
 /* ── Decode pool sizing ── */
 
 /**
- * Set the historical (MDDS) gRPC host. host must be a non-null,
- * NUL-terminated, valid-UTF-8 C string. Returns 0 on success, -1 if
- * config is null or host is null / not valid UTF-8.
+ * Set the historical (MDDS) gRPC host.
+ * @param config Config handle to mutate.
+ * @param host Non-null, NUL-terminated, valid-UTF-8 C string.
+ * @return 0 on success, -1 if config is null or host is null / not valid
+ *         UTF-8.
  */
 int32_t tdx_config_set_mdds_host(TdxConfig* config, const char* host);
 
 /**
- * Read the current historical (MDDS) gRPC host. Returns a heap-owned
- * NUL-terminated C string the caller MUST free with tdx_string_free, or
- * null if config is null or the value contains an interior NUL.
+ * Read the configured historical (MDDS) gRPC host.
+ * @param config Config handle to read.
+ * @return A heap-owned NUL-terminated C string the caller MUST free with
+ *         tdx_string_free, or NULL if config is null or the value contains
+ *         an interior NUL.
  */
 char* tdx_config_get_mdds_host(const TdxConfig* config);
 
-/** Set the historical (MDDS) gRPC port. */
+/**
+ * Set the historical (MDDS) gRPC port.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param port The gRPC port.
+ */
 void tdx_config_set_mdds_port(TdxConfig* config, uint16_t port);
 
 /**
- * Read the configured historical (MDDS) gRPC port. Writes the value
- * into *out_port. Returns 0 on success, -1 if either pointer is null.
+ * Read the configured historical (MDDS) gRPC port.
+ * @param config Config handle to read.
+ * @param out_port Receives the gRPC port on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_mdds_port(const TdxConfig* config, uint16_t* out_port);
 
 /**
  * Set the number of concurrent in-flight gRPC requests.
- *
- *   n=0 (default): auto-detect from the Nexus subscription tier
- *     (Free=1 / Value=2 / Standard=4 / Pro=8).
- *   n>0: explicit cap, clamped to the tier cap at connect time
- *     with a `tracing::warn!` if exceeded.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param n 0 (default) auto-detects the cap from the subscription
+ *          entitlement; a positive value is an explicit cap, clamped to
+ *          the entitlement cap at connect time with a logged warning if
+ *          exceeded.
  */
 void tdx_config_set_concurrent_requests(TdxConfig* config, uint32_t n);
 
 /**
- * Read the current concurrent in-flight gRPC request count. Writes the
- * value into *out_n (0 = auto-detect from the tier). Returns 0 on
- * success, -1 if either pointer is null.
+ * Read the current concurrent in-flight gRPC request count.
+ * @param config Config handle to read.
+ * @param out_n Receives the count on success (0 = auto-detect).
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_concurrent_requests(const TdxConfig* config, uint32_t* out_n);
 
 /**
  * Set the warn_on_buffered_threshold_bytes ceiling on a config.
  *
- * Pre-stream-API endpoints (the non-`.stream()` shape) log a
- * `tracing::warn!` when a buffered response's decoded total exceeds
- * this threshold, guiding users to the streaming variant. The
- * payload is still delivered.
- *
- *   n=0 disables the warning entirely.
- *   default = 100 * 1024 * 1024 (100 MiB).
+ * Buffered (non-streaming) endpoints log a warning when a response's
+ * decoded total exceeds this threshold, guiding users to the streaming
+ * variant. The payload is still delivered.
+ * @param config Config handle to mutate; no-op when NULL.
+ * @param n Threshold in bytes; 0 disables the warning. Default
+ *          100 * 1024 * 1024 (100 MiB).
  */
 void tdx_config_set_warn_on_buffered_threshold_bytes(TdxConfig* config, size_t n);
 
 /**
  * Read the current warn_on_buffered_threshold_bytes setting.
- *
- * Writes the configured byte count into *out_n. Returns 0 on success,
- * -1 if either pointer is null.
+ * @param config Config handle to read.
+ * @param out_n Receives the configured byte count on success.
+ * @return 0 on success, -1 if either pointer is null.
  */
 int32_t tdx_config_get_warn_on_buffered_threshold_bytes(const TdxConfig* config, size_t* out_n);
 
 /* ── MddsClient ── */
 
-/** Connect a historical (MDDS) client to ThetaData servers. Returns NULL on
- *  connection/auth failure. */
+/** Connect a historical (MDDS) client to ThetaData servers.
+ *  @param creds Credentials handle; must be non-NULL.
+ *  @param config Config handle; must be non-NULL.
+ *  @return A connected client the caller must release with
+ *          tdx_mdds_client_free, or NULL on connection/auth failure
+ *          (check tdx_last_error()). */
 TdxMddsClient* tdx_mdds_client_connect(const TdxCredentials* creds, const TdxConfig* config);
 
-/** Connect a historical (MDDS) client, loading credentials from a file
+/** Connect a historical (MDDS) client, reading credentials from a file
  *  (line 1 = email, line 2 = password). One-call equivalent of
- *  tdx_credentials_from_file + tdx_mdds_client_connect. Free with
- *  tdx_mdds_client_free. Returns NULL on argument or connection/auth failure. */
+ *  tdx_credentials_from_file + tdx_mdds_client_connect.
+ *  @param path Filesystem path to the credentials file; must be non-NULL.
+ *  @param config Config handle; must be non-NULL.
+ *  @return A connected client the caller must release with
+ *          tdx_mdds_client_free, or NULL on argument or connection/auth
+ *          failure (check tdx_last_error()). */
 TdxMddsClient* tdx_mdds_client_connect_from_file(const char* path, const TdxConfig* config);
 
-/** Free a historical (MDDS) client handle. */
+/** Release a historical (MDDS) client handle.
+ *  @param client Handle from a tdx_mdds_client_connect* call; no-op when
+ *                NULL. Call exactly once. */
 void tdx_mdds_client_free(TdxMddsClient* client);
 
 /* ── String free ── */
 
-/** Free a string returned by any tdx_* function. */
+/** Free a string returned by any tdx_* function.
+ *  @param s Heap-owned string from a tdx_* call; no-op when NULL. Call
+ *           exactly once. */
 void tdx_string_free(char* s);
 
 /* Generated option-aware endpoint declarations. */
@@ -1609,82 +1880,117 @@ int tdx_implied_volatility(double spot, double strike, double rate, double div_y
 /* ═══════════════════════════════════════════════════════════════════════ */
 
 /* All `tdx_*_name` / `tdx_*_description` / `tdx_exchange_*` returns are
- * NUL-terminated UTF-8 C strings owned by the library. They are
- * `'static`-lifetime — DO NOT FREE. The pointer remains valid for the
- * lifetime of the process.  Unknown codes return either "UNKNOWN" (name
- * lookup) or "" (description lookup), never NULL. */
+ * NUL-terminated UTF-8 C strings owned by the library — DO NOT FREE. The
+ * pointer remains valid for the lifetime of the process. Unknown codes
+ * return either "UNKNOWN" (name lookup) or "" (description lookup), never
+ * NULL. */
 
-/** Trade condition name lookup. Returns "UNKNOWN" for unrecognised codes. */
+/** Trade condition name lookup.
+ *  @param code The trade condition code.
+ *  @return A process-lifetime string; "UNKNOWN" for unrecognised codes.
+ *          Never NULL; DO NOT FREE. */
 const char* tdx_condition_name(int32_t code);
 
-/** Trade condition description lookup. Returns "" for unrecognised codes. */
+/** Trade condition description lookup.
+ *  @param code The trade condition code.
+ *  @return A process-lifetime string; "" for unrecognised codes. Never
+ *          NULL; DO NOT FREE. */
 const char* tdx_condition_description(int32_t code);
 
-/** True if the trade condition code represents a cancellation. */
+/** Whether a trade condition code represents a cancellation.
+ *  @param code The trade condition code.
+ *  @return true if the code represents a cancellation, false otherwise. */
 bool tdx_condition_is_cancel(int32_t code);
 
-/** True if the trade condition code updates the volume bar. */
+/** Whether a trade condition code updates the volume bar.
+ *  @param code The trade condition code.
+ *  @return true if the code updates the volume bar, false otherwise. */
 bool tdx_condition_updates_volume(int32_t code);
 
-/** Quote condition name lookup. Returns "UNKNOWN" for unrecognised codes. */
+/** Quote condition name lookup.
+ *  @param code The quote condition code.
+ *  @return A process-lifetime string; "UNKNOWN" for unrecognised codes.
+ *          Never NULL; DO NOT FREE. */
 const char* tdx_quote_condition_name(int32_t code);
 
-/** Quote condition description lookup. Returns "" for unrecognised codes. */
+/** Quote condition description lookup.
+ *  @param code The quote condition code.
+ *  @return A process-lifetime string; "" for unrecognised codes. Never
+ *          NULL; DO NOT FREE. */
 const char* tdx_quote_condition_description(int32_t code);
 
-/** True if the quote condition is firm (binding). */
+/** Whether a quote condition is firm (binding).
+ *  @param code The quote condition code.
+ *  @return true if the quote condition is firm, false otherwise. */
 bool tdx_quote_condition_is_firm(int32_t code);
 
-/** True if the quote condition indicates a trading halt. */
+/** Whether a quote condition indicates a trading halt.
+ *  @param code The quote condition code.
+ *  @return true if the quote condition indicates a trading halt, false
+ *          otherwise. */
 bool tdx_quote_condition_is_halted(int32_t code);
 
-/** Exchange name lookup (e.g. 3 -> "NewYorkStockExchange"). */
+/** Exchange name lookup (e.g. 3 -> "NewYorkStockExchange").
+ *  @param code The exchange code.
+ *  @return A process-lifetime string; "UNKNOWN" for unrecognised codes.
+ *          Never NULL; DO NOT FREE. */
 const char* tdx_exchange_name(int32_t code);
 
-/** Exchange MIC-like symbol lookup (e.g. 3 -> "NYSE"). */
+/** Exchange MIC-like symbol lookup (e.g. 3 -> "NYSE").
+ *  @param code The exchange code.
+ *  @return A process-lifetime string; "UNKNOWN" for unrecognised codes.
+ *          Never NULL; DO NOT FREE. */
 const char* tdx_exchange_symbol(int32_t code);
 
 /** Calendar day-type vocabulary lookup (0 -> "open", 1 -> "early_close",
- *  2 -> "full_close", 3 -> "weekend"; "UNKNOWN" otherwise). 'static
- *  lifetime — DO NOT FREE. */
+ *  2 -> "full_close", 3 -> "weekend").
+ *  @param code The calendar day-type code.
+ *  @return A process-lifetime string; "UNKNOWN" for unrecognised codes.
+ *          Never NULL; DO NOT FREE. */
 const char* tdx_calendar_status_name(int32_t code);
 
 /** Combine an Eastern-Time YYYYMMDD date and milliseconds-of-day into
  *  Unix epoch milliseconds (UTC, DST-aware). Usable with any
- *  (date, *_ms_of_day) pair on the tick structs. Returns -1 when date
- *  is not a valid YYYYMMDD (including the 0 absent fill) or ms_of_day
- *  is outside 0..86,400,000. */
+ *  (date, *_ms_of_day) pair on the tick structs.
+ *  @param date An Eastern-Time YYYYMMDD date.
+ *  @param ms_of_day Milliseconds since midnight Eastern.
+ *  @return Unix epoch milliseconds, or -1 when date is not a valid YYYYMMDD
+ *          (including the 0 absent fill) or ms_of_day is outside
+ *          0..86,400,000. */
 int64_t tdx_timestamp_ms(int32_t date, int32_t ms_of_day);
 
 /** Convert a signed wire-encoded trade-sequence value to its unsigned
- *  monotonic form. `signed_value` must lie in the i32 wire range
- *  (-2,147,483,648 ..= 2,147,483,647). Writes the result to `out` and
- *  returns 0 on success; returns -1 and sets tdx_last_error_code to
- *  TDX_ERR_INVALID_PARAMETER when `signed_value` is outside the wire
- *  range or `out` is null, so an out-of-range value is rejected rather
- *  than silently reinterpreted. */
+ *  monotonic form.
+ *  @param signed_value Wire value; must lie in the 32-bit signed wire range
+ *                      (-2,147,483,648 ..= 2,147,483,647).
+ *  @param out Receives the unsigned monotonic value on success.
+ *  @return 0 on success; -1 with tdx_last_error_code set to
+ *          TDX_ERR_INVALID_PARAMETER when signed_value is outside the wire
+ *          range or out is null, so an out-of-range value is rejected rather
+ *          than silently reinterpreted. */
 int32_t tdx_sequence_signed_to_unsigned(int64_t signed_value, uint64_t* out);
 
 /** Convert an unsigned monotonic trade-sequence value back to its signed
- *  wire encoding. `unsigned_value` must lie in the unsigned wire range
- *  (0 ..= 2^32 - 1). Writes the result to `out` and returns 0 on
- *  success; returns -1 and sets tdx_last_error_code to
- *  TDX_ERR_INVALID_PARAMETER when `unsigned_value` is above the wire
- *  range or `out` is null. */
+ *  wire encoding.
+ *  @param unsigned_value Monotonic value; must lie in the unsigned wire
+ *                        range (0 ..= 2^32 - 1).
+ *  @param out Receives the signed wire value on success.
+ *  @return 0 on success; -1 with tdx_last_error_code set to
+ *          TDX_ERR_INVALID_PARAMETER when unsigned_value is above the wire
+ *          range or out is null. */
 int32_t tdx_sequence_unsigned_to_signed(uint64_t unsigned_value, int64_t* out);
 
 /* ═══════════════════════════════════════════════════════════════════════ */
-/*  Streaming — #[repr(C)] event types                                    */
+/*  Streaming — C-layout event types                                      */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
 /* Streaming event structs are schema-driven. The include below pulls in
- * the typedefs generated at build time from the same schema as the Rust
- * `#[repr(C)]` layout — so the C++ header can never drift from it again.
- * See `thetadx.hpp` for `static_assert(offsetof)` guards that fail the
- * build at compile time if the schema and the C++ consumer ever
- * disagree.
+ * the typedefs generated at build time from the canonical wire schema — so
+ * the C++ header can never drift from it again. See `thetadx.hpp` for
+ * `static_assert(offsetof)` guards that fail the build at compile time if
+ * the schema and the C++ consumer ever disagree.
  *
- * Each variant is a typed `#[repr(C)]` struct. Consumers dispatch via
+ * Each variant is a typed fixed-layout struct. Consumers dispatch via
  * `event->kind` and read the matching `event-><variant>` payload —
  * for example
  *
@@ -1702,31 +2008,45 @@ int32_t tdx_sequence_unsigned_to_signed(uint64_t unsigned_value, int64_t* out);
 /** Read the option strike of a streaming TdxContract in dollars, folding
  *  the has_strike presence flag into the return value. TdxContract.strike
  *  already carries dollars; this surfaces the presence flag a plain field
- *  read would drop. Writes the dollar value to *out_dollars and returns
- *  true when the contract is an option; returns false (leaving *out_dollars
- *  untouched) for a non-option, null contract, or null output pointer.
- *  Mirrors the C++ tdx::strike(const TdxContract&) accessor. */
+ *  read would drop. Mirrors the C++ tdx::strike(const TdxContract&) accessor.
+ *  @param contract The streaming contract to read.
+ *  @param out_dollars Receives the strike in dollars when the contract is an
+ *                     option; left untouched otherwise.
+ *  @return true when the contract is an option and out_dollars was written;
+ *          false for a non-option, null contract, or null output pointer. */
 bool tdx_contract_strike_dollars(const TdxContract* contract, double* out_dollars);
 
 /* ═══════════════════════════════════════════════════════════════════════ */
 /*  Real-time streaming client                                            */
 /* ═══════════════════════════════════════════════════════════════════════ */
 
-/** Connect to the real-time streaming servers. Returns NULL on failure. */
+/** Connect to the real-time streaming servers.
+ *  @param creds Credentials handle; must be non-NULL.
+ *  @param config Config handle; must be non-NULL.
+ *  @return A streaming handle the caller must release with tdx_fpss_free, or
+ *          NULL on failure (check tdx_last_error()). */
 TdxFpssHandle* tdx_fpss_connect(const TdxCredentials* creds, const TdxConfig* config);
 
-/** Connect to the real-time streaming servers, loading credentials from a file
- *  (line 1 = email, line 2 = password). One-call equivalent of
- *  tdx_credentials_from_file + tdx_fpss_connect. Free with tdx_fpss_free.
- *  Returns NULL on failure. */
+/** Connect to the real-time streaming servers, reading credentials from a
+ *  file (line 1 = email, line 2 = password). One-call equivalent of
+ *  tdx_credentials_from_file + tdx_fpss_connect.
+ *  @param path Filesystem path to the credentials file; must be non-NULL.
+ *  @param config Config handle; must be non-NULL.
+ *  @return A streaming handle the caller must release with tdx_fpss_free, or
+ *          NULL on failure (check tdx_last_error()). */
 TdxFpssHandle* tdx_fpss_connect_from_file(const char* path, const TdxConfig* config);
 
 /** Polymorphic subscribe / unsubscribe — see TdxSubscriptionRequest below. */
 
-/** Check if authenticated. Returns 1 if true, 0 if false. */
+/** Report whether the streaming session is authenticated.
+ *  @param h The streaming handle.
+ *  @return 1 when authenticated, 0 otherwise. */
 int tdx_fpss_is_authenticated(const TdxFpssHandle* h);
 
-/** Get active subscriptions as typed array. Caller must free with tdx_subscription_array_free. */
+/** Read the active subscriptions as a typed array.
+ *  @param h The streaming handle.
+ *  @return A subscription array the caller MUST free with
+ *          tdx_subscription_array_free. */
 TdxSubscriptionArray* tdx_fpss_active_subscriptions(const TdxFpssHandle* h);
 
 /** User callback signature for tdx_*_set_callback.
@@ -1737,8 +2057,9 @@ typedef void (*TdxFpssCallback)(const TdxFpssEvent* event, void* ctx);
 
 /** Register a streaming callback and open the streaming connection.
  *
- *  Events flow `streaming reader -> bounded ring -> consumer thread ->
- *  catch_unwind(callback)`. The reader thread NEVER blocks on user code:
+ *  Events flow from the streaming reader through a bounded ring to a
+ *  dedicated consumer thread, which invokes the callback inside an
+ *  isolation boundary. The reader thread NEVER blocks on user code:
  *  on ring overflow events are dropped and counted (tdx_fpss_dropped_events).
  *
  *  ## ctx lifetime + thread affinity
@@ -1770,99 +2091,102 @@ typedef void (*TdxFpssCallback)(const TdxFpssEvent* event, void* ctx);
 int tdx_fpss_set_callback(const TdxFpssHandle* h, TdxFpssCallback callback, void* ctx);
 
 /** Reconnect the streaming session using the previously-registered
- *  callback. Returns 0 or -1. Returns -1 with "streaming handle has
- *  already been shut down -- this is terminal" if the handle is past
- *  tdx_fpss_shutdown. */
+ *  callback.
+ *  @param h The streaming handle.
+ *  @return 0 on success, -1 on error; -1 with "streaming handle has already
+ *          been shut down -- this is terminal" if the handle is past
+ *          tdx_fpss_shutdown. */
 int tdx_fpss_reconnect(const TdxFpssHandle* h);
 
-/** Cumulative count of streaming events the TLS reader could not publish
- *  into the bounded ring because the consumer fell behind and the ring
- *  was full. Returns 0 if the handle is null or no callback has been
- *  installed yet. */
+/** Cumulative count of streaming events that could not be published into
+ *  the bounded ring because the consumer fell behind and the ring was full.
+ *  @param h The streaming handle.
+ *  @return The dropped-event count, or 0 if the handle is null or no
+ *          callback has been installed yet. */
 uint64_t tdx_fpss_dropped_events(const TdxFpssHandle* h);
 
 /** Point-in-time count of streaming events published into the event ring
  *  but not yet drained into the registered callback — the in-flight depth
- *  between the I/O thread and the dispatcher. Rising occupancy that
- *  approaches tdx_fpss_ring_capacity predicts drops before
- *  tdx_fpss_dropped_events moves; sampling never blocks the feed and is
- *  safe from any thread. Returns 0 if the handle is null or has been shut
- *  down. */
+ *  between the feed and the dispatcher. Rising occupancy that approaches
+ *  tdx_fpss_ring_capacity predicts drops before tdx_fpss_dropped_events
+ *  moves; sampling never blocks the feed and is safe from any thread.
+ *  @param h The streaming handle.
+ *  @return The current ring occupancy, or 0 if the handle is null or has
+ *          been shut down. */
 uint64_t tdx_fpss_ring_occupancy(const TdxFpssHandle* h);
 
 /** Configured capacity of the streaming event ring in slots (the
  *  fpss_ring_size setting, a power of two) — the fixed denominator for
- *  tdx_fpss_ring_occupancy. Returns 0 if the handle is null or has been
- *  shut down. */
+ *  tdx_fpss_ring_occupancy.
+ *  @param h The streaming handle.
+ *  @return The ring capacity in slots, or 0 if the handle is null or has
+ *          been shut down. */
 uint64_t tdx_fpss_ring_capacity(const TdxFpssHandle* h);
 
-/**
- * Milliseconds since the most recent inbound streaming frame of any
- * kind on this FPSS handle. Returns 0 on success with the value in
- * *out_ms, 1 when no session is live or no frame has been received
- * yet, -1 on a null pointer.
- */
+/** Milliseconds since the most recent inbound streaming frame of any kind
+ *  on this streaming handle.
+ *  @param h The streaming handle.
+ *  @param out_ms Receives the elapsed milliseconds on success.
+ *  @return 0 on success with the value in *out_ms, 1 when no session is live
+ *          or no frame has been received yet, -1 on a null pointer. */
 int32_t tdx_fpss_millis_since_last_event(const TdxFpssHandle* h, uint64_t* out_ms);
 
-/**
- * UNIX-nanosecond receive timestamp of the most recent inbound
- * streaming frame of any kind on this FPSS handle. Returns 0 when the
- * handle is null, no session is live, or no frame has been received
- * yet.
- */
+/** UNIX-nanosecond receive timestamp of the most recent inbound streaming
+ *  frame of any kind on this streaming handle.
+ *  @param h The streaming handle.
+ *  @return The receive timestamp in Unix nanoseconds, or 0 when the handle
+ *          is null, no session is live, or no frame has been received yet. */
 int64_t tdx_fpss_last_event_received_at_unix_nanos(const TdxFpssHandle* h);
 
-/**
- * Address (host:port) of the streaming server the current FPSS session
- * is connected to, following the session across auto-reconnects.
- * Returns a heap-owned C string the caller must release with
- * tdx_string_free, or NULL when no session is live.
- */
+/** Address (host:port) of the streaming server the current session is
+ *  connected to, following the session across auto-reconnects.
+ *  @param h The streaming handle.
+ *  @return A heap-owned C string the caller must release with
+ *          tdx_string_free, or NULL when no session is live. */
 char* tdx_fpss_last_connected_addr(const TdxFpssHandle* h);
 
 
 
-/** Cumulative count of user-callback panics caught by the per-invocation
- *  catch_unwind boundary since the current stream started. A panic in the
- *  callback is caught, recorded here, and does not stop event delivery —
- *  the next event continues normally. Returns 0 if the handle is null or
- *  no callback has been installed yet. Safe to call from any thread. */
+/** Cumulative count of user-callback failures contained by the
+ *  per-invocation isolation boundary since the current stream started. If
+ *  the callback aborts on a given event, the failure is contained, recorded
+ *  here, and does not stop event delivery — the next event continues
+ *  normally. Returns 0 if the handle is null or no callback has been
+ *  installed yet. Safe to call from any thread. */
 uint64_t tdx_fpss_panic_count(const TdxFpssHandle* h);
 
 /** Shut down the streaming client. Terminal: every subsequent
  *  set_callback / reconnect / shutdown call on this handle returns -1
  *  with a clear tdx_last_error() string. The handle remains valid for
- *  tdx_fpss_free() only. Returns asynchronously: the streaming reader
- *  and consumer continue draining in-flight events through the
- *  registered callback until they observe the shutdown signal and
- *  exit. Pair with tdx_fpss_await_drain() (or use tdx_fpss_free(), which
- *  applies the drain barrier internally) before freeing the callback
- *  ctx. */
+ *  tdx_fpss_free() only. Returns asynchronously: in-flight events
+ *  continue draining through the registered callback until the shutdown
+ *  signal is observed.
+ *  @param h The streaming handle.
+ *  @note Pair with tdx_fpss_await_drain() (or use tdx_fpss_free(), which
+ *        applies the drain barrier internally) before freeing the callback
+ *        ctx. */
 void tdx_fpss_shutdown(const TdxFpssHandle* h);
 
 /** Wait for the previously-superseded streaming session to quiesce.
- *
- *  Returns 1 once the previous tdx_fpss_reconnect / tdx_fpss_shutdown
- *  session's consumer has finished firing the registered callback.
- *  Returns 0 on timeout or when no session has been superseded on this
- *  handle.
- *
- *  Must be called from a thread other than the streaming consumer
- *  thread; calling it from inside the user callback would block the
- *  helper the consumer is waiting on and always time out. */
+ *  @param h The streaming handle.
+ *  @param timeout_ms Maximum time to wait, in milliseconds.
+ *  @return 1 once the previous tdx_fpss_reconnect / tdx_fpss_shutdown
+ *          session has finished firing the registered callback; 0 on timeout
+ *          or when no session has been superseded on this handle.
+ *  @note Must be called from a thread other than the streaming consumer;
+ *        calling it from inside the user callback would block the very work
+ *        it waits on and always time out. */
 int tdx_fpss_await_drain(const TdxFpssHandle* h, uint64_t timeout_ms);
 
-/** Free the streaming handle.
- *
- *  Accepts the handle in either lifecycle state: if shutdown has not
- *  yet been called, tdx_fpss_free performs the shutdown sequence
- *  itself. Returns only after the consumer thread has finished firing
- *  the registered callback (internal 5-second drain barrier). On
- *  drain-flag timeout, emits a tracing::error! and proceeds with
- *  destruction; in that diagnostic case the consumer may still be
- *  firing, so user code must keep ctx valid past return. Under normal
- *  operation drain completes in low single-digit milliseconds, so ctx
- *  is safe to free immediately on return. */
+/** Free the streaming handle. Accepts the handle in either lifecycle state:
+ *  if shutdown has not yet been called, this performs the shutdown sequence
+ *  itself. Returns only after the registered callback has finished firing
+ *  (internal 5-second drain barrier). On drain timeout it logs an error and
+ *  proceeds with destruction; in that diagnostic case the callback may still
+ *  be firing, so user code must keep ctx valid past return. Under normal
+ *  operation drain completes in low single-digit milliseconds, so ctx is
+ *  safe to free immediately on return.
+ *  @param h The streaming handle; no-op when NULL. Call exactly once. */
 void tdx_fpss_free(TdxFpssHandle* h);
 
 /* ======================================================================= */
@@ -1870,19 +2194,27 @@ void tdx_fpss_free(TdxFpssHandle* h);
 /* ======================================================================= */
 
 /** Connect to ThetaData (historical only -- real-time streaming is NOT started).
- *  Returns NULL on connection/auth failure (check tdx_last_error()). */
+ *  @param creds Credentials handle; must be non-NULL.
+ *  @param config Config handle; must be non-NULL.
+ *  @return A unified handle the caller must release with tdx_unified_free, or
+ *          NULL on connection/auth failure (check tdx_last_error()). */
 TdxUnified* tdx_unified_connect(const TdxCredentials* creds, const TdxConfig* config);
 
-/** Connect a unified client, loading credentials from a file (line 1 = email,
+/** Connect a unified client, reading credentials from a file (line 1 = email,
  *  line 2 = password). One-call equivalent of tdx_credentials_from_file +
- *  tdx_unified_connect. Free with tdx_unified_free. Returns NULL on argument
- *  or connection/auth failure (check tdx_last_error()). */
+ *  tdx_unified_connect.
+ *  @param path Filesystem path to the credentials file; must be non-NULL.
+ *  @param config Config handle; must be non-NULL.
+ *  @return A unified handle the caller must release with tdx_unified_free, or
+ *          NULL on argument or connection/auth failure (check
+ *          tdx_last_error()). */
 TdxUnified* tdx_unified_connect_from_file(const char* path, const TdxConfig* config);
 
 /** Register a streaming callback and start streaming on the unified client.
  *
- *  Events flow `streaming reader -> bounded ring -> consumer thread ->
- *  catch_unwind(callback)`. Reader never blocks on user code; ring-overflow
+ *  Events flow from the streaming reader through a bounded ring to a
+ *  dedicated consumer thread, which invokes the callback inside an
+ *  isolation boundary. Reader never blocks on user code; ring-overflow
  *  events are dropped (tdx_unified_dropped_events).
  *
  *  ## ctx lifetime + thread affinity
@@ -1921,7 +2253,7 @@ int tdx_unified_set_callback(const TdxUnified* handle, TdxFpssCallback callback,
 
 /** Polymorphic subscribe / unsubscribe request payload.
  *
- * Mirrors the Rust `Subscription` enum across the C ABI.
+ * One payload type expresses every subscription shape across the C ABI.
  *
  * - Per-contract stock: scope=CONTRACT, symbol="AAPL", option fields NULL.
  * - Per-contract option: scope=CONTRACT, symbol="SPY", expiration / strike / right set.
@@ -1937,120 +2269,147 @@ typedef struct {
     const char* sec_type;     /* full-stream only */
 } TdxSubscriptionRequest;
 
-/** Polymorphic subscribe on the unified client. Returns 0 or -1. */
+/** Polymorphic subscribe on the unified client.
+ *  @param handle The unified handle.
+ *  @param request The subscription request payload.
+ *  @return 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_unified_subscribe(const TdxUnified* handle, const TdxSubscriptionRequest* request);
 
-/** Polymorphic unsubscribe on the unified client. Returns 0 or -1. */
+/** Polymorphic unsubscribe on the unified client.
+ *  @param handle The unified handle.
+ *  @param request The subscription request payload.
+ *  @return 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_unified_unsubscribe(const TdxUnified* handle, const TdxSubscriptionRequest* request);
 
-/** Polymorphic subscribe on the standalone streaming client. Returns 0 or -1. */
+/** Polymorphic subscribe on the standalone streaming client.
+ *  @param h The streaming handle.
+ *  @param request The subscription request payload.
+ *  @return 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_fpss_subscribe(const TdxFpssHandle* h, const TdxSubscriptionRequest* request);
 
-/** Polymorphic unsubscribe on the standalone streaming client. Returns 0 or -1. */
+/** Polymorphic unsubscribe on the standalone streaming client.
+ *  @param h The streaming handle.
+ *  @param request The subscription request payload.
+ *  @return 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_fpss_unsubscribe(const TdxFpssHandle* h, const TdxSubscriptionRequest* request);
 
-/** Reconnect unified streaming, re-subscribing all previous subscriptions. Returns 0 or -1. */
+/** Reconnect unified streaming, re-subscribing all previous subscriptions.
+ *  @param handle The unified handle.
+ *  @return 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_unified_reconnect(const TdxUnified* handle);
 
-/** Check if streaming is active. Returns 1 if streaming, 0 otherwise. */
+/** Report whether streaming is active on the unified client.
+ *  @param handle The unified handle.
+ *  @return 1 when streaming, 0 otherwise. */
 int tdx_unified_is_streaming(const TdxUnified* handle);
 
-/** Get active subscriptions as typed array. Caller must free with tdx_subscription_array_free. */
+/** Read the active subscriptions as a typed array.
+ *  @param handle The unified handle.
+ *  @return A subscription array the caller MUST free with
+ *          tdx_subscription_array_free. */
 TdxSubscriptionArray* tdx_unified_active_subscriptions(const TdxUnified* handle);
 
-/** Get active full-stream subscriptions as typed array. Each entry's
+/** Read the active full-stream subscriptions as a typed array. Each entry's
  *  `contract` field carries the security-type discriminant
  *  ("Stock" / "Option" / "Index") the full-stream subscription is bound
  *  to; the `kind` field is the snake_case full-stream kind label
  *  ("full_trades" / "full_open_interest"), matching the Python /
- *  TypeScript `Subscription.kind` accessor. Returns null on error.
- *  Caller must free with tdx_subscription_array_free. */
+ *  TypeScript `Subscription.kind` accessor.
+ *  @param handle The unified handle.
+ *  @return A subscription array the caller MUST free with
+ *          tdx_subscription_array_free, or NULL on error. */
 TdxSubscriptionArray* tdx_unified_active_full_subscriptions(const TdxUnified* handle);
 
-/** Borrow the historical client from a unified handle. Do NOT free the returned pointer. */
+/** Borrow the historical client from a unified handle.
+ *  @param handle The unified handle.
+ *  @return A borrowed historical client pointer owned by the unified handle;
+ *          do NOT free it. */
 const TdxMddsClient* tdx_unified_historical(const TdxUnified* handle);
 
 /** Stop streaming on the unified client. Historical remains available.
- *  Returns asynchronously: the streaming reader and consumer continue
- *  draining in-flight events through the registered callback until they
- *  observe the shutdown signal. Pair with tdx_unified_await_drain()
- *  (or use tdx_unified_free(), which applies the drain barrier
- *  internally) before freeing the callback ctx. */
+ *  Returns asynchronously: in-flight events continue draining through the
+ *  registered callback until the shutdown signal is observed.
+ *  @param handle The unified handle.
+ *  @note Pair with tdx_unified_await_drain() (or use tdx_unified_free(),
+ *        which applies the drain barrier internally) before freeing the
+ *        callback ctx. */
 void tdx_unified_stop_streaming(const TdxUnified* handle);
 
 /** Wait for the previously-superseded streaming session to quiesce.
- *
- *  Returns 1 once the previous consumer thread has finished firing the
- *  registered callback. Returns 0 on timeout or when no stream has ever
- *  been started or stopped on this handle.
- *
- *  Must be called from a thread other than the streaming consumer thread. */
+ *  @param handle The unified handle.
+ *  @param timeout_ms Maximum time to wait, in milliseconds.
+ *  @return 1 once the previous session has finished firing the registered
+ *          callback; 0 on timeout or when no stream has ever been started or
+ *          stopped on this handle.
+ *  @note Must be called from a thread other than the streaming consumer. */
 int tdx_unified_await_drain(const TdxUnified* handle, uint64_t timeout_ms);
 
-/** Cumulative count of streaming events the TLS reader could not publish
- *  into the bounded ring because the consumer fell behind and the ring
- *  was full. Returns 0 if the handle is null or no callback has been
- *  installed yet. */
+/** Cumulative count of streaming events that could not be published into
+ *  the bounded ring because the consumer fell behind and the ring was full.
+ *  @param handle The unified handle.
+ *  @return The dropped-event count, or 0 if the handle is null or no
+ *          callback has been installed yet. */
 uint64_t tdx_unified_dropped_events(const TdxUnified* handle);
 
 /** Point-in-time count of streaming events published into the event ring
  *  but not yet drained into the registered callback — the in-flight depth
- *  between the I/O thread and the dispatcher. Rising occupancy that
- *  approaches tdx_unified_ring_capacity predicts drops before
- *  tdx_unified_dropped_events moves; sampling never blocks the feed and is
- *  safe from any thread. Returns 0 if the handle is null or no callback
- *  has been installed yet. */
+ *  between the feed and the dispatcher. Rising occupancy that approaches
+ *  tdx_unified_ring_capacity predicts drops before tdx_unified_dropped_events
+ *  moves; sampling never blocks the feed and is safe from any thread.
+ *  @param handle The unified handle.
+ *  @return The current ring occupancy, or 0 if the handle is null or no
+ *          callback has been installed yet. */
 uint64_t tdx_unified_ring_occupancy(const TdxUnified* handle);
 
 /** Configured capacity of the streaming event ring in slots (the
  *  fpss_ring_size setting, a power of two) — the fixed denominator for
- *  tdx_unified_ring_occupancy. Returns 0 if the handle is null or no
- *  callback has been installed yet. */
+ *  tdx_unified_ring_occupancy.
+ *  @param handle The unified handle.
+ *  @return The ring capacity in slots, or 0 if the handle is null or no
+ *          callback has been installed yet. */
 uint64_t tdx_unified_ring_capacity(const TdxUnified* handle);
 
-/**
- * Milliseconds since the most recent inbound streaming frame of any
- * kind on this unified handle. Returns 0 on success with the value in
- * *out_ms, 1 when streaming has not started or no frame has been
- * received yet, -1 on a null pointer.
- */
+/** Milliseconds since the most recent inbound streaming frame of any kind
+ *  on this unified handle.
+ *  @param handle The unified handle.
+ *  @param out_ms Receives the elapsed milliseconds on success.
+ *  @return 0 on success with the value in *out_ms, 1 when streaming has not
+ *          started or no frame has been received yet, -1 on a null pointer. */
 int32_t tdx_unified_millis_since_last_event(const TdxUnified* handle, uint64_t* out_ms);
 
-/**
- * UNIX-nanosecond receive timestamp of the most recent inbound
- * streaming frame of any kind on this unified handle. Returns 0 when
- * the handle is null, streaming has not started, or no frame has been
- * received yet.
- */
+/** UNIX-nanosecond receive timestamp of the most recent inbound streaming
+ *  frame of any kind on this unified handle.
+ *  @param handle The unified handle.
+ *  @return The receive timestamp in Unix nanoseconds, or 0 when the handle
+ *          is null, streaming has not started, or no frame has been received
+ *          yet. */
 int64_t tdx_unified_last_event_received_at_unix_nanos(const TdxUnified* handle);
 
-/**
- * Address (host:port) of the streaming server the current session is
- * connected to, following the session across auto-reconnects. Returns
- * a heap-owned C string the caller must release with tdx_string_free,
- * or NULL when streaming has not started.
- */
+/** Address (host:port) of the streaming server the current session is
+ *  connected to, following the session across auto-reconnects.
+ *  @param handle The unified handle.
+ *  @return A heap-owned C string the caller must release with
+ *          tdx_string_free, or NULL when streaming has not started. */
 char* tdx_unified_last_connected_addr(const TdxUnified* handle);
 
 
 
-/** Cumulative count of user-callback panics caught by the per-invocation
- *  catch_unwind boundary since the current stream started. A panic in the
- *  callback is caught, recorded here, and does not stop event delivery —
- *  the next event continues normally. Returns 0 if the handle is null or
- *  no callback has been installed yet. Safe to call from any thread. */
+/** Cumulative count of user-callback failures contained by the
+ *  per-invocation isolation boundary since the current stream started. If
+ *  the callback aborts on a given event, the failure is contained, recorded
+ *  here, and does not stop event delivery — the next event continues
+ *  normally. Returns 0 if the handle is null or no callback has been
+ *  installed yet. Safe to call from any thread. */
 uint64_t tdx_unified_panic_count(const TdxUnified* handle);
 
-/** Free a unified client handle.
- *
- *  Calls tdx_unified_stop_streaming internally, then waits up to 5
- *  seconds for the consumer thread to finish firing the registered
- *  callback before destroying the handle. On drain-flag timeout,
- *  emits a tracing::error! and proceeds with destruction; in that
- *  diagnostic case the consumer may still be firing, so user code
- *  must keep ctx valid past return. Under normal operation drain
- *  completes in low single-digit milliseconds, so ctx is safe to
- *  free immediately on return. */
+/** Free a unified client handle. Calls tdx_unified_stop_streaming
+ *  internally, then waits up to 5 seconds for the registered callback to
+ *  finish firing before destroying the handle. On drain timeout it logs an
+ *  error and proceeds with destruction; in that diagnostic case the callback
+ *  may still be firing, so user code must keep ctx valid past return. Under
+ *  normal operation drain completes in low single-digit milliseconds, so ctx
+ *  is safe to free immediately on return.
+ *  @param handle The unified handle; no-op when NULL. Call exactly once. */
 void tdx_unified_free(TdxUnified* handle);
 
 
@@ -2062,7 +2421,7 @@ void tdx_unified_free(TdxUnified* handle);
  * serialise to Arrow IPC bytes when you want columnar output.
  */
 
-/** Opaque handle wrapping a decoded `Vec<FlatFileRow>`. Created by
+/** Opaque handle wrapping a decoded set of flat-file rows. Created by
  *  tdx_flatfile_request_decoded; freed by tdx_flatfile_rowlist_free. */
 typedef struct TdxFlatFileRowList TdxFlatFileRowList;
 
@@ -2076,41 +2435,54 @@ typedef struct TdxFlatFileBytes {
 
 /** Pull a decoded flat-file blob for (sec_type, req_type, date) and
  *  return an opaque row-list handle.
- *
- *  sec_type  -- "OPTION" / "STOCK" / "INDEX"
- *  req_type  -- "EOD" / "QUOTE" / "OPEN_INTEREST" / "OHLC" / "TRADE" /
- *               "TRADE_QUOTE"
- *  date      -- "YYYYMMDD"
- *
- *  Returns NULL on error; check tdx_last_error(). The returned handle
- *  MUST be freed with tdx_flatfile_rowlist_free. */
+ *  @param handle The unified handle.
+ *  @param sec_type "OPTION", "STOCK", or "INDEX".
+ *  @param req_type "EOD", "QUOTE", "OPEN_INTEREST", "OHLC", "TRADE", or
+ *                  "TRADE_QUOTE".
+ *  @param date The snapshot date as "YYYYMMDD".
+ *  @return A row-list handle the caller MUST free with
+ *          tdx_flatfile_rowlist_free, or NULL on error (check
+ *          tdx_last_error()). */
 TdxFlatFileRowList* tdx_flatfile_request_decoded(
     const TdxUnified* handle,
     const char* sec_type,
     const char* req_type,
     const char* date);
 
-/** Number of rows in a row-list handle. Returns 0 if rowlist is NULL. */
+/** Number of rows in a row-list handle.
+ *  @param rowlist The row-list handle.
+ *  @return The row count, or 0 if rowlist is NULL. */
 size_t tdx_flatfile_rows_count(const TdxFlatFileRowList* rowlist);
 
-/** Serialise the row list as Arrow IPC stream bytes. The schema is
- *  inferred from the first row by `flatfiles::arrow::rows_to_arrow`.
- *
- *  Returns (data=NULL, len=0) on error; check tdx_last_error().
- *  Caller MUST free the returned bytes with tdx_flatfile_bytes_free. */
+/** Serialise the row list as Arrow IPC stream bytes. The schema is inferred
+ *  from the first row.
+ *  @param rowlist The row-list handle.
+ *  @return An Arrow IPC byte buffer the caller MUST free with
+ *          tdx_flatfile_bytes_free, or (data=NULL, len=0) on error (check
+ *          tdx_last_error()). */
 TdxFlatFileBytes tdx_flatfile_rows_to_arrow_ipc(
     const TdxFlatFileRowList* rowlist);
 
-/** Free a byte buffer returned by tdx_flatfile_rows_to_arrow_ipc. */
+/** Free a byte buffer returned by tdx_flatfile_rows_to_arrow_ipc.
+ *  @param bytes Buffer from tdx_flatfile_rows_to_arrow_ipc; a (data=NULL,
+ *               len=0) buffer is a no-op. Call exactly once. */
 void tdx_flatfile_bytes_free(TdxFlatFileBytes bytes);
 
-/** Free a row-list handle returned by tdx_flatfile_request_decoded. */
+/** Free a row-list handle returned by tdx_flatfile_request_decoded.
+ *  @param rowlist Handle from tdx_flatfile_request_decoded; no-op when NULL.
+ *                 Call exactly once. */
 void tdx_flatfile_rowlist_free(TdxFlatFileRowList* rowlist);
 
-/** Pull a flat-file blob and write the requested vendor format
- *  ("csv" / "jsonl") directly to `path`. Returns 0 on success, -1 on
- *  error; check tdx_last_error(). The format extension is appended to
- *  `path` automatically if missing. */
+/** Pull a flat-file blob and write the requested vendor format directly to
+ *  a file. The format extension is appended to path automatically if missing.
+ *  @param handle The unified handle.
+ *  @param sec_type "OPTION", "STOCK", or "INDEX".
+ *  @param req_type "EOD", "QUOTE", "OPEN_INTEREST", "OHLC", "TRADE", or
+ *                  "TRADE_QUOTE".
+ *  @param date The snapshot date as "YYYYMMDD".
+ *  @param path Output file path; the format extension is appended if missing.
+ *  @param format Output format, "csv" or "jsonl".
+ *  @return 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_flatfile_request_to_path(
     const TdxUnified* handle,
     const char* sec_type,

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -4,8 +4,8 @@
  * RAII wrappers around the C FFI layer. Provides idiomatic C++ access to
  * ThetaData market data with automatic resource management.
  *
- * Tick data is returned directly as #[repr(C)] structs — no JSON parsing.
- * The C++ tick types are layout-compatible with the Rust originals.
+ * Tick data is returned directly as fixed-layout structs — no JSON parsing.
+ * The C++ tick types are layout-compatible with the C ABI structs.
  */
 
 #ifndef THETADX_HPP
@@ -80,7 +80,7 @@ private:
 
 // ── Tick types (re-exported from thetadx.h for C++ convenience) ──
 // These are typedef aliases to the C types defined in thetadx.h.
-// They are #[repr(C)] layout-compatible with the Rust originals.
+// They are fixed-layout and ABI-compatible with those C structs.
 
 using EodTick = TdxEodTick;
 using OhlcTick = TdxOhlcTick;
@@ -119,9 +119,9 @@ using TradeQuoteTick = TdxTradeQuoteTick;
 //
 // Field-level offsetof guards. The `TdxFpssEvent` data-variant field
 // order is generated from `fpss_event_schema.toml` — the same schema
-// the Rust FFI and the Go header are emitted from — so the C++ consumer
-// and the Rust producer agree on member order by construction rather
-// than by hand-kept convention. These asserts catch any ABI-level drift
+// every binding is emitted from — so the C++ consumer and the data
+// producer agree on member order by construction rather than by
+// hand-kept convention. These asserts catch any ABI-level drift
 // (padding, alignment, scalar widths) the schema alone cannot express.
 
 // Every data variant carries an embedded `TdxContract contract` as
@@ -217,9 +217,8 @@ struct GreeksResult {
 // a generic `catch (const std::runtime_error&)` observes both the
 // typed leaves and any plain-`runtime_error` site unchanged.
 
-/// gRPC canonical status kind. Mirror of [`Rust::GrpcStatusKind`].
-/// Enum values match the gRPC wire codes one-for-one (RFC 5234) so
-/// pattern-matching is portable across bindings.
+/// gRPC canonical status kind. Enum values match the gRPC wire codes
+/// one-for-one (RFC 5234) so pattern-matching is portable across bindings.
 enum class GrpcStatusKind : uint32_t {
     Ok = 0,
     Cancelled = 1,
@@ -993,14 +992,14 @@ public:
 
 
     /** Set the async worker-thread count using the (has_value, n) shape
-     *  that preserves Some(0) across the C boundary. has_value=false
+     *  that preserves an explicit 0 across the C boundary. has_value=false
      *  defers to the default sizing. */
     int32_t set_worker_threads(bool has_value, size_t n) {
         return tdx_config_set_worker_threads(handle_.get(), has_value, n);
     }
 
-    /** Read worker_threads back. Returns @c std::nullopt for the None
-     *  (auto-size) sentinel; returns the wrapped count when pinned. */
+    /** Read worker_threads back. Returns @c std::nullopt for the unset
+     *  (auto-size) sentinel; returns the wrapped count when set. */
     std::optional<size_t> get_worker_threads() const {
         bool has_value = false;
         size_t n = 0;
@@ -1151,8 +1150,8 @@ public:
 
     /**
      * Read the current @c metrics.port setting. Returns
-     * @c std::nullopt for the disabled (`None`) sentinel; returns the
-     * wrapped @c std::uint16_t when an explicit port is pinned.
+     * @c std::nullopt for the disabled sentinel; returns the wrapped
+     * @c std::uint16_t when an explicit port is set.
      *
      * Throws a @c tdx::ThetaDataError leaf on a null-handle FFI failure,
      * routing through the typed class the FFI error code selects.
@@ -1260,9 +1259,9 @@ public:
     /**
      * Set the warn_on_buffered_threshold_bytes ceiling.
      *
-     * Pre-stream-API endpoints log a `tracing::warn!` when a buffered
-     * response's decoded total exceeds this threshold, guiding users
-     * to the streaming variant. The payload is still delivered.
+     * Buffered (non-streaming) endpoints log a warning when a response's
+     * decoded total exceeds this threshold, guiding users to the streaming
+     * variant. The payload is still delivered.
      *
      * @p n = 0 disables the warning entirely.
      * Default is `100 * 1024 * 1024` (100 MiB).
@@ -1328,12 +1327,12 @@ private:
 
 // ── FPSS event types (re-exported from thetadx.h) ──
 //
-// Each `FpssControl::*` Rust variant has its own typed C struct rather
-// than a single flat `{ kind, id, detail }` envelope. Consumers
-// dispatch via `event.kind` and read the matching `event.<variant>`
-// payload (`event.login_success.permissions`,
-// `event.disconnected.reason`, etc.). The aliases below mirror every
-// generated type so C++ users can stay in the `tdx::` namespace.
+// Each control variant has its own typed C struct rather than a single
+// flat `{ kind, id, detail }` envelope. Consumers dispatch via
+// `event.kind` and read the matching `event.<variant>` payload
+// (`event.login_success.permissions`, `event.disconnected.reason`,
+// etc.). The aliases below mirror every generated type so C++ users can
+// stay in the `tdx::` namespace.
 
 using FpssEventKind = TdxFpssEventKind;
 using FpssQuote = TdxFpssQuote;
@@ -1341,7 +1340,7 @@ using FpssTrade = TdxFpssTrade;
 using FpssOpenInterest = TdxFpssOpenInterest;
 using FpssOhlcvc = TdxFpssOhlcvc;
 using FpssMarketValue = TdxFpssMarketValue;
-// Typed control variants — one alias per `FpssControl::*` Rust variant.
+// Typed control variants — one alias per control event type.
 using FpssConnected = TdxFpssConnected;
 using FpssContractAssigned = TdxFpssContractAssigned;
 using FpssDisconnected = TdxFpssDisconnected;
@@ -1364,9 +1363,10 @@ using FpssEvent = TdxFpssEvent;
 // ── Real-time streaming client ──
 //
 // Event delivery is callback-driven via `set_callback(fn)`. Events flow
-// `streaming reader -> bounded ring -> consumer thread ->
-// catch_unwind(fn)`. The reader thread never blocks on user code; on
-// ring overflow events are dropped and counted via `dropped_events()`.
+// from the streaming reader through a bounded ring to a dedicated consumer
+// thread, which invokes `fn` inside an isolation boundary. The reader
+// thread never blocks on user code; on ring overflow events are dropped
+// and counted via `dropped_events()`.
 //
 // The FpssClient owns the `std::function`. A free `extern "C"` shim retrieves
 // the stored function from the registered `void* ctx` and invokes it with
@@ -1448,8 +1448,8 @@ public:
     }
 
     /** Register a streaming callback and open the streaming connection.
-     *  `fn` runs on the consumer thread under `catch_unwind`, never on
-     *  the streaming reader. The reader thread cannot be blocked by
+     *  `fn` runs on the consumer thread inside an isolation boundary, never
+     *  on the streaming reader. The reader thread cannot be blocked by
      *  user code: on ring overflow events are dropped and counted via
      *  `dropped_events()`. Throws on registration failure.
      *
@@ -1514,12 +1514,12 @@ public:
         return handle_ ? tdx_fpss_ring_capacity(handle_.get()) : 0;
     }
 
-    /** Cumulative count of user-callback panics caught by the
-     *  per-invocation catch_unwind boundary since the current stream
-     *  started. A panic in the callback is caught, recorded here, and
-     *  does not stop event delivery — the next event continues normally.
-     *  Returns 0 when no callback has been installed yet.
-     *  Safe to call from any thread without blocking. */
+    /** Cumulative count of user-callback failures contained by the
+     *  per-invocation isolation boundary since the current stream
+     *  started. If the callback aborts on a given event, the failure is
+     *  contained, recorded here, and does not stop event delivery — the
+     *  next event continues normally. Returns 0 when no callback has been
+     *  installed yet. Safe to call from any thread without blocking. */
     uint64_t panic_count() const {
         return handle_ ? tdx_fpss_panic_count(handle_.get()) : 0;
     }
@@ -1553,7 +1553,7 @@ public:
 
 
 private:
-    // Free C-ABI shim that the Rust dispatcher invokes. `ctx` is the
+    // Free C-ABI shim that the dispatcher invokes. `ctx` is the
     // `std::function*` we registered alongside the callback. The event
     // pointer is non-null and valid only for the duration of this call.
     static void callback_shim(const TdxFpssEvent* event, void* ctx) noexcept {
@@ -1563,7 +1563,8 @@ private:
             (*fn)(*event);
         } catch (...) {
             // User callbacks must not propagate exceptions across the
-            // C ABI boundary — Rust would unwind into UB. Swallow.
+            // C ABI boundary — unwinding across it is undefined behavior.
+            // Swallow.
         }
     }
 
@@ -1855,8 +1856,8 @@ public:
     const TdxUnified* get() const noexcept { return handle_.get(); }
 
     /** Register a streaming push callback and open the streaming session.
-     *  `fn` runs on the consumer thread under `catch_unwind`, never on
-     *  the streaming reader. The reader thread cannot be blocked by
+     *  `fn` runs on the consumer thread inside an isolation boundary, never
+     *  on the streaming reader. The reader thread cannot be blocked by
      *  user code: on ring overflow events are dropped and counted via
      *  `dropped_event_count()`. Throws on registration failure.
      *
@@ -1970,12 +1971,12 @@ public:
         return handle_ ? tdx_unified_ring_capacity(handle_.get()) : 0;
     }
 
-    /// Cumulative count of user-callback panics caught by the
-    /// per-invocation catch_unwind boundary since the current stream
-    /// started. A panic in the callback is caught, recorded here, and
-    /// does not stop event delivery — the next event continues normally.
-    /// Returns 0 when no callback has been installed yet.
-    /// Safe to call from any thread without blocking.
+    /// Cumulative count of user-callback failures contained by the
+    /// per-invocation isolation boundary since the current stream
+    /// started. If the callback aborts on a given event, the failure is
+    /// contained, recorded here, and does not stop event delivery — the
+    /// next event continues normally. Returns 0 when no callback has been
+    /// installed yet. Safe to call from any thread without blocking.
     uint64_t panic_count() const {
         return handle_ ? tdx_unified_panic_count(handle_.get()) : 0;
     }
@@ -2061,7 +2062,7 @@ public:
     }
 
 private:
-    // Free C-ABI shim that the Rust dispatcher invokes. `ctx` is the
+    // Free C-ABI shim that the dispatcher invokes. `ctx` is the
     // `std::function*` we registered alongside the callback. The event
     // pointer is non-null and valid only for the duration of this call.
     static void callback_shim(const TdxFpssEvent* event, void* ctx) noexcept {
@@ -2071,7 +2072,8 @@ private:
             (*fn)(*event);
         } catch (...) {
             // User callbacks must not propagate exceptions across the
-            // C ABI boundary — Rust would unwind into UB. Swallow.
+            // C ABI boundary — unwinding across it is undefined behavior.
+            // Swallow.
         }
     }
 
@@ -2103,8 +2105,7 @@ private:
 // Fluent contract-first API
 // ══════════════════════════════════════════════════════════════════════════
 //
-// Mirrors the Rust target shape from
-// `report/ThetaDataDxClient_API_DX_Review_Rust_Python.md`:
+// The fluent contract-first surface mirrored across every binding:
 //
 //     auto stock  = tdx::Contract::stock("AAPL");
 //     auto option = tdx::Contract::option("SPY", "20260620", "550", "C");
@@ -2162,8 +2163,8 @@ public:
             // A full-stream `FluentSubscription` is therefore only ever
             // built for those two kinds (see `FluentSecType::full_trades`
             // / `full_open_interest`), and the label set is the same two
-            // strings the Rust `FullSubscriptionKind::kind_str` and the
-            // Python / TypeScript `Subscription.kind` accessors emit. The
+            // strings the Python / TypeScript `Subscription.kind` accessors
+            // emit. The
             // remaining kinds fall through to the trade label so the
             // method never invents a non-canonical string.
             switch (kind_) {
@@ -2424,8 +2425,8 @@ using SecType = FluentSecType;
 // Implemented out-of-class so the class body can reference the fluent
 // types by forward declaration, then dispatch at the call site through
 // the polymorphic C ABI (`tdx_unified_subscribe` /
-// `tdx_unified_unsubscribe`) which mirrors the Rust `subscribe`
-// signature one-for-one.
+// `tdx_unified_unsubscribe`), the same subscribe surface every binding
+// exposes.
 
 namespace detail {
 
@@ -2519,8 +2520,8 @@ inline void FpssClient::unsubscribe_many(
 
 // ── Cross-language utility helpers ──────────────────────────────────────
 //
-// Thin std::string wrappers over the `'static` C-string accessors in
-// `thetadx.h`. Each call copies the table entry once into a
+// Thin std::string wrappers over the process-lifetime C-string accessors
+// in `thetadx.h`. Each call copies the table entry once into a
 // std::string so consumers don't need to think about C-string
 // lifetimes. The underlying C functions are zero-cost lookups
 // (no heap allocation, table-bounded).
@@ -2579,8 +2580,7 @@ inline std::string exchange_symbol(int32_t code) {
 }
 
 /// Convert a signed wire-encoded trade-sequence value to its unsigned
-/// monotonic form. Mirrors `thetadatadx::utils::sequences::signed_to_unsigned`.
-/// `signed_value` must lie in the i32 wire range
+/// monotonic form. `signed_value` must lie in the 32-bit signed wire range
 /// (`-2'147'483'648 ..= 2'147'483'647`); a value outside that domain
 /// throws @c tdx::InvalidParameterError rather than being silently
 /// reinterpreted, matching the Python `ValueError` / TypeScript
@@ -2594,8 +2594,7 @@ inline uint64_t sequence_signed_to_unsigned(int64_t signed_value) {
 }
 
 /// Convert an unsigned monotonic trade-sequence value back to its
-/// signed wire encoding. Mirrors `thetadatadx::utils::sequences::unsigned_to_signed`.
-/// `unsigned_value` must lie in the unsigned wire range
+/// signed wire encoding. `unsigned_value` must lie in the unsigned wire range
 /// (`0 ..= 2^32 - 1`); a value above that domain throws
 /// @c tdx::InvalidParameterError rather than being silently
 /// reinterpreted.
@@ -2613,7 +2612,7 @@ inline int64_t sequence_unsigned_to_signed(uint64_t unsigned_value) {
 //
 // C++ users get the same fluent surface Python and TypeScript see —
 // the strike in dollars, the option side as a `char`, `sec_type` as a
-// symbolic uppercase name, and `reason_name` for `RemoveReason`
+// symbolic uppercase name, and `reason_name` for disconnect-reason
 // values. These inline helpers take the C struct by reference and
 // return the same shape Python / TypeScript bindings expose as fields.
 
@@ -2642,7 +2641,7 @@ inline std::optional<char> right(const TdxContract& c) noexcept {
 
 /// Vendor vocabulary text for a `TdxCalendarDay.status` code
 /// (`"open"` / `"early_close"` / `"full_close"` / `"weekend"`;
-/// `"UNKNOWN"` otherwise). 'static lifetime — never freed.
+/// `"UNKNOWN"` otherwise). Process-lifetime string — never freed.
 inline std::string_view calendar_status_name(int32_t status) noexcept {
     return tdx_calendar_status_name(status);
 }
@@ -2651,7 +2650,7 @@ inline std::string_view calendar_status_name(int32_t status) noexcept {
 /// into Unix epoch milliseconds (UTC, DST-aware). Usable with any
 /// `(date, *_ms_of_day)` pair on the tick structs. Returns
 /// `std::nullopt` when `date` is absent (`0`) or either input is out
-/// of domain — mirrors the Rust / Python `*_timestamp_ms()` accessors.
+/// of domain — mirrors the Python / TypeScript `*_timestamp_ms()` accessors.
 inline std::optional<int64_t> timestamp_ms(int32_t date, int32_t ms_of_day) noexcept {
     const int64_t epoch = tdx_timestamp_ms(date, ms_of_day);
     if (epoch < 0) {
@@ -2661,10 +2660,9 @@ inline std::optional<int64_t> timestamp_ms(int32_t date, int32_t ms_of_day) noex
 }
 
 /// Security type as a symbolic uppercase name (`"STOCK"` /
-/// `"OPTION"` / `"INDEX"` / `"RATE"` / `"UNKNOWN"`). Mirrors
-/// `SecType::as_str()` on the Rust core and the Python / TypeScript
-/// `sec_type` string surface. Returns `"UNKNOWN"` for unrecognised
-/// discriminants so callers stay total.
+/// `"OPTION"` / `"INDEX"` / `"RATE"` / `"UNKNOWN"`). Mirrors the
+/// Python / TypeScript `sec_type` string surface. Returns `"UNKNOWN"`
+/// for unrecognised discriminants so callers stay total.
 inline std::string_view sec_type_name(int32_t sec_type) noexcept {
     switch (sec_type) {
         case 0:
@@ -2681,8 +2679,7 @@ inline std::string_view sec_type_name(int32_t sec_type) noexcept {
 }
 
 /// Disconnect reason name (`"TooManyRequests"`, `"InvalidCredentials"`,
-/// ...). Mirrors `thetadatadx::RemoveReason::as_str()` on the
-/// Rust core and the Python / TypeScript `reason_name` field surface.
+/// ...). Mirrors the Python / TypeScript `reason_name` field surface.
 /// Returns `"Unspecified"` for unrecognised discriminants so callers
 /// stay total.
 inline std::string_view reason_name(int32_t reason) noexcept {


### PR DESCRIPTION
Completes the Doxygen pass on the hand-written C++ headers and scrubs every remaining implementation-detail leak from comments. Comments and docstrings only; no declaration, signature, or behavior changes.

## thetadx.h — Doxygen coverage

Converts every public C declaration that takes parameters, returns a value or handle, or can fail to proper Doxygen: connect and from-file factories, credentials and config lifecycle, the full reconnect / retry / flatfile / auth / metrics / decode-pool setter and getter family, the condition / quote / exchange / calendar lookups, sequence and timestamp utilities, the standalone-streaming and unified-client surfaces, and the flat-file request and free pairs. Each non-obvious parameter gets a `@param`, the return and error-code contract gets `@return`, and handle-returning and streaming entry points carry ownership, free-function, lifetime, and thread `@note` text. The `@param`/`@return` tag count goes from 18 to 410.

## Both headers — user-facing language

Comments now describe behavior a consumer can observe rather than engine, runtime, or source-language internals. Callback failure isolation is described in terms of containment and continued delivery; event flow reads as feed to ring to dispatcher; struct layout reads as fixed-layout and ABI-compatible; the host-shuffle, worker-thread, and metrics-port boundaries read as set / unset; lookup-table returns read as process-lifetime strings; and a buffered-response warning reads as a logged warning.

## Verification

- C++ library, examples, and test suite build clean against the headers (cmake, C++17).
- Offline C++ test suite: 45/45 pass (live round-trip cases skip without credentials), including the doctest harness that compiles and runs the in-header examples.
- `cargo build -p thetadatadx-ffi --release` then `check_c_abi_completeness.py`: clean, 305 symbols, bidirectional parity.
- `check_public_surface_leak.py`: clean.
- Implementation-vocabulary sweep over both headers returns zero matches.
- Diff is comments-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)