### PR TITLE
fix(ci): lift the Windows FFI build timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,7 @@ jobs:
               target/release/thetadatadx_ffi.dll.lib
     runs-on: ${{ matrix.os }}
     needs: check
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust-deps


### PR DESCRIPTION
The `Build FFI (windows-latest)` job rides at the edge of its 45-minute cap and intermittently times out (the macOS/Ubuntu FFI builds finish well under it). This raises that job to 75 minutes. Supersedes #777, whose error.rs portion is already on main (rustdoc is green) — only this timeout bump remained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)