### PR TITLE
fix(contract): render the option strike in dollars in the contract string

### DIFF
--- a/crates/thetadatadx/src/fpss/protocol/contract.rs
+++ b/crates/thetadatadx/src/fpss/protocol/contract.rs
@@ -710,6 +710,13 @@ impl std::fmt::Display for Contract {
                 } else {
                     "P"
                 };
+                // Render the strike in dollars, not the wire-level
+                // `strike_thousandths` fixed-point integer, so every binding
+                // (Rust / Python / TypeScript / C++) prints the same
+                // human-readable identity. `f64` Display drops a trailing
+                // `.0` for whole-dollar strikes (`550`) and keeps the needed
+                // decimals for fractional ones (`552.5`).
+                let strike = self.strike_dollars().unwrap_or(0.0);
                 write!(
                     f,
                     "{} {} {} {} {}",
@@ -717,7 +724,7 @@ impl std::fmt::Display for Contract {
                     self.sec_type.as_str(),
                     self.expiration.unwrap_or(0),
                     right,
-                    self.strike_thousandths.unwrap_or(0),
+                    strike,
                 )
             }
             _ => write!(f, "{} {}", self.symbol, self.sec_type.as_str()),
@@ -927,7 +934,36 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(c.to_string(), "SPY OPTION 20261218 P 45000");
+        assert_eq!(c.to_string(), "SPY OPTION 20261218 P 45");
+    }
+
+    #[test]
+    fn contract_display_option_renders_strike_in_dollars() {
+        // The rendered strike is dollars, not the wire-level
+        // `strike_thousandths` integer, so the Rust `Display` matches the
+        // C++ `operator<<` and the Python / TypeScript string surface.
+        let whole = Contract::option(
+            "SPY",
+            OptionLeg {
+                expiration: "20260620",
+                strike: "550",
+                right: "C",
+            },
+        )
+        .unwrap();
+        assert_eq!(whole.to_string(), "SPY OPTION 20260620 C 550");
+
+        // Fractional strikes keep the needed decimals.
+        let fractional = Contract::option(
+            "SPY",
+            OptionLeg {
+                expiration: "20260620",
+                strike: "552.5",
+                right: "P",
+            },
+        )
+        .unwrap();
+        assert_eq!(fractional.to_string(), "SPY OPTION 20260620 P 552.5");
     }
 
     // -- Wire-format parity tests ----------------------------------------------

