### PR TITLE
docs: frame protocol behavior without reverse-engineering provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,20 @@ jobs:
           python3 scripts/check_doc_defaults.py --selftest
           python3 scripts/check_doc_defaults.py
 
+  no-re-framing:
+    name: Source docs reverse-engineering framing
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Reverse-engineering framing detector
+        run: |
+          python3 scripts/check_no_re_framing.py --selftest
+          python3 scripts/check_no_re_framing.py
+
   cargo-deny:
     name: Cargo deny
     runs-on: ubuntu-latest

--- a/crates/thetadatadx/build_support_bin/ticks/python_classes.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/python_classes.rs
@@ -427,10 +427,18 @@ fn render_python_tick_class_struct(type_name: &str, def: &TickTypeDef) -> String
             combined.push('\n');
             combined.push_str(line);
         }
-        combined
+        // Drop wire-provenance prose so the rendered Python class doc
+        // describes only stable behavior, matching the Rust tick struct
+        // surface: the wire-column listings and the sentences recording
+        // where a layout was checked are removed, behavioral prose stays.
+        super::tdbe_structs::scrub_provenance(&combined)
     };
     for line in doc_text.lines() {
-        writeln!(out, "/// {line}").unwrap();
+        if line.is_empty() {
+            out.push_str("///\n");
+        } else {
+            writeln!(out, "/// {line}").unwrap();
+        }
     }
     // `#[must_use]` — these ticks come from expensive network calls; dropping
     // the result silently is a bug. `skip_from_py_object` opts out of the

