### PR TITLE
docs: migrate the public cookbook and examples to the client.historical/client.stream surface

### DIFF
--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -665,19 +665,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let symbols = client.stock_list_symbols().await?;
+            let symbols = client.historical().stock_list_symbols().await?;
         - lang: python
           label: Python
           source: |
-            symbols = client.stock_list_symbols()
+            symbols = client.historical.stock_list_symbols()
         - lang: go
           label: Go
           source: |
-            symbols, err := client.StockListSymbols()
+            symbols, err := client.Historical().StockListSymbols()
         - lang: cpp
           label: C++
           source: |
-            auto symbols = client.stock_list_symbols();
+            auto symbols = client.historical().stock_list_symbols();
 
   /stock/list/dates:
     x-min-subscription: free
@@ -698,19 +698,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let dates = client.stock_list_dates("TRADE", "AAPL").await?;
+            let dates = client.historical().stock_list_dates("TRADE", "AAPL").await?;
         - lang: python
           label: Python
           source: |
-            dates = client.stock_list_dates("TRADE", "AAPL")
+            dates = client.historical.stock_list_dates("TRADE", "AAPL")
         - lang: go
           label: Go
           source: |
-            dates, err := client.StockListDates("TRADE", "AAPL")
+            dates, err := client.Historical().StockListDates("TRADE", "AAPL")
         - lang: cpp
           label: C++
           source: |
-            auto dates = client.stock_list_dates("TRADE", "AAPL");
+            auto dates = client.historical().stock_list_dates("TRADE", "AAPL");
 
   # =========================================================================
   # STOCK / SNAPSHOT
@@ -737,19 +737,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let ohlc = client.stock_snapshot_ohlc(&["AAPL"]).await?;
+            let ohlc = client.historical().stock_snapshot_ohlc(&["AAPL"]).await?;
         - lang: python
           label: Python
           source: |
-            ohlc = client.stock_snapshot_ohlc(["AAPL"])
+            ohlc = client.historical.stock_snapshot_ohlc(["AAPL"])
         - lang: go
           label: Go
           source: |
-            ohlc, err := client.StockSnapshotOHLC([]string{"AAPL"})
+            ohlc, err := client.Historical().StockSnapshotOHLC([]string{"AAPL"})
         - lang: cpp
           label: C++
           source: |
-            auto ohlc = client.stock_snapshot_ohlc({"AAPL"});
+            auto ohlc = client.historical().stock_snapshot_ohlc({"AAPL"});
 
   /stock/snapshot/trade:
     x-min-subscription: standard
@@ -772,19 +772,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let trades = client.stock_snapshot_trade(&["AAPL"]).await?;
+            let trades = client.historical().stock_snapshot_trade(&["AAPL"]).await?;
         - lang: python
           label: Python
           source: |
-            trades = client.stock_snapshot_trade(["AAPL"])
+            trades = client.historical.stock_snapshot_trade(["AAPL"])
         - lang: go
           label: Go
           source: |
-            trades, err := client.StockSnapshotTrade([]string{"AAPL"})
+            trades, err := client.Historical().StockSnapshotTrade([]string{"AAPL"})
         - lang: cpp
           label: C++
           source: |
-            auto trades = client.stock_snapshot_trade({"AAPL"});
+            auto trades = client.historical().stock_snapshot_trade({"AAPL"});
 
   /stock/snapshot/quote:
     x-min-subscription: value
@@ -807,19 +807,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let quotes = client.stock_snapshot_quote(&["AAPL"]).await?;
+            let quotes = client.historical().stock_snapshot_quote(&["AAPL"]).await?;
         - lang: python
           label: Python
           source: |
-            quotes = client.stock_snapshot_quote(["AAPL"])
+            quotes = client.historical.stock_snapshot_quote(["AAPL"])
         - lang: go
           label: Go
           source: |
-            quotes, err := client.StockSnapshotQuote([]string{"AAPL"})
+            quotes, err := client.Historical().StockSnapshotQuote([]string{"AAPL"})
         - lang: cpp
           label: C++
           source: |
-            auto quotes = client.stock_snapshot_quote({"AAPL"});
+            auto quotes = client.historical().stock_snapshot_quote({"AAPL"});
 
   /stock/snapshot/market_value:
     x-min-subscription: standard
@@ -840,19 +840,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let mv = client.stock_snapshot_market_value(&["AAPL"]).await?;
+            let mv = client.historical().stock_snapshot_market_value(&["AAPL"]).await?;
         - lang: python
           label: Python
           source: |
-            mv = client.stock_snapshot_market_value(["AAPL"])
+            mv = client.historical.stock_snapshot_market_value(["AAPL"])
         - lang: go
           label: Go
           source: |
-            mv, err := client.StockSnapshotMarketValue([]string{"AAPL"})
+            mv, err := client.Historical().StockSnapshotMarketValue([]string{"AAPL"})
         - lang: cpp
           label: C++
           source: |
-            auto mv = client.stock_snapshot_market_value({"AAPL"});
+            auto mv = client.historical().stock_snapshot_market_value({"AAPL"});
 
   # =========================================================================
   # STOCK / HISTORY
@@ -877,19 +877,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let eod = client.stock_history_eod("AAPL", "20240101", "20240301").await?;
+            let eod = client.historical().stock_history_eod("AAPL", "20240101", "20240301").await?;
         - lang: python
           label: Python
           source: |
-            df = client.stock_history_eod("AAPL", "20240101", "20240301").to_pandas()
+            df = client.historical.stock_history_eod("AAPL", "20240101", "20240301").to_pandas()
         - lang: go
           label: Go
           source: |
-            eod, err := client.StockHistoryEOD("AAPL", "20240101", "20240301")
+            eod, err := client.Historical().StockHistoryEOD("AAPL", "20240101", "20240301")
         - lang: cpp
           label: C++
           source: |
-            auto eod = client.stock_history_eod("AAPL", "20240101", "20240301");
+            auto eod = client.historical().stock_history_eod("AAPL", "20240101", "20240301");
 
   /stock/history/ohlc:
     x-min-subscription: value
