### PR TITLE
fix(mcp): map invalid-parameter faults to the JSON-RPC invalid-params code

### DIFF
--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -172,8 +172,8 @@ Whole-universe daily snapshots for one `(security type, request type, date)` at 
 use thetadatadx::flatfiles::{FlatFileFormat, ReqType, SecType};
 
 let path = thetadatadx::flatfile_request(
-    &creds, SecType::Option, ReqType::Quote, "20260428",
-    std::path::Path::new("/tmp/option-quote"), FlatFileFormat::Csv,
+    &creds, SecType::Option, ReqType::TradeQuote, "20260428",
+    std::path::Path::new("/tmp/option-trade-quote"), FlatFileFormat::Csv,
 ).await?;
 ```
 

--- a/docs-site/docs/articles/flat-files.md
+++ b/docs-site/docs/articles/flat-files.md
@@ -60,7 +60,7 @@ auto ipc = rows.to_arrow_ipc();  // std::vector<uint8_t>
 <template #http>
 
 ```bash
-curl 'http://127.0.0.1:25503/v3/flatfile/option/trade_quote?date=2025-03-03&format=csv' -o trade_quotes.csv
+curl 'http://127.0.0.1:25503/v3/flatfile/option/trade_quote?date=20250303&format=csv' -o trade_quotes.csv
 ```
 
 The server streams the response body in chunks, so downloads of any size run in bounded memory. The same surface is available from the CLI: `thetadatadx flatfile trade_quote 20250303 --format csv -o trade_quotes.csv`.
@@ -71,7 +71,7 @@ The server streams the response body in chunks, so downloads of any size run in 
 
 ## Size guidance
 
-Flat files are large — a whole-universe option-quote day commonly exceeds 100 MB and tens of millions of rows.
+Flat files are large — a whole-universe option `trade_quote` day commonly exceeds 100 MB and tens of millions of rows.
 
 - The decoded-rows path materializes everything in memory before returning; reserve it for machines with headroom.
 - The to-disk path (`flatfile_to_path`, the HTTP route, the CLI) keeps peak memory bounded and is the right default for ETL.

--- a/docs-site/docs/server/http.md
+++ b/docs-site/docs/server/http.md
@@ -51,12 +51,12 @@ Failures use one envelope shape across every route — see the [error codes tabl
 Whole-universe daily archives stream through dedicated routes with chunked bodies (bounded server memory at any download size):
 
 ```bash
-curl 'http://127.0.0.1:25503/v3/flatfile/option/quote?date=2025-03-03&format=csv' -o quotes.csv
+curl 'http://127.0.0.1:25503/v3/flatfile/option/trade_quote?date=20250303&format=csv' -o trade_quotes.csv
 
 curl -X POST 'http://127.0.0.1:25503/v3/flatfile/request' \
     -H 'Content-Type: application/json' \
