### PR TITLE
fix(ci): disambiguate the Error doc link and lift the Windows FFI build timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,7 @@ jobs:
               target/release/thetadatadx_ffi.dll.lib
     runs-on: ${{ matrix.os }}
     needs: check
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust-deps

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -1,6 +1,6 @@
-//! The crate's public [`Error`] type and its category enums.
+//! The crate's public [`enum@Error`] type and its category enums.
 //!
-//! [`Error`] is the single error surface returned across the SDK. Every
+//! [`enum@Error`] is the single error surface returned across the SDK. Every
 //! variant carries a typed category (`kind`) alongside a human-readable
 //! message so callers can pattern-match on the failure class without
 //! parsing `Display` strings, and the `Display` shapes stay stable for


### PR DESCRIPTION
Two CI-health fixes. The `error` module header used a bare `[\`Error\`]` intra-doc link that is ambiguous (the module also imports the derive macro of the same name), so the rustdoc broken-link gate has been red on main; this qualifies it as `[\`enum@Error\`]`. Separately, the `Build FFI (windows-latest)` job rides at the edge of its 45-minute cap and intermittently times out, so its timeout is raised to 75 minutes. Supersedes #774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)