### PR TITLE
docs: strip doc-site links from SDK surfaces and close the last doc-quality gaps

### DIFF
--- a/crates/thetadatadx/endpoint_surface.toml
+++ b/crates/thetadatadx/endpoint_surface.toml
@@ -1099,8 +1099,8 @@ template = "stock_snapshot"
 description = "Get the latest OHLC snapshot for one or more stocks."
 vendor_docstring = """
 Provides a real-time Open, High, Low, Close for the current day.
-* Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-* Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+* Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+* Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
 * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 """
 rest_path = "/v3/stock/snapshot/ohlc"
@@ -1111,7 +1111,7 @@ name = "stock_snapshot_trade"
 template = "stock_snapshot"
 description = "Get the latest trade snapshot for one or more stocks."
 vendor_docstring = """
-Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 
 - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 """
@@ -1123,8 +1123,8 @@ name = "stock_snapshot_quote"
 template = "stock_snapshot"
 description = "Get the latest NBBO quote snapshot for one or more stocks."
 vendor_docstring = """
-* Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-* Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+* Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+* Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
 - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 """
 rest_path = "/v3/stock/snapshot/quote"
@@ -1135,8 +1135,8 @@ name = "stock_snapshot_market_value"
 template = "stock_snapshot"
 description = "Get the latest market value snapshot for one or more stocks."
 vendor_docstring = """
-* Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-* Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+* Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+* Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
 - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 """
 rest_path = "/v3/stock/snapshot/market_value"
@@ -1147,7 +1147,7 @@ name = "stock_history_eod"
 template = "stock_history_eod"
 description = "Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day."
 vendor_docstring = """
-Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
 """
 rest_path = "/v3/stock/history/eod"
 returns = "EodTicks"
@@ -1157,8 +1157,8 @@ name = "stock_history_ohlc"
 template = "stock_history_intraday_interval"
 description = "Fetch intraday OHLC bars for a stock on a single date."
 vendor_docstring = """
-- Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
-- Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+- Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
+- Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/stock/history/ohlc"
@@ -1169,7 +1169,7 @@ name = "stock_history_trade"
 template = "stock_history_intraday_ticks"
 description = "Fetch all trades for a stock on a given date."
 vendor_docstring = """
-Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/stock/history/trade"
@@ -1180,9 +1180,9 @@ name = "stock_history_quote"
 template = "stock_history_intraday_interval"
 description = "Fetch NBBO quotes for a stock on a given date at a given interval."
 vendor_docstring = """
-- Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs). 
+- Returns every NBBO quote reported by UTP and CTA. 
 - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
-- Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+- Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/stock/history/quote"
@@ -1193,7 +1193,7 @@ name = "stock_history_trade_quote"
 template = "stock_history_trade_quote"
 description = "Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable."
 vendor_docstring = """
-Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/stock/history/trade_quote"
@@ -1205,12 +1205,12 @@ template = "stock_at_time"
 description = "Fetch the trade at a specific time of day across a date range."
 vendor_docstring = """
 #### Real-time request:
-- Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-- Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+- Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+- Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
 
 #### Historical request:
-Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+Trade condition mappings can be found here.
 """
 rest_path = "/v3/stock/at_time/trade"
 returns = "TradeTicks"
@@ -1222,11 +1222,11 @@ description = "Fetch the quote at a specific time of day across a date range."
 vendor_docstring = """
 #### Real-time request:
   - Subscription tier standard or higher will default to NQB.
-  - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-  - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+  - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+  - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
 
 #### Historical request:
-  Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+  Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
 """
 rest_path = "/v3/stock/at_time/quote"
 returns = "QuoteTicks"
@@ -1381,7 +1381,7 @@ vendor_docstring = """
 Returns implied volatilies calculated using the national best bid, mid, and ask price
 of the option respectively. The underlying price represents whatever the last underlying price was at the
 ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-[here](/Articles/Data-And-Requests/Option-Greeks.html).
+here.
 """
 rest_path = "/v3/option/snapshot/greeks/implied_volatility"
 returns = "IvTicks"
@@ -1443,10 +1443,10 @@ name = "option_history_eod"
 template = "option_history_eod"
 description = "Fetch end-of-day option data for a contract over a date range."
 vendor_docstring = """
-- Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+- Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
 - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
 - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
-- You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+- You can read more about EOD & OHLC data here.
 """
 rest_path = "/v3/option/history/eod"
 returns = "EodTicks"
@@ -1456,7 +1456,7 @@ name = "option_history_ohlc"
 template = "option_history_ohlc"
 description = "Fetch intraday OHLC bars for an option contract."
 vendor_docstring = """
-- Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
+- Aggregated OHLC bars that use SIP rules for each bar. 
 - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
 - Multi-day requests are limited to 1 month of data.
 """
@@ -1468,9 +1468,9 @@ name = "option_history_trade"
 template = "option_history_trade"
 description = "Fetch all trades for an option contract on a given date."
 vendor_docstring = """
-- Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-- Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-- Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+- Returns every trade reported by OPRA. 
+- Trade condition mappings can be found here.
+- Extended trade conditions are not reported by OPRA for options, so they can be ignored.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade"
@@ -1481,7 +1481,7 @@ name = "option_history_quote"
 template = "option_history_quote"
 description = "Fetch NBBO quotes for an option contract on a given date."
 vendor_docstring = """
-- Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+- Returns every NBBO quote reported by OPRA. 
 - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
@@ -1493,7 +1493,7 @@ name = "option_history_trade_quote"
 template = "option_history_trade_quote"
 description = "Fetch combined trade + quote ticks for an option contract."
 vendor_docstring = """
-- Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+- Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
 - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
 - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
@@ -1506,8 +1506,8 @@ name = "option_history_open_interest"
 template = "option_history_open_interest"
 description = "Fetch open interest history for an option contract."
 vendor_docstring = """
-- Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-- A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+- Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+- A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
 - The reported open interest represents the open interest at the end of the previous trading day.
 """
 rest_path = "/v3/option/history/open_interest"
@@ -1531,8 +1531,8 @@ template = "option_history_greeks"
 description = "Fetch all Greeks history for an option contract (intraday, sampled by interval)."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
-- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/all"
@@ -1544,8 +1544,8 @@ template = "option_history_trade_greeks"
 description = "Fetch all Greeks on each trade for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
-- Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Calculates greeks for every trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/all"
@@ -1557,8 +1557,8 @@ template = "option_history_greeks"
 description = "Fetch first-order Greeks history (intraday, sampled by interval)."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
-- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/first_order"
@@ -1570,8 +1570,8 @@ template = "option_history_trade_greeks"
 description = "Fetch first-order Greeks on each trade for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Calculates greeks for every trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/first_order"
@@ -1583,8 +1583,8 @@ template = "option_history_greeks"
 description = "Fetch second-order Greeks history (intraday, sampled by interval)."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
-- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/second_order"
@@ -1596,8 +1596,8 @@ template = "option_history_trade_greeks"
 description = "Fetch second-order Greeks on each trade for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Calculates greeks for every trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/second_order"
@@ -1609,8 +1609,8 @@ template = "option_history_greeks"
 description = "Fetch third-order Greeks history (intraday, sampled by interval)."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration. 
-- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/third_order"
@@ -1622,8 +1622,8 @@ template = "option_history_trade_greeks"
 description = "Fetch third-order Greeks on each trade for an option contract."
 vendor_docstring = """
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Calculates greeks for every trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/third_order"
@@ -1635,7 +1635,7 @@ template = "option_history_greeks"
 description = "Fetch implied volatility history (intraday, sampled by interval)."
 vendor_docstring = """
 - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 """
 rest_path = "/v3/option/history/greeks/implied_volatility"
@@ -1646,8 +1646,8 @@ name = "option_history_trade_greeks_implied_volatility"
 template = "option_history_trade_greeks"
 description = "Fetch implied volatility on each trade for an option contract."
 vendor_docstring = """
-- Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+- Returns implied volatilies calculated using the trade reported by OPRA. 
+- The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 """
 rest_path = "/v3/option/history/trade_greeks/implied_volatility"
@@ -1658,9 +1658,9 @@ name = "option_at_time_trade"
 template = "option_at_time"
 description = "Fetch the trade at a specific time of day across a date range for an option."
 vendor_docstring = """
-- Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-- Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-- Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+- Returns the last trade reported by OPRA at a specified millisecond of the day.
+- Trade condition mappings can be found here.
+- Extended trade conditions are not reported by OPRA for options, so they can be ignored.
 - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
 """
 rest_path = "/v3/option/at_time/trade"
@@ -1671,7 +1671,7 @@ name = "option_at_time_quote"
 template = "option_at_time"
 description = "Fetch the quote at a specific time of day across a date range for an option."
 vendor_docstring = """
-- Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+- Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
 - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
 """
 rest_path = "/v3/option/at_time/quote"
@@ -1706,7 +1706,7 @@ template = "index_snapshot"
 description = "Get the latest OHLC snapshot for one or more indices."
 vendor_docstring = """
 - Retrieves the real-time current day OHLC.
-- [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Exchanges typically generate a price report every second for popular indices like SPX.
 """
 rest_path = "/v3/index/snapshot/ohlc"
 returns = "OhlcTicks"
@@ -1717,7 +1717,7 @@ template = "index_snapshot"
 description = "Get the latest price snapshot for one or more indices."
 vendor_docstring = """
 - Retrieves a real-time last index price.
-- [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Exchanges typically generate a price report every second for popular indices like SPX.
 """
 rest_path = "/v3/index/snapshot/price"
 returns = "PriceTicks"
@@ -1728,7 +1728,7 @@ template = "index_snapshot"
 description = "Get the latest market value snapshot for one or more indices."
 vendor_docstring = """
 - Retrieves a real-time last index market value.
-- [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Exchanges typically generate a price report every second for popular indices like SPX.
 """
 rest_path = "/v3/index/snapshot/market_value"
 returns = "MarketValueTicks"
@@ -1738,7 +1738,7 @@ name = "index_history_eod"
 template = "index_history_eod"
 description = "Fetch end-of-day index data for a date range."
 vendor_docstring = """
-- Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+- Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
 """
 rest_path = "/v3/index/history/eod"
 returns = "EodTicks"
@@ -1748,9 +1748,9 @@ name = "index_history_ohlc"
 template = "index_history_ohlc"
 description = "Fetch intraday OHLC bars for an index."
 vendor_docstring = """
-- Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+- Aggregated OHLC bars that use SIP rules for each bar.
 - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
-- [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Exchanges typically generate a price report every second for popular indices like SPX.
 """
 rest_path = "/v3/index/history/ohlc"
 returns = "OhlcTicks"
@@ -1760,7 +1760,7 @@ name = "index_history_price"
 template = "index_history_price"
 description = "Fetch intraday price history for an index."
 vendor_docstring = """
-- Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
 - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
 - A price update from the exchange is omitted if the price remained the same from the previous update.
 - Multi-day requests are limited to 1 month of data.
@@ -1773,7 +1773,7 @@ name = "index_at_time_price"
 template = "index_at_time"
 description = "Fetch the index price at a specific time of day across a date range."
 vendor_docstring = """
-- Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
 - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
 """
 rest_path = "/v3/index/at_time/price"

--- a/crates/thetadatadx/src/config/fpss.rs
+++ b/crates/thetadatadx/src/config/fpss.rs
@@ -101,7 +101,7 @@ pub struct FpssConfig {
     /// Drives the per-connection initial socket read timeout, the framing
     /// layer's mid-frame stall budget, and the I/O loop's overall
     /// "no frames received" deadline that triggers
-    /// [`crate::tdbe::types::enums::RemoveReason::TimedOut`]. Default `3_000`
+    /// [`crate::RemoveReason::TimedOut`]. Default `3_000`
     /// — the server heartbeats every ~100 ms on a quiet session, so
     /// three seconds of total silence is ~30 missed heartbeats and a
     /// dead link is declared quickly instead of after the previous

--- a/docs-site/docs/reference/index/at-time/price.md
+++ b/docs-site/docs/reference/index/at-time/price.md
@@ -11,7 +11,7 @@ description: "Fetch the index price at a specific time of day across a date rang
 
 Fetch the index price at a specific time of day across a date range.
 
-- Retrieves historical indices price reports. [Exchanges](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
 - The `time_of_day` parameter represents the 00:00:00.000 ET that the price should be provided for.
 
 <SdkTabs>

--- a/docs-site/docs/reference/index/history/eod.md
+++ b/docs-site/docs/reference/index/history/eod.md
@@ -11,7 +11,7 @@ description: "Fetch end-of-day index data for a date range."
 
 Fetch end-of-day index data for a date range.
 
-- Since [the indices feeds](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+- Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/index/history/ohlc.md
+++ b/docs-site/docs/reference/index/history/ohlc.md
@@ -11,9 +11,9 @@ description: "Fetch intraday OHLC bars for an index."
 
 Fetch intraday OHLC bars for an index.
 
-- Aggregated OHLC bars that use [SIP rules](https://docs.thetadata.us/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+- Aggregated OHLC bars that use SIP rules for each bar.
 - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  `bar timestamp` <= `trade time` < `bar timestamp + interval`.
-- [Exchanges](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Exchanges typically generate a price report every second for popular indices like SPX.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/index/history/price.md
+++ b/docs-site/docs/reference/index/history/price.md
@@ -11,7 +11,7 @@ description: "Fetch intraday price history for an index."
 
 Fetch intraday price history for an index.
 
-- Retrieves historical indices price reports. [Exchanges](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
 - When the `interval` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
 - A price update from the exchange is omitted if the price remained the same from the previous update.
 - Multi-day requests are limited to 1 month of data.

--- a/docs-site/docs/reference/index/snapshot/market-value.md
+++ b/docs-site/docs/reference/index/snapshot/market-value.md
@@ -12,7 +12,7 @@ description: "Get the latest market value snapshot for one or more indices."
 Get the latest market value snapshot for one or more indices.
 
 - Retrieves a real-time last index market value.
-- [Exchanges](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Exchanges typically generate a price report every second for popular indices like SPX.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/index/snapshot/ohlc.md
+++ b/docs-site/docs/reference/index/snapshot/ohlc.md
@@ -12,7 +12,7 @@ description: "Get the latest OHLC snapshot for one or more indices."
 Get the latest OHLC snapshot for one or more indices.
 
 - Retrieves the real-time current day OHLC.
-- [Exchanges](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Exchanges typically generate a price report every second for popular indices like SPX.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/index/snapshot/price.md
+++ b/docs-site/docs/reference/index/snapshot/price.md
@@ -12,7 +12,7 @@ description: "Get the latest price snapshot for one or more indices."
 Get the latest price snapshot for one or more indices.
 
 - Retrieves a real-time last index price.
-- [Exchanges](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+- Exchanges typically generate a price report every second for popular indices like SPX.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/option/at-time/quote.md
+++ b/docs-site/docs/reference/option/at-time/quote.md
@@ -11,7 +11,7 @@ description: "Fetch the quote at a specific time of day across a date range for 
 
 Fetch the quote at a specific time of day across a date range for an option.
 
-- Returns the last NBBO quote reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+- Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
 - The `time_of_day`parameter represents the 00:00:00.000 ET that the quote should be provided for.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/at-time/trade.md
+++ b/docs-site/docs/reference/option/at-time/trade.md
@@ -11,9 +11,9 @@ description: "Fetch the trade at a specific time of day across a date range for 
 
 Fetch the trade at a specific time of day across a date range for an option.
 
-- Returns the last trade reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-- Trade condition mappings can be found [here](/articles/conditions).
-- Extended trade conditions are not reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+- Returns the last trade reported by OPRA at a specified millisecond of the day.
+- Trade condition mappings can be found here.
+- Extended trade conditions are not reported by OPRA for options, so they can be ignored.
 - The `time_of_day`parameter represents the 00:00:00.000 ET that the trade should be provided for.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/eod.md
+++ b/docs-site/docs/reference/option/history/eod.md
@@ -11,10 +11,10 @@ description: "Fetch end-of-day option data for a contract over a date range."
 
 Fetch end-of-day option data for a contract over a date range.
 
-- Since [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+- Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
 - `created` represents the datetime the report was generated and `last_trade` represents the datetime of the last trade.
 - The quote in the response represents the last NBBO reported by OPRA at the time of report generation.
-- You can read more about EOD & OHLC data [here](https://docs.thetadata.us/Articles/Data-And-Requests/OHLC-EOD.html).
+- You can read more about EOD & OHLC data here.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/option/history/greeks/all.md
+++ b/docs-site/docs/reference/option/history/greeks/all.md
@@ -12,8 +12,8 @@ description: "Fetch all Greeks history for an option contract (intraday, sampled
 Fetch all Greeks history for an option contract (intraday, sampled by interval).
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](https://docs.thetadata.us/operations/option_history_quote.html) endpoint.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/greeks/first-order.md
+++ b/docs-site/docs/reference/option/history/greeks/first-order.md
@@ -12,8 +12,8 @@ description: "Fetch first-order Greeks history (intraday, sampled by interval)."
 Fetch first-order Greeks history (intraday, sampled by interval).
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](https://docs.thetadata.us/operations/option_history_quote.html) endpoint.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/history/greeks/implied-volatility.md
@@ -12,7 +12,7 @@ description: "Fetch implied volatility history (intraday, sampled by interval)."
 Fetch implied volatility history (intraday, sampled by interval).
 
 - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/greeks/second-order.md
+++ b/docs-site/docs/reference/option/history/greeks/second-order.md
@@ -12,8 +12,8 @@ description: "Fetch second-order Greeks history (intraday, sampled by interval).
 Fetch second-order Greeks history (intraday, sampled by interval).
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](https://docs.thetadata.us/operations/option_history_quote.html) endpoint.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/greeks/third-order.md
+++ b/docs-site/docs/reference/option/history/greeks/third-order.md
@@ -12,8 +12,8 @@ description: "Fetch third-order Greeks history (intraday, sampled by interval)."
 Fetch third-order Greeks history (intraday, sampled by interval).
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](https://docs.thetadata.us/operations/option_history_quote.html) endpoint.
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/ohlc.md
+++ b/docs-site/docs/reference/option/history/ohlc.md
@@ -11,7 +11,7 @@ description: "Fetch intraday OHLC bars for an option contract."
 
 Fetch intraday OHLC bars for an option contract.
 
-- Aggregated OHLC bars that use [SIP rules](https://docs.thetadata.us/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+- Aggregated OHLC bars that use SIP rules for each bar.
 - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  `bar timestamp` <= `trade time` < `bar timestamp + interval`.
 - Multi-day requests are limited to 1 month of data.
 

--- a/docs-site/docs/reference/option/history/open-interest.md
+++ b/docs-site/docs/reference/option/history/open-interest.md
@@ -11,8 +11,8 @@ description: "Fetch open interest history for an option contract."
 
 Fetch open interest history for an option contract.
 
-- Open Interest is normally reported once per day by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-- A new open interest message might not be sent by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+- Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+- A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
 - The reported open interest represents the open interest at the end of the previous trading day.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/quote.md
+++ b/docs-site/docs/reference/option/history/quote.md
@@ -11,7 +11,7 @@ description: "Fetch NBBO quotes for an option contract on a given date."
 
 Fetch NBBO quotes for an option contract on a given date.
 
-- Returns every NBBO quote reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html).
+- Returns every NBBO quote reported by OPRA.
 - If the `interval` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 

--- a/docs-site/docs/reference/option/history/trade-greeks/all.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/all.md
@@ -12,8 +12,8 @@ description: "Fetch all Greeks on each trade for an option contract."
 Fetch all Greeks on each trade for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculates greeks for every trade reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Calculates greeks for every trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/trade-greeks/first-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/first-order.md
@@ -12,8 +12,8 @@ description: "Fetch first-order Greeks on each trade for an option contract."
 Fetch first-order Greeks on each trade for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculates greeks for every trade reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Calculates greeks for every trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/trade-greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/implied-volatility.md
@@ -11,8 +11,8 @@ description: "Fetch implied volatility on each trade for an option contract."
 
 Fetch implied volatility on each trade for an option contract.
 
-- Returns implied volatilies calculated using the trade reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Returns implied volatilies calculated using the trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/trade-greeks/second-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/second-order.md
@@ -12,8 +12,8 @@ description: "Fetch second-order Greeks on each trade for an option contract."
 Fetch second-order Greeks on each trade for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculates greeks for every trade reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Calculates greeks for every trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/trade-greeks/third-order.md
+++ b/docs-site/docs/reference/option/history/trade-greeks/third-order.md
@@ -12,8 +12,8 @@ description: "Fetch third-order Greeks on each trade for an option contract."
 Fetch third-order Greeks on each trade for an option contract.
 
 - Returns the data for all contracts that share the same provided symbol and expiration.
-- Calculates greeks for every trade reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html).
-- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks [here](/articles/option-greeks).
+- Calculates greeks for every trade reported by OPRA.
+- The underlying price represents whatever the last underlying price was at the `timestamp` field. You can read more about how Theta Data calculates greeks here.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/history/trade-quote.md
+++ b/docs-site/docs/reference/option/history/trade-quote.md
@@ -11,7 +11,7 @@ description: "Fetch combined trade + quote ticks for an option contract."
 
 Fetch combined trade + quote ticks for an option contract.
 
-- Returns every [trade](https://docs.thetadata.us/operations/option_history_trade.html) reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+- Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
 - A quote is matched with a trade if its timestamp `<=` the trade timestamp.
 - To match trades with quotes timestamps that are `<` the trade timestamp, specify the `exclusive`parameter to `true`. After thorough testing, we have determined that using `exclusive=true` might yield better results for various applications.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.

--- a/docs-site/docs/reference/option/history/trade.md
+++ b/docs-site/docs/reference/option/history/trade.md
@@ -11,9 +11,9 @@ description: "Fetch all trades for an option contract on a given date."
 
 Fetch all trades for an option contract on a given date.
 
-- Returns every trade reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html).
-- Trade condition mappings can be found [here](/articles/conditions).
-- Extended trade conditions are not reported by [OPRA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+- Returns every trade reported by OPRA.
+- Trade condition mappings can be found here.
+- Extended trade conditions are not reported by OPRA for options, so they can be ignored.
 - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/snapshot/greeks/implied-volatility.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/implied-volatility.md
@@ -14,7 +14,7 @@ Get implied volatility snapshot for an option contract (from ThetaData server).
 Returns implied volatilies calculated using the national best bid, mid, and ask price
 of the option respectively. The underlying price represents whatever the last underlying price was at the
 `underlying_timestamp` field. You can read more about how Theta Data calculates greeks
-[here](/articles/option-greeks).
+here.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/stock/at-time/quote.md
+++ b/docs-site/docs/reference/stock/at-time/quote.md
@@ -13,11 +13,11 @@ Fetch the quote at a specific time of day across a date range.
 
 #### Real-time request:
   - Subscription tier standard or higher will default to NQB.
-  - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-  - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+  - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+  - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
 
 #### Historical request:
-  Returns the last NBBO quote reported by [UTP & CTA feeds](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+  Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/stock/at-time/trade.md
+++ b/docs-site/docs/reference/stock/at-time/trade.md
@@ -12,12 +12,12 @@ description: "Fetch the trade at a specific time of day across a date range."
 Fetch the trade at a specific time of day across a date range.
 
 #### Real-time request:
-- Returns a real-time session from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-- Returns a 15-minute delayed session from the [UTP & CTA feeds](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+- Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+- Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
 
 #### Historical request:
-Returns the last trade reported by [UTP & CTA feeds](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-Trade condition mappings can be found [here](/articles/conditions).
+Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+Trade condition mappings can be found here.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/stock/history/eod.md
+++ b/docs-site/docs/reference/stock/history/eod.md
@@ -11,7 +11,7 @@ description: "Fetch end-of-day stock data for a date range. Returns OHLCV + bid/
 
 Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
 
-Since [the equity SIPs](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. `created` represents the datetime the report was generated and `last_trade` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](https://docs.thetadata.us/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. `created` represents the datetime the report was generated and `last_trade` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/stock/history/ohlc.md
+++ b/docs-site/docs/reference/stock/history/ohlc.md
@@ -11,8 +11,8 @@ description: "Fetch intraday OHLC bars for a stock on a single date."
 
 Fetch intraday OHLC bars for a stock on a single date.
 
-- Aggregated OHLC bars that use [SIP rules](https://docs.thetadata.us/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  `bar time` <= `trade time` < `bar timestamp + ivl`, where ivl is the specified interval size in milliseconds.
-- Set the `venue` parameter to `nqb` to access current-day real-time historic data from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+- Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  `bar time` <= `trade time` < `bar timestamp + ivl`, where ivl is the specified interval size in milliseconds.
+- Set the `venue` parameter to `nqb` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/stock/history/quote.md
+++ b/docs-site/docs/reference/stock/history/quote.md
@@ -11,9 +11,9 @@ description: "Fetch NBBO quotes for a stock on a given date at a given interval.
 
 Fetch NBBO quotes for a stock on a given date at a given interval.
 
-- Returns every NBBO quote reported by [UTP and CTA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs).
+- Returns every NBBO quote reported by UTP and CTA.
 - If the `interval` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp.
-- Set the `venue` parameter to `nqb` to access current-day real-time historic data from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+- Set the `venue` parameter to `nqb` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/stock/history/trade-quote.md
+++ b/docs-site/docs/reference/stock/history/trade-quote.md
@@ -11,7 +11,7 @@ description: "Fetch combined trade + quote ticks for a stock on a given date. Re
 
 Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
 
-Returns every trade reported by [UTP & CTA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp `<=` the trade timestamp. If you prefer to match quotes with timestamps that are `<` the trade timestamp, specify the `exclusive` parameter to `true`. Set the `venue` parameter to `nqb` to access current-day real-time historic data from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp `<=` the trade timestamp. If you prefer to match quotes with timestamps that are `<` the trade timestamp, specify the `exclusive` parameter to `true`. Set the `venue` parameter to `nqb` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/stock/history/trade.md
+++ b/docs-site/docs/reference/stock/history/trade.md
@@ -11,7 +11,7 @@ description: "Fetch all trades for a stock on a given date."
 
 Fetch all trades for a stock on a given date.
 
-Returns every trade reported by [UTP & CTA](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs). Set the `venue` parameter to `nqb` to access current-day real-time historic data from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+Returns every trade reported by UTP & CTA. Set the `venue` parameter to `nqb` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 - Multi-day requests are limited to 1 month of data.
 
 <SdkTabs>

--- a/docs-site/docs/reference/stock/snapshot/market-value.md
+++ b/docs-site/docs/reference/stock/snapshot/market-value.md
@@ -11,8 +11,8 @@ description: "Get the latest market value snapshot for one or more stocks."
 
 Get the latest market value snapshot for one or more stocks.
 
-* Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-* Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+* Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+* Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
 - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 
 <SdkTabs>

--- a/docs-site/docs/reference/stock/snapshot/ohlc.md
+++ b/docs-site/docs/reference/stock/snapshot/ohlc.md
@@ -12,8 +12,8 @@ description: "Get the latest OHLC snapshot for one or more stocks."
 Get the latest OHLC snapshot for one or more stocks.
 
 Provides a real-time Open, High, Low, Close for the current day.
-* Returns a real-time session OHLC from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-* Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+* Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+* Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
 * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 
 <SdkTabs>

--- a/docs-site/docs/reference/stock/snapshot/quote.md
+++ b/docs-site/docs/reference/stock/snapshot/quote.md
@@ -11,8 +11,8 @@ description: "Get the latest NBBO quote snapshot for one or more stocks."
 
 Get the latest NBBO quote snapshot for one or more stocks.
 
-* Returns a real-time last BBO quote from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-* Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+* Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+* Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
 - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 
 <SdkTabs>

--- a/docs-site/docs/reference/stock/snapshot/trade.md
+++ b/docs-site/docs/reference/stock/snapshot/trade.md
@@ -11,7 +11,7 @@ description: "Get the latest trade snapshot for one or more stocks."
 
 Get the latest trade snapshot for one or more stocks.
 
-Returns a real-time last trade from the [Nasdaq Basic feed](https://docs.thetadata.us/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 
 - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -2087,7 +2087,10 @@ typedef void (*TdxFpssCallback)(const TdxFpssEvent* event, void* ctx);
  *  This is intentionally stricter than tdx_unified_set_callback(), where
  *  set-after-stop is supported as a normal user flow.
  *
- *  Returns 0 on success, -1 on error (check tdx_last_error()). */
+ *  @param h        The streaming handle.
+ *  @param callback The callback invoked once per streaming event.
+ *  @param ctx      Opaque user pointer passed to every callback invocation.
+ *  @return 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_fpss_set_callback(const TdxFpssHandle* h, TdxFpssCallback callback, void* ctx);
 
 /** Reconnect the streaming session using the previously-registered
@@ -2151,8 +2154,10 @@ char* tdx_fpss_last_connected_addr(const TdxFpssHandle* h);
  *  per-invocation isolation boundary since the current stream started. If
  *  the callback aborts on a given event, the failure is contained, recorded
  *  here, and does not stop event delivery — the next event continues
- *  normally. Returns 0 if the handle is null or no callback has been
- *  installed yet. Safe to call from any thread. */
+ *  normally. Safe to call from any thread.
+ *  @param h The streaming handle.
+ *  @return The contained-failure count, or 0 if the handle is null or no
+ *          callback has been installed yet. */
 uint64_t tdx_fpss_panic_count(const TdxFpssHandle* h);
 
 /** Shut down the streaming client. Terminal: every subsequent
@@ -2238,7 +2243,10 @@ TdxUnified* tdx_unified_connect_from_file(const char* path, const TdxConfig* con
  *  while streaming is already active returns -1 with "streaming already
  *  started".
  *
- *  Returns 0 on success, -1 on error. */
+ *  @param handle   The unified handle.
+ *  @param callback The callback invoked once per streaming event.
+ *  @param ctx      Opaque user pointer passed to every callback invocation.
+ *  @return 0 on success, -1 on error (check tdx_last_error()). */
 int tdx_unified_set_callback(const TdxUnified* handle, TdxFpssCallback callback, void* ctx);
 
 /** Subscription request scope discriminator (TdxSubscriptionRequest.scope). */
@@ -2398,8 +2406,10 @@ char* tdx_unified_last_connected_addr(const TdxUnified* handle);
  *  per-invocation isolation boundary since the current stream started. If
  *  the callback aborts on a given event, the failure is contained, recorded
  *  here, and does not stop event delivery — the next event continues
- *  normally. Returns 0 if the handle is null or no callback has been
- *  installed yet. Safe to call from any thread. */
+ *  normally. Safe to call from any thread.
+ *  @param handle The unified handle.
+ *  @return The contained-failure count, or 0 if the handle is null or no
+ *          callback has been installed yet. */
 uint64_t tdx_unified_panic_count(const TdxUnified* handle);
 
 /** Free a unified client handle. Calls tdx_unified_stop_streaming

--- a/sdks/python/src/_generated/historical_methods.rs
+++ b/sdks/python/src/_generated/historical_methods.rs
@@ -133,8 +133,8 @@ impl StockListDatesBuilder {
 /// Get the latest OHLC snapshot for one or more stocks.
 ///
 /// Provides a real-time Open, High, Low, Close for the current day.
-/// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-/// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+/// * Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+/// * Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
 /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 ///
 /// Defaults (upstream):
@@ -228,7 +228,7 @@ impl StockSnapshotOhlcBuilder {
 
 /// Get the latest trade snapshot for one or more stocks.
 ///
-/// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+/// Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 ///
 /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 ///
@@ -323,8 +323,8 @@ impl StockSnapshotTradeBuilder {
 
 /// Get the latest NBBO quote snapshot for one or more stocks.
 ///
-/// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-/// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+/// * Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+/// * Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
 /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 ///
 /// Defaults (upstream):
@@ -418,8 +418,8 @@ impl StockSnapshotQuoteBuilder {
 
 /// Get the latest market value snapshot for one or more stocks.
 ///
-/// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-/// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+/// * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+/// * Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
 /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
 ///
 /// Defaults (upstream):
@@ -513,7 +513,7 @@ impl StockSnapshotMarketValueBuilder {
 
 /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
 ///
-/// Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+/// Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
 #[pyclass(module = "thetadatadx", name = "StockHistoryEodBuilder")]
 pub struct StockHistoryEodBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDxClient>,
@@ -683,8 +683,8 @@ impl StockHistoryEodBuilder {
 
 /// Fetch intraday OHLC bars for a stock on a single date.
 ///
-/// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
-/// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+/// - Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
+/// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -988,7 +988,7 @@ impl StockHistoryOhlcBuilder {
 
 /// Fetch all trades for a stock on a given date.
 ///
-/// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+/// Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -1268,9 +1268,9 @@ impl StockHistoryTradeBuilder {
 
 /// Fetch NBBO quotes for a stock on a given date at a given interval.
 ///
-/// - Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs). 
+/// - Returns every NBBO quote reported by UTP and CTA. 
 /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
-/// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+/// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -1574,7 +1574,7 @@ impl StockHistoryQuoteBuilder {
 
 /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
 ///
-/// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+/// Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -1879,12 +1879,12 @@ impl StockHistoryTradeQuoteBuilder {
 /// Fetch the trade at a specific time of day across a date range.
 ///
 /// #### Real-time request:
-/// - Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-/// - Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+/// - Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+/// - Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
 ///
 /// #### Historical request:
-/// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-/// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+/// Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+/// Trade condition mappings can be found here.
 ///
 /// Defaults (upstream):
 /// - `venue`: `"nqb"`
@@ -2093,11 +2093,11 @@ impl StockAtTimeTradeBuilder {
 ///
 /// #### Real-time request:
 ///   - Subscription tier standard or higher will default to NQB.
-///   - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-///   - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+///   - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+///   - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
 ///
 /// #### Historical request:
-///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+///   Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
 ///
 /// Defaults (upstream):
 /// - `venue`: `"nqb"`
@@ -3512,7 +3512,7 @@ impl OptionSnapshotMarketValueBuilder {
 /// Returns implied volatilies calculated using the national best bid, mid, and ask price
 /// of the option respectively. The underlying price represents whatever the last underlying price was at the
 /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-/// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// here.
 ///
 /// Defaults (upstream):
 /// - `strike`: `"*"`
@@ -4719,10 +4719,10 @@ impl OptionSnapshotGreeksThirdOrderBuilder {
 
 /// Fetch end-of-day option data for a contract over a date range.
 ///
-/// - Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+/// - Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
 /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
 /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
-/// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+/// - You can read more about EOD & OHLC data here.
 ///
 /// Defaults (upstream):
 /// - `strike`: `"*"`
@@ -4999,7 +4999,7 @@ impl OptionHistoryEodBuilder {
 
 /// Fetch intraday OHLC bars for an option contract.
 ///
-/// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
+/// - Aggregated OHLC bars that use SIP rules for each bar. 
 /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
 /// - Multi-day requests are limited to 1 month of data.
 ///
@@ -5362,9 +5362,9 @@ impl OptionHistoryOhlcBuilder {
 
 /// Fetch all trades for an option contract on a given date.
 ///
-/// - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-/// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-/// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+/// - Returns every trade reported by OPRA. 
+/// - Trade condition mappings can be found here.
+/// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -5725,7 +5725,7 @@ impl OptionHistoryTradeBuilder {
 
 /// Fetch NBBO quotes for an option contract on a given date.
 ///
-/// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+/// - Returns every NBBO quote reported by OPRA. 
 /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
@@ -6111,7 +6111,7 @@ impl OptionHistoryQuoteBuilder {
 
 /// Fetch combined trade + quote ticks for an option contract.
 ///
-/// - Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+/// - Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
 /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
 /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
@@ -6498,8 +6498,8 @@ impl OptionHistoryTradeQuoteBuilder {
 
 /// Fetch open interest history for an option contract.
 ///
-/// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-/// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+/// - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+/// - A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
 /// - The reported open interest represents the open interest at the end of the previous trading day.
 ///
 /// Defaults (upstream):
@@ -7210,8 +7210,8 @@ impl OptionHistoryGreeksEodBuilder {
 /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-/// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -7668,8 +7668,8 @@ impl OptionHistoryGreeksAllBuilder {
 /// Fetch all Greeks on each trade for an option contract.
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-/// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Calculates greeks for every trade reported by OPRA.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -8125,8 +8125,8 @@ impl OptionHistoryTradeGreeksAllBuilder {
 /// Fetch first-order Greeks history (intraday, sampled by interval).
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-/// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -8583,8 +8583,8 @@ impl OptionHistoryGreeksFirstOrderBuilder {
 /// Fetch first-order Greeks on each trade for an option contract.
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration.
-/// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Calculates greeks for every trade reported by OPRA.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -9040,8 +9040,8 @@ impl OptionHistoryTradeGreeksFirstOrderBuilder {
 /// Fetch second-order Greeks history (intraday, sampled by interval).
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-/// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -9498,8 +9498,8 @@ impl OptionHistoryGreeksSecondOrderBuilder {
 /// Fetch second-order Greeks on each trade for an option contract.
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration.
-/// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Calculates greeks for every trade reported by OPRA.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -9955,8 +9955,8 @@ impl OptionHistoryTradeGreeksSecondOrderBuilder {
 /// Fetch third-order Greeks history (intraday, sampled by interval).
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-/// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -10413,8 +10413,8 @@ impl OptionHistoryGreeksThirdOrderBuilder {
 /// Fetch third-order Greeks on each trade for an option contract.
 ///
 /// - Returns the data for all contracts that share the same provided symbol and expiration.
-/// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Calculates greeks for every trade reported by OPRA.
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -10870,7 +10870,7 @@ impl OptionHistoryTradeGreeksThirdOrderBuilder {
 /// Fetch implied volatility history (intraday, sampled by interval).
 ///
 /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data.
 ///
 /// Defaults (upstream):
@@ -11326,8 +11326,8 @@ impl OptionHistoryGreeksImpliedVolatilityBuilder {
 
 /// Fetch implied volatility on each trade for an option contract.
 ///
-/// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+/// - Returns implied volatilies calculated using the trade reported by OPRA. 
+/// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
 /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
 ///
 /// Defaults (upstream):
@@ -11782,9 +11782,9 @@ impl OptionHistoryTradeGreeksImpliedVolatilityBuilder {
 
 /// Fetch the trade at a specific time of day across a date range for an option.
 ///
-/// - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-/// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-/// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+/// - Returns the last trade reported by OPRA at a specified millisecond of the day.
+/// - Trade condition mappings can be found here.
+/// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
 /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
 ///
 /// Defaults (upstream):
@@ -12073,7 +12073,7 @@ impl OptionAtTimeTradeBuilder {
 
 /// Fetch the quote at a specific time of day across a date range for an option.
 ///
-/// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+/// - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
 /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
 ///
 /// Defaults (upstream):
@@ -12484,7 +12484,7 @@ impl IndexListDatesBuilder {
 /// Get the latest OHLC snapshot for one or more indices.
 ///
 /// - Retrieves the real-time current day OHLC.
-/// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+/// - Exchanges typically generate a price report every second for popular indices like SPX.
 #[pyclass(module = "thetadatadx", name = "IndexSnapshotOhlcBuilder")]
 pub struct IndexSnapshotOhlcBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDxClient>,
@@ -12560,7 +12560,7 @@ impl IndexSnapshotOhlcBuilder {
 /// Get the latest price snapshot for one or more indices.
 ///
 /// - Retrieves a real-time last index price.
-/// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+/// - Exchanges typically generate a price report every second for popular indices like SPX.
 #[pyclass(module = "thetadatadx", name = "IndexSnapshotPriceBuilder")]
 pub struct IndexSnapshotPriceBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDxClient>,
@@ -12636,7 +12636,7 @@ impl IndexSnapshotPriceBuilder {
 /// Get the latest market value snapshot for one or more indices.
 ///
 /// - Retrieves a real-time last index market value.
-/// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+/// - Exchanges typically generate a price report every second for popular indices like SPX.
 #[pyclass(module = "thetadatadx", name = "IndexSnapshotMarketValueBuilder")]
 pub struct IndexSnapshotMarketValueBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDxClient>,
@@ -12711,7 +12711,7 @@ impl IndexSnapshotMarketValueBuilder {
 
 /// Fetch end-of-day index data for a date range.
 ///
-/// - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+/// - Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
 #[pyclass(module = "thetadatadx", name = "IndexHistoryEodBuilder")]
 pub struct IndexHistoryEodBuilder {
     tdx: std::sync::Arc<thetadatadx::ThetaDataDxClient>,
@@ -12881,9 +12881,9 @@ impl IndexHistoryEodBuilder {
 
 /// Fetch intraday OHLC bars for an index.
 ///
-/// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+/// - Aggregated OHLC bars that use SIP rules for each bar.
 /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
-/// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+/// - Exchanges typically generate a price report every second for popular indices like SPX.
 ///
 /// Defaults (upstream):
 /// - `interval`: `"1s"`
@@ -13127,7 +13127,7 @@ impl IndexHistoryOhlcBuilder {
 
 /// Fetch intraday price history for an index.
 ///
-/// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+/// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
 /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
 /// - A price update from the exchange is omitted if the price remained the same from the previous update.
 /// - Multi-day requests are limited to 1 month of data.
@@ -13409,7 +13409,7 @@ impl IndexHistoryPriceBuilder {
 
 /// Fetch the index price at a specific time of day across a date range.
 ///
-/// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+/// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
 /// - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
 #[pyclass(module = "thetadatadx", name = "IndexAtTimePriceBuilder")]
 pub struct IndexAtTimePriceBuilder {
@@ -14414,8 +14414,8 @@ impl ThetaDataDxClient {
     /// Get the latest OHLC snapshot for one or more stocks.
     ///
     /// Provides a real-time Open, High, Low, Close for the current day.
-    /// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+    /// * Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
     /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -14447,8 +14447,8 @@ impl ThetaDataDxClient {
     /// Get the latest OHLC snapshot for one or more stocks.
     ///
     /// Provides a real-time Open, High, Low, Close for the current day.
-    /// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+    /// * Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
     /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -14506,7 +14506,7 @@ impl ThetaDataDxClient {
 
     /// Get the latest trade snapshot for one or more stocks.
     ///
-    /// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     ///
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
@@ -14538,7 +14538,7 @@ impl ThetaDataDxClient {
 
     /// Get the latest trade snapshot for one or more stocks.
     ///
-    /// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     ///
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
@@ -14597,8 +14597,8 @@ impl ThetaDataDxClient {
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
     ///
-    /// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// * Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -14629,8 +14629,8 @@ impl ThetaDataDxClient {
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
     ///
-    /// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// * Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -14688,8 +14688,8 @@ impl ThetaDataDxClient {
 
     /// Get the latest market value snapshot for one or more stocks.
     ///
-    /// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -14720,8 +14720,8 @@ impl ThetaDataDxClient {
 
     /// Get the latest market value snapshot for one or more stocks.
     ///
-    /// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -14779,7 +14779,7 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
     ///
-    /// Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+    /// Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
     #[pyo3(signature = (symbol, start_date, end_date, *, timeout_ms=None))]
     fn stock_history_eod(
         &self,
@@ -14799,7 +14799,7 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
     ///
-    /// Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+    /// Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -14848,8 +14848,8 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for a stock on a single date.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
-    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -14899,8 +14899,8 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for a stock on a single date.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
-    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -14983,7 +14983,7 @@ impl ThetaDataDxClient {
 
     /// Fetch all trades for a stock on a given date.
     ///
-    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -15028,7 +15028,7 @@ impl ThetaDataDxClient {
 
     /// Fetch all trades for a stock on a given date.
     ///
-    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -15105,9 +15105,9 @@ impl ThetaDataDxClient {
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
     ///
-    /// - Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs). 
+    /// - Returns every NBBO quote reported by UTP and CTA. 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
-    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -15157,9 +15157,9 @@ impl ThetaDataDxClient {
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
     ///
-    /// - Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs). 
+    /// - Returns every NBBO quote reported by UTP and CTA. 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
-    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -15242,7 +15242,7 @@ impl ThetaDataDxClient {
 
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     ///
-    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -15292,7 +15292,7 @@ impl ThetaDataDxClient {
 
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     ///
-    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -15376,12 +15376,12 @@ impl ThetaDataDxClient {
     /// Fetch the trade at a specific time of day across a date range.
     ///
     /// #### Real-time request:
-    /// - Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// - Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// - Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// - Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
     ///
     /// #### Historical request:
-    /// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-    /// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    /// Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+    /// Trade condition mappings can be found here.
     ///
     /// Defaults (upstream):
     /// - `venue`: `"nqb"`
@@ -15410,12 +15410,12 @@ impl ThetaDataDxClient {
     /// Fetch the trade at a specific time of day across a date range.
     ///
     /// #### Real-time request:
-    /// - Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// - Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// - Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// - Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
     ///
     /// #### Historical request:
-    /// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-    /// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    /// Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+    /// Trade condition mappings can be found here.
     ///
     /// Defaults (upstream):
     /// - `venue`: `"nqb"`
@@ -15477,11 +15477,11 @@ impl ThetaDataDxClient {
     ///
     /// #### Real-time request:
     ///   - Subscription tier standard or higher will default to NQB.
-    ///   - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    ///   - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
     ///
     /// #### Historical request:
-    ///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+    ///   Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
     ///
     /// Defaults (upstream):
     /// - `venue`: `"nqb"`
@@ -15511,11 +15511,11 @@ impl ThetaDataDxClient {
     ///
     /// #### Real-time request:
     ///   - Subscription tier standard or higher will default to NQB.
-    ///   - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    ///   - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
     ///
     /// #### Historical request:
-    ///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+    ///   Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
     ///
     /// Defaults (upstream):
     /// - `venue`: `"nqb"`
@@ -16567,7 +16567,7 @@ impl ThetaDataDxClient {
     /// Returns implied volatilies calculated using the national best bid, mid, and ask price
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
     /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-    /// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// here.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -16640,7 +16640,7 @@ impl ThetaDataDxClient {
     /// Returns implied volatilies calculated using the national best bid, mid, and ask price
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
     /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-    /// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// here.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -17484,10 +17484,10 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day option data for a contract over a date range.
     ///
-    /// - Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+    /// - Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
     /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
     /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
-    /// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+    /// - You can read more about EOD & OHLC data here.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -17528,10 +17528,10 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day option data for a contract over a date range.
     ///
-    /// - Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+    /// - Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
     /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
     /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
-    /// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+    /// - You can read more about EOD & OHLC data here.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -17607,7 +17607,7 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for an option contract.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
+    /// - Aggregated OHLC bars that use SIP rules for each bar. 
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
     /// - Multi-day requests are limited to 1 month of data.
     ///
@@ -17668,7 +17668,7 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for an option contract.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
+    /// - Aggregated OHLC bars that use SIP rules for each bar. 
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
     /// - Multi-day requests are limited to 1 month of data.
     ///
@@ -17766,9 +17766,9 @@ impl ThetaDataDxClient {
 
     /// Fetch all trades for an option contract on a given date.
     ///
-    /// - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Returns every trade reported by OPRA. 
+    /// - Trade condition mappings can be found here.
+    /// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -17827,9 +17827,9 @@ impl ThetaDataDxClient {
 
     /// Fetch all trades for an option contract on a given date.
     ///
-    /// - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Returns every trade reported by OPRA. 
+    /// - Trade condition mappings can be found here.
+    /// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -17925,7 +17925,7 @@ impl ThetaDataDxClient {
 
     /// Fetch NBBO quotes for an option contract on a given date.
     ///
-    /// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+    /// - Returns every NBBO quote reported by OPRA. 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
@@ -17990,7 +17990,7 @@ impl ThetaDataDxClient {
 
     /// Fetch NBBO quotes for an option contract on a given date.
     ///
-    /// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+    /// - Returns every NBBO quote reported by OPRA. 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
@@ -18093,7 +18093,7 @@ impl ThetaDataDxClient {
 
     /// Fetch combined trade + quote ticks for an option contract.
     ///
-    /// - Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+    /// - Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
     /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
     /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
@@ -18159,7 +18159,7 @@ impl ThetaDataDxClient {
 
     /// Fetch combined trade + quote ticks for an option contract.
     ///
-    /// - Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+    /// - Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
     /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
     /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
@@ -18263,8 +18263,8 @@ impl ThetaDataDxClient {
 
     /// Fetch open interest history for an option contract.
     ///
-    /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-    /// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+    /// - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+    /// - A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
     /// - The reported open interest represents the open interest at the end of the previous trading day.
     ///
     /// Defaults (upstream):
@@ -18313,8 +18313,8 @@ impl ThetaDataDxClient {
 
     /// Fetch open interest history for an option contract.
     ///
-    /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-    /// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+    /// - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+    /// - A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
     /// - The reported open interest represents the open interest at the end of the previous trading day.
     ///
     /// Defaults (upstream):
@@ -18571,8 +18571,8 @@ impl ThetaDataDxClient {
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -18651,8 +18651,8 @@ impl ThetaDataDxClient {
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -18772,8 +18772,8 @@ impl ThetaDataDxClient {
     /// Fetch all Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -18851,8 +18851,8 @@ impl ThetaDataDxClient {
     /// Fetch all Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -18971,8 +18971,8 @@ impl ThetaDataDxClient {
     /// Fetch first-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19051,8 +19051,8 @@ impl ThetaDataDxClient {
     /// Fetch first-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19172,8 +19172,8 @@ impl ThetaDataDxClient {
     /// Fetch first-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -19251,8 +19251,8 @@ impl ThetaDataDxClient {
     /// Fetch first-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -19371,8 +19371,8 @@ impl ThetaDataDxClient {
     /// Fetch second-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19451,8 +19451,8 @@ impl ThetaDataDxClient {
     /// Fetch second-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19572,8 +19572,8 @@ impl ThetaDataDxClient {
     /// Fetch second-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -19651,8 +19651,8 @@ impl ThetaDataDxClient {
     /// Fetch second-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -19771,8 +19771,8 @@ impl ThetaDataDxClient {
     /// Fetch third-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19851,8 +19851,8 @@ impl ThetaDataDxClient {
     /// Fetch third-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -19972,8 +19972,8 @@ impl ThetaDataDxClient {
     /// Fetch third-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20051,8 +20051,8 @@ impl ThetaDataDxClient {
     /// Fetch third-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20171,7 +20171,7 @@ impl ThetaDataDxClient {
     /// Fetch implied volatility history (intraday, sampled by interval).
     ///
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -20250,7 +20250,7 @@ impl ThetaDataDxClient {
     /// Fetch implied volatility history (intraday, sampled by interval).
     ///
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -20369,8 +20369,8 @@ impl ThetaDataDxClient {
 
     /// Fetch implied volatility on each trade for an option contract.
     ///
-    /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Returns implied volatilies calculated using the trade reported by OPRA. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20447,8 +20447,8 @@ impl ThetaDataDxClient {
 
     /// Fetch implied volatility on each trade for an option contract.
     ///
-    /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Returns implied volatilies calculated using the trade reported by OPRA. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -20566,9 +20566,9 @@ impl ThetaDataDxClient {
 
     /// Fetch the trade at a specific time of day across a date range for an option.
     ///
-    /// - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Returns the last trade reported by OPRA at a specified millisecond of the day.
+    /// - Trade condition mappings can be found here.
+    /// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
     ///
     /// Defaults (upstream):
@@ -20611,9 +20611,9 @@ impl ThetaDataDxClient {
 
     /// Fetch the trade at a specific time of day across a date range for an option.
     ///
-    /// - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Returns the last trade reported by OPRA at a specified millisecond of the day.
+    /// - Trade condition mappings can be found here.
+    /// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
     ///
     /// Defaults (upstream):
@@ -20693,7 +20693,7 @@ impl ThetaDataDxClient {
 
     /// Fetch the quote at a specific time of day across a date range for an option.
     ///
-    /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+    /// - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
     ///
     /// Defaults (upstream):
@@ -20736,7 +20736,7 @@ impl ThetaDataDxClient {
 
     /// Fetch the quote at a specific time of day across a date range for an option.
     ///
-    /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+    /// - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
     ///
     /// Defaults (upstream):
@@ -20955,7 +20955,7 @@ impl ThetaDataDxClient {
     /// Get the latest OHLC snapshot for one or more indices.
     ///
     /// - Retrieves the real-time current day OHLC.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[pyo3(signature = (symbols, *, min_time=None, timeout_ms=None))]
     fn index_snapshot_ohlc(
         &self,
@@ -20979,7 +20979,7 @@ impl ThetaDataDxClient {
     /// Get the latest OHLC snapshot for one or more indices.
     ///
     /// - Retrieves the real-time current day OHLC.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -21029,7 +21029,7 @@ impl ThetaDataDxClient {
     /// Get the latest price snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index price.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[pyo3(signature = (symbols, *, min_time=None, timeout_ms=None))]
     fn index_snapshot_price(
         &self,
@@ -21053,7 +21053,7 @@ impl ThetaDataDxClient {
     /// Get the latest price snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index price.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -21103,7 +21103,7 @@ impl ThetaDataDxClient {
     /// Get the latest market value snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index market value.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[pyo3(signature = (symbols, *, min_time=None, timeout_ms=None))]
     fn index_snapshot_market_value(
         &self,
@@ -21127,7 +21127,7 @@ impl ThetaDataDxClient {
     /// Get the latest market value snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index market value.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -21176,7 +21176,7 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day index data for a date range.
     ///
-    /// - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+    /// - Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
     #[pyo3(signature = (symbol, start_date, end_date, *, timeout_ms=None))]
     fn index_history_eod(
         &self,
@@ -21196,7 +21196,7 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day index data for a date range.
     ///
-    /// - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+    /// - Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
     ///
     ///
     /// Async companion — returns an awaitable (`asyncio.Future`).
@@ -21245,9 +21245,9 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for an index.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+    /// - Aggregated OHLC bars that use SIP rules for each bar.
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     ///
     /// Defaults (upstream):
     /// - `interval`: `"1s"`
@@ -21284,9 +21284,9 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for an index.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+    /// - Aggregated OHLC bars that use SIP rules for each bar.
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     ///
     /// Defaults (upstream):
     /// - `interval`: `"1s"`
@@ -21355,7 +21355,7 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday price history for an index.
     ///
-    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
     /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
     /// - A price update from the exchange is omitted if the price remained the same from the previous update.
     /// - Multi-day requests are limited to 1 month of data.
@@ -21402,7 +21402,7 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday price history for an index.
     ///
-    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
     /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
     /// - A price update from the exchange is omitted if the price remained the same from the previous update.
     /// - Multi-day requests are limited to 1 month of data.
@@ -21481,7 +21481,7 @@ impl ThetaDataDxClient {
 
     /// Fetch the index price at a specific time of day across a date range.
     ///
-    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
     /// - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
     #[pyo3(signature = (symbol, start_date, end_date, time_of_day, *, timeout_ms=None))]
     fn index_at_time_price(
@@ -21503,7 +21503,7 @@ impl ThetaDataDxClient {
 
     /// Fetch the index price at a specific time of day across a date range.
     ///
-    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
     /// - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
     ///
     ///

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -819,8 +819,8 @@ export declare class MddsClient {
    * Get the latest OHLC snapshot for one or more stocks.
    *
    * Provides a real-time Open, High, Low, Close for the current day.
-   * * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   * * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+   * * Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   * * Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
    * * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
    *
    * Defaults (upstream):
@@ -830,7 +830,7 @@ export declare class MddsClient {
   /**
    * Get the latest trade snapshot for one or more stocks.
    *
-   * Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    *
    * - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
    *
@@ -841,8 +841,8 @@ export declare class MddsClient {
   /**
    * Get the latest NBBO quote snapshot for one or more stocks.
    *
-   * * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   * * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+   * * Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   * * Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
    * - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
    *
    * Defaults (upstream):
@@ -852,8 +852,8 @@ export declare class MddsClient {
   /**
    * Get the latest market value snapshot for one or more stocks.
    *
-   * * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   * * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+   * * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   * * Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
    * - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
    *
    * Defaults (upstream):
@@ -863,7 +863,7 @@ export declare class MddsClient {
   /**
    * Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
    *
-   * Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+   * Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
    */
   stockHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `stock_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
@@ -871,8 +871,8 @@ export declare class MddsClient {
   /**
    * Fetch intraday OHLC bars for a stock on a single date.
    *
-   * - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds.
-   * - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * - Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds.
+   * - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -887,7 +887,7 @@ export declare class MddsClient {
   /**
    * Fetch all trades for a stock on a given date.
    *
-   * Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -901,9 +901,9 @@ export declare class MddsClient {
   /**
    * Fetch NBBO quotes for a stock on a given date at a given interval.
    *
-   * - Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs).
+   * - Returns every NBBO quote reported by UTP and CTA.
    * - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp.
-   * - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -918,7 +918,7 @@ export declare class MddsClient {
   /**
    * Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
    *
-   * Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -934,12 +934,12 @@ export declare class MddsClient {
    * Fetch the trade at a specific time of day across a date range.
    *
    * #### Real-time request:
-   * - Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   * - Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+   * - Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   * - Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
    *
    * #### Historical request:
-   * Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-   * Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+   * Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+   * Trade condition mappings can be found here.
    *
    * Defaults (upstream):
    * - `venue`: `"nqb"`
@@ -952,11 +952,11 @@ export declare class MddsClient {
    *
    * #### Real-time request:
    *   - Subscription tier standard or higher will default to NQB.
-   *   - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   *   - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+   *   - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   *   - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
    *
    * #### Historical request:
-   *   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+   *   Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
    *
    * Defaults (upstream):
    * - `venue`: `"nqb"`
@@ -1071,7 +1071,7 @@ export declare class MddsClient {
    * Returns implied volatilies calculated using the national best bid, mid, and ask price
    * of the option respectively. The underlying price represents whatever the last underlying price was at the
    * ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks
-   * [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * here.
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -1148,10 +1148,10 @@ export declare class MddsClient {
   /**
    * Fetch end-of-day option data for a contract over a date range.
    *
-   * - Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+   * - Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
    * - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade.
    * - The quote in the response represents the last NBBO reported by OPRA at the time of report generation.
-   * - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+   * - You can read more about EOD & OHLC data here.
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -1163,7 +1163,7 @@ export declare class MddsClient {
   /**
    * Fetch intraday OHLC bars for an option contract.
    *
-   * - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+   * - Aggregated OHLC bars that use SIP rules for each bar.
    * - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
    * - Multi-day requests are limited to 1 month of data.
    *
@@ -1180,9 +1180,9 @@ export declare class MddsClient {
   /**
    * Fetch all trades for an option contract on a given date.
    *
-   * - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-   * - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+   * - Returns every trade reported by OPRA.
+   * - Trade condition mappings can be found here.
+   * - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1197,7 +1197,7 @@ export declare class MddsClient {
   /**
    * Fetch NBBO quotes for an option contract on a given date.
    *
-   * - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
+   * - Returns every NBBO quote reported by OPRA.
    * - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
@@ -1214,7 +1214,7 @@ export declare class MddsClient {
   /**
    * Fetch combined trade + quote ticks for an option contract.
    *
-   * - Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+   * - Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
    * - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp.
    * - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
@@ -1232,8 +1232,8 @@ export declare class MddsClient {
   /**
    * Fetch open interest history for an option contract.
    *
-   * - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-   * - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+   * - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+   * - A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
    * - The reported open interest represents the open interest at the end of the previous trading day.
    *
    * Defaults (upstream):
@@ -1264,8 +1264,8 @@ export declare class MddsClient {
    * Fetch all Greeks history for an option contract (intraday, sampled by interval).
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1284,8 +1284,8 @@ export declare class MddsClient {
    * Fetch all Greeks on each trade for an option contract.
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculates greeks for every trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1303,8 +1303,8 @@ export declare class MddsClient {
    * Fetch first-order Greeks history (intraday, sampled by interval).
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1323,8 +1323,8 @@ export declare class MddsClient {
    * Fetch first-order Greeks on each trade for an option contract.
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculates greeks for every trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1342,8 +1342,8 @@ export declare class MddsClient {
    * Fetch second-order Greeks history (intraday, sampled by interval).
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1362,8 +1362,8 @@ export declare class MddsClient {
    * Fetch second-order Greeks on each trade for an option contract.
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculates greeks for every trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1381,8 +1381,8 @@ export declare class MddsClient {
    * Fetch third-order Greeks history (intraday, sampled by interval).
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1401,8 +1401,8 @@ export declare class MddsClient {
    * Fetch third-order Greeks on each trade for an option contract.
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculates greeks for every trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1420,7 +1420,7 @@ export declare class MddsClient {
    * Fetch implied volatility history (intraday, sampled by interval).
    *
    * - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1438,8 +1438,8 @@ export declare class MddsClient {
   /**
    * Fetch implied volatility on each trade for an option contract.
    *
-   * - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Returns implied volatilies calculated using the trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -1456,9 +1456,9 @@ export declare class MddsClient {
   /**
    * Fetch the trade at a specific time of day across a date range for an option.
    *
-   * - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-   * - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-   * - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+   * - Returns the last trade reported by OPRA at a specified millisecond of the day.
+   * - Trade condition mappings can be found here.
+   * - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
    * - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
    *
    * Defaults (upstream):
@@ -1471,7 +1471,7 @@ export declare class MddsClient {
   /**
    * Fetch the quote at a specific time of day across a date range for an option.
    *
-   * - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+   * - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
    * - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
    *
    * Defaults (upstream):
@@ -1497,27 +1497,27 @@ export declare class MddsClient {
    * Get the latest OHLC snapshot for one or more indices.
    *
    * - Retrieves the real-time current day OHLC.
-   * - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotOHLC(symbols: string | Array<string>, options?: IndexSnapshotOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
   /**
    * Get the latest price snapshot for one or more indices.
    *
    * - Retrieves a real-time last index price.
-   * - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotPrice(symbols: string | Array<string>, options?: IndexSnapshotPriceOptions | undefined | null): Promise<Array<PriceTick>>
   /**
    * Get the latest market value snapshot for one or more indices.
    *
    * - Retrieves a real-time last index market value.
-   * - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotMarketValue(symbols: string | Array<string>, options?: IndexSnapshotMarketValueOptions | undefined | null): Promise<Array<MarketValueTick>>
   /**
    * Fetch end-of-day index data for a date range.
    *
-   * - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+   * - Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
    */
   indexHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `index_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
@@ -1525,9 +1525,9 @@ export declare class MddsClient {
   /**
    * Fetch intraday OHLC bars for an index.
    *
-   * - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+   * - Aggregated OHLC bars that use SIP rules for each bar.
    * - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
-   * - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Exchanges typically generate a price report every second for popular indices like SPX.
    *
    * Defaults (upstream):
    * - `interval`: `"1s"`
@@ -1540,7 +1540,7 @@ export declare class MddsClient {
   /**
    * Fetch intraday price history for an index.
    *
-   * - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
    * - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
    * - A price update from the exchange is omitted if the price remained the same from the previous update.
    * - Multi-day requests are limited to 1 month of data.
@@ -1556,7 +1556,7 @@ export declare class MddsClient {
   /**
    * Fetch the index price at a specific time of day across a date range.
    *
-   * - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
    * - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
    */
   indexAtTimePrice(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: IndexAtTimePriceOptions | undefined | null): Promise<Array<IndexPriceAtTimeTick>>
@@ -1817,8 +1817,8 @@ export declare class ThetaDataDxClient {
    * Get the latest OHLC snapshot for one or more stocks.
    *
    * Provides a real-time Open, High, Low, Close for the current day.
-   * * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   * * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+   * * Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   * * Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
    * * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
    *
    * Defaults (upstream):
@@ -1828,7 +1828,7 @@ export declare class ThetaDataDxClient {
   /**
    * Get the latest trade snapshot for one or more stocks.
    *
-   * Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    *
    * - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
    *
@@ -1839,8 +1839,8 @@ export declare class ThetaDataDxClient {
   /**
    * Get the latest NBBO quote snapshot for one or more stocks.
    *
-   * * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   * * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+   * * Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   * * Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
    * - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
    *
    * Defaults (upstream):
@@ -1850,8 +1850,8 @@ export declare class ThetaDataDxClient {
   /**
    * Get the latest market value snapshot for one or more stocks.
    *
-   * * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   * * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+   * * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   * * Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
    * - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
    *
    * Defaults (upstream):
@@ -1861,7 +1861,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
    *
-   * Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+   * Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
    */
   stockHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `stock_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
@@ -1869,8 +1869,8 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch intraday OHLC bars for a stock on a single date.
    *
-   * - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds.
-   * - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * - Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds.
+   * - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1885,7 +1885,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch all trades for a stock on a given date.
    *
-   * Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1899,9 +1899,9 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch NBBO quotes for a stock on a given date at a given interval.
    *
-   * - Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs).
+   * - Returns every NBBO quote reported by UTP and CTA.
    * - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp.
-   * - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1916,7 +1916,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
    *
-   * Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+   * Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -1932,12 +1932,12 @@ export declare class ThetaDataDxClient {
    * Fetch the trade at a specific time of day across a date range.
    *
    * #### Real-time request:
-   * - Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   * - Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+   * - Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   * - Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
    *
    * #### Historical request:
-   * Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-   * Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+   * Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+   * Trade condition mappings can be found here.
    *
    * Defaults (upstream):
    * - `venue`: `"nqb"`
@@ -1950,11 +1950,11 @@ export declare class ThetaDataDxClient {
    *
    * #### Real-time request:
    *   - Subscription tier standard or higher will default to NQB.
-   *   - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-   *   - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+   *   - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+   *   - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
    *
    * #### Historical request:
-   *   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+   *   Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
    *
    * Defaults (upstream):
    * - `venue`: `"nqb"`
@@ -2069,7 +2069,7 @@ export declare class ThetaDataDxClient {
    * Returns implied volatilies calculated using the national best bid, mid, and ask price
    * of the option respectively. The underlying price represents whatever the last underlying price was at the
    * ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks
-   * [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * here.
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -2146,10 +2146,10 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch end-of-day option data for a contract over a date range.
    *
-   * - Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+   * - Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
    * - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade.
    * - The quote in the response represents the last NBBO reported by OPRA at the time of report generation.
-   * - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+   * - You can read more about EOD & OHLC data here.
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -2161,7 +2161,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch intraday OHLC bars for an option contract.
    *
-   * - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+   * - Aggregated OHLC bars that use SIP rules for each bar.
    * - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
    * - Multi-day requests are limited to 1 month of data.
    *
@@ -2178,9 +2178,9 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch all trades for an option contract on a given date.
    *
-   * - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-   * - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+   * - Returns every trade reported by OPRA.
+   * - Trade condition mappings can be found here.
+   * - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2195,7 +2195,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch NBBO quotes for an option contract on a given date.
    *
-   * - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
+   * - Returns every NBBO quote reported by OPRA.
    * - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
@@ -2212,7 +2212,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch combined trade + quote ticks for an option contract.
    *
-   * - Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+   * - Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
    * - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp.
    * - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
@@ -2230,8 +2230,8 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch open interest history for an option contract.
    *
-   * - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-   * - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+   * - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+   * - A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
    * - The reported open interest represents the open interest at the end of the previous trading day.
    *
    * Defaults (upstream):
@@ -2262,8 +2262,8 @@ export declare class ThetaDataDxClient {
    * Fetch all Greeks history for an option contract (intraday, sampled by interval).
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2282,8 +2282,8 @@ export declare class ThetaDataDxClient {
    * Fetch all Greeks on each trade for an option contract.
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculates greeks for every trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2301,8 +2301,8 @@ export declare class ThetaDataDxClient {
    * Fetch first-order Greeks history (intraday, sampled by interval).
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2321,8 +2321,8 @@ export declare class ThetaDataDxClient {
    * Fetch first-order Greeks on each trade for an option contract.
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculates greeks for every trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2340,8 +2340,8 @@ export declare class ThetaDataDxClient {
    * Fetch second-order Greeks history (intraday, sampled by interval).
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2360,8 +2360,8 @@ export declare class ThetaDataDxClient {
    * Fetch second-order Greeks on each trade for an option contract.
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculates greeks for every trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2379,8 +2379,8 @@ export declare class ThetaDataDxClient {
    * Fetch third-order Greeks history (intraday, sampled by interval).
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2399,8 +2399,8 @@ export declare class ThetaDataDxClient {
    * Fetch third-order Greeks on each trade for an option contract.
    *
    * - Returns the data for all contracts that share the same provided symbol and expiration.
-   * - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Calculates greeks for every trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2418,7 +2418,7 @@ export declare class ThetaDataDxClient {
    * Fetch implied volatility history (intraday, sampled by interval).
    *
    * - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively.
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data.
    *
    * Defaults (upstream):
@@ -2436,8 +2436,8 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch implied volatility on each trade for an option contract.
    *
-   * - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+   * - Returns implied volatilies calculated using the trade reported by OPRA.
+   * - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
    * - Multi-day requests are limited to 1 month of data, and must specify an expiration.
    *
    * Defaults (upstream):
@@ -2454,9 +2454,9 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch the trade at a specific time of day across a date range for an option.
    *
-   * - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-   * - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-   * - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+   * - Returns the last trade reported by OPRA at a specified millisecond of the day.
+   * - Trade condition mappings can be found here.
+   * - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
    * - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
    *
    * Defaults (upstream):
@@ -2469,7 +2469,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch the quote at a specific time of day across a date range for an option.
    *
-   * - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+   * - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
    * - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
    *
    * Defaults (upstream):
@@ -2495,27 +2495,27 @@ export declare class ThetaDataDxClient {
    * Get the latest OHLC snapshot for one or more indices.
    *
    * - Retrieves the real-time current day OHLC.
-   * - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotOHLC(symbols: string | Array<string>, options?: IndexSnapshotOhlcOptions | undefined | null): Promise<Array<OhlcTick>>
   /**
    * Get the latest price snapshot for one or more indices.
    *
    * - Retrieves a real-time last index price.
-   * - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotPrice(symbols: string | Array<string>, options?: IndexSnapshotPriceOptions | undefined | null): Promise<Array<PriceTick>>
   /**
    * Get the latest market value snapshot for one or more indices.
    *
    * - Retrieves a real-time last index market value.
-   * - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Exchanges typically generate a price report every second for popular indices like SPX.
    */
   indexSnapshotMarketValue(symbols: string | Array<string>, options?: IndexSnapshotMarketValueOptions | undefined | null): Promise<Array<MarketValueTick>>
   /**
    * Fetch end-of-day index data for a date range.
    *
-   * - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+   * - Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
    */
   indexHistoryEOD(symbol: string, startDate: string | Date, endDate: string | Date, options?: IndexHistoryEodOptions | undefined | null): Promise<Array<EodTick>>
   /** Stream `index_history_eod` rows into `callback` without materialising the full response in memory. `callback(chunk: EodTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `indexHistoryEOD` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
@@ -2523,9 +2523,9 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch intraday OHLC bars for an index.
    *
-   * - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+   * - Aggregated OHLC bars that use SIP rules for each bar.
    * - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
-   * - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Exchanges typically generate a price report every second for popular indices like SPX.
    *
    * Defaults (upstream):
    * - `interval`: `"1s"`
@@ -2538,7 +2538,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch intraday price history for an index.
    *
-   * - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
    * - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
    * - A price update from the exchange is omitted if the price remained the same from the previous update.
    * - Multi-day requests are limited to 1 month of data.
@@ -2554,7 +2554,7 @@ export declare class ThetaDataDxClient {
   /**
    * Fetch the index price at a specific time of day across a date range.
    *
-   * - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+   * - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
    * - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
    */
   indexAtTimePrice(symbol: string, startDate: string | Date, endDate: string | Date, timeOfDay: string | Date, options?: IndexAtTimePriceOptions | undefined | null): Promise<Array<IndexPriceAtTimeTick>>

--- a/sdks/typescript/src/_generated/historical_methods.rs
+++ b/sdks/typescript/src/_generated/historical_methods.rs
@@ -1535,8 +1535,8 @@ impl ThetaDataDxClient {
     /// Get the latest OHLC snapshot for one or more stocks.
     ///
     /// Provides a real-time Open, High, Low, Close for the current day.
-    /// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+    /// * Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
     /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -1576,7 +1576,7 @@ impl ThetaDataDxClient {
 
     /// Get the latest trade snapshot for one or more stocks.
     ///
-    /// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     ///
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
@@ -1617,8 +1617,8 @@ impl ThetaDataDxClient {
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
     ///
-    /// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// * Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -1658,8 +1658,8 @@ impl ThetaDataDxClient {
 
     /// Get the latest market value snapshot for one or more stocks.
     ///
-    /// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -1699,7 +1699,7 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
     ///
-    /// Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+    /// Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
     #[napi(js_name = "stockHistoryEOD")]
     pub async fn stock_history_eod(
         &self,
@@ -1763,8 +1763,8 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for a stock on a single date.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
-    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -1879,7 +1879,7 @@ impl ThetaDataDxClient {
 
     /// Fetch all trades for a stock on a given date.
     ///
-    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -1985,9 +1985,9 @@ impl ThetaDataDxClient {
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
     ///
-    /// - Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs). 
+    /// - Returns every NBBO quote reported by UTP and CTA. 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
-    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -2102,7 +2102,7 @@ impl ThetaDataDxClient {
 
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     ///
-    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -2218,12 +2218,12 @@ impl ThetaDataDxClient {
     /// Fetch the trade at a specific time of day across a date range.
     ///
     /// #### Real-time request:
-    /// - Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// - Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// - Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// - Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
     ///
     /// #### Historical request:
-    /// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-    /// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    /// Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+    /// Trade condition mappings can be found here.
     ///
     /// Defaults (upstream):
     /// - `venue`: `"nqb"`
@@ -2304,11 +2304,11 @@ impl ThetaDataDxClient {
     ///
     /// #### Real-time request:
     ///   - Subscription tier standard or higher will default to NQB.
-    ///   - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    ///   - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
     ///
     /// #### Historical request:
-    ///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+    ///   Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
     ///
     /// Defaults (upstream):
     /// - `venue`: `"nqb"`
@@ -2855,7 +2855,7 @@ impl ThetaDataDxClient {
     /// Returns implied volatilies calculated using the national best bid, mid, and ask price
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
     /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-    /// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// here.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -3262,10 +3262,10 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day option data for a contract over a date range.
     ///
-    /// - Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+    /// - Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
     /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
     /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
-    /// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+    /// - You can read more about EOD & OHLC data here.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -3369,7 +3369,7 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for an option contract.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
+    /// - Aggregated OHLC bars that use SIP rules for each bar. 
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
     /// - Multi-day requests are limited to 1 month of data.
     ///
@@ -3506,9 +3506,9 @@ impl ThetaDataDxClient {
 
     /// Fetch all trades for an option contract on a given date.
     ///
-    /// - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Returns every trade reported by OPRA. 
+    /// - Trade condition mappings can be found here.
+    /// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -3643,7 +3643,7 @@ impl ThetaDataDxClient {
 
     /// Fetch NBBO quotes for an option contract on a given date.
     ///
-    /// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+    /// - Returns every NBBO quote reported by OPRA. 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
@@ -3788,7 +3788,7 @@ impl ThetaDataDxClient {
 
     /// Fetch combined trade + quote ticks for an option contract.
     ///
-    /// - Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+    /// - Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
     /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
     /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
@@ -3934,8 +3934,8 @@ impl ThetaDataDxClient {
 
     /// Fetch open interest history for an option contract.
     ///
-    /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-    /// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+    /// - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+    /// - A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
     /// - The reported open interest represents the open interest at the end of the previous trading day.
     ///
     /// Defaults (upstream):
@@ -4202,8 +4202,8 @@ impl ThetaDataDxClient {
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -4374,8 +4374,8 @@ impl ThetaDataDxClient {
     /// Fetch all Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -4545,8 +4545,8 @@ impl ThetaDataDxClient {
     /// Fetch first-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -4717,8 +4717,8 @@ impl ThetaDataDxClient {
     /// Fetch first-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -4888,8 +4888,8 @@ impl ThetaDataDxClient {
     /// Fetch second-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -5060,8 +5060,8 @@ impl ThetaDataDxClient {
     /// Fetch second-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -5231,8 +5231,8 @@ impl ThetaDataDxClient {
     /// Fetch third-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -5403,8 +5403,8 @@ impl ThetaDataDxClient {
     /// Fetch third-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -5574,7 +5574,7 @@ impl ThetaDataDxClient {
     /// Fetch implied volatility history (intraday, sampled by interval).
     ///
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -5744,8 +5744,8 @@ impl ThetaDataDxClient {
 
     /// Fetch implied volatility on each trade for an option contract.
     ///
-    /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Returns implied volatilies calculated using the trade reported by OPRA. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -5914,9 +5914,9 @@ impl ThetaDataDxClient {
 
     /// Fetch the trade at a specific time of day across a date range for an option.
     ///
-    /// - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Returns the last trade reported by OPRA at a specified millisecond of the day.
+    /// - Trade condition mappings can be found here.
+    /// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
     ///
     /// Defaults (upstream):
@@ -6025,7 +6025,7 @@ impl ThetaDataDxClient {
 
     /// Fetch the quote at a specific time of day across a date range for an option.
     ///
-    /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+    /// - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
     ///
     /// Defaults (upstream):
@@ -6192,7 +6192,7 @@ impl ThetaDataDxClient {
     /// Get the latest OHLC snapshot for one or more indices.
     ///
     /// - Retrieves the real-time current day OHLC.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotOHLC")]
     pub async fn index_snapshot_ohlc(
         &self,
@@ -6225,7 +6225,7 @@ impl ThetaDataDxClient {
     /// Get the latest price snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index price.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotPrice")]
     pub async fn index_snapshot_price(
         &self,
@@ -6258,7 +6258,7 @@ impl ThetaDataDxClient {
     /// Get the latest market value snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index market value.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotMarketValue")]
     pub async fn index_snapshot_market_value(
         &self,
@@ -6290,7 +6290,7 @@ impl ThetaDataDxClient {
 
     /// Fetch end-of-day index data for a date range.
     ///
-    /// - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+    /// - Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
     #[napi(js_name = "indexHistoryEOD")]
     pub async fn index_history_eod(
         &self,
@@ -6354,9 +6354,9 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday OHLC bars for an index.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+    /// - Aggregated OHLC bars that use SIP rules for each bar.
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     ///
     /// Defaults (upstream):
     /// - `interval`: `"1s"`
@@ -6449,7 +6449,7 @@ impl ThetaDataDxClient {
 
     /// Fetch intraday price history for an index.
     ///
-    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
     /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
     /// - A price update from the exchange is omitted if the price remained the same from the previous update.
     /// - Multi-day requests are limited to 1 month of data.
@@ -6557,7 +6557,7 @@ impl ThetaDataDxClient {
 
     /// Fetch the index price at a specific time of day across a date range.
     ///
-    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
     /// - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
     #[napi(js_name = "indexAtTimePrice")]
     pub async fn index_at_time_price(
@@ -6942,8 +6942,8 @@ impl MddsClient {
     /// Get the latest OHLC snapshot for one or more stocks.
     ///
     /// Provides a real-time Open, High, Low, Close for the current day.
-    /// * Returns a real-time session OHLC from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed session OHLC from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the stocks value subscription.
+    /// * Returns a real-time session OHLC from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed session OHLC from the UTP & CTA feeds if the account has the stocks value subscription.
     /// * Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -6983,7 +6983,7 @@ impl MddsClient {
 
     /// Get the latest trade snapshot for one or more stocks.
     ///
-    /// Returns a real-time last trade from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns a real-time last trade from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     ///
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
@@ -7024,8 +7024,8 @@ impl MddsClient {
 
     /// Get the latest NBBO quote snapshot for one or more stocks.
     ///
-    /// * Returns a real-time last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// * Returns a real-time last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed NBBO quote from the UTP & CTA feeds account has the stocks value subscription subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -7065,8 +7065,8 @@ impl MddsClient {
 
     /// Get the latest market value snapshot for one or more stocks.
     ///
-    /// * Returns a real-time market value derived from the last BBO quote from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs) if the account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// * Returns a real-time market value derived from the last BBO quote from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// * Returns a 15-minute delayed market value derived from an NBBO quote from the UTP & CTA feeds if the account has the stocks value subscription subscription.
     /// - Theta Data resets its snapshot cache at midnight ET every day. This endpoint may not work on a weekend where there were no eligible messages sent over exchange feeds. We recommend using historic requests during the weekend.
     ///
     /// Defaults (upstream):
@@ -7106,7 +7106,7 @@ impl MddsClient {
 
     /// Fetch end-of-day stock data for a date range. Returns OHLCV + bid/ask per trading day.
     ///
-    /// Since [the equity SIPs](/Articles/Data-And-Requests/The-SIPs.html) only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by [CTA or UTP](/Articles/Data-And-Requests/The-SIPs.html) at the time of report generation. You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html). Theta Data plans to avail SIP EOD reports in the near future.
+    /// Since the equity SIPs only generate a partial EOD report, Theta Data generates a national EOD report at 17:15 ET each day. ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. The quote in the response represents the last NBBO reported by CTA or UTP at the time of report generation. You can read more about EOD & OHLC data here. Theta Data plans to avail SIP EOD reports in the near future.
     #[napi(js_name = "stockHistoryEOD")]
     pub async fn stock_history_eod(
         &self,
@@ -7170,8 +7170,8 @@ impl MddsClient {
 
     /// Fetch intraday OHLC bars for a stock on a single date.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
-    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Aggregated OHLC bars that use SIP rules for each bar. Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar time`` <= ``trade time`` < ``bar timestamp + ivl``, where ivl is the specified interval size in milliseconds. 
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -7286,7 +7286,7 @@ impl MddsClient {
 
     /// Fetch all trades for a stock on a given date.
     ///
-    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs). Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns every trade reported by UTP & CTA. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -7392,9 +7392,9 @@ impl MddsClient {
 
     /// Fetch NBBO quotes for a stock on a given date at a given interval.
     ///
-    /// - Returns every NBBO quote reported by [UTP and CTA](/Articles/Data-And-Requests/The-SIPs). 
+    /// - Returns every NBBO quote reported by UTP and CTA. 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote prior to the interval's timestamp. 
-    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// - Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -7509,7 +7509,7 @@ impl MddsClient {
 
     /// Fetch combined trade + quote ticks for a stock on a given date. Returns raw DataTable.
     ///
-    /// Returns every trade reported by [UTP & CTA](/Articles/Data-And-Requests/The-SIPs) paired with the last BBO quote reported by [UTP or CTA](/Articles/Data-And-Requests/The-SIPs) at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
+    /// Returns every trade reported by UTP & CTA paired with the last BBO quote reported by UTP or CTA at the time of trade. A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. If you prefer to match quotes with timestamps that are ``<`` the trade timestamp, specify the ``exclusive`` parameter to ``true``. Set the ``venue`` parameter to ``nqb`` to access current-day real-time historic data from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -7625,12 +7625,12 @@ impl MddsClient {
     /// Fetch the trade at a specific time of day across a date range.
     ///
     /// #### Real-time request:
-    /// - Returns a real-time session from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    /// - Returns a 15-minute delayed session from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    /// - Returns a real-time session from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    /// - Returns a 15-minute delayed session from the UTP & CTA feeds account has the stocks value subscription subscription.
     ///
     /// #### Historical request:
-    /// Returns the last trade reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
-    /// Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
+    /// Returns the last trade reported by UTP & CTA feeds at a specified millisecond of the day.
+    /// Trade condition mappings can be found here.
     ///
     /// Defaults (upstream):
     /// - `venue`: `"nqb"`
@@ -7711,11 +7711,11 @@ impl MddsClient {
     ///
     /// #### Real-time request:
     ///   - Subscription tier standard or higher will default to NQB.
-    ///   - Real-time last BBO quote at-time_of_day-time from the [Nasdaq Basic feed](/Articles/Data-And-Requests/The-SIPs.html#nasdaq-basic) if the account has a [stocks standard or pro subscription](https://www.thetadata.net/subscribe.html#stocks).
-    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) account has the [stocks value subscription](https://www.thetadata.net/subscribe.html#stocks) subscription.
+    ///   - Real-time last BBO quote at-time_of_day-time from the Nasdaq Basic feed if the account has a stocks standard or pro subscription.
+    ///   - 15-minute delayed NBBO quote at-time_of_day-time from the UTP & CTA feeds account has the stocks value subscription subscription.
     ///
     /// #### Historical request:
-    ///   Returns the last NBBO quote reported by [UTP & CTA feeds](/Articles/Data-And-Requests/The-SIPs.html#equities-cta-utp) at a specified millisecond of the day.
+    ///   Returns the last NBBO quote reported by UTP & CTA feeds at a specified millisecond of the day.
     ///
     /// Defaults (upstream):
     /// - `venue`: `"nqb"`
@@ -8262,7 +8262,7 @@ impl MddsClient {
     /// Returns implied volatilies calculated using the national best bid, mid, and ask price
     /// of the option respectively. The underlying price represents whatever the last underlying price was at the
     /// ``underlying_timestamp`` field. You can read more about how Theta Data calculates greeks 
-    /// [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// here.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -8669,10 +8669,10 @@ impl MddsClient {
 
     /// Fetch end-of-day option data for a contract over a date range.
     ///
-    /// - Since [OPRA](/Articles/Data-And-Requests/The-SIPs.html) does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
+    /// - Since OPRA does not provide a national EOD report for options, Theta Data generates a national EOD report at 17:15 ET each day.
     /// - ``created`` represents the datetime the report was generated and ``last_trade`` represents the datetime of the last trade. 
     /// - The quote in the response represents the last NBBO reported by OPRA at the time of report generation. 
-    /// - You can read more about EOD & OHLC data [here](/Articles/Data-And-Requests/OHLC-EOD.html).
+    /// - You can read more about EOD & OHLC data here.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -8776,7 +8776,7 @@ impl MddsClient {
 
     /// Fetch intraday OHLC bars for an option contract.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar. 
+    /// - Aggregated OHLC bars that use SIP rules for each bar. 
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
     /// - Multi-day requests are limited to 1 month of data.
     ///
@@ -8913,9 +8913,9 @@ impl MddsClient {
 
     /// Fetch all trades for an option contract on a given date.
     ///
-    /// - Returns every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Returns every trade reported by OPRA. 
+    /// - Trade condition mappings can be found here.
+    /// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -9050,7 +9050,7 @@ impl MddsClient {
 
     /// Fetch NBBO quotes for an option contract on a given date.
     ///
-    /// - Returns every NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
+    /// - Returns every NBBO quote reported by OPRA. 
     /// - If the ``interval`` parameter is specified, the quote for each interval represents the last quote at the interval's timestamp.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
@@ -9195,7 +9195,7 @@ impl MddsClient {
 
     /// Fetch combined trade + quote ticks for an option contract.
     ///
-    /// - Returns every [trade](/operations/option_history_trade.html) reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) paired with the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at the time of trade.
+    /// - Returns every trade reported by OPRA paired with the last NBBO quote reported by OPRA at the time of trade.
     /// - A quote is matched with a trade if its timestamp ``<=`` the trade timestamp. 
     /// - To match trades with quotes timestamps that are ``<`` the trade timestamp, specify the ``exclusive``parameter to ``true``. After thorough testing, we have determined that using ``exclusive=true`` might yield better results for various applications.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
@@ -9341,8 +9341,8 @@ impl MddsClient {
 
     /// Fetch open interest history for an option contract.
     ///
-    /// - Open Interest is normally reported once per day by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at approximately 06:30 ET.
-    /// - A new open interest message might not be sent by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) if there is no open interest for the option contract.
+    /// - Open Interest is normally reported once per day by OPRA at approximately 06:30 ET.
+    /// - A new open interest message might not be sent by OPRA if there is no open interest for the option contract.
     /// - The reported open interest represents the open interest at the end of the previous trading day.
     ///
     /// Defaults (upstream):
@@ -9609,8 +9609,8 @@ impl MddsClient {
     /// Fetch all Greeks history for an option contract (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -9781,8 +9781,8 @@ impl MddsClient {
     /// Fetch all Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -9952,8 +9952,8 @@ impl MddsClient {
     /// Fetch first-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -10124,8 +10124,8 @@ impl MddsClient {
     /// Fetch first-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -10295,8 +10295,8 @@ impl MddsClient {
     /// Fetch second-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -10467,8 +10467,8 @@ impl MddsClient {
     /// Fetch second-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -10638,8 +10638,8 @@ impl MddsClient {
     /// Fetch third-order Greeks history (intraday, sampled by interval).
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration. 
-    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the [quote](/operations/option_history_quote.html) endpoint. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculated using the option and underlying midpoint price. If an interval size is specified (*highly recommended*), the option quote used in the calculation follows the same rules as the quote endpoint. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -10810,8 +10810,8 @@ impl MddsClient {
     /// Fetch third-order Greeks on each trade for an option contract.
     ///
     /// - Returns the data for all contracts that share the same provided symbol and expiration.
-    /// - Calculates greeks for every trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html).
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Calculates greeks for every trade reported by OPRA.
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -10981,7 +10981,7 @@ impl MddsClient {
     /// Fetch implied volatility history (intraday, sampled by interval).
     ///
     /// - Returns implied volatilies calculated using the national best bid, mid, and ask price of the option respectively. 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data.
     ///
     /// Defaults (upstream):
@@ -11151,8 +11151,8 @@ impl MddsClient {
 
     /// Fetch implied volatility on each trade for an option contract.
     ///
-    /// - Returns implied volatilies calculated using the trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html). 
-    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks [here](/Articles/Data-And-Requests/Option-Greeks.html).
+    /// - Returns implied volatilies calculated using the trade reported by OPRA. 
+    /// - The underlying price represents whatever the last underlying price was at the ``timestamp`` field. You can read more about how Theta Data calculates greeks here.
     /// - Multi-day requests are limited to 1 month of data, and must specify an expiration.
     ///
     /// Defaults (upstream):
@@ -11321,9 +11321,9 @@ impl MddsClient {
 
     /// Fetch the trade at a specific time of day across a date range for an option.
     ///
-    /// - Returns the last trade reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
-    /// - Trade condition mappings can be found [here](/Articles/Errors-Exchanges-Conditions/Trade-Conditions.html).
-    /// - Extended trade conditions are not reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) for options, so they can be ignored.
+    /// - Returns the last trade reported by OPRA at a specified millisecond of the day.
+    /// - Trade condition mappings can be found here.
+    /// - Extended trade conditions are not reported by OPRA for options, so they can be ignored.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the trade should be provided for.
     ///
     /// Defaults (upstream):
@@ -11432,7 +11432,7 @@ impl MddsClient {
 
     /// Fetch the quote at a specific time of day across a date range for an option.
     ///
-    /// - Returns the last NBBO quote reported by [OPRA](/Articles/Data-And-Requests/The-SIPs.html) at a specified millisecond of the day.
+    /// - Returns the last NBBO quote reported by OPRA at a specified millisecond of the day.
     /// - The ``time_of_day``parameter represents the 00:00:00.000 ET that the quote should be provided for.
     ///
     /// Defaults (upstream):
@@ -11599,7 +11599,7 @@ impl MddsClient {
     /// Get the latest OHLC snapshot for one or more indices.
     ///
     /// - Retrieves the real-time current day OHLC.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotOHLC")]
     pub async fn index_snapshot_ohlc(
         &self,
@@ -11632,7 +11632,7 @@ impl MddsClient {
     /// Get the latest price snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index price.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotPrice")]
     pub async fn index_snapshot_price(
         &self,
@@ -11665,7 +11665,7 @@ impl MddsClient {
     /// Get the latest market value snapshot for one or more indices.
     ///
     /// - Retrieves a real-time last index market value.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     #[napi(js_name = "indexSnapshotMarketValue")]
     pub async fn index_snapshot_market_value(
         &self,
@@ -11697,7 +11697,7 @@ impl MddsClient {
 
     /// Fetch end-of-day index data for a date range.
     ///
-    /// - Since [the indices feeds](/Articles/Data-And-Requests/The-SIPs.html) do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
+    /// - Since the indices feeds do not provide a national EOD report, Theta Data generates a national EOD report at 17:15 each day.
     #[napi(js_name = "indexHistoryEOD")]
     pub async fn index_history_eod(
         &self,
@@ -11761,9 +11761,9 @@ impl MddsClient {
 
     /// Fetch intraday OHLC bars for an index.
     ///
-    /// - Aggregated OHLC bars that use [SIP rules](/Articles/Data-And-Requests/OHLC-EOD.html) for each bar.
+    /// - Aggregated OHLC bars that use SIP rules for each bar.
     /// - Time timestamp of the bar represents the opening time of the bar. For a trade to be part of the bar:  ``bar timestamp`` <= ``trade time`` < ``bar timestamp + interval``.
-    /// - [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Exchanges typically generate a price report every second for popular indices like SPX.
     ///
     /// Defaults (upstream):
     /// - `interval`: `"1s"`
@@ -11856,7 +11856,7 @@ impl MddsClient {
 
     /// Fetch intraday price history for an index.
     ///
-    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
     /// - When the ``interval`` parameter is specified, the returned data represents the price at the exact time of each timestamp. If the timestamp in the response is 10:30:00, the price field represents the price at that exact time of the day.
     /// - A price update from the exchange is omitted if the price remained the same from the previous update.
     /// - Multi-day requests are limited to 1 month of data.
@@ -11964,7 +11964,7 @@ impl MddsClient {
 
     /// Fetch the index price at a specific time of day across a date range.
     ///
-    /// - Retrieves historical indices price reports. [Exchanges](/Articles/Data-And-Requests/The-SIPs.html) typically generate a price report every second for popular indices like SPX.
+    /// - Retrieves historical indices price reports. Exchanges typically generate a price report every second for popular indices like SPX.
     /// - The ``time_of_day`` parameter represents the 00:00:00.000 ET that the price should be provided for.
     #[napi(js_name = "indexAtTimePrice")]
     pub async fn index_at_time_price(


### PR DESCRIPTION
The endpoint vendor docstrings embedded markdown links that flowed into the shipped TypeScript stub, C header, and Python type surface, where they render as dead text because the shipped artifacts carry no base URL. This strips the link syntax at the shared endpoint surface, keeping each link's text as plain prose, then regenerates every downstream surface so the shipped SDK docs are link-free while remaining faithful to the source descriptions.

It also points the FpssConfig.timeout_ms doc at the public RemoveReason::TimedOut path instead of an internal module path, and gives the four remaining streaming C APIs proper Doxygen param and return tags to match the rest of the header.

All changes are documentation text only. No signatures, types, or runtime behavior change.

Verification (all green): cargo fmt check, cargo clippy -p thetadatadx --all-features -D warnings, both surface and docs-site drift --check, cargo test -p thetadatadx --doc, check_binding_parity, check_public_surface_leak, check_docs_consistency, TypeScript test suite, and the C++ examples build. The markdown-link grep over the shipped SDK surfaces (index.d.ts, cpp headers, python stubs) returns zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)