### PR TITLE
fix(docs): disambiguate the Error intra-doc link in the error module

### DIFF
--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -1,6 +1,6 @@
-//! The crate's public [`Error`] type and its category enums.
+//! The crate's public [`enum@Error`] type and its category enums.
 //!
-//! [`Error`] is the single error surface returned across the SDK. Every
+//! [`enum@Error`] is the single error surface returned across the SDK. Every
 //! variant carries a typed category (`kind`) alongside a human-readable
 //! message so callers can pattern-match on the failure class without
 //! parsing `Display` strings, and the `Display` shapes stay stable for


### PR DESCRIPTION
The `error` module header linked the umbrella `Error` type as a bare `[\`Error\`]` reference, but the module also imports the derive macro of the same name, so rustdoc treats the reference as ambiguous and the broken-intra-doc-links gate fails. This qualifies it as `[\`enum@Error\`]`. The same bare reference elsewhere in the crate resolves unambiguously because the derive macro is not in scope there. Verified `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc --no-deps` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)