### PR TITLE
fix(ci): emit the TS shape manifest from the sub-namespace views

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,7 +425,7 @@ jobs:
               target/release/thetadatadx_ffi.dll.lib
     runs-on: ${{ matrix.os }}
     needs: check
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust-deps

--- a/sdks/typescript/scripts/emit_validator_manifest.mjs
+++ b/sdks/typescript/scripts/emit_validator_manifest.mjs
@@ -131,7 +131,12 @@ function parseMethods(source) {
   let depth = 0;
   for (let i = 0; i < lines.length; i++) {
     const trimmed = lines[i].trim();
-    if (trimmed.startsWith('export declare class Client')) {
+    // The unified client exposes historical/stream methods through the
+    // `historical` / `stream` sub-namespace views, so the projected
+    // methods live on `HistoricalView` / `StreamView` rather than flat on
+    // `Client`. Scope the parse to all three (exact match excludes the
+    // standalone `HistoricalClient` / `StreamingClient`).
+    if (/^export declare class (Client|HistoricalView|StreamView)\b/.test(trimmed)) {
       inClass = true;
       depth = 1;
       continue;


### PR DESCRIPTION
The `Build (x86_64-unknown-linux-gnu)` job's "Emit TypeScript shape manifest" step failed with `no records emitted; did the index.d.ts shape change?` — `emit_validator_manifest.mjs` scoped its method parse to the unified `Client` class, but the historical/streaming methods now live on the `HistoricalView`/`StreamView` classes that `client.historical`/`client.stream` return, so it matched none of the projected methods. This scopes the parse to `Client`, `HistoricalView`, and `StreamView` (exact match, excluding the standalone `HistoricalClient`/`StreamingClient`); the emitter now produces all 8 records again.

Also folds in the Windows FFI build timeout bump (45→75) — supersedes #781, which was blocked by this same Build failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)