--- a/crates/thetadatadx/build_support_bin/ticks/tdbe_structs.rs
+++ b/crates/thetadatadx/build_support_bin/ticks/tdbe_structs.rs
@@ -325,7 +325,7 @@ fn rewrite_count_phrase(line: &str, count: usize) -> String {
 /// the wire-column listings (Markdown tables, indented header dumps) those
 /// sentences introduce. Behavioral sentences sharing a paragraph with a
 /// provenance sentence are preserved.
-fn scrub_provenance(doc: &str) -> String {
+pub(super) fn scrub_provenance(doc: &str) -> String {
     let mut kept: Vec<String> = Vec::new();
 
     for paragraph in split_paragraphs(doc) {

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -992,7 +992,8 @@ impl ThetaDataDxClient {
 
     /// Reconnect the streaming connection, re-subscribing all previous subscriptions.
     ///
-    /// This is the caller-driven equivalent of Java's `handleInvoluntaryDisconnect()`.
+    /// This is the caller-driven equivalent of the JVM terminal's
+    /// involuntary-disconnect recovery.
     /// It saves active subscriptions, stops the current streaming connection,
     /// starts a new one with the provided handler, and re-subscribes everything.
     ///
@@ -1202,7 +1203,7 @@ impl ThetaDataDxClient {
     // ---------------------------------------------------------------------
     // FLATFILES surface (third public surface, alongside FPSS and MDDS).
     //
-    // The legacy MDDS port (12000) speaks a custom binary PacketStream
+    // The legacy MDDS port (12000) speaks a custom binary packet-stream
     // protocol that supports a single FLAT_FILE request type. The server
     // pre-builds an INDEX + DATA blob per (sec_type, data_type, date)
     // tuple overnight and streams it back on demand. See

--- a/crates/thetadatadx/src/config/mdds.rs
+++ b/crates/thetadatadx/src/config/mdds.rs
@@ -34,13 +34,14 @@ pub struct MddsConfig {
 
     /// Max concurrent in-flight gRPC requests.
     ///
-    /// JVM equivalent: `2^subscription_tier` (Free=1, Value=2, Standard=4, Pro=8).
-    /// Set to 0 to auto-detect from the subscription tier returned by Nexus auth.
+    /// The JVM terminal caps this at `2^subscription_tier` (Free=1, Value=2,
+    /// Standard=4, Pro=8). Set to 0 to auto-detect from the subscription tier
+    /// returned by Nexus auth.
     pub concurrent_requests: usize,
 
     /// Max inbound gRPC message size in bytes.
     ///
-    /// JVM equivalent: `maxInboundMessageSize(0x100000 * config.messageSize())`,
+    /// Caps the gRPC inbound message size at `1 MiB * message_size`,
     /// default 4MB, max 10MB.
     pub max_message_size: usize,
 

--- a/crates/thetadatadx/src/config/runtime.rs
+++ b/crates/thetadatadx/src/config/runtime.rs
@@ -26,7 +26,7 @@ pub struct RuntimeConfig {
     ///   sentinel survives across binding boundaries.
     /// * `Some(n)` for `n >= 1` — pins the worker pool to exactly `n`.
     ///
-    /// JVM equivalent: `-Xmx` + `HTTP_CONCURRENCY` thread pool sizing.
+    /// Controls async runtime worker-pool sizing for HTTP concurrency.
     pub tokio_worker_threads: Option<usize>,
 }
 

--- a/crates/thetadatadx/src/flatfiles/datatype.rs
+++ b/crates/thetadatadx/src/flatfiles/datatype.rs
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn vendor_lowercase_naming_holds() {
-        // Sanity: every name is ASCII lowercase or underscore, never a Java
+        // Sanity: every name is ASCII lowercase or underscore, never a
         // CamelCase leak.
         for code in [1, 121, 0, 134, 138] {
             let n = DataType::from_code(code).name();

--- a/crates/thetadatadx/src/flatfiles/framing.rs
+++ b/crates/thetadatadx/src/flatfiles/framing.rs
@@ -1,4 +1,4 @@
-//! PacketStream wire framing for the MDDS legacy port.
+//! Packet-stream wire framing for the MDDS legacy port.
 //!
 //! Frame layout (all big-endian):
 //!

--- a/crates/thetadatadx/src/flatfiles/session.rs
+++ b/crates/thetadatadx/src/flatfiles/session.rs
@@ -69,7 +69,7 @@ pub(crate) async fn connect_tls(target: MddsHost<'_>) -> Result<TlsStream<TcpStr
 
 /// Build the VERSION payload — `[u32 BE jsonlen][json_utf8]`.
 ///
-/// The vendor terminal serialises every JVM system property; the server
+/// The JVM terminal serialises a large host-property map; the server
 /// only inspects the `terminal.version` key. A minimal map keeps the
 /// server's MDC log showing a recognisable client identity without leaking
 /// host details.

--- a/crates/thetadatadx/src/fpss/accumulator.rs
+++ b/crates/thetadatadx/src/fpss/accumulator.rs
@@ -102,12 +102,12 @@ impl OhlcvcAccumulator {
     }
 }
 
-/// Convert a price from one `price_type` to another (mirrors Java
-/// `PriceCalcUtils.changePriceType`). The JVM terminal performs `int * int`
-/// which silently wraps on overflow under Java's two's-complement semantics;
-/// downstream consumers depend on that exact wire-bit pattern, so we use
-/// `wrapping_mul` to reproduce it byte-for-byte. Plain `*` would panic in
-/// debug Rust on the same inputs that the JVM accepts without comment.
+/// Convert a price from one `price_type` to another. The JVM terminal
+/// performs `int * int` which silently wraps on overflow under 32-bit
+/// two's-complement semantics; downstream consumers depend on that exact
+/// wire-bit pattern, so we use `wrapping_mul` to reproduce it byte-for-byte.
+/// Plain `*` would panic in debug Rust on the same inputs the JVM terminal
+/// accepts without comment.
 pub(super) fn change_price_type(price: i32, price_type: i32, new_price_type: i32) -> i32 {
     const POW10: [i32; 10] = [
         1,
@@ -128,7 +128,7 @@ pub(super) fn change_price_type(price: i32, price_type: i32, new_price_type: i32
     if exp <= 0 {
         let idx = usize::try_from(-exp).unwrap_or(0);
         if idx < POW10.len() {
-            // Match Java terminal's `int * int` wrap; differs from Rust's
+            // Match the JVM terminal's `int * int` wrap; differs from Rust's
             // default `*` which panics in debug. wrapping_mul makes the
             // overflow contract explicit and debug-safe.
             price.wrapping_mul(POW10[idx])
@@ -139,7 +139,7 @@ pub(super) fn change_price_type(price: i32, price_type: i32, new_price_type: i32
         let idx = usize::try_from(exp).unwrap_or(0);
         if idx < POW10.len() {
             // Down-scale by integer division. |i32| / 10^k <= |i32|, so this
-            // never overflows; mirrors Java's `int / int` exactly.
+            // never overflows; mirrors the JVM terminal's `int / int` exactly.
             price / POW10[idx]
         } else {
             0
@@ -239,12 +239,12 @@ mod tests {
 
     /// One unit past the boundary: 2_148 * 10^6 = 2_148_000_000.
     ///
-    /// Java semantics: `int * int` wraps mod 2^32. Manual calculation:
+    /// Wire semantics: `int * int` wraps mod 2^32. Manual calculation:
     ///   2_148 * 1_000_000 = 2_148_000_000 (mathematical)
     ///   2_148_000_000 - 2^32 = 2_148_000_000 - 4_294_967_296 = -2_146_967_296
     /// JVM terminal emits -2_146_967_296 on the wire and we mirror it.
     #[test]
-    fn change_price_type_wraps_like_java_at_2148() {
+    fn change_price_type_wraps_at_2148() {
         assert_eq!(change_price_type(2_148, 6, 0), -2_146_967_296);
     }
 
@@ -256,13 +256,13 @@ mod tests {
     ///                            = 713_968_650_000 - 712_964_571_136
     ///                            = 1_004_078_864
     /// 1_004_078_864 < 2^31 so the signed result is +1_004_078_864.
-    /// This matches what `PriceCalcUtils.changePriceType` returns in the JVM.
+    /// This matches the value the JVM terminal emits on the wire.
     #[test]
-    fn change_price_type_brk_a_wraps_like_java() {
+    fn change_price_type_brk_a_wraps() {
         assert_eq!(change_price_type(71_396_865, 8, 4), 1_004_078_864);
     }
 
-    /// A second tick whose rescale wraps under Java semantics must produce
+    /// A second tick whose rescale wraps under 32-bit semantics must produce
     /// the same wrapped value the JVM terminal would compute, so accumulator
     /// state stays bit-identical to the reference implementation.
     /// 71_396_865 * 10_000 wraps to +1_004_078_864 (see test above).

--- a/crates/thetadatadx/src/fpss/connection.rs
+++ b/crates/thetadatadx/src/fpss/connection.rs
@@ -412,8 +412,8 @@ mod tests {
     }
 
     #[test]
-    fn connect_timeout_matches_java() {
-        // Java parity reference: terminal hardcodes `socket.connect(addr, 2000)`.
+    fn connect_timeout_matches_terminal() {
+        // Parity reference: the JVM terminal connects with a 2000 ms deadline.
         // Used as the default seed for `FpssConfig::connect_timeout_ms`; the
         // public knob now overrides this constant for callers who need to
         // dial in a different per-server connect deadline.

--- a/crates/thetadatadx/src/fpss/delta.rs
+++ b/crates/thetadatadx/src/fpss/delta.rs
@@ -83,8 +83,8 @@ impl DeltaState {
     /// Clear all accumulated delta state.
     ///
     /// Called on START/STOP (market open/close) signals to reset delta
-    /// decompression, matching Java's behavior where `Tick.readID()` starts
-    /// fresh after a session boundary.
+    /// decompression: the contract-id read starts fresh after a session
+    /// boundary.
     ///
     /// Note: `last_stop` is intentionally NOT cleared here because STOP
     /// itself calls `clear()`, and the timestamp must survive to suppress
@@ -112,12 +112,9 @@ impl DeltaState {
     /// individual fields directly from `out` to construct the public event
     /// — no `Vec<i32>` is allocated on the decode path.
     ///
-    /// Equivalent to the upstream sequence:
-    /// ```text
-    /// fitReader.open(p.data(), 0, p.len());  // FIT starts at offset 0
-    /// int size = fitReader.readChanges(alloc); // alloc[0] = contract_id
-    /// Contract c = idToContract.get(alloc[0]); // first field IS the contract_id
-    /// ```
+    /// Wire sequence: the FIT reader opens at offset 0 and decodes the row's
+    /// changes into `alloc`, where `alloc[0]` is the `contract_id` used to
+    /// resolve the contract and `alloc[1..]` are the tick fields.
     ///
     /// Returns `Some((contract_id, data_field_count))` on success, or `None`
     /// when the payload is empty or the FIT row is a DATE marker. Sets
@@ -169,12 +166,9 @@ impl DeltaState {
         out[..expected_fields].copy_from_slice(&self.alloc_buf[1..total_fields]);
 
         // Delta decompression applies only to the tick portion (excluding
-        // contract_id), matching Java's `Tick.readID()`:
-        //   for (int i = 1; i < len; ++i) {
-        //       this.data[i - 1] = firstData[i] + this.data[i - 1];
-        //   }
-        // It skips firstData[0] (contract_id) and applies deltas from
-        // firstData[1..] onto tick data[0..].
+        // contract_id): the first field (contract_id) is skipped, and deltas
+        // from `firstData[1..]` accumulate onto `data[0..]`:
+        //   for i in 1..len { data[i - 1] = firstData[i] + data[i - 1]; }
         let tick_n = n.saturating_sub(1);
 
         let key = (msg_code, contract_id);

--- a/crates/thetadatadx/src/fpss/events.rs
+++ b/crates/thetadatadx/src/fpss/events.rs
@@ -800,7 +800,7 @@ mod tests {
     #[test]
     fn fpss_control_connected_ping_reconnected_server_restart_variants() {
         // Every new control variant must round-trip and expose its payload
-        // correctly — matching the Java terminal hand-off where codes
+        // correctly — matching the JVM terminal hand-off where codes
         // 4 / 10 / 13 / 31 each land on their own typed listener.
         let connected = FpssEvent::Control(FpssControl::Connected);
         assert!(matches!(

--- a/crates/thetadatadx/src/fpss/framing.rs
+++ b/crates/thetadatadx/src/fpss/framing.rs
@@ -62,7 +62,7 @@ pub(crate) fn is_transient_read(io_err: &std::io::Error) -> bool {
 
 /// Maximum payload length (single unsigned byte).
 ///
-/// Source: `PacketStream.java` -- the length field is one byte.
+/// The framing length field is a single byte, capping the payload at 255.
 pub const MAX_PAYLOAD_LEN: usize = 255;
 
 /// Wall-clock cap on the mid-frame retry budget.
@@ -80,7 +80,7 @@ pub const MAX_PAYLOAD_LEN: usize = 255;
 /// `FpssErrorKind::ProtocolError` with a `DRAIN_YIELD_MARKER` substring.
 /// At 200 ms it is 4× the 50 ms drain cadence, generous enough for
 /// normal TCP gaps yet tight enough that a pathological trickler cannot
-/// block heartbeats past the 2 s Java-side ping grace.
+/// block heartbeats past the 2 s ping grace.
 pub const MID_FRAME_DRAIN_WINDOW_MS: u64 = 200;
 
 /// Marker substring the I/O loop matches to recognise a drain-yield
@@ -183,16 +183,17 @@ fn read_header<R: Read>(
 /// Read the 2-byte FPSS header with configurable per-stall timeout
 /// and drain-yield budget.
 ///
-/// Byte-for-byte match with Java `PacketStream2.readCopy` +
-/// `socket.setSoTimeout(10_000)` on the per-stall half; a
-/// `drain_budget` yield on top. Contract:
+/// Byte-for-byte match with the JVM terminal's framed read under a
+/// 10_000 ms per-stall socket timeout; a `drain_budget` yield on top.
+/// Contract:
 /// - EOF before any byte → `Ok(None)` (graceful server close).
 /// - Pre-header `WouldBlock` / `TimedOut` (n == 0) → propagate as
 ///   `Error::Io` so `io_loop::is_read_timeout` drains pings +
 ///   command queue.
 /// - Mid-header `WouldBlock` / `TimedOut` (n > 0) → retry. The
 ///   stall deadline is **re-armed on every successful byte**,
-///   matching Java's per-`read()` `setSoTimeout` semantics. Fatal
+///   matching the JVM terminal's per-`read()` socket-timeout
+///   semantics. Fatal
 ///   if `stall_timeout` elapses without any forward progress.
 /// - Mid-header retries exceeding `drain_budget` of aggregate
 ///   wall-clock time → return a `ProtocolError` carrying the
@@ -311,8 +312,8 @@ fn read_exact_payload<R: Read>(
 /// Read exactly `buf.len()` bytes of payload with configurable
 /// per-stall timeout and drain-yield budget.
 ///
-/// Matches Java `DataInputStream.readNBytes` +
-/// `setSoTimeout(10_000)` on the per-stall half: every `WouldBlock` /
+/// Matches the JVM terminal's read-N-bytes under a 10_000 ms per-stall
+/// socket timeout: every `WouldBlock` /
 /// `TimedOut` re-arms a fresh `stall_timeout` deadline from the last
 /// successful byte of progress, not from function entry. A stream
 /// that dribbles data in slowly but steadily is fine; only
@@ -331,8 +332,8 @@ fn read_exact_payload<R: Read>(
 /// Earlier revisions treated the first `WouldBlock` as a fatal
 /// desync. Raw-byte tap captures on dev + prod showed every
 /// "corruption" event was a valid frame that finished arriving
-/// 50-76 ms after the first `WouldBlock`. Java tolerates that gap
-/// silently; so do we now, bounded by the drain-yield budget.
+/// 50-76 ms after the first `WouldBlock`. The JVM terminal tolerates
+/// that gap silently; so do we now, bounded by the drain-yield budget.
 ///
 /// `Interrupted` is retried (POSIX signal wakeups are benign).
 /// `EOF` and going `stall_timeout` without progress are still fatal.
@@ -441,7 +442,7 @@ pub fn read_frame_into<R: Read>(
 }
 
 /// Like [`read_frame_into`] but takes the per-stall mid-frame timeout
-/// from the caller instead of the Java-parity [`READ_TIMEOUT_MS`]
+/// from the caller instead of the parity-reference [`READ_TIMEOUT_MS`]
 /// default. The I/O loop threads the user-supplied
 /// [`crate::config::FpssConfig::timeout_ms`] through this entry point
 /// so the public knob actually controls the framing stall budget.
@@ -573,7 +574,7 @@ pub fn is_drain_yield(err: &crate::error::Error) -> bool {
 
 /// Write a single FPSS frame to a blocking writer.
 ///
-/// # Wire format (from `PacketStream.writeFrame()`)
+/// # Wire format
 ///
 /// Writes `[LEN: u8] [CODE: u8] [PAYLOAD: LEN bytes]` and flushes.
 ///
@@ -888,7 +889,8 @@ mod tests {
 
     /// Mid-header `WouldBlock` (one byte delivered, second stalls briefly)
     /// must retry within the `READ_TIMEOUT_MS` aggregate deadline, matching
-    /// Java `readByte` + `setSoTimeout(10_000)`. Capture evidence: real
+    /// the JVM terminal's single-byte read under a 10_000 ms socket timeout.
+    /// Capture evidence: real
     /// server pauses between LEN and CODE measured at 50-76 ms on dev; the
     /// surrounding bytes were valid.
     #[test]
@@ -907,8 +909,9 @@ mod tests {
     }
 
     /// Mid-payload `WouldBlock` (header + partial payload, brief stall,
-    /// rest arrives) must retry and complete, matching Java `readNBytes`
-    /// + `setSoTimeout(10_000)`. Overwhelmingly most common case in the field.
+    /// rest arrives) must retry and complete, matching the JVM terminal's
+    /// read-N-bytes under a 10_000 ms socket timeout. Overwhelmingly most
+    /// common case in the field.
     #[test]
     fn mid_payload_would_block_retries_and_recovers() {
         // header: len=4, code=PING; 2 payload bytes; 3 stalls; 2 more payload bytes.
@@ -991,8 +994,9 @@ mod tests {
 
     /// A slow-trickling stream whose gaps are each under the deadline but
     /// whose aggregate duration exceeds it must still succeed. Proves the
-    /// deadline re-arms on every successful byte (Java `setSoTimeout`
-    /// per-read semantics) rather than running from function entry.
+    /// deadline re-arms on every successful byte (the JVM terminal's
+    /// per-read socket-timeout semantics) rather than running from function
+    /// entry.
     /// Delivers one byte per `Ok`, with each byte preceded by a single
     /// `WouldBlock` that sleeps for `sleep_per_stall` wall-clock time.
     /// Used to verify the stall-deadline actually resets on progress —
@@ -1029,7 +1033,7 @@ mod tests {
     /// - Cumulative wall time: 8 × 15 ms = 120 ms (> 40 ms)
     /// - Longest single gap: 15 ms (< 40 ms)
     ///
-    /// Must succeed under the Java-parity "reset on progress" semantics.
+    /// Must succeed under the parity "reset on progress" semantics.
     /// A fixed deadline from function entry (prior implementation style)
     /// would fail around cycle 3 once cumulative sleep crossed 40 ms.
     #[test]

--- a/crates/thetadatadx/src/fpss/io_loop/mod.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/mod.rs
@@ -109,7 +109,7 @@ type ActiveFullSubs = Arc<
 /// [`crate::config::FpssConfig`] tuning into the auto-reconnect path
 /// (so manual [`std::net::TcpStream::connect_timeout`] re-attempts and
 /// the framing-layer mid-frame stall budget honour the configured
-/// values, not the Java-parity hardcoded defaults).
+/// values, not the parity-reference hardcoded defaults).
 ///
 /// `producer` is the ring publisher built by the caller via
 /// [`build_poller_producer`]. The io_loop only ever calls

--- a/crates/thetadatadx/src/fpss/io_loop/ping.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/ping.rs
@@ -35,9 +35,8 @@ pub(in crate::fpss) fn ping_loop(
 ) {
     let ping_payload = build_ping_payload();
 
-    // scheduleAtFixedRate(task, 2000L, 100L): first execution at 2000ms,
-    // then every 100ms. scheduleAtFixedRate sends THEN waits, so the first
-    // ping fires at exactly 2000ms.
+    // Fixed-rate heartbeat: first execution at 2000ms, then every 100ms.
+    // The task sends THEN waits, so the first ping fires at exactly 2000ms.
     thread::sleep(Duration::from_millis(2000));
 
     loop {
@@ -50,8 +49,8 @@ pub(in crate::fpss) fn ping_loop(
             continue;
         }
 
-        // Send ping FIRST, then sleep — matches scheduleAtFixedRate semantics
-        // (execute the task, then wait the interval).
+        // Send ping FIRST, then sleep — fixed-rate semantics (execute the
+        // task, then wait the interval).
         let cmd = IoCommand::WriteFrame {
             code: StreamMsgType::Ping,
             payload: ping_payload.clone(),
@@ -78,9 +77,9 @@ mod tests {
     /// background heartbeat. Setting a 30 ms interval must produce
     /// roughly one ping per 30 ms (within scheduling jitter), and the
     /// total elapsed time across N pings must scale linearly with the
-    /// configured interval. The 2 s startup grace from the Java
-    /// terminal's `scheduleAtFixedRate(.., 2000, ..)` is short-circuited
-    /// here by waiting `2000 + N * interval` and counting pings.
+    /// configured interval. The 2 s startup grace before the first
+    /// heartbeat is short-circuited here by waiting
+    /// `2000 + N * interval` and counting pings.
     ///
     /// Asserts the wiring path:
     /// `FpssConnectArgs::ping_interval_ms`
@@ -101,9 +100,8 @@ mod tests {
             ping_loop(cmd_tx, shutdown_clone, auth_clone, interval_clone);
         });
 
-        // The loop sleeps 2 s before its first ping (mirrors
-        // `scheduleAtFixedRate(.., 2000, ..)`), so the test waits past
-        // that grace plus four full intervals.
+        // The loop sleeps 2 s before its first ping (the fixed-rate startup
+        // grace), so the test waits past that grace plus four full intervals.
         let start = Instant::now();
         let deadline = start + Duration::from_millis(2_000) + interval * 5;
         let mut pings: Vec<Instant> = Vec::new();

--- a/crates/thetadatadx/src/fpss/protocol/contract.rs
+++ b/crates/thetadatadx/src/fpss/protocol/contract.rs
@@ -50,17 +50,15 @@ pub struct OptionLeg<'a> {
 
 /// A contract identifier for FPSS subscriptions.
 ///
-/// Matches the wire format from `Contract.java`:
+/// Matches the FPSS contract wire format:
 /// - Stock/Index/Rate: root ticker + security type
 /// - Option: root ticker + security type + expiration + call/put + strike
-///
-/// Source: `Contract.java` — `toBytes()`, `fromBytes()`, constructor overloads.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub struct Contract {
     /// Ticker symbol (ASCII, max ~6 chars in practice). Named `symbol` to
     /// match the v3 vendor surface; the wire codec still encodes it as the
-    /// root field per `Contract.toBytes()` parity.
+    /// root field per the contract wire format.
     ///
     /// Stored as `Arc<str>` so every `Arc<Contract>` clone that flows
     /// through the hot-path event ring pays only an atomic refcount
@@ -84,7 +82,7 @@ pub struct Contract {
 impl Contract {
     /// Create a stock contract.
     ///
-    /// Source: `Contract(String root)` constructor in `Contract.java` — defaults to STOCK.
+    /// A root with no security type defaults to STOCK on the wire.
     ///
     /// ```
     /// use thetadatadx::fpss::protocol::Contract;
@@ -494,7 +492,7 @@ impl Contract {
 
     /// Serialize to the wire format used in FPSS subscription messages.
     ///
-    /// # Wire format (from `Contract.toBytes()`)
+    /// # Wire format
     ///
     /// Stock/Index/Rate:
     /// ```text
@@ -507,18 +505,17 @@ impl Contract {
     /// [exp_date: i32 BE] [is_call: u8] [strike: i32 BE]
     /// ```
     ///
-    /// `total_size` counts the entire buffer including itself, matching Java's
-    /// `Contract.toBytes()` exactly:
+    /// `total_size` counts the entire buffer including itself:
     ///   - Stock: `3 + root.length()` = size(1) + `root_len(1)` + root(N) + `sec_type(1)`
     ///   - Option: `12 + root.length()` = size(1) + `root_len(1)` + root(N) + `sec_type(1)` + exp(4) + `is_call(1)` + strike(4)
     ///
-    /// Java's `fromBytes()` validates `len == size`, confirming the size byte
-    /// counts itself.
+    /// The decoder validates `len == size`, confirming the size byte counts
+    /// itself.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Config`] if the contract root exceeds 16 bytes,
-    /// which is the maximum length accepted by Java's `Contract.toBytes()`.
+    /// which is the maximum encoded root length the wire format accepts.
     /// All FPSS subscribe / unsubscribe paths surface this error to the
     /// caller; user input is never permitted to panic the encoder.
     pub fn try_to_bytes(&self) -> Result<Vec<u8>, Error> {
@@ -554,7 +551,7 @@ impl Contract {
     /// # Errors
     ///
     /// Returns [`Error::Config`] if the root is empty or longer than 16
-    /// bytes. The 16-byte limit matches Java's `Contract.toBytes()`.
+    /// bytes. The 16-byte limit is the wire format's maximum encoded root.
     pub fn validate(&self) -> Result<(), Error> {
         let len = self.symbol.len();
         if len == 0 {
@@ -564,7 +561,7 @@ impl Contract {
             return Err(Error::config_invalid(
                 "contract.symbol",
                 format!(
-                    "contract symbol too long: {len} bytes (max 16 to match Java Contract.toBytes())"
+                    "contract symbol too long: {len} bytes (wire format caps the encoded root at 16 bytes)"
                 ),
             ));
         }
@@ -572,10 +569,10 @@ impl Contract {
     }
 
     fn encode_unchecked(&self) -> Vec<u8> {
-        // Local names mirror the wire spec (`Contract.java::toBytes`):
-        // the wire field is "root_len / root", and keeping the byte-level
-        // codec named that way keeps this file diffing cleanly against the
-        // upstream binary protocol. The struct binding is `symbol`.
+        // Local names mirror the wire spec: the wire field is "root_len /
+        // root", and keeping the byte-level codec named that way keeps this
+        // file diffing cleanly against the binary protocol layout. The
+        // struct binding is `symbol`.
         let root_bytes = self.symbol.as_bytes();
         let root_len = u8::try_from(root_bytes.len()).expect("validate() bounds root_len to <= 16");
 
@@ -591,7 +588,7 @@ impl Contract {
 
         let mut buf = Vec::with_capacity(total_size);
 
-        // total_size byte (includes itself — matches Java's Contract.toBytes())
+        // total_size byte (includes itself per the wire format).
         // Max total_size = 12 + 16 = 28, safely fits u8.
         buf.push(u8::try_from(total_size).expect("total_size <= 28"));
         // root_len
@@ -615,9 +612,9 @@ impl Contract {
 
     /// Deserialize from the wire format.
     ///
-    /// Input starts at the `total_size` byte (the first byte of `Contract.toBytes()` output).
+    /// Input starts at the `total_size` byte (the first byte of the encoded
+    /// contract).
     ///
-    /// Source: `Contract.fromBytes()` in `Contract.java`.
     /// # Errors
     ///
     /// Returns an error on network, authentication, or parsing failure.
@@ -626,8 +623,9 @@ impl Contract {
             return Err(ContractParseError::TooShort);
         }
 
-        // Java's size byte counts itself: the total buffer length equals the size byte value.
-        // Java fromBytes: `if (len != size) throw ...` where len is the total span including size.
+        // The size byte counts itself: the total buffer length equals the
+        // size byte value. The decoder rejects `len != size`, where `len` is
+        // the total span including the size byte.
         let total_size = data[0] as usize;
         if data.len() < total_size {
             return Err(ContractParseError::TooShort);
@@ -1100,9 +1098,9 @@ mod tests {
     }
 
     #[test]
-    fn java_parity_single_char_root() {
+    fn wire_parity_single_char_root() {
         // Edge case: root="A" (1 byte), sec=STOCK
-        // Java allocates: 3 + 1 = 4 bytes
+        // Wire size: 3 + 1 = 4 bytes
         let c = Contract::stock("A");
         let bytes = c.to_bytes();
         assert_eq!(bytes[0], 4);
@@ -1294,8 +1292,8 @@ mod tests {
 
     // -- Contract::from_str wire-codec parity ---------------------------------
     //
-    // `to_bytes()` accepts roots up to 16 bytes (Java
-    // `Contract.toBytes()` matches); `from_bytes()` round-trips
+    // `to_bytes()` accepts roots up to 16 bytes (the wire format's
+    // encoded-root cap); `from_bytes()` round-trips
     // whatever the wire delivers. The bare-root parser must accept the
     // same 1..=16 range so `from_str` / `to_bytes` / `from_bytes`
     // round-trip symmetrically.

--- a/crates/thetadatadx/src/fpss/protocol/mod.rs
+++ b/crates/thetadatadx/src/fpss/protocol/mod.rs
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn socket_timeouts_match_policy() {
-        // socket.connect(addr, 2000), setSoTimeout(10000).
+        // Parity reference: 2000 ms connect deadline, 10000 ms read timeout.
         assert_eq!(CONNECT_TIMEOUT_MS, 2_000);
         assert_eq!(READ_TIMEOUT_MS, 10_000);
     }

--- a/crates/thetadatadx/src/fpss/protocol/subscription.rs
+++ b/crates/thetadatadx/src/fpss/protocol/subscription.rs
@@ -1,7 +1,6 @@
 //! Subscription kind classification for FPSS subscribe / unsubscribe paths.
 //!
-//! Source: `PacketStream.addQuote()` uses code 21, `addTrade()` uses 22,
-//! `addOpenInterest()` uses 23.
+//! Wire codes: quote subscriptions use code 21, trade 22, open interest 23.
 //!
 //! # Public surface
 //!

--- a/crates/thetadatadx/src/mdds/client.rs
+++ b/crates/thetadatadx/src/mdds/client.rs
@@ -28,7 +28,7 @@ const TERMINAL_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// MDDS client for `ThetaData` server access.
 ///
-/// Connects to MDDS (gRPC, historical data) without requiring the Java
+/// Connects to MDDS (gRPC, historical data) without requiring the JVM
 /// terminal. Authenticates via the Nexus HTTP API, then issues gRPC
 /// requests to the upstream MDDS server.
 ///
@@ -70,7 +70,7 @@ pub struct MddsClient {
     client_type: String,
     /// Semaphore limiting concurrent in-flight gRPC requests.
     ///
-    /// The Java terminal limits concurrent requests to `2^subscription_tier`
+    /// The JVM terminal limits concurrent requests to `2^subscription_tier`
     /// (Free=1, Value=2, Standard=4, Pro=8). This semaphore enforces the same
     /// bound to prevent server-side rate limiting / 429 disconnects.
     pub(crate) request_semaphore: Arc<tokio::sync::Semaphore>,
@@ -195,10 +195,9 @@ impl MddsClient {
             auth_token: Some(proto::AuthToken { session_uuid: uuid }),
             query_parameters: self.query_parameters.clone(),
             client_type: self.client_type.clone(),
-            // Intentional divergence from Java (see jvm-deviations.md):
-            // Java fills this with the terminal's build git commit hash.
-            // We are not the Java terminal and have no git commit to report,
-            // so we leave it empty. The server accepts empty strings here.
+            // The JVM terminal fills this with its own build git commit
+            // hash. This SDK has no such commit to report, so we leave it
+            // empty; the server accepts empty strings here.
             terminal_git_commit: String::new(),
             terminal_version: TERMINAL_VERSION.to_string(),
         }

--- a/crates/thetadatadx/src/mdds/decode/cell.rs
+++ b/crates/thetadatadx/src/mdds/decode/cell.rs
@@ -79,14 +79,14 @@ pub(crate) fn row_date(row: &proto::DataValueList, idx: usize) -> Result<Option<
     }
 }
 
-/// Decode an `i32`-valued cell with Java-matching strict semantics.
+/// Decode an `i32`-valued cell with strict wire-matching semantics.
 ///
 /// Accepts:
 /// - `Number(n)` → `Ok(Some(n))` after bounds-checking the wire `int64`
 ///   against the destination `i32` range.
 /// - `Timestamp(ts)` → `Ok(Some(ms_of_day))` — v3 MDDS sends time columns as
 ///   proto `Timestamp`; the parser expects milliseconds-of-day in Eastern Time.
-/// - `NullValue` → `Ok(None)`, matching Java `null` return.
+/// - `NullValue` → `Ok(None)`, matching the wire's null sentinel.
 ///
 /// Any other variant produces [`DecodeError::TypeMismatch`], including the
 /// case where the `DataValue` arrived with its `data_type` oneof unset
@@ -190,7 +190,7 @@ pub(crate) fn row_price_type(
 /// [`DecodeError::MissingCell`] on a missing cell. Returns
 /// [`DecodeError::InvalidPriceType`] when the wire `price_type` falls
 /// outside `0..=crate::tdbe::types::price::MAX_PRICE_TYPE`.
-// Reason: protocol-defined integer widths from Java FPSS specification.
+// Reason: protocol-defined integer widths from the FPSS wire specification.
 #[allow(clippy::cast_possible_truncation)]
 #[inline]
 pub(crate) fn row_price_f64(

--- a/crates/thetadatadx/src/mdds/decode/error.rs
+++ b/crates/thetadatadx/src/mdds/decode/error.rs
@@ -6,7 +6,7 @@
 //! [`DecodeError::ChunkHeaderDrift`] when a mid-stream chunk's header set
 //! diverges from the first chunk's schema.
 //!
-//! Behaviour mirrors the upstream Java terminal.
+//! Behaviour mirrors the JVM terminal.
 
 use crate::proto;
 use thiserror::Error as ThisError;

--- a/crates/thetadatadx/src/mdds/decode/tests.rs
+++ b/crates/thetadatadx/src/mdds/decode/tests.rs
@@ -832,7 +832,7 @@ fn parse_trade_ticks_errors_on_unset_injected_right() {
 fn parse_greeks_all_ticks_decodes_price_encoded_greeks() {
     // Regression: an earlier strict decode rejected Price cells for Greek
     // columns, but the v3 MDDS server sends Greeks as Price-encoded
-    // values (mirroring Java's `dataValue2Object` -> BigDecimal path).
+    // values (decoded through the decimal-cell path, not the integer one).
     // Pins Price-cell decoding for both IV and a Greek.
     let table = proto::DataTable {
         headers: vec![
@@ -899,7 +899,7 @@ fn parse_greeks_all_ticks_resolves_implied_vol_and_underlying_timestamp_aliases(
 #[test]
 fn parse_greeks_all_ticks_still_decodes_number_cells() {
     // Companion to the Price-cell regression test: Number cells must
-    // still decode, matching Java's dispatch-on-wire-type semantics.
+    // still decode, matching the dispatch-on-wire-type semantics.
     let table = proto::DataTable {
         headers: vec!["ms_of_day".into(), "implied_volatility".into()],
         data_table: vec![row_of(vec![dv_number(34_200_000), dv_number(0)])],

--- a/crates/thetadatadx/src/mdds/tier.rs
+++ b/crates/thetadatadx/src/mdds/tier.rs
@@ -1,7 +1,7 @@
 //! Typed subscription-tier enum for the MDDS client.
 //!
 //! ThetaData's Nexus auth response carries a small integer per asset class
-//! that encodes the customer's subscription level. The Java terminal uses
+//! that encodes the customer's subscription level. The JVM terminal uses
 //! it to size the concurrent-request semaphore as `2^tier`. We keep the
 //! same wire shape (the integer comes straight off the JSON response) but
 //! lift it into a typed enum the moment it crosses into Rust state, so

--- a/crates/thetadatadx/src/tdbe/codec/mod.rs
+++ b/crates/thetadatadx/src/tdbe/codec/mod.rs
@@ -1,8 +1,8 @@
 //! FIT/FIE codec for `ThetaData`'s FPSS streaming protocol.
 //!
-//! Mirrors the Java terminal implementation for byte-for-byte wire parity:
-//! - `FITReader.java` — nibble-oriented variable-length integer decoder (FIT)
-//! - `FIE.java` — string-to-nibble encoder for request building (FIE)
+//! Matches the JVM terminal byte-for-byte on the wire:
+//! - FIT — nibble-oriented variable-length integer decoder
+//! - FIE — string-to-nibble encoder for request building
 //!
 //! FIT (Field-Indexed Tick) is a nibble-oriented (4-bit) compression format
 //! used to encode integer fields in FPSS tick data. Each byte packs two nibbles

--- a/crates/thetadatadx/src/tdbe/sequences.rs
+++ b/crates/thetadatadx/src/tdbe/sequences.rs
@@ -22,7 +22,7 @@ pub struct TradeSequence {
 
 impl TradeSequence {
     /// Create from a raw sequence value (absolute = raw as u64).
-    // Reason: protocol-level wrapping for Java i32 sequence interop.
+    // Reason: protocol-level wrapping for 32-bit sequence interop.
     #[allow(clippy::cast_sign_loss)]
     #[inline]
     #[must_use]
@@ -129,7 +129,7 @@ impl SequenceTracker {
     }
 
     /// Process a raw sequence value, returning the update details.
-    // Reason: protocol-level wrapping for Java i32 sequence overflow handling.
+    // Reason: protocol-level wrapping for 32-bit sequence overflow handling.
     #[allow(clippy::cast_sign_loss)]
     pub fn process(&mut self, raw: i64) -> SequenceUpdate {
         let mut is_overflow = false;
@@ -249,7 +249,7 @@ pub struct SequenceUpdate {
 }
 
 /// Convert a signed raw sequence to an unsigned absolute value.
-// Reason: protocol-level wrapping for Java i32 sequence interop.
+// Reason: protocol-level wrapping for 32-bit sequence interop.
 #[allow(clippy::cast_sign_loss)]
 #[inline]
 #[must_use]
@@ -262,7 +262,7 @@ pub const fn signed_to_unsigned(signed: i64) -> u64 {
 }
 
 /// Convert an unsigned absolute value back to a signed raw sequence.
-// Reason: protocol-level wrapping for Java i32 sequence interop.
+// Reason: protocol-level wrapping for 32-bit sequence interop.
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_wrap)]
 #[inline]
 #[must_use]

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -344,7 +344,7 @@ pub unsafe extern "C" fn tdx_config_get_reconnect_wait_ms(
 /// Set the reconnect delay (ms) honoured for `TooManyRequests`
 /// rate-limited disconnects. Plumbed through to the FPSS I/O loop at
 /// connect time and consumed by the `Auto` reconnect arm via
-/// `reconnect_delay_for`. Default `130_000` (matches the Java terminal's
+/// `reconnect_delay_for`. Default `130_000` (matches the JVM terminal's
 /// 130 s rate-limit cooldown).
 #[no_mangle]
 pub unsafe extern "C" fn tdx_config_set_reconnect_wait_rate_limited_ms(

--- a/scripts/check_no_re_framing.py
+++ b/scripts/check_no_re_framing.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Gate the publicly-rendered SDK source against reverse-engineering framing.
+
+The Rust, FFI, and binding source ships verbatim: it compiles into the
+crates published on crates.io and its `///` / `//!` doc comments render on
+docs.rs. Any sentence that frames the protocol work as reverse-engineering
+the vendor's JVM terminal — naming a decompiled class or method, citing a
+jar build the wire layout was checked against, or using the words
+"reverse-engineered" / "decompiled" — ships to every reader who opens the
+docs.
+
+The approved story is the no-JVM SDK closing the parity gap with the
+vendor's JVM terminal. The terminal is a legitimate parity reference, so
+"Theta Terminal" and "JVM terminal" stay. What must never appear is the
+provenance of how the wire format was learned: named internal Java
+identifiers, jar-build verification notes, and the reverse-engineering /
+decompilation vocabulary itself.
+
+This gate scans the publicly-rendered source trees — the Rust crate
+source (including generated `.rs`), the FFI source, and the Python and
+TypeScript binding source — for that framing and fails with `file:line`
+on any hit.
+
+Run::
+
+    python3 scripts/check_no_re_framing.py
+
+Exit codes:
+
+* ``0`` — clean.
+* ``1`` — at least one source file frames the protocol as reverse-engineered.
+
+Selftest::
+
+    python3 scripts/check_no_re_framing.py --selftest
+
+The selftest plants a `reverse-engineered the Java terminal` line in a
+synthetic source file and confirms the gate flags it, then confirms a
+clean file (one that names only the allow-listed "JVM terminal" /
+"Theta Terminal" parity reference) passes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+from typing import Iterable
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+# Globs describing the publicly-rendered source, relative to the repo
+# root. Every file here either compiles into a published crate or ships
+# its doc comments to docs.rs. Generated `.rs` is included on purpose:
+# the checked-in generated tick classes render exactly like hand-written
+# source, so they must clear the same bar.
+SCAN_GLOBS = (
+    "crates/thetadatadx/src/**/*.rs",
+    "ffi/src/**/*.rs",
+    "sdks/python/src/**/*.rs",
+    "sdks/typescript/src/**/*.rs",
+    "sdks/typescript/src/**/*.ts",
+)
+
+
+# Path fragments that exclude a candidate even when it matches a scan
+# glob: vendored deps and build output never carry our prose.
+EXEMPT_PATH_FRAGMENTS = (
+    "/node_modules/",
+    "/target/",
+    "/.git/",
+)
+
+
+# Reverse-engineering framing that must never appear in the rendered
+# source. Each entry is a compiled regex matched case-insensitively:
+#
+# * Named internal Java identifiers a reader could only learn from
+#   decompilation (`Foo.toBytes()`, `Contract.java`, `FITReader.java`,
+#   `javap`).
+# * The verification-provenance note that records which terminal jar
+#   build a wire layout was checked against.
+# * The reverse-engineering / decompilation vocabulary itself.
+#
+# "Java terminal" is forbidden too: the approved spelling is "JVM
+# terminal" (allow-listed below), so an explicit "Java terminal" hit is
+# a drift signal, not a parity reference.
+FORBIDDEN_PATTERNS = (
+    re.compile(r"java\s+terminal", re.IGNORECASE),
+    re.compile(r"\.toBytes\b"),
+    re.compile(r"\.fromBytes\b"),
+    re.compile(r"\bFITReader\.java\b"),
+    re.compile(r"\bFIE\.java\b"),
+    re.compile(r"\b\w+\.java\b"),
+    re.compile(r"\bjavap\b", re.IGNORECASE),
+    re.compile(r"decompil", re.IGNORECASE),
+    re.compile(r"reverse[- ]engineer", re.IGNORECASE),
+    re.compile(r"jar\s+build", re.IGNORECASE),
+    re.compile(r"verified-live\s+against\s+terminal", re.IGNORECASE),
+)
+
+
+# The only parity-reference spellings that may name the vendor's product.
+# A matched line is exonerated when removing every allow-listed phrase
+# leaves no forbidden pattern behind, so the allow-list never masks a
+# genuine leak that merely shares a line with the parity reference.
+ALLOWLISTED_PHRASES = (
+    "JVM terminal",
+    "Theta Terminal",
+)
+
+
+def _is_exempt(rel_path: pathlib.Path) -> bool:
+    parts = "/" + rel_path.as_posix() + "/"
+    return any(fragment in parts for fragment in EXEMPT_PATH_FRAGMENTS)
+
+
+def _iter_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
+    seen: set[pathlib.Path] = set()
+    for pattern in SCAN_GLOBS:
+        for candidate in root.glob(pattern):
+            if not candidate.is_file():
+                continue
+            rel = candidate.relative_to(root)
+            if _is_exempt(rel):
+                continue
+            if rel in seen:
+                continue
+            seen.add(rel)
+            yield candidate
+
+
+def _strip_allowlisted(line: str) -> str:
+    """Remove every allow-listed parity-reference phrase from `line`.
+
+    Forbidden-pattern matching runs against the residue. A line whose
+    only matches come from the allow-listed phrases is thereby cleared,
+    while a real leak sharing a line with a parity reference still trips.
+    """
+    residue = line
+    for phrase in ALLOWLISTED_PHRASES:
+        residue = re.sub(re.escape(phrase), " ", residue, flags=re.IGNORECASE)
+    return residue
+
+
+def _scan_line(line: str) -> list[str]:
+    """Return the forbidden patterns that survive allow-list stripping."""
+    residue = _strip_allowlisted(line)
+    return [pat.search(residue).group(0) for pat in FORBIDDEN_PATTERNS if pat.search(residue)]
+
+
+def _scan(root: pathlib.Path) -> list[tuple[pathlib.Path, int, str, str]]:
+    """Return (rel_path, lineno, matched, line_text) for every hit found."""
+    hits: list[tuple[pathlib.Path, int, str, str]] = []
+    for path in _iter_files(root):
+        rel = path.relative_to(root)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for matched in _scan_line(line):
+                hits.append((rel, lineno, matched, line.strip()))
+    return hits
+
+
+def _selftest() -> int:
+    """Plant RE framing in a synthetic source file and confirm the gate fires.
+
+    Three cases:
+
+    * A file with `reverse-engineered the Java terminal` plus a jar-build
+      provenance note — must be flagged.
+    * A clean file that names only the allow-listed "JVM terminal" /
+      "Theta Terminal" parity reference — must pass.
+    * A clean file whose factual wire description shares a line with the
+      allow-listed parity reference — must pass.
+    """
+    import tempfile
+
+    leaky = (
+        "//! We reverse-engineered the Java terminal to learn this layout.\n"
+        "/// Wire layout verified-live against terminal jar build `202605221`.\n"
+        "/// Source: `Contract.toBytes()` in `Contract.java`.\n"
+    )
+    clean = (
+        "//! Matches the JVM terminal byte-for-byte on the wire.\n"
+        "/// Parity reference: the JVM terminal connects with a 2000 ms deadline.\n"
+    )
+    vendor_line = (
+        "/// The wire format caps the encoded root at 16 bytes, matching the\n"
+        "/// JVM terminal. Decoded against the Theta Terminal parity reference.\n"
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+
+        leaky_path = root / "crates" / "thetadatadx" / "src" / "leaky.rs"
+        leaky_path.parent.mkdir(parents=True, exist_ok=True)
+        leaky_path.write_text(leaky, encoding="utf-8")
+
+        clean_path = root / "ffi" / "src" / "clean.rs"
+        clean_path.parent.mkdir(parents=True, exist_ok=True)
+        clean_path.write_text(clean, encoding="utf-8")
+
+        vendor_path = root / "sdks" / "python" / "src" / "vendor.rs"
+        vendor_path.parent.mkdir(parents=True, exist_ok=True)
+        vendor_path.write_text(vendor_line, encoding="utf-8")
+
+        hits = _scan(root)
+
+        leaky_hits = [h for h in hits if h[0].name == "leaky.rs"]
+        if not leaky_hits:
+            print("selftest FAILED: the planted RE-framing line was not flagged")
+            return 1
+        if any(rel.name == "clean.rs" for (rel, _, _, _) in hits):
+            print("selftest FAILED: a clean JVM-terminal file was flagged")
+            return 1
+        if any(rel.name == "vendor.rs" for (rel, _, _, _) in hits):
+            print("selftest FAILED: an allow-listed parity-reference file was flagged")
+            return 1
+
+    print("selftest: ok")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="Run the embedded self-test and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return _selftest()
+
+    hits = _scan(REPO_ROOT)
+    if not hits:
+        print("no-re-framing: clean")
+        return 0
+    print(
+        f"no-re-framing: {len(hits)} reverse-engineering framing leak(s) in "
+        "the publicly-rendered source"
+    )
+    for rel, lineno, matched, line in hits:
+        print(f"  {rel}:{lineno}: frames as `{matched}`")
+        print(f"    {line}")
+    print(
+        "  -> The source renders on docs.rs. Describe the wire behavior "
+        "factually and reference the parity target only as the "
+        "`JVM terminal` / `Theta Terminal`; never name a decompiled "
+        "identifier, a jar build, or the reverse-engineering act."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdks/python/src/_generated/tick_classes.rs
+++ b/sdks/python/src/_generated/tick_classes.rs
@@ -14,7 +14,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 
 /// Calendar day. Market open/close schedule.
-/// 
+///
 /// `status` carries the vendor's own day-type vocabulary (`open` /
 /// `early_close` / `full_close` / `weekend`); unknown wire text fails
 /// decode loudly rather than degrading to a sentinel. `date` is `0` on
@@ -49,7 +49,7 @@ impl CalendarDay {
 }
 
 /// End-of-day tick. Full EOD snapshot with OHLC + quote.
-/// 
+///
 /// The two time columns carry the vendor's v3 field semantics under their
 /// v3 names: `created` is when the EOD report was generated (~17:15 ET,
 /// NOT a trade time) and `last_trade` is the time of the day's final
@@ -135,13 +135,13 @@ impl EodTick {
 
 /// Full union Greeks tick -- every Greek the v3 server publishes on the
 /// `option_*_greeks_all` and `option_*_greeks_eod` endpoints.
-/// 
+///
 /// The vendor's per-order endpoints (`option_*_greeks_first_order`,
 /// `_second_order`, `_third_order`) emit strict subsets of these columns
 /// and bind to `GreeksFirstOrderTick`, `GreeksSecondOrderTick`,
 /// `GreeksThirdOrderTick` respectively. `option_*_greeks_implied_volatility`
 /// binds to `IvTick`.
-/// 
+///
 /// The wire-level `timestamp` -> `ms_of_day`, `underlying_timestamp` ->
 /// `underlying_ms_of_day`, and `implied_vol` -> `implied_volatility`
 /// mappings are applied through `HEADER_ALIASES` in
@@ -250,27 +250,13 @@ impl GreeksAllTick {
 /// `bid_size`, `bid_exchange`, `bid_condition`, `ask_size`,
 /// `ask_exchange`, `ask_condition`) that identify the daily bar + closing
 /// NBBO snapshot the Greeks were calculated against.
-/// 
+///
 /// The bare `GreeksAllTick` previously routed by `endpoint_surface.toml`
 /// (28 fields) silently dropped those twelve EOD columns from the
 /// 39-column EOD response -- the same data-loss class as the per-trade
 /// Greeks endpoints. `GreeksEodTick` carries the full
 /// EOD wire shape end-to-end across every binding.
-/// 
-/// Wire layout verified-live against terminal jar build `202605221`
-/// (SPY 2024-06-21 expiration query on 2024-06-14):
-/// 
-///   symbol, expiration, strike, right,
-///   timestamp, open, high, low, close, volume, count,
-///   bid_size, bid_exchange, bid, bid_condition,
-///   ask_size, ask_exchange, ask, ask_condition,
-///   delta, theta, vega, rho, epsilon, lambda,
-///   gamma, vanna, charm, vomma, veta, vera,
-///   speed, zomma, color, ultima,
-///   d1, d2, dual_delta, dual_gamma,
-///   implied_vol, iv_error,
-///   underlying_timestamp, underlying_price
-/// 
+///
 /// The `timestamp` -> `ms_of_day`, `underlying_timestamp` ->
 /// `underlying_ms_of_day`, and `implied_vol` -> `implied_volatility`
 /// mappings are applied through `HEADER_ALIASES`.
@@ -618,11 +604,7 @@ impl GreeksThirdOrderTick {
 /// `ms_of_day`, `price`, `date`) silently dropped seven server-emitted
 /// columns -- `sequence`, `ext_condition1..4`, `condition`, `size`,
 /// `exchange` -- including the SIP-exchange attribution field.
-/// 
-/// Wire layout verified-live against terminal jar build `202605221`:
-/// 
-///   timestamp, sequence, ext_condition1..4, condition, size, exchange, price
-/// 
+///
 /// The `timestamp` -> `ms_of_day` and `timestamp` -> `date` mappings are
 /// applied through the existing `HEADER_ALIASES` rows in
 /// `crates/thetadatadx/src/mdds/decode/headers.rs`.
@@ -676,15 +658,7 @@ impl IndexPriceAtTimeTick {
 }
 
 /// Interest rate tick. End-of-day interest rate (percent).
-/// 
-/// Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`
-/// and verified-live against terminal jar build `202605221`:
-/// 
-/// | Schema field | Wire header | Wire type        | Mapping                    |
-/// |--------------|-------------|------------------|----------------------------|
-/// | `date`       | `created`   | Text (ISO date)  | `"2025-04-28"` -> 20250428 |
-/// | `rate`       | `rate`      | Number (percent) | `4.3600` -> 4.36           |
-/// 
+///
 /// The `date` decode flows through `thetadatadx::decode::row_date`, which
 /// accepts `Number`, `Timestamp`, and `Text` cells uniformly — so this tick
 /// decodes either the documented Text-ISO shape or any future
@@ -712,24 +686,7 @@ impl InterestRateTick {
 }
 
 /// Implied volatility tick.
-/// 
-/// Wire layout verified-live against `option_history_greeks_implied_volatility`
-/// (terminal jar build `202605221`):
-/// 
-/// | Schema field                | Wire header               | Type   |
-/// |-----------------------------|---------------------------|--------|
-/// | `ms_of_day`                 | `timestamp`               | i32    |
-/// | `bid`                       | `bid`                     | price  |
-/// | `bid_implied_volatility`    | `bid_implied_vol`         | f64    |
-/// | `midpoint`                  | `midpoint`                | price  |
-/// | `implied_volatility`        | `implied_vol`             | f64    |
-/// | `ask`                       | `ask`                     | price  |
-/// | `ask_implied_volatility`    | `ask_implied_vol`         | f64    |
-/// | `iv_error`                  | `iv_error`                | f64    |
-/// | `underlying_ms_of_day`      | `underlying_timestamp`    | i32    |
-/// | `underlying_price`          | `underlying_price`        | price  |
-/// | `date`                      | `timestamp`               | i32    |
-/// 
+///
 /// The snapshot variant (`option_snapshot_greeks_implied_volatility`) emits
 /// a 4-column subset (`ms_of_day, implied_vol, iv_error, date`); the
 /// generator's optional-column path defaults the missing fields to 0.0 so
@@ -843,14 +800,8 @@ impl MarketValueTick {
 }
 
 /// OHLC tick. Aggregated bar data including SIP-rule VWAP.
-/// 
-/// Wire layout verified-live (terminal jar build `202605221`) against
-/// `stock_history_ohlc`, `option_history_ohlc`, and `index_history_ohlc`,
-/// which emit the same 8 data columns (`timestamp,open,high,low,close,
-/// volume,count,vwap`). The snapshot variants (`*_snapshot_ohlc`) omit
-/// `vwap`; the generated parser's optional-column path defaults the
-/// field to `0.0` for those endpoints, mirroring how `volume`/`count`
-/// already zero-default on quote-only intraday bars.
+///
+/// The snapshot variants (`*_snapshot_ohlc`) omit `vwap`; the generated parser's optional-column path defaults the field to `0.0` for those endpoints, mirroring how `volume`/`count` already zero-default on quote-only intraday bars.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
@@ -943,7 +894,7 @@ impl OpenInterestTick {
 }
 
 /// Option contract. Contract specification.
-/// 
+///
 /// Cannot be `Copy` because of the `String` symbol field.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
@@ -1006,7 +957,7 @@ impl PriceTick {
 }
 
 /// Quote tick. NBBO quote data.
-/// 
+///
 /// Wire layout: the full shape is 11 columns (`ms_of_day`,
 /// `bid_size`, `bid_exchange`, `bid`, `bid_condition`, `ask_size`,
 /// `ask_exchange`, `ask`, `ask_condition`, `price_type`, `date`).
@@ -1077,18 +1028,7 @@ impl QuoteTick {
 /// columns (`sequence`, `ext_condition1..4`, `condition`, `size`,
 /// `exchange`, `price`) that identify which OPRA print each Greek was
 /// calculated against.
-/// 
-/// Wire layout verified-live against terminal jar build `202605221`:
-/// 
-///   symbol, expiration, strike, right,
-///   timestamp, sequence, ext_condition1..4, condition, size, exchange, price,
-///   delta, theta, vega, rho, epsilon, lambda,
-///   gamma, vanna, charm, vomma, veta, vera,
-///   speed, zomma, color, ultima,
-///   d1, d2, dual_delta, dual_gamma,
-///   implied_vol, iv_error,
-///   underlying_timestamp, underlying_price
-/// 
+///
 /// The `timestamp` -> `ms_of_day`, `underlying_timestamp` ->
 /// `underlying_ms_of_day`, and `implied_vol` -> `implied_volatility`
 /// mappings are applied through `HEADER_ALIASES`.
@@ -1204,10 +1144,7 @@ impl TradeGreeksAllTick {
     }
 }
 
-/// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon
-/// / lambda) paired with the trade-side execution columns identifying the
-/// OPRA print each Greek was calculated against. Wire layout verified-live
-/// against terminal jar build `202605221`.
+/// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon / lambda) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
@@ -1292,11 +1229,7 @@ impl TradeGreeksFirstOrderTick {
     }
 }
 
-/// Per-trade implied-volatility tick (single `implied_volatility` +
-/// `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled
-/// `IvTick`) paired with the trade-side execution columns identifying the
-/// OPRA print the IV was calculated against. Wire layout verified-live
-/// against terminal jar build `202605221`.
+/// Per-trade implied-volatility tick (single `implied_volatility` + `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled `IvTick`) paired with the trade-side execution columns identifying the OPRA print the IV was calculated against.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
@@ -1369,10 +1302,7 @@ impl TradeGreeksImpliedVolatilityTick {
     }
 }
 
-/// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma /
-/// veta) paired with the trade-side execution columns identifying the OPRA
-/// print each Greek was calculated against. Wire layout verified-live
-/// against terminal jar build `202605221`.
+/// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma / veta) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
@@ -1455,11 +1385,7 @@ impl TradeGreeksSecondOrderTick {
     }
 }
 
-/// Per-trade third-order Greeks tick (speed / zomma / color / ultima)
-/// paired with the trade-side execution columns identifying the OPRA print
-/// each Greek was calculated against. The vendor's third-order schema does
-/// not publish `vera`. Wire layout verified-live against terminal jar build
-/// `202605221`.
+/// Per-trade third-order Greeks tick (speed / zomma / color / ultima) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against. The vendor's third-order schema does not publish `vera`.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]

--- a/sdks/python/src/chunking.rs
+++ b/sdks/python/src/chunking.rs
@@ -157,8 +157,8 @@ impl Ymd {
     }
 }
 
-/// Maximum span accepted by the server (inclusive). 365 matches the
-/// behavior observed during reverse-engineering.
+/// Maximum span accepted by the server (inclusive). The server caps a
+/// single request at 365 days.
 pub const MAX_SPAN_DAYS: i64 = 365;
 
 /// Split `(start, end)` (YYYYMMDD strings, inclusive on both ends) into

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -342,7 +342,7 @@ impl Config {
 
     /// Set the reconnect delay (ms) honoured for ``TooManyRequests``
     /// rate-limited disconnects. Default ``130_000`` (matches the
-    /// Java terminal's 130 s rate-limit cooldown).
+    /// JVM terminal's 130 s rate-limit cooldown).
     #[setter]
     fn set_reconnect_wait_rate_limited_ms(&self, ms: u64) {
         let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());


### PR DESCRIPTION
The Rust crate, FFI, and binding source compile into the published crates and render their doc comments on docs.rs. Several comments and doc-strings framed the wire protocol as reverse-engineered from the vendor's JVM terminal: they named decompiled Java identifiers (`Contract.toBytes()`, `FITReader.java`, `setSoTimeout`, `scheduleAtFixedRate`, `PacketStream`), cited the terminal jar build a wire layout was checked against, and used the reverse-engineering vocabulary directly. That text ships verbatim to every reader.

This rewrites the prose to describe the wire behavior factually. The JVM terminal stays as the parity reference under its approved spelling; the encoded-contract limit, the socket-timeout semantics, the fixed-rate heartbeat, and the integer-wrap arithmetic are now stated as wire-format constraints with no internal identifier attached.

The generated Python tick classes carried the same jar-build provenance because the Python class emitter spliced the schema doc verbatim while the Rust tick-struct emitter already scrubbed it. This routes the Python emitter through the existing provenance-scrubbing pass and regenerates the checked-in output, so the generated surface matches the Rust structs (behavioral prose kept, wire-column dumps and provenance dropped).

A new gate scans the publicly-rendered source for reverse-engineering framing and allow-lists only the approved `JVM terminal` / `Theta Terminal` parity spellings. It ships a `--selftest` that plants a reverse-engineered Java-terminal line and confirms the gate fires, then confirms an allow-listed file passes clean. It is wired into CI alongside the documented-defaults and public-surface-leak gates.

Verification run locally: `cargo fmt --all -- --check`; core / ffi / python / typescript clippy with `-D warnings`; `generate_sdk_surfaces --check` and `generate_docs_site --check` (no drift after the emitter change); `cargo test -p thetadatadx --doc`; `check_public_surface_leak.py`; `check_doc_defaults.py`; `check_no_re_framing.py` + selftest + plant-revert; `npm test` (138 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)