### PR TITLE
fix(runtime): honor worker_threads in the embedded bindings

### DIFF
--- a/crates/thetadatadx/src/config/runtime.rs
+++ b/crates/thetadatadx/src/config/runtime.rs
@@ -7,8 +7,10 @@
 /// (typically via `#[tokio::main(flavor = "multi_thread")]` or an
 /// explicit `tokio::runtime::Builder::new_multi_thread().build()`).
 /// The embedded bindings that DO own their runtime (FFI, the
-/// `thetadatadx-py` and `thetadatadx-napi` SDKs) read this struct at
-/// module init / first-use to size the worker thread pool.
+/// `thetadatadx-py` and `thetadatadx-napi` SDKs) read this struct when
+/// the first client in the process connects to size the worker thread
+/// pool. That pool is process-global and built once, so the field is
+/// honoured for the first client created in the process.
 ///
 /// For Rust callers building their own runtime, use
 /// [`RuntimeConfig::build_runtime`] to honour the field directly.

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -5,7 +5,6 @@ use std::os::raw::c_char;
 use std::ptr;
 
 use crate::error::{cstr_to_str, set_error, set_error_from};
-use crate::runtime;
 use crate::types::{TdxConfig, TdxCredentials, TdxMddsClient};
 
 // ── Credentials ──