--- a/sdks/cpp/tests/fluent_rendering.cpp
+++ b/sdks/cpp/tests/fluent_rendering.cpp
@@ -35,6 +35,11 @@ TEST_CASE("FluentContract renders symbol and option identity", "[fluent][offline
     REQUIRE(render(option) == "SPY OPTION 20260620 C 550");
     REQUIRE(tdx::str(option) == "SPY OPTION 20260620 C 550");
 
+    // Fractional strikes keep the needed decimals — same rendering as the
+    // Rust `Display` / Python `__str__` / TypeScript `toString` surface.
+    const auto fractional = tdx::Contract::option("SPY", {.expiration = "20260620", .strike = "552.5", .right = "P"});
+    REQUIRE(render(fractional) == "SPY OPTION 20260620 P 552.5");
+
     // An index contract renders "INDEX", not "STOCK" — it carries its
     // own security type rather than borrowing the stock-shape default.
     const auto index = tdx::Contract::index("VIX");

--- a/sdks/python/tests/test_fluent_contract_example.py
+++ b/sdks/python/tests/test_fluent_contract_example.py
@@ -107,3 +107,28 @@ def test_contract_sec_type_is_symbolic_string(thetadatadx_mod) -> None:
 
     index = thetadatadx_mod.Contract.index("SPX")
     assert index.sec_type == "INDEX"
+
+
+def test_contract_str_renders_strike_in_dollars(thetadatadx_mod) -> None:
+    """`str(Contract)` renders the strike in dollars, identical to the
+    C++ `operator<<` / TypeScript `toString` / Rust `Display` surface — a
+    `$550` strike reads `550`, never the wire-level `550000`."""
+    option = thetadatadx_mod.Contract.option(
+        "SPY",
+        expiration="20260620",
+        strike="550",
+        right="C",
+    )
+    assert str(option) == "SPY OPTION 20260620 C 550"
+
+    # Fractional strikes keep the needed decimals.
+    fractional = thetadatadx_mod.Contract.option(
+        "SPY",
+        expiration="20260620",
+        strike="552.5",
+        right="P",
+    )
+    assert str(fractional) == "SPY OPTION 20260620 P 552.5"
+
+    stock = thetadatadx_mod.Contract.stock("AAPL")
+    assert str(stock) == "AAPL STOCK"

--- a/sdks/typescript/__tests__/fluent_rendering.test.mjs
+++ b/sdks/typescript/__tests__/fluent_rendering.test.mjs
@@ -28,7 +28,12 @@ describe('toString on the fluent value classes', () => {
     assert.equal(Contract.stock('AAPL').toString(), 'AAPL STOCK');
     assert.equal(
       Contract.option('SPY', { expiration: '20260620', strike: '550', right: 'C' }).toString(),
-      'SPY OPTION 20260620 C 550000'
+      'SPY OPTION 20260620 C 550'
+    );
+    // Fractional strikes keep the needed decimals.
+    assert.equal(
+      Contract.option('SPY', { expiration: '20260620', strike: '552.5', right: 'P' }).toString(),
+      'SPY OPTION 20260620 P 552.5'
     );
   });
 
@@ -39,7 +44,7 @@ describe('toString on the fluent value classes', () => {
 
   it('Subscription renders scope, kind, and contract', () => {
     const perContract = Contract.option('SPY', { expiration: '20260620', strike: '550', right: 'C' }).trade();
-    assert.equal(perContract.toString(), 'Subscription(Trade, SPY OPTION 20260620 C 550000)');
+    assert.equal(perContract.toString(), 'Subscription(Trade, SPY OPTION 20260620 C 550)');
     const marketValue = Contract.stock('AAPL').marketValue();
     assert.equal(marketValue.toString(), 'Subscription(MarketValue, AAPL STOCK)');
     const full = SecType.option().fullOpenInterest();

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -434,11 +434,9 @@ export declare class Config {
 /**
  * Fluent contract identifier — stock or option.
  *
- * Exposed to JS as `ContractRef` (the bare `Contract` name on the JS
- * side already refers to the FPSS event payload data object — see
- * `fpss_event_classes.rs`). The `index.d.ts` post-processor emits an
- * `export const Contract = ContractRef` alias so users still write
- * `Contract.stock("AAPL")` per the documented surface.
+ * Use `Contract.stock("AAPL")` / `Contract.option(...)` to build one.
+ * The class is also exported under the name `ContractRef`; `Contract`
+ * is an alias for it, so the two names are interchangeable.
  */
 export declare class ContractRef {
   /** Construct a stock contract. */
@@ -483,7 +481,8 @@ export declare class ContractRef {
   get right(): string | null
   /**
    * String rendering for `console.log` / template literals, e.g.
-   * `"SPY OPTION 20260620 C 550000"` or `"AAPL STOCK"`. Delegates to
+   * `"SPY OPTION 20260620 C 550"` or `"AAPL STOCK"`. The strike reads
+   * in dollars, matching the `strike` getter. Delegates to
    * the same core rendering the Python `Contract` `__str__` uses, so
    * the two bindings print a contract identically. Without it a
    * `ContractRef` prints as an opaque `ContractRef {}` because its
@@ -523,8 +522,8 @@ export declare class Credentials {
 export declare class FlatFileRowList {
   /**
    * Number of decoded rows. Same value as `.length` on the JSON
-   * representation, exposed as a method to keep the JS API stable
-   * when napi-rs adds first-class iterator support.
+   * representation, exposed as a method so the API stays stable if
+   * the list later gains first-class iterator support.
    */
   len(): number
   /** Whether the decoded row vector is empty. */
@@ -1675,7 +1674,7 @@ export declare class Subscription {
   get secType(): SecType | null
   /**
    * String rendering for `console.log` / template literals, e.g.
-   * `"Subscription(Trade, SPY OPTION 20260620 C 550000)"` or
+   * `"Subscription(Trade, SPY OPTION 20260620 C 550)"` or
    * `"Subscription(full Trades, OPTION)"`. Mirrors the Python
    * `Subscription` `__repr__`. Without it a `Subscription` prints as
    * an opaque `Subscription {}` because its getters do not surface on
@@ -5640,10 +5639,7 @@ export interface WorkerThreadsSetting {
   n: number
 }
 
-// ─────────────────────────────────────────────────────────────
-// U7 closure: `Contract` is the documented public name for the
-// fluent contract builder. napi-rs emits the class as
-// `ContractRef` to avoid colliding with the FPSS event
-// payload field; this alias keeps the documented name live.
-// ─────────────────────────────────────────────────────────────
+// `Contract` is the public name for the fluent contract builder; it
+// is an alias for the `ContractRef` class, so the two are
+// interchangeable.
 export const Contract: typeof ContractRef;

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -588,9 +588,9 @@ if (!nativeBinding) {
 module.exports = nativeBinding
 module.exports.Config = nativeBinding.Config
 module.exports.ContractRef = nativeBinding.ContractRef
-// U7 closure: alias the documented public name `Contract` to the
-// napi-emitted `ContractRef` constructor. Without this, `require
-// ('thetadatadx').Contract.stock(...)` is undefined at runtime.
+// `Contract` is the public name for the fluent contract builder; it
+// aliases the `ContractRef` constructor so
+// `require('thetadatadx').Contract.stock(...)` resolves.
 module.exports.Contract = nativeBinding.ContractRef;
 module.exports.Credentials = nativeBinding.Credentials
 module.exports.FlatFileRowList = nativeBinding.FlatFileRowList

--- a/sdks/typescript/scripts/postbuild_alias_contract.mjs
+++ b/sdks/typescript/scripts/postbuild_alias_contract.mjs
@@ -31,12 +31,9 @@ if (dtsText.includes(DTS_ALIAS_LINE)) {
 } else {
   const dtsTrailer =
     "\n" +
-    "// ─────────────────────────────────────────────────────────────\n" +
-    "// U7 closure: `Contract` is the documented public name for the\n" +
-    "// fluent contract builder. napi-rs emits the class as\n" +
-    "// `ContractRef` to avoid colliding with the FPSS event\n" +
-    "// payload field; this alias keeps the documented name live.\n" +
-    "// ─────────────────────────────────────────────────────────────\n" +
+    "// `Contract` is the public name for the fluent contract builder; it\n" +
+    "// is an alias for the `ContractRef` class, so the two are\n" +
+    "// interchangeable.\n" +
     `${DTS_ALIAS_LINE};\n`;
   writeFileSync(dtsPath, dtsText + dtsTrailer, "utf-8");
   console.log(`postbuild_alias_contract: appended dts alias to ${dtsPath}`);
@@ -60,9 +57,9 @@ if (jsText.includes(JS_ALIAS_LINE)) {
   }
   const insertAt = jsText.indexOf("\n", idx) + 1;
   const jsAlias =
-    "// U7 closure: alias the documented public name `Contract` to the\n" +
-    "// napi-emitted `ContractRef` constructor. Without this, `require\n" +
-    "// ('thetadatadx').Contract.stock(...)` is undefined at runtime.\n" +
+    "// `Contract` is the public name for the fluent contract builder; it\n" +
+    "// aliases the `ContractRef` constructor so\n" +
+    "// `require('thetadatadx').Contract.stock(...)` resolves.\n" +
     `${JS_ALIAS_LINE};\n`;
   const out = jsText.slice(0, insertAt) + jsAlias + jsText.slice(insertAt);
   writeFileSync(jsPath, out, "utf-8");

--- a/sdks/typescript/src/flatfile_methods.rs
+++ b/sdks/typescript/src/flatfile_methods.rs
@@ -89,8 +89,8 @@ pub struct FlatFileRowList {
 #[napi]
 impl FlatFileRowList {
     /// Number of decoded rows. Same value as `.length` on the JSON
-    /// representation, exposed as a method to keep the JS API stable
-    /// when napi-rs adds first-class iterator support.
+    /// representation, exposed as a method so the API stays stable if
+    /// the list later gains first-class iterator support.
     #[napi(js_name = "len")]
     pub fn len(&self) -> u32 {
         u32::try_from(self.rows.len()).unwrap_or(u32::MAX)

--- a/sdks/typescript/src/fluent.rs
+++ b/sdks/typescript/src/fluent.rs
@@ -116,11 +116,9 @@ pub struct OptionLeg {
 
 /// Fluent contract identifier — stock or option.
 ///
-/// Exposed to JS as `ContractRef` (the bare `Contract` name on the JS
-/// side already refers to the FPSS event payload data object — see
-/// `fpss_event_classes.rs`). The `index.d.ts` post-processor emits an
-/// `export const Contract = ContractRef` alias so users still write
-/// `Contract.stock("AAPL")` per the documented surface.
+/// Use `Contract.stock("AAPL")` / `Contract.option(...)` to build one.
+/// The class is also exported under the name `ContractRef`; `Contract`
+/// is an alias for it, so the two names are interchangeable.
 #[napi(js_name = "ContractRef")]
 pub struct ContractRef {
     pub(crate) inner: protocol::Contract,
@@ -240,7 +238,8 @@ impl ContractRef {
     }
 
     /// String rendering for `console.log` / template literals, e.g.
-    /// `"SPY OPTION 20260620 C 550000"` or `"AAPL STOCK"`. Delegates to
+    /// `"SPY OPTION 20260620 C 550"` or `"AAPL STOCK"`. The strike reads
+    /// in dollars, matching the `strike` getter. Delegates to
     /// the same core rendering the Python `Contract` `__str__` uses, so
     /// the two bindings print a contract identically. Without it a
     /// `ContractRef` prints as an opaque `ContractRef {}` because its
@@ -324,7 +323,7 @@ impl Subscription {
     }
 
     /// String rendering for `console.log` / template literals, e.g.
-    /// `"Subscription(Trade, SPY OPTION 20260620 C 550000)"` or
+    /// `"Subscription(Trade, SPY OPTION 20260620 C 550)"` or
     /// `"Subscription(full Trades, OPTION)"`. Mirrors the Python
     /// `Subscription` `__repr__`. Without it a `Subscription` prints as
     /// an opaque `Subscription {}` because its getters do not surface on


### PR DESCRIPTION
The human-readable contract string rendered the strike as the wire-level fixed-point integer, so a `$550` option printed as `SPY OPTION 20260620 C 550000`. The Rust `Display` is the shared rendering that Python `__str__` and TypeScript `toString` delegate to, so three of the four bindings disagreed with the C++ `operator<<`, with their own `strike` getter, and with the struct's documented contract that every binding exposes the strike in dollars.

This renders the strike through the existing `strike_dollars` conversion. Whole-dollar strikes drop the trailing `.0` (`550`); fractional strikes keep the needed decimals (`552.5`). All four bindings now print an identical dollar-form string for the same option:

| Binding | Whole | Fractional |
| --- | --- | --- |
| Rust `Display` | `SPY OPTION 20260620 C 550` | `SPY OPTION 20260620 P 552.5` |
| Python `__str__` | `SPY OPTION 20260620 C 550` | `SPY OPTION 20260620 P 552.5` |
| TypeScript `toString` | `SPY OPTION 20260620 C 550` | `SPY OPTION 20260620 P 552.5` |
| C++ `operator<<` | `SPY OPTION 20260620 C 550` | `SPY OPTION 20260620 P 552.5` |

Tests across all four bindings and the doc examples are updated to the dollar form, and a fractional-strike case is pinned in each.

A second change rewords the shipped TypeScript `index.d.ts` JSDoc to drop build-tooling internals (a generator source file name, a build-time post-processing pass, the code-generator package name) that had leaked into the user-facing stubs. The reworded stubs describe only the public surface; the build rationale stays in the non-shipping generator comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)