-    -d '{"sec_type":"OPTION","req_type":"QUOTE","date":"20250303","format":"csv"}' \
-    -o quotes.csv
+    -d '{"sec_type":"OPTION","req_type":"TRADE_QUOTE","date":"20250303","format":"csv"}' \
+    -o trade_quotes.csv
 ```
 
 See [Flat Files](/articles/flat-files) for sizing guidance.

--- a/tools/mcp/src/flatfile_tools.rs
+++ b/tools/mcp/src/flatfile_tools.rs
@@ -258,8 +258,74 @@ pub(crate) async fn try_execute_flatfile_tool(
             "format": format.extension(),
             "date": date,
         })),
-        Err(e) => Err(ToolError::ServerError(crate::sanitize_error(
-            &e.to_string(),
-        ))),
+        Err(e) => Err(classify_core_error(&e)),
     })
+}
+
+/// Map a core [`thetadatadx::Error`] onto the JSON-RPC error taxonomy.
+///
+/// An unserved `(sec_type, req_type)` pair fails the SDK's local dataset
+/// gate with a typed invalid-parameter error before any upstream call —
+/// that is a client request fault (`-32602` Invalid params), not a
+/// server-side outage (`-32000` Server error). This mirrors the REST
+/// `400` and C-ABI `TDX_ERR_INVALID_PARAMETER` mappings: any core error
+/// whose kind reports [`is_invalid_parameter`](thetadatadx::ConfigErrorKind::is_invalid_parameter)
+/// routes to Invalid params, generically — never keyed on the tool name.
+fn classify_core_error(e: &thetadatadx::Error) -> ToolError {
+    let message = crate::sanitize_error(&e.to_string());
+    if matches!(
+        e,
+        thetadatadx::Error::Config { kind, .. } if kind.is_invalid_parameter()
+    ) {
+        ToolError::InvalidParams(message)
+    } else {
+        ToolError::ServerError(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An unserved (sec_type, req_type) flat-file pair — e.g. option
+    /// quote — is rejected by the core dataset gate with the same typed
+    /// invalid-parameter error reproduced here. It must surface through
+    /// the MCP tool dispatch as `-32602` Invalid params (via
+    /// `ToolError::InvalidParams`), mirroring the REST 400, not `-32000`
+    /// Server error.
+    #[test]
+    fn unserved_pair_maps_to_invalid_params() {
+        // Byte-for-byte the error the core dataset gate raises for an
+        // unserved pair (see flatfiles::request::validate_dataset).
+        let err = thetadatadx::Error::config_invalid(
+            "flatfiles.dataset",
+            "flat-file service does not serve option quote",
+        );
+        let thetadatadx::Error::Config { kind, .. } = &err else {
+            panic!("config_invalid must build an Error::Config");
+        };
+        assert!(
+            kind.is_invalid_parameter(),
+            "the unserved-pair error must classify as invalid-parameter"
+        );
+        assert!(
+            matches!(classify_core_error(&err), ToolError::InvalidParams(_)),
+            "MCP dispatch must route an invalid-parameter core error to -32602 Invalid params"
+        );
+    }
+
+    /// A genuine upstream/server fault carries no invalid-parameter
+    /// classification and must stay on `-32000` Server error.
+    #[test]
+    fn server_fault_maps_to_server_error() {
+        let err = thetadatadx::Error::config_internal("flatfiles: decode task panicked");
+        let thetadatadx::Error::Config { kind, .. } = &err else {
+            panic!("config_internal must build an Error::Config");
+        };
+        assert!(!kind.is_invalid_parameter());
+        assert!(matches!(
+            classify_core_error(&err),
+            ToolError::ServerError(_)
+        ));
+    }
 }


### PR DESCRIPTION
The generic flat-file MCP tool wrapped every core error as a ServerError, which the JSON-RPC dispatch boundary emitted as code -32000 (Server error). An unserved (sec_type, req_type) pair — for example option quote — is rejected by the core dataset gate with a typed invalid-parameter error before any upstream call, so it is a client request fault, not a server-side outage. The REST path already maps that classification to HTTP 400 and the C ABI maps it to TDX_ERR_INVALID_PARAMETER; the MCP path now mirrors them.

A new classify_core_error helper routes any core error whose kind reports is_invalid_parameter() to ToolError::InvalidParams (-32602 Invalid params) and leaves every other error on -32000. The branch keys on the error classification, never on the tool name, so any invalid-parameter core error surfacing through MCP tool dispatch maps to -32602 generically. Two unit tests assert that the unserved-pair error maps to Invalid params and that a genuine server fault stays on Server error.

The flat-files article and the HTTP and Rust SDK READMEs documented an option quote day as a flat-file workload and used a dashed date the core validator rejects (it accepts only YYYYMMDD). Those examples now use the served option trade_quote dataset with a YYYYMMDD date, so every documented flat-file example runs as written and no doc implies an unserved flat-file dataset is available.

Verification: cargo fmt --all -- --check, cargo test and cargo clippy -D warnings on tools/mcp (new tests included), check_docs_consistency.py, check_public_surface_leak.py, check_no_re_framing.py, and generate_docs_site --check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)