### PR TITLE
fix(runtime): seed the runtime from config on standalone FPSS connect

### DIFF
--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -255,7 +255,7 @@ pub unsafe extern "C" fn tdx_config_set_reconnect_policy(
 }
 
 /// Set the per-class transient-failure attempt budget for the
-/// auto-reconnect path. Default `3`. No effect unless the reconnect
+/// auto-reconnect path. Default `30`. No effect unless the reconnect
 /// policy is `Auto`.
 #[no_mangle]
 pub unsafe extern "C" fn tdx_config_set_reconnect_max_attempts(

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -1413,6 +1413,11 @@ pub unsafe extern "C" fn tdx_fpss_connect(
         // SAFETY: config is a non-null pointer returned by tdx_direct_config_new and not yet freed.
         let config = unsafe { &*config };
 
+        // Seed the process-global async runtime from this client's config so
+        // `worker_threads` is honored when a standalone FPSS client is the
+        // first client created in the process; the worker pool is built once.
+        crate::runtime_from_config(&config.inner.runtime);
+
         Box::into_raw(Box::new(TdxFpssHandle {
             inner: Arc::new(Mutex::new(None)),
             connect_params: FpssConnectParams {


### PR DESCRIPTION
A full-main audit found `worker_threads` was honored on the unified, historical, and managed-binding connect paths but not on the C ABI standalone FPSS connect. If a standalone FPSS client was the first client created in a process, its `worker_threads` was ignored and a later connect could seed the process-global pool from a different config. This seeds the runtime from the client config in `tdx_fpss_connect` (which `tdx_fpss_connect_from_file` delegates to), so the worker pool reflects the first client uniformly across every embedded connect path.

Also corrects the C ABI doc comment for the reconnect attempt budget (it said three; the applied default is thirty, already documented on the C header and the typed stubs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)