@@ -1437,9 +1436,14 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_callback(
 ///
 /// * `has_value = false` → `None` (default sizing, one worker per
 ///   logical CPU). `n` is ignored.
-/// * `has_value = true` → `Some(n)`. Embedders consuming
-///   [`thetadatadx::RuntimeConfig::build_runtime`] honour the value
-///   verbatim, clamping `0` to `1` so at least one worker is started.
+/// * `has_value = true` → `Some(n)`, clamping `0` to `1` so at least one
+///   worker is started.
+///
+/// The async worker pool is process-global: it is built once, from the
+/// `config` of the first client connected in the process. This setting is
+/// therefore honoured when the first client in the process is created;
+/// clients connected later share the already-built pool, so changing it
+/// on a subsequent `config` has no effect.
 ///
 /// Returns `0` on success, `-1` if `config` is null.
 #[no_mangle]
@@ -2219,10 +2223,9 @@ pub unsafe extern "C" fn tdx_mdds_client_connect(
         let creds = unsafe { &*creds };
         // SAFETY: config is a non-null pointer returned by tdx_direct_config_new and not yet freed.
         let config = unsafe { &*config };
-        match runtime().block_on(thetadatadx::mdds::MddsClient::connect(
-            &creds.inner,
-            config.inner.clone(),
-        )) {
+        match crate::runtime_from_config(&config.inner.runtime).block_on(
+            thetadatadx::mdds::MddsClient::connect(&creds.inner, config.inner.clone()),
+        ) {
             Ok(client) => Box::into_raw(Box::new(TdxMddsClient { inner: client })),
             Err(e) => {
                 set_error_from(&e);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -47,12 +47,44 @@ use std::sync::OnceLock;
 
 // ── Global tokio runtime (same pattern as the Python bindings) ──
 
-pub(crate) fn runtime() -> &'static tokio::runtime::Runtime {
-    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+/// Build (or return the already-built) process-global async runtime,
+/// sizing the worker pool from the first client's
+/// [`thetadatadx::RuntimeConfig`].
+///
+/// The embedded runtime is process-global and built exactly once: the
+/// first connect in the process seeds it from that client's
+/// `config.runtime`, so `tdx_config_set_worker_threads` takes effect for
+/// the first client created in the process. Later connects share the
+/// already-built pool and their `runtime` config is a no-op by design.
+pub(crate) fn runtime_from_config(
+    cfg: &thetadatadx::RuntimeConfig,
+) -> &'static tokio::runtime::Runtime {
     RT.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
+        cfg.build_runtime()
+            .expect("failed to create tokio runtime for thetadatadx-ffi")
+    })
+}
+
+/// Build the process-global runtime from `cfg` and report its worker
+/// count. Test-only hook proving `tdx_config_set_worker_threads` reaches
+/// the tokio builder; not part of the C ABI.
+#[doc(hidden)]
+pub fn __test_runtime_worker_count(cfg: &thetadatadx::RuntimeConfig) -> usize {
+    runtime_from_config(cfg).metrics().num_workers()
+}
+
+/// Return the process-global async runtime, building it with tokio
+/// default sizing if no client has seeded it yet.
+///
+/// Connect functions seed the pool from config via
+/// [`runtime_from_config`]; every post-connect endpoint call resolves the
+/// already-built runtime through this accessor.
+pub(crate) fn runtime() -> &'static tokio::runtime::Runtime {
+    RT.get_or_init(|| {
+        thetadatadx::RuntimeConfig::default()
+            .build_runtime()
             .expect("failed to create tokio runtime for thetadatadx-ffi")
     })
 }

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -29,7 +29,6 @@ use std::sync::atomic::{AtomicU8, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
 
 use crate::error::{set_error, set_error_from};
-use crate::runtime;
 use crate::types::{TdxConfig, TdxCredentials, TdxMddsClient};
 use thetadatadx::DispatcherSession as FfpssDispatcherSession;
 
@@ -420,10 +419,9 @@ pub unsafe extern "C" fn tdx_unified_connect(
         // SAFETY: config is a non-null pointer returned by tdx_direct_config_new and not yet freed.
         let config = unsafe { &*config };
 
-        match runtime().block_on(thetadatadx::ThetaDataDxClient::connect(
-            &creds.inner,
-            config.inner.clone(),
-        )) {
+        match crate::runtime_from_config(&config.inner.runtime).block_on(
+            thetadatadx::ThetaDataDxClient::connect(&creds.inner, config.inner.clone()),
+        ) {
             Ok(tdx) => Box::into_raw(Box::new(TdxUnified {
                 inner: tdx,
                 callback: Mutex::new(None),

--- a/ffi/tests/worker_threads.rs
+++ b/ffi/tests/worker_threads.rs
@@ -1,0 +1,23 @@
+//! Proves `tdx_config_set_worker_threads` is wired through to the embedded
+//! async runtime rather than being a no-op.
+//!
+//! The embedded runtime is a process-global `OnceLock`, so this test runs
+//! in its own integration-test binary: it is the only thing that builds
+//! the runtime in this process, making the `num_workers()` assertion
+//! deterministic.
+
+/// Setting `worker_threads` to a small N must produce a runtime whose
+/// worker pool is exactly N. A pre-fix no-op runtime would report the
+/// default (one worker per logical CPU) and fail this assertion on any
+/// host with more than two cores.
+#[test]
+fn worker_threads_sizes_the_embedded_runtime() {
+    let mut cfg = thetadatadx::RuntimeConfig::default();
+    cfg.tokio_worker_threads = Some(2);
+    let workers = thetadatadx_ffi::__test_runtime_worker_count(&cfg);
+    assert_eq!(
+        workers, 2,
+        "worker_threads=2 must size the embedded runtime to 2 workers; \
+         got {workers} (the knob is a no-op if this is the host CPU count)"
+    );
+}

--- a/sdks/cpp/include/thetadx.h
+++ b/sdks/cpp/include/thetadx.h
@@ -1471,6 +1471,12 @@ int32_t tdx_config_get_flatfiles_jitter(const TdxConfig* config, bool* out_jitte
  * Set the async worker-thread count for embedded runtimes, using the
  * widened (has_value, n) shape so an unset value is distinct from any
  * explicit count across the Python / TypeScript / C++ bindings.
+ *
+ * The async worker pool is process-global: it is built once, from the
+ * config of the first client connected in the process. This setting is
+ * therefore honoured when the first client in the process is created;
+ * clients connected later share the already-built pool, so setting it on
+ * a subsequent config has no effect.
  * @param config Config handle to mutate.
  * @param has_value false leaves the count unset (auto-sized) and ignores n;
  *                  true sets an explicit count. An explicit 0 is preserved

--- a/sdks/cpp/include/thetadx.hpp
+++ b/sdks/cpp/include/thetadx.hpp
@@ -993,7 +993,11 @@ public:
 
     /** Set the async worker-thread count using the (has_value, n) shape
      *  that preserves an explicit 0 across the C boundary. has_value=false
-     *  defers to the default sizing. */
+     *  defers to the default sizing. The async worker pool is
+     *  process-global: it is built once, from the config of the first
+     *  client connected in the process, so this is honoured when the first
+     *  client in the process is created; later clients share the
+     *  already-built pool and setting it again has no effect. */
     int32_t set_worker_threads(bool has_value, size_t n) {
         return tdx_config_set_worker_threads(handle_.get(), has_value, n);
     }

--- a/sdks/python/src/fpss_client.rs
+++ b/sdks/python/src/fpss_client.rs
@@ -243,6 +243,11 @@ impl FpssClient {
                 "FpssClient: config.fpss.hosts is empty (set THETADATA_FPSS_HOSTS or use Config::production())",
             ));
         }
+        // Seed the process-global runtime from this client's runtime config
+        // so `worker_threads` is honoured when this is the first client in
+        // the process, even though the FPSS TLS connection itself is
+        // deferred to `start_streaming`.
+        crate::runtime_from_config(&direct.runtime);
         Ok(Self {
             params: FpssParams::from_config(&creds.inner, &direct),
             inner: Mutex::new(None),

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -33,18 +33,56 @@ use errors::to_py_err;
 /// Shared tokio runtime for running async Rust from sync Python.
 ///
 /// The `pyo3-async-runtimes` layer consumes the same runtime handle via
-/// `pyo3_async_runtimes::tokio::init_with_runtime(...)` at module init
-/// time (see [`thetadatadx_py`]). No second runtime is ever constructed,
-/// so the sync and async code paths share worker threads, connection
-/// pools, and the request semaphore on the underlying `MddsClient`.
+/// `pyo3_async_runtimes::tokio::init_with_runtime(...)`. No second runtime
+/// is ever constructed, so the sync and async code paths share worker
+/// threads, connection pools, and the request semaphore on the underlying
+/// `MddsClient`.
+///
+/// The runtime is process-global and built exactly once. The first client
+/// connected in the process seeds it from that client's `config.runtime`
+/// via [`runtime_from_config`], so `Config.worker_threads` takes effect
+/// for the first client created in the process. The runtime is built
+/// lazily — never at module import — so a `worker_threads` value set on
+/// the config before the first connect is honoured.
+static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+/// Teach `pyo3-async-runtimes` to reuse our runtime, exactly once, the
+/// first time the runtime is resolved. Guarded by `Once` so the cost is
+/// paid a single time and the registration lands before any
+/// `future_into_py` runs on the async path.
+fn register_async_runtime(rt: &'static tokio::runtime::Runtime) {
+    static REGISTERED: std::sync::Once = std::sync::Once::new();
+    REGISTERED.call_once(|| {
+        let _ = pyo3_async_runtimes::tokio::init_with_runtime(rt);
+    });
+}
+
+/// Build (or return the already-built) process-global runtime, sizing the
+/// worker pool from the first client's [`thetadatadx::RuntimeConfig`].
+///
+/// The first connect in the process seeds the pool from its
+/// `config.runtime`; later connects share the already-built runtime, so
+/// their `runtime` config is a no-op by design.
+fn runtime_from_config(cfg: &thetadatadx::RuntimeConfig) -> &'static tokio::runtime::Runtime {
+    let rt = RT.get_or_init(|| cfg.build_runtime().expect("failed to create tokio runtime"));
+    register_async_runtime(rt);
+    rt
+}
+
+/// Return the process-global runtime, building it with tokio default
+/// sizing if no client has seeded it from config yet.
+///
+/// Connect constructors seed the pool via [`runtime_from_config`] before
+/// their first `run_blocking`; this accessor resolves the already-built
+/// runtime for every subsequent call.
 fn runtime() -> &'static tokio::runtime::Runtime {
-    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-    RT.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
+    let rt = RT.get_or_init(|| {
+        thetadatadx::RuntimeConfig::default()
+            .build_runtime()
             .expect("failed to create tokio runtime")
-    })
+    });
+    register_async_runtime(rt);
+    rt
 }
 
 /// Run an async future to completion while periodically honoring Python's
@@ -770,9 +808,11 @@ impl Config {
     /// preserved across the binding boundary and clamps to ``1`` so the
     /// runtime always has at least one worker.
     ///
-    /// Note that the runtime backing ``ThetaDataDxClient`` is built
-    /// process-once at module init; mutating this value after import
-    /// affects only freshly-constructed runtimes.
+    /// The async worker pool is process-global: it is built once, from the
+    /// config of the first client connected in the process. This setting
+    /// is therefore honoured when the first client in the process is
+    /// created; clients connected later share the already-built pool, so
+    /// setting it on a subsequent ``Config`` has no effect.
     #[setter]
     fn set_worker_threads(&self, n: Option<usize>) {
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
@@ -1243,6 +1283,10 @@ impl ThetaDataDxClient {
             let guard = config.inner.lock().unwrap_or_else(|e| e.into_inner());
             guard.clone()
         };
+        // Seed the process-global runtime from this client's runtime config
+        // before the first `run_blocking` resolves it, so `worker_threads`
+        // takes effect when the first client in the process connects.
+        runtime_from_config(&direct_config.runtime);
         let inner_creds = creds.inner.clone();
         let tdx = run_blocking(py, async move {
             thetadatadx::ThetaDataDxClient::connect(&inner_creds, direct_config).await
@@ -1794,18 +1838,14 @@ fn thetadatadx_py(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // user-configured `logging.getLogger("thetadatadx")` handlers.
     logging_bridge::install_logging_bridge();
 
-    // Teach pyo3-async-runtimes to reuse our shared tokio runtime. This is
-    // the critical coupling that keeps `runtime()` — the one the sync
-    // path uses — and the async path aligned: one runtime, one request
-    // semaphore, one connection pool. Failing to call this early would
-    // cause `pyo3_async_runtimes::tokio::future_into_py` to spin up its
-    // own runtime on first use.
-    //
-    // `init_with_runtime` requires a `&'static tokio::runtime::Runtime`
-    // handle. Our `runtime()` singleton satisfies that contract — the
-    // `OnceLock` leaks the runtime for the lifetime of the process, so
-    // the borrow holds.
-    let _ = pyo3_async_runtimes::tokio::init_with_runtime(runtime());
+    // The tokio runtime is built lazily on the first client connect, not
+    // here, so a `Config.worker_threads` value set before that connect is
+    // honoured (the runtime is sized from the first client's
+    // `config.runtime`). `pyo3-async-runtimes` is taught to reuse that
+    // same runtime at build time via `register_async_runtime`, keeping
+    // the sync and async paths on one runtime, one request semaphore, one
+    // connection pool. Building it here would freeze the worker count at
+    // import, before the user can set it.
 
     m.add_class::<Credentials>()?;
     m.add_class::<Config>()?;

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -285,7 +285,7 @@ impl Config {
     }
 
     /// Set the per-class transient-failure attempt budget for the
-    /// auto-reconnect path. Default `3`. No effect unless the
+    /// auto-reconnect path. Default `30`. No effect unless the
     /// reconnect policy is `Auto`.
     #[setter]
     fn set_reconnect_max_attempts(&self, max_attempts: u32) -> PyResult<()> {
@@ -326,14 +326,14 @@ impl Config {
     /// Set the reconnect delay (ms) honoured for generic transient
     /// disconnects (TimedOut, ServerRestarting, Unspecified, …).
     /// Plumbed through to the streaming I/O loop at connect time.
-    /// Default ``2_000``.
+    /// Default ``250``.
     #[setter]
     fn set_reconnect_wait_ms(&self, ms: u64) {
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         guard.reconnect.wait_ms = ms;
     }
 
-    /// Current reconnect ``wait_ms`` value (default ``2_000``).
+    /// Current reconnect ``wait_ms`` value (default ``250``).
     #[getter]
     fn get_reconnect_wait_ms(&self) -> u64 {
         let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
@@ -866,7 +866,7 @@ impl Config {
 
     /// Set the total attempt budget for the historical-channel retry policy. ``1``
     /// disables retry (single call only); higher values permit retries
-    /// up to ``max_attempts - 1`` after the initial call. Default ``5``.
+    /// up to ``max_attempts - 1`` after the initial call. Default ``20``.
     #[setter]
     fn set_retry_max_attempts(&self, n: u32) {
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
@@ -909,7 +909,7 @@ impl Config {
     /// Set the total attempt budget for the flatfile driver retry loop.
     /// ``1`` disables retry (single call only); higher values permit
     /// retries up to ``max_attempts - 1`` after the initial call.
-    /// Default ``3``. Validated to the range ``[1, 10]`` at connect
+    /// Default ``10``. Validated to the range ``[1, 100]`` at connect
     /// time.
     #[setter]
     fn set_flatfiles_max_attempts(&self, n: u32) {
@@ -942,7 +942,7 @@ impl Config {
 
     /// Set the upper-bound backoff delay (seconds) for the flatfile
     /// driver retry loop. The doubling schedule never exceeds this
-    /// value regardless of attempt number. Default ``4``. Must be
+    /// value regardless of attempt number. Default ``30``. Must be
     /// greater than or equal to :attr:`flatfiles_initial_backoff_secs`
     /// (rejected at connect-time validate otherwise).
     #[setter]

--- a/sdks/python/tests/test_worker_threads.py
+++ b/sdks/python/tests/test_worker_threads.py
@@ -1,0 +1,99 @@
+"""Proves ``Config.worker_threads`` is wired through to the embedded
+async runtime rather than being a no-op.
+
+The async runtime is a process-global singleton built once, on the first
+client connect. To observe the worker pool deterministically the probe
+runs in a fresh subprocess (fresh singleton), sets ``worker_threads`` to a
+small N well below the host CPU count, triggers the lazy runtime build via
+a connect attempt, then counts the live tokio worker OS threads by name.
+
+The runtime is seeded from the client config *before* the connect
+handshake runs, so the worker pool is already sized to N by the time the
+connect resolves. A no-op knob would instead leave the pool at tokio's
+default sizing (one worker per logical CPU), which on any multi-core CI
+host is far larger than N — that is the signal this test keys on.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+# Probe run in its own interpreter so it owns a fresh process-global
+# runtime. Sets worker_threads=N, builds the runtime via a connect
+# attempt, and prints the count of tokio worker OS threads. tokio names
+# multi-thread workers ``tokio-rt-worker``; the count tracks N exactly
+# (tokio's own ``num_workers()`` metric is asserted == N by the Rust FFI
+# test ``worker_threads_sizes_the_embedded_runtime``). Authenticating the
+# connect spins at most one auxiliary tokio thread, so the OS-thread count
+# is allowed a +1 slack here while still proving the pool is sized to N
+# and not to the host CPU count.
+_PROBE = r"""
+import collections
+import glob
+
+import thetadatadx as tdx
+
+N = 2
+
+cfg = tdx.Config.dev()
+cfg.worker_threads = N
+
+try:
+    # Any client constructor seeds the process-global runtime from
+    # `cfg.runtime` before the connect handshake runs. The connect itself
+    # is expected to fail on throwaway credentials — we only care that the
+    # runtime was built at the configured size.
+    tdx.MddsClient(tdx.Credentials("nobody@example.invalid", "x"), cfg)
+except Exception:
+    pass
+
+counts = collections.Counter()
+for comm_path in glob.glob("/proc/self/task/*/comm"):
+    try:
+        with open(comm_path) as fh:
+            counts[fh.read().strip()] += 1
+    except OSError:
+        continue
+
+workers = counts.get("tokio-rt-worker", 0)
+print(workers)
+"""
+
+
+def test_worker_threads_sizes_the_embedded_runtime() -> None:
+    """``worker_threads = 2`` must size the embedded runtime to ~2 workers.
+
+    A no-op knob would leave the pool at tokio's default size (one worker
+    per logical CPU), so on any host with more than three cores this test
+    fails if the value is ignored.
+    """
+    if not sys.platform.startswith("linux"):
+        import pytest
+
+        pytest.skip("thread-name probe reads /proc, Linux-only")
+
+    n = 2
+    cpu_count = os.cpu_count() or 1
+    if cpu_count <= n + 1:
+        import pytest
+
+        pytest.skip(f"host has only {cpu_count} CPUs; default sizing is indistinguishable from N={n}")
+
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"probe exited non-zero: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    workers = int(result.stdout.strip().splitlines()[-1])
+    # Honored: pool tracks N (allowing one auxiliary tokio thread). A
+    # no-op knob would land at cpu_count (one worker per logical CPU).
+    assert n <= workers <= n + 1, (
+        f"expected ~{n} tokio worker threads for worker_threads={n}, got {workers} "
+        f"(host has {cpu_count} CPUs — a no-op knob would sit near {cpu_count})"
+    )

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -293,6 +293,12 @@ export declare class Config {
    * `hasValue=false` defers to the default sizing; `hasValue=true`
    * pins worker count to `n` (with `n=0` preserved verbatim rather
    * than treated as unset).
+   *
+   * The async worker pool is process-global: it is built once, from the
+   * config of the first client connected in the process. This setting
+   * is therefore honored when the first client in the process is
+   * created; clients connected later share the already-built pool, so
+   * setting it on a subsequent config has no effect.
    */
   setWorkerThreads(hasValue: boolean, n: number): void
   /**

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -1020,6 +1020,12 @@ impl Config {
     /// `hasValue=false` defers to the default sizing; `hasValue=true`
     /// pins worker count to `n` (with `n=0` preserved verbatim rather
     /// than treated as unset).
+    ///
+    /// The async worker pool is process-global: it is built once, from the
+    /// config of the first client connected in the process. This setting
+    /// is therefore honored when the first client in the process is
+    /// created; clients connected later share the already-built pool, so
+    /// setting it on a subsequent config has no effect.
     #[napi(js_name = "setWorkerThreads")]
     pub fn set_worker_threads(&self, has_value: bool, n: u32) -> napi::Result<()> {
         let mut guard = self

--- a/sdks/typescript/src/fpss_client.rs
+++ b/sdks/typescript/src/fpss_client.rs
@@ -327,6 +327,11 @@ impl FpssClient {
     #[napi(factory)]
     pub fn connect(creds: &Credentials, config: Option<&Config>) -> napi::Result<FpssClient> {
         let direct = config_or_production(config);
+        // Seed the process-global runtime from this client's runtime config
+        // so `workerThreads` is honored when this is the first client in
+        // the process, even though the FPSS connection is opened lazily by
+        // `startStreaming`.
+        crate::runtime_from_config(&direct.runtime);
         let params = params_from_direct(&creds.inner, &direct)?;
         Ok(FpssClient::from_params(params))
     }
@@ -339,6 +344,11 @@ impl FpssClient {
     pub fn connect_from_file(path: String, config: Option<&Config>) -> napi::Result<FpssClient> {
         let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
         let direct = config_or_production(config);
+        // Seed the process-global runtime from this client's runtime config
+        // so `workerThreads` is honored when this is the first client in
+        // the process, even though the FPSS connection is opened lazily by
+        // `startStreaming`.
+        crate::runtime_from_config(&direct.runtime);
         let params = params_from_direct(&creds, &direct)?;
         Ok(FpssClient::from_params(params))
     }

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -14,12 +14,34 @@ use thetadatadx::config;
 use thetadatadx::fpss;
 
 /// Shared tokio runtime for running async Rust from Node.js.
+///
+/// The runtime is process-global and built exactly once. The first client
+/// connected in the process seeds it from that client's `config.runtime`
+/// via [`runtime_from_config`], so `Config.workerThreads` takes effect for
+/// the first client created in the process.
+static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+
+/// Build (or return the already-built) process-global runtime, sizing the
+/// worker pool from the first client's [`thetadatadx::RuntimeConfig`].
+///
+/// The first connect in the process seeds the pool from its
+/// `config.runtime`; later connects share the already-built runtime, so
+/// their `runtime` config is a no-op by design.
+pub(crate) fn runtime_from_config(
+    cfg: &thetadatadx::RuntimeConfig,
+) -> &'static tokio::runtime::Runtime {
+    RT.get_or_init(|| cfg.build_runtime().expect("failed to create tokio runtime"))
+}
+
+/// Return the process-global runtime, building it with tokio default
+/// sizing if no client has seeded it from config yet.
+///
+/// Connect functions seed the pool via [`runtime_from_config`]; every
+/// post-connect call resolves the already-built runtime here.
 pub(crate) fn runtime() -> &'static tokio::runtime::Runtime {
-    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
     RT.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
+        thetadatadx::RuntimeConfig::default()
+            .build_runtime()
             .expect("failed to create tokio runtime")
     })
 }
@@ -402,7 +424,7 @@ impl ThetaDataDxClient {
         config: Option<&Config>,
     ) -> napi::Result<ThetaDataDxClient> {
         let cfg = config_or_production(config);
-        let tdx = runtime()
+        let tdx = runtime_from_config(&cfg.runtime)
             .block_on(thetadatadx::ThetaDataDxClient::connect(
                 // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
                 &creds.inner,
@@ -426,7 +448,7 @@ impl ThetaDataDxClient {
     ) -> napi::Result<ThetaDataDxClient> {
         let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
         let cfg = config_or_production(config);
-        let tdx = runtime()
+        let tdx = runtime_from_config(&cfg.runtime)
             .block_on(thetadatadx::ThetaDataDxClient::connect(
                 // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
                 &creds, cfg,
@@ -628,7 +650,7 @@ impl MddsClient {
     #[napi(factory)]
     pub fn connect(creds: &Credentials, config: Option<&Config>) -> napi::Result<MddsClient> {
         let cfg = config_or_production(config);
-        let tdx = runtime()
+        let tdx = runtime_from_config(&cfg.runtime)
             .block_on(thetadatadx::ThetaDataDxClient::connect(
                 // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
                 &creds.inner,
@@ -646,7 +668,7 @@ impl MddsClient {
     pub fn connect_from_file(path: String, config: Option<&Config>) -> napi::Result<MddsClient> {
         let creds = auth::Credentials::from_file(&path).map_err(to_napi_err)?;
         let cfg = config_or_production(config);
-        let tdx = runtime()
+        let tdx = runtime_from_config(&cfg.runtime)
             .block_on(thetadatadx::ThetaDataDxClient::connect(
                 // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
                 &creds, cfg,


### PR DESCRIPTION
The `worker_threads` runtime knob is exposed and documented across the C ABI, Python, TypeScript, and C++ surfaces, but it was a no-op: every embedded binding built its async runtime as a hard-coded global singleton that never read `DirectConfig.runtime`. Setting `worker_threads` (or any other `RuntimeConfig` field) had zero effect on the worker pool.

This makes the embedded runtime build lazily from the first client's runtime config at connect time via `RuntimeConfig::build_runtime`, so the knob actually sizes the tokio worker pool. The Python binding no longer instantiates the runtime at module import, so a value set before the first connect is honored; `pyo3-async-runtimes` is registered against that same runtime exactly once, when it is first built. Every binding's connect path seeds the pool from its config, and `FpssClient` seeds it too even though its transport opens lazily.

The pool is process-global and built once, so the value takes effect for the first client created in the process. The `worker_threads` documentation on every binding now states this precisely instead of implying per-client effect.

A Rust FFI test asserts the runtime's `num_workers()` metric equals the configured count, and a Python test confirms the live worker pool tracks the knob rather than the host CPU count, proving the setting is no longer a no-op. A live connect with `worker_threads=2` runs a historical query successfully with the pool pinned to two workers on a sixteen-core host.

The second commit corrects several `Config` setter docstrings whose stated defaults disagreed with the Rust source: the reconnect attempt budget (30, not 3), the generic reconnect wait (250 ms, not 2000), the historical retry budget (20, not 5), the flatfile retry budget (10 over [1, 100], not 3 over [1, 10]), and the flatfile max backoff (30 seconds, not 4).

## Verification

`cargo fmt --all -- --check`, clippy on the core / FFI / napi / py crates with `-D warnings`, `generate_sdk_surfaces --check`, `generate_docs_site --check`, the workspace test suite, the Python wheel test suite (383 passed), the TypeScript build and test suite (138 passed), `check_binding_parity.py`, and `check_public_surface_leak.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)