@@ -914,19 +914,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let bars = client.stock_history_ohlc("AAPL", "20240315", "60000").await?;
+            let bars = client.historical().stock_history_ohlc("AAPL", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            bars = client.stock_history_ohlc("AAPL", "20240315", "60000")
+            bars = client.historical.stock_history_ohlc("AAPL", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            bars, err := client.StockHistoryOHLC("AAPL", "20240315", "60000")
+            bars, err := client.Historical().StockHistoryOHLC("AAPL", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto bars = client.stock_history_ohlc("AAPL", "20240315", "60000");
+            auto bars = client.historical().stock_history_ohlc("AAPL", "20240315", "60000");
 
   /stock/history/ohlc_range:
     x-min-subscription: value
@@ -952,19 +952,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let bars = client.stock_history_ohlc_range("AAPL", "20240101", "20240301", "60000").await?;
+            let bars = client.historical().stock_history_ohlc_range("AAPL", "20240101", "20240301", "60000").await?;
         - lang: python
           label: Python
           source: |
-            bars = client.stock_history_ohlc_range("AAPL", "20240101", "20240301", "60000")
+            bars = client.historical.stock_history_ohlc_range("AAPL", "20240101", "20240301", "60000")
         - lang: go
           label: Go
           source: |
-            bars, err := client.StockHistoryOHLCRange("AAPL", "20240101", "20240301", "60000")
+            bars, err := client.Historical().StockHistoryOHLCRange("AAPL", "20240101", "20240301", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto bars = client.stock_history_ohlc_range("AAPL", "20240101", "20240301", "60000");
+            auto bars = client.historical().stock_history_ohlc_range("AAPL", "20240101", "20240301", "60000");
 
   /stock/history/trade:
     x-min-subscription: standard
@@ -999,19 +999,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let trades = client.stock_history_trade("AAPL", "20240315").await?;
+            let trades = client.historical().stock_history_trade("AAPL", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            trades = client.stock_history_trade("AAPL", "20240315")
+            trades = client.historical.stock_history_trade("AAPL", "20240315")
         - lang: go
           label: Go
           source: |
-            trades, err := client.StockHistoryTrade("AAPL", "20240315")
+            trades, err := client.Historical().StockHistoryTrade("AAPL", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto trades = client.stock_history_trade("AAPL", "20240315");
+            auto trades = client.historical().stock_history_trade("AAPL", "20240315");
   /stock/history/quote:
     x-min-subscription: value
     get:
@@ -1046,19 +1046,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let quotes = client.stock_history_quote("AAPL", "20240315", "60000").await?;
+            let quotes = client.historical().stock_history_quote("AAPL", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            quotes = client.stock_history_quote("AAPL", "20240315", "60000")
+            quotes = client.historical.stock_history_quote("AAPL", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            quotes, err := client.StockHistoryQuote("AAPL", "20240315", "60000")
+            quotes, err := client.Historical().StockHistoryQuote("AAPL", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto quotes = client.stock_history_quote("AAPL", "20240315", "60000");
+            auto quotes = client.historical().stock_history_quote("AAPL", "20240315", "60000");
   /stock/history/trade_quote:
     x-min-subscription: standard
     get:
@@ -1094,19 +1094,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let tq = client.stock_history_trade_quote("AAPL", "20240315").await?;
+            let tq = client.historical().stock_history_trade_quote("AAPL", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            tq = client.stock_history_trade_quote("AAPL", "20240315")
+            tq = client.historical.stock_history_trade_quote("AAPL", "20240315")
         - lang: go
           label: Go
           source: |
-            tq, err := client.StockHistoryTradeQuote("AAPL", "20240315")
+            tq, err := client.Historical().StockHistoryTradeQuote("AAPL", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto tq = client.stock_history_trade_quote("AAPL", "20240315");
+            auto tq = client.historical().stock_history_trade_quote("AAPL", "20240315");
 
   # =========================================================================
   # STOCK / AT-TIME
@@ -1134,19 +1134,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let trades = client.stock_at_time_trade("AAPL", "20240101", "20240301", "09:30:00.000").await?;
+            let trades = client.historical().stock_at_time_trade("AAPL", "20240101", "20240301", "09:30:00.000").await?;
         - lang: python
           label: Python
           source: |
-            trades = client.stock_at_time_trade("AAPL", "20240101", "20240301", "09:30:00.000")
+            trades = client.historical.stock_at_time_trade("AAPL", "20240101", "20240301", "09:30:00.000")
         - lang: go
           label: Go
           source: |
-            trades, err := client.StockAtTimeTrade("AAPL", "20240101", "20240301", "09:30:00.000")
+            trades, err := client.Historical().StockAtTimeTrade("AAPL", "20240101", "20240301", "09:30:00.000")
         - lang: cpp
           label: C++
           source: |
-            auto trades = client.stock_at_time_trade("AAPL", "20240101", "20240301", "09:30:00.000");
+            auto trades = client.historical().stock_at_time_trade("AAPL", "20240101", "20240301", "09:30:00.000");
 
   /stock/at_time/quote:
     x-min-subscription: value
@@ -1169,19 +1169,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let quotes = client.stock_at_time_quote("AAPL", "20240101", "20240301", "09:30:00.000").await?;
+            let quotes = client.historical().stock_at_time_quote("AAPL", "20240101", "20240301", "09:30:00.000").await?;
         - lang: python
           label: Python
           source: |
-            quotes = client.stock_at_time_quote("AAPL", "20240101", "20240301", "09:30:00.000")
+            quotes = client.historical.stock_at_time_quote("AAPL", "20240101", "20240301", "09:30:00.000")
         - lang: go
           label: Go
           source: |
-            quotes, err := client.StockAtTimeQuote("AAPL", "20240101", "20240301", "09:30:00.000")
+            quotes, err := client.Historical().StockAtTimeQuote("AAPL", "20240101", "20240301", "09:30:00.000")
         - lang: cpp
           label: C++
           source: |
-            auto quotes = client.stock_at_time_quote("AAPL", "20240101", "20240301", "09:30:00.000");
+            auto quotes = client.historical().stock_at_time_quote("AAPL", "20240101", "20240301", "09:30:00.000");
 
   # =========================================================================
   # OPTION / LIST
@@ -1203,19 +1203,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let symbols = client.option_list_symbols().await?;
+            let symbols = client.historical().option_list_symbols().await?;
         - lang: python
           label: Python
           source: |
-            symbols = client.option_list_symbols()
+            symbols = client.historical.option_list_symbols()
         - lang: go
           label: Go
           source: |
-            symbols, err := client.OptionListSymbols()
+            symbols, err := client.Historical().OptionListSymbols()
         - lang: cpp
           label: C++
           source: |
-            auto symbols = client.option_list_symbols();
+            auto symbols = client.historical().option_list_symbols();
 
   /option/list/dates:
     x-min-subscription: free
@@ -1238,19 +1238,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let dates = client.option_list_dates("TRADE", "SPY", "20240419", "500", "C").await?;
+            let dates = client.historical().option_list_dates("TRADE", "SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            dates = client.option_list_dates("TRADE", "SPY", "20240419", "500", "C")
+            dates = client.historical.option_list_dates("TRADE", "SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            dates, err := client.OptionListDates("TRADE", "SPY", "20240419", "500", "C")
+            dates, err := client.Historical().OptionListDates("TRADE", "SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto dates = client.option_list_dates("TRADE", "SPY", "20240419", "500", "C");
+            auto dates = client.historical().option_list_dates("TRADE", "SPY", "20240419", "500", "C");
 
   /option/list/expirations:
     x-min-subscription: free
@@ -1269,19 +1269,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let exps = client.option_list_expirations("SPY").await?;
+            let exps = client.historical().option_list_expirations("SPY").await?;
         - lang: python
           label: Python
           source: |
-            exps = client.option_list_expirations("SPY")
+            exps = client.historical.option_list_expirations("SPY")
         - lang: go
           label: Go
           source: |
-            exps, err := client.OptionListExpirations("SPY")
+            exps, err := client.Historical().OptionListExpirations("SPY")
         - lang: cpp
           label: C++
           source: |
-            auto exps = client.option_list_expirations("SPY");
+            auto exps = client.historical().option_list_expirations("SPY");
 
   /option/list/strikes:
     x-min-subscription: free
@@ -1308,19 +1308,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let strikes = client.option_list_strikes("SPY", "20240419").await?;
+            let strikes = client.historical().option_list_strikes("SPY", "20240419").await?;
         - lang: python
           label: Python
           source: |
-            strikes = client.option_list_strikes("SPY", "20240419")
+            strikes = client.historical.option_list_strikes("SPY", "20240419")
         - lang: go
           label: Go
           source: |
-            strikes, err := client.OptionListStrikes("SPY", "20240419")
+            strikes, err := client.Historical().OptionListStrikes("SPY", "20240419")
         - lang: cpp
           label: C++
           source: |
-            auto strikes = client.option_list_strikes("SPY", "20240419");
+            auto strikes = client.historical().option_list_strikes("SPY", "20240419");
 
   /option/list/contracts:
     x-min-subscription: free
@@ -1343,19 +1343,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let contracts = client.option_list_contracts("TRADE", "SPY", "20240315").await?;
+            let contracts = client.historical().option_list_contracts("TRADE", "SPY", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            contracts = client.option_list_contracts("TRADE", "SPY", "20240315")
+            contracts = client.historical.option_list_contracts("TRADE", "SPY", "20240315")
         - lang: go
           label: Go
           source: |
-            contracts, err := client.OptionListContracts("TRADE", "SPY", "20240315")
+            contracts, err := client.Historical().OptionListContracts("TRADE", "SPY", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto contracts = client.option_list_contracts("TRADE", "SPY", "20240315");
+            auto contracts = client.historical().option_list_contracts("TRADE", "SPY", "20240315");
 
   # =========================================================================
   # OPTION / SNAPSHOT
@@ -1384,19 +1384,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let ohlc = client.option_snapshot_ohlc("SPY", "20240419", "500", "C").await?;
+            let ohlc = client.historical().option_snapshot_ohlc("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            ohlc = client.option_snapshot_ohlc("SPY", "20240419", "500", "C")
+            ohlc = client.historical.option_snapshot_ohlc("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            ohlc, err := client.OptionSnapshotOHLC("SPY", "20240419", "500", "C")
+            ohlc, err := client.Historical().OptionSnapshotOHLC("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto ohlc = client.option_snapshot_ohlc("SPY", "20240419", "500", "C");
+            auto ohlc = client.historical().option_snapshot_ohlc("SPY", "20240419", "500", "C");
 
   /option/snapshot/trade:
     x-min-subscription: standard
@@ -1420,19 +1420,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let trades = client.option_snapshot_trade("SPY", "20240419", "500", "C").await?;
+            let trades = client.historical().option_snapshot_trade("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            trades = client.option_snapshot_trade("SPY", "20240419", "500", "C")
+            trades = client.historical.option_snapshot_trade("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            trades, err := client.OptionSnapshotTrade("SPY", "20240419", "500", "C")
+            trades, err := client.Historical().OptionSnapshotTrade("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto trades = client.option_snapshot_trade("SPY", "20240419", "500", "C");
+            auto trades = client.historical().option_snapshot_trade("SPY", "20240419", "500", "C");
 
   /option/snapshot/quote:
     x-min-subscription: value
@@ -1457,19 +1457,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let quotes = client.option_snapshot_quote("SPY", "20240419", "500", "C").await?;
+            let quotes = client.historical().option_snapshot_quote("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            quotes = client.option_snapshot_quote("SPY", "20240419", "500", "C")
+            quotes = client.historical.option_snapshot_quote("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            quotes, err := client.OptionSnapshotQuote("SPY", "20240419", "500", "C")
+            quotes, err := client.Historical().OptionSnapshotQuote("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto quotes = client.option_snapshot_quote("SPY", "20240419", "500", "C");
+            auto quotes = client.historical().option_snapshot_quote("SPY", "20240419", "500", "C");
 
   /option/snapshot/open_interest:
     x-min-subscription: value
@@ -1494,19 +1494,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let oi = client.option_snapshot_open_interest("SPY", "20240419", "500", "C").await?;
+            let oi = client.historical().option_snapshot_open_interest("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            oi = client.option_snapshot_open_interest("SPY", "20240419", "500", "C")
+            oi = client.historical.option_snapshot_open_interest("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            oi, err := client.OptionSnapshotOpenInterest("SPY", "20240419", "500", "C")
+            oi, err := client.Historical().OptionSnapshotOpenInterest("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto oi = client.option_snapshot_open_interest("SPY", "20240419", "500", "C");
+            auto oi = client.historical().option_snapshot_open_interest("SPY", "20240419", "500", "C");
 
   /option/snapshot/market_value:
     x-min-subscription: standard
@@ -1531,19 +1531,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let mv = client.option_snapshot_market_value("SPY", "20240419", "500", "C").await?;
+            let mv = client.historical().option_snapshot_market_value("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            mv = client.option_snapshot_market_value("SPY", "20240419", "500", "C")
+            mv = client.historical.option_snapshot_market_value("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            mv, err := client.OptionSnapshotMarketValue("SPY", "20240419", "500", "C")
+            mv, err := client.Historical().OptionSnapshotMarketValue("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto mv = client.option_snapshot_market_value("SPY", "20240419", "500", "C");
+            auto mv = client.historical().option_snapshot_market_value("SPY", "20240419", "500", "C");
 
   # =========================================================================
   # OPTION / SNAPSHOT GREEKS
@@ -1578,19 +1578,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let iv = client.option_snapshot_greeks_implied_volatility("SPY", "20240419", "500", "C").await?;
+            let iv = client.historical().option_snapshot_greeks_implied_volatility("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            iv = client.option_snapshot_greeks_implied_volatility("SPY", "20240419", "500", "C")
+            iv = client.historical.option_snapshot_greeks_implied_volatility("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            iv, err := client.OptionSnapshotGreeksIV("SPY", "20240419", "500", "C")
+            iv, err := client.Historical().OptionSnapshotGreeksIV("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto iv = client.option_snapshot_greeks_implied_volatility("SPY", "20240419", "500", "C");
+            auto iv = client.historical().option_snapshot_greeks_implied_volatility("SPY", "20240419", "500", "C");
 
   /option/snapshot/greeks/all:
     x-min-subscription: professional
@@ -1622,19 +1622,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let greeks = client.option_snapshot_greeks_all("SPY", "20240419", "500", "C").await?;
+            let greeks = client.historical().option_snapshot_greeks_all("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            greeks = client.option_snapshot_greeks_all("SPY", "20240419", "500", "C")
+            greeks = client.historical.option_snapshot_greeks_all("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            greeks, err := client.OptionSnapshotGreeksAll("SPY", "20240419", "500", "C")
+            greeks, err := client.Historical().OptionSnapshotGreeksAll("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto greeks = client.option_snapshot_greeks_all("SPY", "20240419", "500", "C");
+            auto greeks = client.historical().option_snapshot_greeks_all("SPY", "20240419", "500", "C");
 
   /option/snapshot/greeks/first_order:
     x-min-subscription: standard
@@ -1665,19 +1665,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g1 = client.option_snapshot_greeks_first_order("SPY", "20240419", "500", "C").await?;
+            let g1 = client.historical().option_snapshot_greeks_first_order("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            g1 = client.option_snapshot_greeks_first_order("SPY", "20240419", "500", "C")
+            g1 = client.historical.option_snapshot_greeks_first_order("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            g1, err := client.OptionSnapshotGreeksFirstOrder("SPY", "20240419", "500", "C")
+            g1, err := client.Historical().OptionSnapshotGreeksFirstOrder("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto g1 = client.option_snapshot_greeks_first_order("SPY", "20240419", "500", "C");
+            auto g1 = client.historical().option_snapshot_greeks_first_order("SPY", "20240419", "500", "C");
 
   /option/snapshot/greeks/second_order:
     x-min-subscription: professional
@@ -1708,19 +1708,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g2 = client.option_snapshot_greeks_second_order("SPY", "20240419", "500", "C").await?;
+            let g2 = client.historical().option_snapshot_greeks_second_order("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            g2 = client.option_snapshot_greeks_second_order("SPY", "20240419", "500", "C")
+            g2 = client.historical.option_snapshot_greeks_second_order("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            g2, err := client.OptionSnapshotGreeksSecondOrder("SPY", "20240419", "500", "C")
+            g2, err := client.Historical().OptionSnapshotGreeksSecondOrder("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto g2 = client.option_snapshot_greeks_second_order("SPY", "20240419", "500", "C");
+            auto g2 = client.historical().option_snapshot_greeks_second_order("SPY", "20240419", "500", "C");
 
   /option/snapshot/greeks/third_order:
     x-min-subscription: professional
@@ -1751,19 +1751,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g3 = client.option_snapshot_greeks_third_order("SPY", "20240419", "500", "C").await?;
+            let g3 = client.historical().option_snapshot_greeks_third_order("SPY", "20240419", "500", "C").await?;
         - lang: python
           label: Python
           source: |
-            g3 = client.option_snapshot_greeks_third_order("SPY", "20240419", "500", "C")
+            g3 = client.historical.option_snapshot_greeks_third_order("SPY", "20240419", "500", "C")
         - lang: go
           label: Go
           source: |
-            g3, err := client.OptionSnapshotGreeksThirdOrder("SPY", "20240419", "500", "C")
+            g3, err := client.Historical().OptionSnapshotGreeksThirdOrder("SPY", "20240419", "500", "C")
         - lang: cpp
           label: C++
           source: |
-            auto g3 = client.option_snapshot_greeks_third_order("SPY", "20240419", "500", "C");
+            auto g3 = client.historical().option_snapshot_greeks_third_order("SPY", "20240419", "500", "C");
 
   # =========================================================================
   # OPTION / HISTORY
@@ -1793,20 +1793,20 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let eod = client.option_history_eod("SPY", "20240419", "500", "C", "20240101", "20240301").await?;
+            let eod = client.historical().option_history_eod("SPY", "20240419", "500", "C", "20240101", "20240301").await?;
         - lang: python
           label: Python
           source: |
-            eod = client.option_history_eod("SPY", "20240419", "500", "C", "20240101", "20240301")
-            df = client.option_history_eod_df("SPY", "20240419", "500", "C", "20240101", "20240301")
+            eod = client.historical.option_history_eod("SPY", "20240419", "500", "C", "20240101", "20240301")
+            df = client.historical.option_history_eod("SPY", "20240419", "500", "C", "20240101", "20240301").to_pandas()
         - lang: go
           label: Go
           source: |
-            eod, err := client.OptionHistoryEOD("SPY", "20240419", "500", "C", "20240101", "20240301")
+            eod, err := client.Historical().OptionHistoryEOD("SPY", "20240419", "500", "C", "20240101", "20240301")
         - lang: cpp
           label: C++
           source: |
-            auto eod = client.option_history_eod("SPY", "20240419", "500", "C", "20240101", "20240301");
+            auto eod = client.historical().option_history_eod("SPY", "20240419", "500", "C", "20240101", "20240301");
 
   /option/history/ohlc:
     x-min-subscription: value
@@ -1845,19 +1845,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let bars = client.option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let bars = client.historical().option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            bars = client.option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000")
+            bars = client.historical.option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            bars, err := client.OptionHistoryOHLC("SPY", "20240419", "500", "C", "20240315", "60000")
+            bars, err := client.Historical().OptionHistoryOHLC("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto bars = client.option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto bars = client.historical().option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000");
 
   /option/history/trade:
     x-min-subscription: standard
@@ -1896,19 +1896,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let trades = client.option_history_trade("SPY", "20240419", "500", "C", "20240315").await?;
+            let trades = client.historical().option_history_trade("SPY", "20240419", "500", "C", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            trades = client.option_history_trade("SPY", "20240419", "500", "C", "20240315")
+            trades = client.historical.option_history_trade("SPY", "20240419", "500", "C", "20240315")
         - lang: go
           label: Go
           source: |
-            trades, err := client.OptionHistoryTrade("SPY", "20240419", "500", "C", "20240315")
+            trades, err := client.Historical().OptionHistoryTrade("SPY", "20240419", "500", "C", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto trades = client.option_history_trade("SPY", "20240419", "500", "C", "20240315");
+            auto trades = client.historical().option_history_trade("SPY", "20240419", "500", "C", "20240315");
   /option/history/quote:
     x-min-subscription: value
     get:
@@ -1947,19 +1947,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let quotes = client.option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let quotes = client.historical().option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            quotes = client.option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000")
+            quotes = client.historical.option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            quotes, err := client.OptionHistoryQuote("SPY", "20240419", "500", "C", "20240315", "60000")
+            quotes, err := client.Historical().OptionHistoryQuote("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto quotes = client.option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto quotes = client.historical().option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000");
   /option/history/trade_quote:
     x-min-subscription: standard
     get:
@@ -1998,19 +1998,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let tq = client.option_history_trade_quote("SPY", "20240419", "500", "C", "20240315").await?;
+            let tq = client.historical().option_history_trade_quote("SPY", "20240419", "500", "C", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            tq = client.option_history_trade_quote("SPY", "20240419", "500", "C", "20240315")
+            tq = client.historical.option_history_trade_quote("SPY", "20240419", "500", "C", "20240315")
         - lang: go
           label: Go
           source: |
-            tq, err := client.OptionHistoryTradeQuote("SPY", "20240419", "500", "C", "20240315")
+            tq, err := client.Historical().OptionHistoryTradeQuote("SPY", "20240419", "500", "C", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto tq = client.option_history_trade_quote("SPY", "20240419", "500", "C", "20240315");
+            auto tq = client.historical().option_history_trade_quote("SPY", "20240419", "500", "C", "20240315");
 
   /option/history/open_interest:
     x-min-subscription: value
@@ -2047,19 +2047,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let oi = client.option_history_open_interest("SPY", "20240419", "500", "C", "20240315").await?;
+            let oi = client.historical().option_history_open_interest("SPY", "20240419", "500", "C", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            oi = client.option_history_open_interest("SPY", "20240419", "500", "C", "20240315")
+            oi = client.historical.option_history_open_interest("SPY", "20240419", "500", "C", "20240315")
         - lang: go
           label: Go
           source: |
-            oi, err := client.OptionHistoryOpenInterest("SPY", "20240419", "500", "C", "20240315")
+            oi, err := client.Historical().OptionHistoryOpenInterest("SPY", "20240419", "500", "C", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto oi = client.option_history_open_interest("SPY", "20240419", "500", "C", "20240315");
+            auto oi = client.historical().option_history_open_interest("SPY", "20240419", "500", "C", "20240315");
 
   # =========================================================================
   # OPTION / HISTORY GREEKS
@@ -2094,19 +2094,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let greeks = client.option_history_greeks_eod("SPY", "20240419", "500", "C", "20240101", "20240301").await?;
+            let greeks = client.historical().option_history_greeks_eod("SPY", "20240419", "500", "C", "20240101", "20240301").await?;
         - lang: python
           label: Python
           source: |
-            greeks = client.option_history_greeks_eod("SPY", "20240419", "500", "C", "20240101", "20240301")
+            greeks = client.historical.option_history_greeks_eod("SPY", "20240419", "500", "C", "20240101", "20240301")
         - lang: go
           label: Go
           source: |
-            greeks, err := client.OptionHistoryGreeksEOD("SPY", "20240419", "500", "C", "20240101", "20240301")
+            greeks, err := client.Historical().OptionHistoryGreeksEOD("SPY", "20240419", "500", "C", "20240101", "20240301")
         - lang: cpp
           label: C++
           source: |
-            auto greeks = client.option_history_greeks_eod("SPY", "20240419", "500", "C", "20240101", "20240301");
+            auto greeks = client.historical().option_history_greeks_eod("SPY", "20240419", "500", "C", "20240101", "20240301");
 
   /option/history/greeks/all:
     x-min-subscription: professional
@@ -2149,19 +2149,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let greeks = client.option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let greeks = client.historical().option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            greeks = client.option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000")
+            greeks = client.historical.option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            greeks, err := client.OptionHistoryGreeksAll("SPY", "20240419", "500", "C", "20240315", "60000")
+            greeks, err := client.Historical().OptionHistoryGreeksAll("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto greeks = client.option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto greeks = client.historical().option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000");
 
   /option/history/greeks/first_order:
     x-min-subscription: standard
@@ -2204,19 +2204,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g1 = client.option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let g1 = client.historical().option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            g1 = client.option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000")
+            g1 = client.historical.option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            g1, err := client.OptionHistoryGreeksFirstOrder("SPY", "20240419", "500", "C", "20240315", "60000")
+            g1, err := client.Historical().OptionHistoryGreeksFirstOrder("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto g1 = client.option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto g1 = client.historical().option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000");
 
   /option/history/greeks/second_order:
     x-min-subscription: professional
@@ -2259,19 +2259,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g2 = client.option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let g2 = client.historical().option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            g2 = client.option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000")
+            g2 = client.historical.option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            g2, err := client.OptionHistoryGreeksSecondOrder("SPY", "20240419", "500", "C", "20240315", "60000")
+            g2, err := client.Historical().OptionHistoryGreeksSecondOrder("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto g2 = client.option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto g2 = client.historical().option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000");
 
   /option/history/greeks/third_order:
     x-min-subscription: professional
@@ -2314,19 +2314,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let g3 = client.option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let g3 = client.historical().option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            g3 = client.option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000")
+            g3 = client.historical.option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            g3, err := client.OptionHistoryGreeksThirdOrder("SPY", "20240419", "500", "C", "20240315", "60000")
+            g3, err := client.Historical().OptionHistoryGreeksThirdOrder("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto g3 = client.option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto g3 = client.historical().option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000");
 
   /option/history/greeks/implied_volatility:
     x-min-subscription: standard
@@ -2369,19 +2369,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let iv = client.option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000").await?;
+            let iv = client.historical().option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            iv = client.option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000")
+            iv = client.historical.option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            iv, err := client.OptionHistoryGreeksImpliedVolatility("SPY", "20240419", "500", "C", "20240315", "60000")
+            iv, err := client.Historical().OptionHistoryGreeksImpliedVolatility("SPY", "20240419", "500", "C", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto iv = client.option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000");
+            auto iv = client.historical().option_history_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315", "60000");
 
   # =========================================================================
   # OPTION / HISTORY TRADE GREEKS
@@ -2428,19 +2428,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let tg = client.option_history_trade_greeks_all("SPY", "20240419", "500", "C", "20240315").await?;
+            let tg = client.historical().option_history_trade_greeks_all("SPY", "20240419", "500", "C", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            tg = client.option_history_trade_greeks_all("SPY", "20240419", "500", "C", "20240315")
+            tg = client.historical.option_history_trade_greeks_all("SPY", "20240419", "500", "C", "20240315")
         - lang: go
           label: Go
           source: |
-            tg, err := client.OptionHistoryTradeGreeksAll("SPY", "20240419", "500", "C", "20240315")
+            tg, err := client.Historical().OptionHistoryTradeGreeksAll("SPY", "20240419", "500", "C", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto tg = client.option_history_trade_greeks_all("SPY", "20240419", "500", "C", "20240315");
+            auto tg = client.historical().option_history_trade_greeks_all("SPY", "20240419", "500", "C", "20240315");
 
   /option/history/trade_greeks/first_order:
     x-min-subscription: professional
@@ -2483,19 +2483,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let tg1 = client.option_history_trade_greeks_first_order("SPY", "20240419", "500", "C", "20240315").await?;
+            let tg1 = client.historical().option_history_trade_greeks_first_order("SPY", "20240419", "500", "C", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            tg1 = client.option_history_trade_greeks_first_order("SPY", "20240419", "500", "C", "20240315")
+            tg1 = client.historical.option_history_trade_greeks_first_order("SPY", "20240419", "500", "C", "20240315")
         - lang: go
           label: Go
           source: |
-            tg1, err := client.OptionHistoryTradeGreeksFirstOrder("SPY", "20240419", "500", "C", "20240315")
+            tg1, err := client.Historical().OptionHistoryTradeGreeksFirstOrder("SPY", "20240419", "500", "C", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto tg1 = client.option_history_trade_greeks_first_order("SPY", "20240419", "500", "C", "20240315");
+            auto tg1 = client.historical().option_history_trade_greeks_first_order("SPY", "20240419", "500", "C", "20240315");
 
   /option/history/trade_greeks/second_order:
     x-min-subscription: professional
@@ -2538,19 +2538,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let tg2 = client.option_history_trade_greeks_second_order("SPY", "20240419", "500", "C", "20240315").await?;
+            let tg2 = client.historical().option_history_trade_greeks_second_order("SPY", "20240419", "500", "C", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            tg2 = client.option_history_trade_greeks_second_order("SPY", "20240419", "500", "C", "20240315")
+            tg2 = client.historical.option_history_trade_greeks_second_order("SPY", "20240419", "500", "C", "20240315")
         - lang: go
           label: Go
           source: |
-            tg2, err := client.OptionHistoryTradeGreeksSecondOrder("SPY", "20240419", "500", "C", "20240315")
+            tg2, err := client.Historical().OptionHistoryTradeGreeksSecondOrder("SPY", "20240419", "500", "C", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto tg2 = client.option_history_trade_greeks_second_order("SPY", "20240419", "500", "C", "20240315");
+            auto tg2 = client.historical().option_history_trade_greeks_second_order("SPY", "20240419", "500", "C", "20240315");
 
   /option/history/trade_greeks/third_order:
     x-min-subscription: professional
@@ -2593,19 +2593,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let tg3 = client.option_history_trade_greeks_third_order("SPY", "20240419", "500", "C", "20240315").await?;
+            let tg3 = client.historical().option_history_trade_greeks_third_order("SPY", "20240419", "500", "C", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            tg3 = client.option_history_trade_greeks_third_order("SPY", "20240419", "500", "C", "20240315")
+            tg3 = client.historical.option_history_trade_greeks_third_order("SPY", "20240419", "500", "C", "20240315")
         - lang: go
           label: Go
           source: |
-            tg3, err := client.OptionHistoryTradeGreeksThirdOrder("SPY", "20240419", "500", "C", "20240315")
+            tg3, err := client.Historical().OptionHistoryTradeGreeksThirdOrder("SPY", "20240419", "500", "C", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto tg3 = client.option_history_trade_greeks_third_order("SPY", "20240419", "500", "C", "20240315");
+            auto tg3 = client.historical().option_history_trade_greeks_third_order("SPY", "20240419", "500", "C", "20240315");
 
   /option/history/trade_greeks/implied_volatility:
     x-min-subscription: professional
@@ -2648,19 +2648,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let tiv = client.option_history_trade_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315").await?;
+            let tiv = client.historical().option_history_trade_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315").await?;
         - lang: python
           label: Python
           source: |
-            tiv = client.option_history_trade_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315")
+            tiv = client.historical.option_history_trade_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315")
         - lang: go
           label: Go
           source: |
-            tiv, err := client.OptionHistoryTradeGreeksImpliedVolatility("SPY", "20240419", "500", "C", "20240315")
+            tiv, err := client.Historical().OptionHistoryTradeGreeksImpliedVolatility("SPY", "20240419", "500", "C", "20240315")
         - lang: cpp
           label: C++
           source: |
-            auto tiv = client.option_history_trade_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315");
+            auto tiv = client.historical().option_history_trade_greeks_implied_volatility("SPY", "20240419", "500", "C", "20240315");
 
   # =========================================================================
   # OPTION / AT-TIME
@@ -2691,19 +2691,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let trades = client.option_at_time_trade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000").await?;
+            let trades = client.historical().option_at_time_trade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000").await?;
         - lang: python
           label: Python
           source: |
-            trades = client.option_at_time_trade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000")
+            trades = client.historical.option_at_time_trade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000")
         - lang: go
           label: Go
           source: |
-            trades, err := client.OptionAtTimeTrade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000")
+            trades, err := client.Historical().OptionAtTimeTrade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000")
         - lang: cpp
           label: C++
           source: |
-            auto trades = client.option_at_time_trade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000");
+            auto trades = client.historical().option_at_time_trade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000");
 
   /option/at_time/quote:
     x-min-subscription: value
@@ -2730,19 +2730,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let quotes = client.option_at_time_quote("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000").await?;
+            let quotes = client.historical().option_at_time_quote("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000").await?;
         - lang: python
           label: Python
           source: |
-            quotes = client.option_at_time_quote("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000")
+            quotes = client.historical.option_at_time_quote("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000")
         - lang: go
           label: Go
           source: |
-            quotes, err := client.OptionAtTimeQuote("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000")
+            quotes, err := client.Historical().OptionAtTimeQuote("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000")
         - lang: cpp
           label: C++
           source: |
-            auto quotes = client.option_at_time_quote("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000");
+            auto quotes = client.historical().option_at_time_quote("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000");
 
   # =========================================================================
   # INDEX / LIST
@@ -2764,19 +2764,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let symbols = client.index_list_symbols().await?;
+            let symbols = client.historical().index_list_symbols().await?;
         - lang: python
           label: Python
           source: |
-            symbols = client.index_list_symbols()
+            symbols = client.historical.index_list_symbols()
         - lang: go
           label: Go
           source: |
-            symbols, err := client.IndexListSymbols()
+            symbols, err := client.Historical().IndexListSymbols()
         - lang: cpp
           label: C++
           source: |
-            auto symbols = client.index_list_symbols();
+            auto symbols = client.historical().index_list_symbols();
 
   /index/list/dates:
     x-min-subscription: free
@@ -2795,19 +2795,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let dates = client.index_list_dates("SPX").await?;
+            let dates = client.historical().index_list_dates("SPX").await?;
         - lang: python
           label: Python
           source: |
-            dates = client.index_list_dates("SPX")
+            dates = client.historical.index_list_dates("SPX")
         - lang: go
           label: Go
           source: |
-            dates, err := client.IndexListDates("SPX")
+            dates, err := client.Historical().IndexListDates("SPX")
         - lang: cpp
           label: C++
           source: |
-            auto dates = client.index_list_dates("SPX");
+            auto dates = client.historical().index_list_dates("SPX");
 
   # =========================================================================
   # INDEX / SNAPSHOT
@@ -2831,19 +2831,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let ohlc = client.index_snapshot_ohlc(&["SPX"]).await?;
+            let ohlc = client.historical().index_snapshot_ohlc(&["SPX"]).await?;
         - lang: python
           label: Python
           source: |
-            ohlc = client.index_snapshot_ohlc(["SPX"])
+            ohlc = client.historical.index_snapshot_ohlc(["SPX"])
         - lang: go
           label: Go
           source: |
-            ohlc, err := client.IndexSnapshotOHLC([]string{"SPX"})
+            ohlc, err := client.Historical().IndexSnapshotOHLC([]string{"SPX"})
         - lang: cpp
           label: C++
           source: |
-            auto ohlc = client.index_snapshot_ohlc({"SPX"});
+            auto ohlc = client.historical().index_snapshot_ohlc({"SPX"});
 
   /index/snapshot/price:
     x-min-subscription: standard
@@ -2863,19 +2863,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let price = client.index_snapshot_price(&["SPX"]).await?;
+            let price = client.historical().index_snapshot_price(&["SPX"]).await?;
         - lang: python
           label: Python
           source: |
-            price = client.index_snapshot_price(["SPX"])
+            price = client.historical.index_snapshot_price(["SPX"])
         - lang: go
           label: Go
           source: |
-            price, err := client.IndexSnapshotPrice([]string{"SPX"})
+            price, err := client.Historical().IndexSnapshotPrice([]string{"SPX"})
         - lang: cpp
           label: C++
           source: |
-            auto price = client.index_snapshot_price({"SPX"});
+            auto price = client.historical().index_snapshot_price({"SPX"});
 
   /index/snapshot/market_value:
     x-min-subscription: standard
@@ -2895,19 +2895,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let mv = client.index_snapshot_market_value(&["SPX"]).await?;
+            let mv = client.historical().index_snapshot_market_value(&["SPX"]).await?;
         - lang: python
           label: Python
           source: |
-            mv = client.index_snapshot_market_value(["SPX"])
+            mv = client.historical.index_snapshot_market_value(["SPX"])
         - lang: go
           label: Go
           source: |
-            mv, err := client.IndexSnapshotMarketValue([]string{"SPX"})
+            mv, err := client.Historical().IndexSnapshotMarketValue([]string{"SPX"})
         - lang: cpp
           label: C++
           source: |
-            auto mv = client.index_snapshot_market_value({"SPX"});
+            auto mv = client.historical().index_snapshot_market_value({"SPX"});
 
   # =========================================================================
   # INDEX / HISTORY
@@ -2932,19 +2932,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let eod = client.index_history_eod("SPX", "20240101", "20240301").await?;
+            let eod = client.historical().index_history_eod("SPX", "20240101", "20240301").await?;
         - lang: python
           label: Python
           source: |
-            eod = client.index_history_eod("SPX", "20240101", "20240301")
+            eod = client.historical.index_history_eod("SPX", "20240101", "20240301")
         - lang: go
           label: Go
           source: |
-            eod, err := client.IndexHistoryEOD("SPX", "20240101", "20240301")
+            eod, err := client.Historical().IndexHistoryEOD("SPX", "20240101", "20240301")
         - lang: cpp
           label: C++
           source: |
-            auto eod = client.index_history_eod("SPX", "20240101", "20240301");
+            auto eod = client.historical().index_history_eod("SPX", "20240101", "20240301");
 
   /index/history/ohlc:
     x-min-subscription: standard
@@ -2968,19 +2968,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let bars = client.index_history_ohlc("SPX", "20240101", "20240301", "60000").await?;
+            let bars = client.historical().index_history_ohlc("SPX", "20240101", "20240301", "60000").await?;
         - lang: python
           label: Python
           source: |
-            bars = client.index_history_ohlc("SPX", "20240101", "20240301", "60000")
+            bars = client.historical.index_history_ohlc("SPX", "20240101", "20240301", "60000")
         - lang: go
           label: Go
           source: |
-            bars, err := client.IndexHistoryOHLC("SPX", "20240101", "20240301", "60000")
+            bars, err := client.Historical().IndexHistoryOHLC("SPX", "20240101", "20240301", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto bars = client.index_history_ohlc("SPX", "20240101", "20240301", "60000");
+            auto bars = client.historical().index_history_ohlc("SPX", "20240101", "20240301", "60000");
 
   /index/history/price:
     x-min-subscription: value
@@ -3015,19 +3015,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let prices = client.index_history_price("SPX", "20240315", "60000").await?;
+            let prices = client.historical().index_history_price("SPX", "20240315", "60000").await?;
         - lang: python
           label: Python
           source: |
-            prices = client.index_history_price("SPX", "20240315", "60000")
+            prices = client.historical.index_history_price("SPX", "20240315", "60000")
         - lang: go
           label: Go
           source: |
-            prices, err := client.IndexHistoryPrice("SPX", "20240315", "60000")
+            prices, err := client.Historical().IndexHistoryPrice("SPX", "20240315", "60000")
         - lang: cpp
           label: C++
           source: |
-            auto prices = client.index_history_price("SPX", "20240315", "60000");
+            auto prices = client.historical().index_history_price("SPX", "20240315", "60000");
 
   # =========================================================================
   # INDEX / AT-TIME
@@ -3053,19 +3053,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let prices = client.index_at_time_price("SPX", "20240101", "20240301", "09:30:00.000").await?;
+            let prices = client.historical().index_at_time_price("SPX", "20240101", "20240301", "09:30:00.000").await?;
         - lang: python
           label: Python
           source: |
-            prices = client.index_at_time_price("SPX", "20240101", "20240301", "09:30:00.000")
+            prices = client.historical.index_at_time_price("SPX", "20240101", "20240301", "09:30:00.000")
         - lang: go
           label: Go
           source: |
-            prices, err := client.IndexAtTimePrice("SPX", "20240101", "20240301", "09:30:00.000")
+            prices, err := client.Historical().IndexAtTimePrice("SPX", "20240101", "20240301", "09:30:00.000")
         - lang: cpp
           label: C++
           source: |
-            auto prices = client.index_at_time_price("SPX", "20240101", "20240301", "09:30:00.000");
+            auto prices = client.historical().index_at_time_price("SPX", "20240101", "20240301", "09:30:00.000");
 
   # =========================================================================
   # CALENDAR
@@ -3087,19 +3087,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let open = client.calendar_open_today().await?;
+            let open = client.historical().calendar_open_today().await?;
         - lang: python
           label: Python
           source: |
-            open = client.calendar_open_today()
+            open = client.historical.calendar_open_today()
         - lang: go
           label: Go
           source: |
-            open, err := client.CalendarOpenToday()
+            open, err := client.Historical().CalendarOpenToday()
         - lang: cpp
           label: C++
           source: |
-            auto open = client.calendar_open_today();
+            auto open = client.historical().calendar_open_today();
 
   /calendar/on_date:
     x-min-subscription: free
@@ -3118,19 +3118,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let cal = client.calendar_on_date("20240315").await?;
+            let cal = client.historical().calendar_on_date("20240315").await?;
         - lang: python
           label: Python
           source: |
-            cal = client.calendar_on_date("20240315")
+            cal = client.historical.calendar_on_date("20240315")
         - lang: go
           label: Go
           source: |
-            cal, err := client.CalendarOnDate("20240315")
+            cal, err := client.Historical().CalendarOnDate("20240315")
         - lang: cpp
           label: C++
           source: |
-            auto cal = client.calendar_on_date("20240315");
+            auto cal = client.historical().calendar_on_date("20240315");
 
   /calendar/year:
     x-min-subscription: free
@@ -3155,19 +3155,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let cal = client.calendar_year("2024").await?;
+            let cal = client.historical().calendar_year("2024").await?;
         - lang: python
           label: Python
           source: |
-            cal = client.calendar_year("2024")
+            cal = client.historical.calendar_year("2024")
         - lang: go
           label: Go
           source: |
-            cal, err := client.CalendarYear("2024")
+            cal, err := client.Historical().CalendarYear("2024")
         - lang: cpp
           label: C++
           source: |
-            auto cal = client.calendar_year("2024");
+            auto cal = client.historical().calendar_year("2024");
 
   # =========================================================================
   # INTEREST RATE
@@ -3192,19 +3192,19 @@ paths:
         - lang: rust
           label: Rust
           source: |
-            let rates = client.interest_rate_history_eod("SOFR", "20240101", "20240301").await?;
+            let rates = client.historical().interest_rate_history_eod("SOFR", "20240101", "20240301").await?;
         - lang: python
           label: Python
           source: |
-            rates = client.interest_rate_history_eod("SOFR", "20240101", "20240301")
+            rates = client.historical.interest_rate_history_eod("SOFR", "20240101", "20240301")
         - lang: go
           label: Go
           source: |
-            rates, err := client.InterestRateHistoryEOD("SOFR", "20240101", "20240301")
+            rates, err := client.Historical().InterestRateHistoryEOD("SOFR", "20240101", "20240301")
         - lang: cpp
           label: C++
           source: |
-            auto rates = client.interest_rate_history_eod("SOFR", "20240101", "20240301");
+            auto rates = client.historical().interest_rate_history_eod("SOFR", "20240101", "20240301");
 
   /v3/system/shutdown:
     post:

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -88,7 +88,7 @@ creds = Credentials.from_file("creds.txt")
 client = Client(creds, Config.production())
 
 # Historical data
-eod = client.stock_history_eod("AAPL", "20240101", "20240315")
+eod = client.historical.stock_history_eod("AAPL", "20240101", "20240315")
 
 # Greeks
 g = all_greeks(spot=150.0, strike=155.0, rate=0.05,
@@ -116,7 +116,7 @@ import { Client } from 'thetadatadx';
 
 const client = await Client.connectFromFile('creds.txt');
 
-const eod = client.stockHistoryEOD('AAPL', '20240101', '20240315');
+const eod = client.historical.stockHistoryEOD('AAPL', '20240101', '20240315');
 ```
 
 Requires Node.js 18+. See [sdks/typescript/README.md](typescript/README.md) for full documentation.


### PR DESCRIPTION
The public OpenAPI cookbook and the SDK quickstart showed the unified client calling historical methods directly on the client, which no longer matches the surface. The unified client reaches historical queries through a historical sub-namespace and real-time data through a stream sub-namespace.

Every cookbook example now uses the correct receiver: client.historical().<method>(...) in Rust, C++, and Go, and client.historical.<method>(...) in Python. The standalone HistoricalClient and StreamingClient examples keep their flat calls, which is the correct surface for those entry points and was left untouched.

The Python DataFrame example previously referenced option_history_eod_df, a method that exists on no binding. There are no per-endpoint _df / _arrow / _polars wrappers; DataFrame output is a terminal chained off the typed result. The example now reads client.historical.option_history_eod(...).to_pandas().

Every method name emitted in the cookbook maps to a real generated endpoint on the historical surface. A sweep of the public docs and current READMEs finds zero unified-client flat historical or stream calls and zero method names that do not exist. The generated reference tree was not hand-edited; generate_docs_site --check and generate_sdk_surfaces --check stay clean, as do check_docs_consistency.py and check_binding_parity.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)