### PR TITLE
fix(docs): correct the generated client name and close the pre-release gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Columnar output — DataFrame / Arrow column names follow the public field names everywhere: `OptionContract` tables emit `symbol` (was the wire spelling `root`) and `InterestRateTick` tables emit `date` (was the wire spelling `created`), matching the row-object attributes.
 - HTTP server — REST responses carry the vendor's v3 field shapes for contract identity: `expiration` is an ISO `YYYY-MM-DD` string and EOD rows use the `created` / `last_trade` keys. Time-of-day values remain Eastern-Time millisecond integers paired with `date`, documented as the SDK's raw-time convention.
 - Python stub — the `StreamParseError` stub alias and the phantom `Error` exception stub are gone; the stub names match the runtime exactly.
-- The async worker-thread configuration knob is renamed to a neutral client name on every binding: Python `worker_threads`, TypeScript `setWorkerThreadsExplicit` / `workerThreads` (and the exported `WorkerThreadsSetting`), C++ `set_worker_threads_explicit` / `get_worker_threads`, and the C-ABI `thetadatadx_config_set_worker_threads_explicit` / `thetadatadx_config_get_worker_threads` (the prior names carried a runtime-internal token). The presence-plus-value ABI shape is unchanged.
+- The async worker-thread configuration knob is renamed to a neutral client name on every binding: Python `worker_threads`, TypeScript `setWorkerThreads` / `workerThreads` (and the exported `WorkerThreadsSetting`), C++ `set_worker_threads` / `get_worker_threads`, and the C-ABI `thetadatadx_config_set_worker_threads` / `thetadatadx_config_get_worker_threads` (the prior names carried a runtime-internal token). The presence-plus-value ABI shape is unchanged.
 
 ### Added
 

--- a/crates/thetadatadx/examples/build_eod_greeks_fixtures.rs
+++ b/crates/thetadatadx/examples/build_eod_greeks_fixtures.rs
@@ -1,12 +1,11 @@
-//! Build verified-live fixtures for the EOD-Greek and index-price
+//! Build wire-shape fixtures for the EOD-Greek and index-price
 //! parser regression tests:
 //!   * `option_history_greeks_eod` -> `GreeksEodTick`
 //!   * `index_at_time_price`        -> `IndexPriceAtTimeTick`
 //!
 //! Each fixture is a single `proto::ResponseData` whose `compressed_data`
 //! is a zstd-compressed `proto::DataTable` with the EXACT wire shape the
-//! terminal jar build `202605221` emitted (queried via `curl
-//! http://127.0.0.1:25503/v3/...`).
+//! server emits (queried via `curl http://127.0.0.1:25503/v3/...`).
 //!
 //! Headers come from the captured CSV header row; the per-row values are
 //! captured CSV row 1 verbatim, encoded as the same `DataValue` shapes
@@ -78,7 +77,7 @@ fn dv_text(s: &str) -> proto::DataValue {
 // option_history_greeks_eod -- SPY 2024-06-21 500 CALL on 2024-06-14
 // ────────────────────────────────────────────────────────────────────────
 //
-// CSV row 1 (verified-live from terminal jar build `202605221`):
+// CSV row 1 (captured from the live server):
 //   "SPY","2024-06-21",500.000,"CALL",
 //   2024-06-14T16:11:12.295,41.71,42.78,40.48,42.78,683,99,
 //   325,5,42.39,50,418,5,43.25,50,
@@ -159,7 +158,7 @@ fn build_greeks_eod_row() -> proto::DataValueList {
 // index_at_time_price -- SPX 2024-06-14 10:30:00 ET
 // ────────────────────────────────────────────────────────────────────────
 //
-// CSV row 1 (verified-live from terminal jar build `202605221`):
+// CSV row 1 (captured from the live server):
 //   2024-06-14T10:30:00.000,0,255,255,255,255,0,0,5,5414.14
 //
 // Index prints carry sequence=0 (no SIP sequence assigned), ext_conditions

--- a/crates/thetadatadx/examples/build_trade_greeks_fixtures.rs
+++ b/crates/thetadatadx/examples/build_trade_greeks_fixtures.rs
@@ -1,9 +1,9 @@
-//! Build verified-live `option_history_trade_greeks_*` fixtures used by
+//! Build `option_history_trade_greeks_*` fixtures used by
 //! `tests/test_trade_greeks_schema.rs`.
 //!
 //! Each fixture is a single `proto::ResponseData` whose `compressed_data`
 //! is a zstd-compressed `proto::DataTable` with the EXACT wire shape the
-//! terminal jar build `202605221` emitted for SPY 2026-01-16 540 CALL on
+//! server emits for SPY 2026-01-16 540 CALL on
 //! 2025-05-02 (queried via `curl
 //! http://127.0.0.1:25503/v3/option/history/trade_greeks/<sub>?...`).
 //!

--- a/crates/thetadatadx/src/tdbe/types/generated/tick.rs
+++ b/crates/thetadatadx/src/tdbe/types/generated/tick.rs
@@ -579,6 +579,8 @@ impl IndexPriceAtTimeTick {
 
 /// Interest rate tick -- 2 fields. End-of-day interest rate (percent).
 ///
+/// Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`:
+///
 /// The `date` decode flows through `thetadatadx::decode::row_date`, which
 /// accepts `Number`, `Timestamp`, and `Text` cells uniformly — so this tick
 /// decodes either the documented Text-ISO shape or any future
@@ -594,6 +596,8 @@ pub struct InterestRateTick {
 }
 
 /// Implied volatility tick -- 14 fields.
+///
+/// The `option_history_greeks_implied_volatility` wire columns map as:
 ///
 /// The snapshot variant (`option_snapshot_greeks_implied_volatility`) emits
 /// a 4-column subset (`ms_of_day, implied_vol, iv_error, date`); the
@@ -691,7 +695,12 @@ impl MarketValueTick {
 
 /// OHLC tick -- 12 fields. Aggregated bar data including SIP-rule VWAP.
 ///
-/// The snapshot variants (`*_snapshot_ohlc`) omit `vwap`; the generated parser's optional-column path defaults the field to `0.0` for those endpoints, mirroring how `volume`/`count` already zero-default on quote-only intraday bars.
+/// `stock_history_ohlc`, `option_history_ohlc`, and `index_history_ohlc`
+/// emit the same 8 data columns (`timestamp,open,high,low,close,
+/// volume,count,vwap`). The snapshot variants (`*_snapshot_ohlc`) omit
+/// `vwap`; the generated parser's optional-column path defaults the
+/// field to `0.0` for those endpoints, mirroring how `volume`/`count`
+/// already zero-default on quote-only intraday bars.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -977,7 +986,9 @@ impl TradeGreeksAllTick {
     }
 }
 
-/// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon / lambda) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against.
+/// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon
+/// / lambda) paired with the trade-side execution columns identifying the
+/// OPRA print each Greek was calculated against.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -1053,7 +1064,10 @@ impl TradeGreeksFirstOrderTick {
     }
 }
 
-/// Per-trade implied-volatility tick (single `implied_volatility` + `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled `IvTick`) paired with the trade-side execution columns identifying the OPRA print the IV was calculated against.
+/// Per-trade implied-volatility tick (single `implied_volatility` +
+/// `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled
+/// `IvTick`) paired with the trade-side execution columns identifying the
+/// OPRA print the IV was calculated against.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -1117,7 +1131,9 @@ impl TradeGreeksImpliedVolatilityTick {
     }
 }
 
-/// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma / veta) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against.
+/// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma /
+/// veta) paired with the trade-side execution columns identifying the OPRA
+/// print each Greek was calculated against.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]
@@ -1191,7 +1207,10 @@ impl TradeGreeksSecondOrderTick {
     }
 }
 
-/// Per-trade third-order Greeks tick (speed / zomma / color / ultima) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against. The vendor's third-order schema does not publish `vera`.
+/// Per-trade third-order Greeks tick (speed / zomma / color / ultima)
+/// paired with the trade-side execution columns identifying the OPRA print
+/// each Greek was calculated against. The vendor's third-order schema does
+/// not publish `vera`.
 #[must_use]
 #[derive(Debug, Clone, Copy)]
 #[repr(C, align(64))]

--- a/crates/thetadatadx/tests/fixtures/captures/index_at_time_price.meta.toml
+++ b/crates/thetadatadx/tests/fixtures/captures/index_at_time_price.meta.toml
@@ -1,4 +1,4 @@
-# Verified-live wire shape captured via the terminal jar build `202605221`:
+# Wire shape captured from the live server:
 #   curl 'http://127.0.0.1:25503/v3/index/at_time/price?symbol=SPX&\
 #     start_date=20240614&end_date=20240614&time_of_day=10:30:00'
 # Synthesised into a single-row `proto::ResponseData` by the

--- a/crates/thetadatadx/tests/fixtures/captures/option_history_greeks_eod.meta.toml
+++ b/crates/thetadatadx/tests/fixtures/captures/option_history_greeks_eod.meta.toml
@@ -1,4 +1,4 @@
-# Verified-live wire shape captured via the terminal jar build `202605221`:
+# Wire shape captured from the live server:
 #   curl http://127.0.0.1:25503/v3/option/history/greeks/eod?\
 #     symbol=SPY&expiration=20240621&start_date=20240614&end_date=20240614
 # Synthesised into a single-row `proto::ResponseData` by the

--- a/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_all.meta.toml
+++ b/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_all.meta.toml
@@ -1,4 +1,4 @@
-# Verified-live wire shape captured via the terminal jar build `202605221`:
+# Wire shape captured from the live server:
 #   curl http://127.0.0.1:25503/v3/option/history/trade_greeks/all?\
 #     symbol=SPY&expiration=20260116&start_date=20250502&end_date=20250502&\
 #     right=C&strike=540

--- a/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_first_order.meta.toml
+++ b/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_first_order.meta.toml
@@ -1,4 +1,4 @@
-# Verified-live wire shape captured via the terminal jar build `202605221`.
+# Wire shape captured from the live server.
 # Synthesised by `build_trade_greeks_fixtures` for the same SPY 2026-01-16
 # 540 CALL print as the `_all` capture.
 

--- a/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_implied_volatility.meta.toml
+++ b/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_implied_volatility.meta.toml
@@ -1,4 +1,4 @@
-# Verified-live wire shape captured via the terminal jar build `202605221`.
+# Wire shape captured from the live server.
 # Synthesised by `build_trade_greeks_fixtures` for the same SPY 2026-01-16
 # 540 CALL print as the `_all` capture. The IV variant ships only the
 # single `implied_vol` + `iv_error` pair (NOT the bid/mid/ask IV triple

--- a/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_second_order.meta.toml
+++ b/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_second_order.meta.toml
@@ -1,4 +1,4 @@
-# Verified-live wire shape captured via the terminal jar build `202605221`.
+# Wire shape captured from the live server.
 # Synthesised by `build_trade_greeks_fixtures` for the same SPY 2026-01-16
 # 540 CALL print as the `_all` capture.
 

--- a/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_third_order.meta.toml
+++ b/crates/thetadatadx/tests/fixtures/captures/option_history_trade_greeks_third_order.meta.toml
@@ -1,4 +1,4 @@
-# Verified-live wire shape captured via the terminal jar build `202605221`.
+# Wire shape captured from the live server.
 # Synthesised by `build_trade_greeks_fixtures` for the same SPY 2026-01-16
 # 540 CALL print as the `_all` capture.
 

--- a/crates/thetadatadx/tests/reconnect_storm.rs
+++ b/crates/thetadatadx/tests/reconnect_storm.rs
@@ -89,7 +89,7 @@ fn reconnect_storm_preserves_framing_invariants() {
     // The decoder state spans cycles in production: between
     // reconnects the io_loop preserves the `DeltaState` cache (FIT
     // delta sequences may resume after a transient disconnect, per
-    // Java terminal). What MUST reset is the framing state and the
+    // JVM terminal). What MUST reset is the framing state and the
     // contract cache (cleared on each session's MarketOpen / restart
     // — and in a real reconnect, on the new login itself).
     let mut delta = DeltaState::new();

--- a/crates/thetadatadx/tests/replay_capture.rs
+++ b/crates/thetadatadx/tests/replay_capture.rs
@@ -332,7 +332,7 @@ fn replay_success_fixture_emits_expected_event_sequence() {
 
 /// Drive the pathological fixture and verify the framing layer never
 /// panics, never deadlocks, and surfaces a typed error on truncation.
-/// Unknown opcodes are silently consumed (matches Java terminal
+/// Unknown opcodes are silently consumed (matches JVM terminal
 /// behaviour); corrupt FIT data falls through to `RawData`.
 #[test]
 fn replay_pathological_fixture_never_panics_or_blocks() {

--- a/crates/thetadatadx/tests/test_endpoint_routing.rs
+++ b/crates/thetadatadx/tests/test_endpoint_routing.rs
@@ -14,7 +14,7 @@
 //! seven endpoints whose silent mis-routing previously dropped the
 //! trade-side execution / EOD trade-quote columns, the harness:
 //!
-//!   1. Loads the verified-live capture fixture as a raw
+//!   1. Loads the captured wire fixture as a raw
 //!      `proto::ResponseData`.
 //!   2. Spins up the in-process `grpc_mock_server` mock and serves
 //!      that single `ResponseData` chunk under the gRPC stub path
@@ -95,8 +95,7 @@ async fn option_history_greeks_eod_routes_to_greeks_eod_parser() {
     assert!(!ticks.is_empty(), "mock served a non-empty fixture");
     let first = ticks.first().expect("non-empty ticks");
     // EOD trade-quote columns the earlier routing dropped. Pin values
-    // from the verified-live capture (terminal jar `202605221`,
-    // fixture meta `first_row_*`).
+    // from the captured wire fixture (fixture meta `first_row_*`).
     assert!(
         (first.open - 41.71).abs() < 1e-4,
         "open dropped or wrong (got {})",

--- a/crates/thetadatadx/tests/test_eod_greeks_schema.rs
+++ b/crates/thetadatadx/tests/test_eod_greeks_schema.rs
@@ -1,7 +1,6 @@
 //! EOD-Greek and index-price schema regression tests.
 //!
-//! Two fixtures replay the verified-live wire shapes (terminal jar build
-//! `202605221`) for:
+//! Two fixtures replay the captured wire shapes for:
 //!
 //!   * `option_history_greeks_eod` -- an earlier `GreeksAllTick` routing
 //!     (28 columns) dropped the twelve EOD trade/quote columns

--- a/crates/thetadatadx/tests/test_interest_rate_schema.rs
+++ b/crates/thetadatadx/tests/test_interest_rate_schema.rs
@@ -7,8 +7,8 @@
 //! call returned `DecodeError::TypeMismatch { expected: "Number|Timestamp",
 //! observed: "Text" }`.
 //!
-//! This test reconstructs the verified-live wire shape (terminal jar build
-//! `202605221`, SOFR 2025-04-28..2025-05-02) as a synthetic `DataTable` and
+//! This test reconstructs the captured wire shape (SOFR
+//! 2025-04-28..2025-05-02) as a synthetic `DataTable` and
 //! asserts the decoded `InterestRateTick` carries the expected
 //! `date=20250428` / `rate=4.36` values for the first row. It pins:
 //!
@@ -48,8 +48,7 @@ fn row(values: Vec<wire::DataValue>) -> wire::DataValueList {
     wire::DataValueList { values }
 }
 
-/// Reference wire dump (verified-live 2026-05-22 against terminal jar
-/// build `202605221`, MDDS endpoint `interest_rate/history/eod`, symbol
+/// Reference wire dump (MDDS endpoint `interest_rate/history/eod`, symbol
 /// `SOFR`, date range 2025-04-28..2025-05-02):
 ///
 /// ```text

--- a/crates/thetadatadx/tests/test_trade_greeks_schema.rs
+++ b/crates/thetadatadx/tests/test_trade_greeks_schema.rs
@@ -1,7 +1,7 @@
 //! `option_history_trade_greeks_*` regression tests.
 //!
-//! Five fixtures replay the verified-live wire shape (terminal jar build
-//! `202605221`) for the five `option_history_trade_greeks_*` endpoints
+//! Five fixtures replay the captured wire shape for the five
+//! `option_history_trade_greeks_*` endpoints
 //! and assert that the sibling tick types preserve every column the
 //! server publishes -- specifically the nine trade-side execution
 //! columns (`sequence`, `ext_condition1..4`, `condition`, `size`,
@@ -93,7 +93,7 @@ fn assert_f64_eq(field: &str, got: f64, expected: f64) {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// Per-endpoint tests. Each pins the verified-live header list, decodes
+// Per-endpoint tests. Each pins the captured header list, decodes
 // through the production `decode_data_table` -> per-tick parser path,
 // and asserts the nine trade-side columns are present AND the Greek
 // values match the captured row 1 verbatim.

--- a/crates/thetadatadx/tick_schema.toml
+++ b/crates/thetadatadx/tick_schema.toml
@@ -171,9 +171,8 @@ pyclass = "QuoteTick"
 [types.OhlcTick]
 doc = """OHLC tick -- 9 fields. Aggregated bar data including SIP-rule VWAP.
 
-Wire layout verified-live (terminal jar build `202605221`) against
-`stock_history_ohlc`, `option_history_ohlc`, and `index_history_ohlc`,
-which emit the same 8 data columns (`timestamp,open,high,low,close,
+`stock_history_ohlc`, `option_history_ohlc`, and `index_history_ohlc`
+emit the same 8 data columns (`timestamp,open,high,low,close,
 volume,count,vwap`). The snapshot variants (`*_snapshot_ohlc`) omit
 `vwap`; the generated parser's optional-column path defaults the
 field to `0.0` for those endpoints, mirroring how `volume`/`count`
@@ -479,20 +478,6 @@ The bare `GreeksAllTick` previously routed by `endpoint_surface.toml`
 Greeks endpoints. `GreeksEodTick` carries the full
 EOD wire shape end-to-end across every binding.
 
-Wire layout verified-live against terminal jar build `202605221`
-(SPY 2024-06-21 expiration query on 2024-06-14):
-
-  symbol, expiration, strike, right,
-  timestamp, open, high, low, close, volume, count,
-  bid_size, bid_exchange, bid, bid_condition,
-  ask_size, ask_exchange, ask, ask_condition,
-  delta, theta, vega, rho, epsilon, lambda,
-  gamma, vanna, charm, vomma, veta, vera,
-  speed, zomma, color, ultima,
-  d1, d2, dual_delta, dual_gamma,
-  implied_vol, iv_error,
-  underlying_timestamp, underlying_price
-
 The `timestamp` -> `ms_of_day`, `underlying_timestamp` ->
 `underlying_ms_of_day`, and `implied_vol` -> `implied_volatility`
 mappings are applied through `HEADER_ALIASES`.
@@ -709,8 +694,7 @@ pyclass = "GreeksThirdOrderTick"
 [types.IvTick]
 doc = """Implied volatility tick -- 11 fields.
 
-Wire layout verified-live against `option_history_greeks_implied_volatility`
-(terminal jar build `202605221`):
+The `option_history_greeks_implied_volatility` wire columns map as:
 
 | Schema field                | Wire header               | Type   |
 |-----------------------------|---------------------------|--------|
@@ -781,9 +765,8 @@ pyclass = "IvTick"
 #
 # These were silently routed to the bare `Greeks*Tick` types in the earlier line
 # line, which dropped every trade-side column on decode -- users got the
-# Greeks but lost the per-trade execution context. Verified-live against
-# terminal jar build `202605221` (CSV captures pinned in
-# `tests/fixtures/captures/option_history_trade_greeks_*.meta.toml`).
+# Greeks but lost the per-trade execution context. CSV captures pinned in
+# `tests/fixtures/captures/option_history_trade_greeks_*.meta.toml`.
 #
 # The IV variant (`option_history_trade_greeks_implied_volatility`) ships
 # only the single `implied_vol` + `iv_error` pair (not the bid/mid/ask IV
@@ -797,17 +780,6 @@ Per-trade union Greeks tick -- every Greek the v3 server publishes on
 columns (`sequence`, `ext_condition1..4`, `condition`, `size`,
 `exchange`, `price`) that identify which OPRA print each Greek was
 calculated against.
-
-Wire layout verified-live against terminal jar build `202605221`:
-
-  symbol, expiration, strike, right,
-  timestamp, sequence, ext_condition1..4, condition, size, exchange, price,
-  delta, theta, vega, rho, epsilon, lambda,
-  gamma, vanna, charm, vomma, veta, vera,
-  speed, zomma, color, ultima,
-  d1, d2, dual_delta, dual_gamma,
-  implied_vol, iv_error,
-  underlying_timestamp, underlying_price
 
 The `timestamp` -> `ms_of_day`, `underlying_timestamp` ->
 `underlying_ms_of_day`, and `implied_vol` -> `implied_volatility`
@@ -879,8 +851,7 @@ pyclass = "TradeGreeksAllTick"
 doc = """
 Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon
 / lambda) paired with the trade-side execution columns identifying the
-OPRA print each Greek was calculated against. Wire layout verified-live
-against terminal jar build `202605221`.
+OPRA print each Greek was calculated against.
 """
 copy = true
 align = 64
@@ -934,8 +905,7 @@ pyclass = "TradeGreeksFirstOrderTick"
 doc = """
 Per-trade second-order Greeks tick (gamma / vanna / charm / vomma /
 veta) paired with the trade-side execution columns identifying the OPRA
-print each Greek was calculated against. Wire layout verified-live
-against terminal jar build `202605221`.
+print each Greek was calculated against.
 """
 copy = true
 align = 64
@@ -989,8 +959,7 @@ doc = """
 Per-trade third-order Greeks tick (speed / zomma / color / ultima)
 paired with the trade-side execution columns identifying the OPRA print
 each Greek was calculated against. The vendor's third-order schema does
-not publish `vera`. Wire layout verified-live against terminal jar build
-`202605221`.
+not publish `vera`.
 """
 copy = true
 align = 64
@@ -1043,8 +1012,7 @@ doc = """
 Per-trade implied-volatility tick (single `implied_volatility` +
 `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled
 `IvTick`) paired with the trade-side execution columns identifying the
-OPRA print the IV was calculated against. Wire layout verified-live
-against terminal jar build `202605221`.
+OPRA print the IV was calculated against.
 """
 copy = true
 align = 64
@@ -1126,10 +1094,6 @@ publishes on `index_at_time_price`. The bare `PriceTick` (3 fields:
 `ms_of_day`, `price`, `date`) silently dropped seven server-emitted
 columns -- `sequence`, `ext_condition1..4`, `condition`, `size`,
 `exchange` -- including the SIP-exchange attribution field.
-
-Wire layout verified-live against terminal jar build `202605221`:
-
-  timestamp, sequence, ext_condition1..4, condition, size, exchange, price
 
 The `timestamp` -> `ms_of_day` and `timestamp` -> `date` mappings are
 applied through the existing `HEADER_ALIASES` rows in
@@ -1214,8 +1178,7 @@ pyclass = "CalendarDay"
 [types.InterestRateTick]
 doc = """Interest rate tick -- 2 fields. End-of-day interest rate (percent).
 
-Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`
-and verified-live against terminal jar build `202605221`:
+Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`:
 
 | Schema field | Wire header | Wire type        | Mapping                    |
 |--------------|-------------|------------------|----------------------------|

--- a/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
+++ b/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
@@ -590,15 +590,15 @@ function symsListRust(): string {
 }
 
 function pyHeader(): string {
-  return `from thetadatadx import ThetaDataDxClient, Credentials, Config
+  return `from thetadatadx import Client, Credentials, Config
 
 creds = Credentials.from_file("creds.txt")
 # Or inline: creds = Credentials("user@example.com", "your-password")
-client = ThetaDataDxClient(creds, Config.production())`
+client = Client(creds, Config.production())`
 }
 
 function rustHeader(): string {
-  return `use thetadatadx::{ThetaDataDxClient, Credentials, DirectConfig};`
+  return `use thetadatadx::{Client, Credentials, DirectConfig};`
 }
 
 function rustMain(body: string): string {
@@ -608,7 +608,7 @@ function rustMain(body: string): string {
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
     // Or inline: let creds = Credentials::new("user@example.com", "your-password");
-    let client = ThetaDataDxClient::connect(&creds, DirectConfig::production()).await?;
+    let client = Client::connect(&creds, DirectConfig::production()).await?;
 
 ${body}
     Ok(())
@@ -1233,7 +1233,7 @@ use thetadatadx::fpss::protocol::Contract;
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
-    let client = ThetaDataDxClient::connect(&creds, DirectConfig::production()).await?;
+    let client = Client::connect(&creds, DirectConfig::production()).await?;
 
     println!("Monitoring quotes for: [${symsListRust()}]");
     println!("{:<8}  {:>8}  {:>8}  {:>8}  {:>8}", "Symbol", "Bid", "Ask", "Spread", "Mid");
@@ -1264,7 +1264,7 @@ use thetadatadx::fpss::protocol::Contract;
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
-    let client = ThetaDataDxClient::connect(&creds, DirectConfig::production()).await?;
+    let client = Client::connect(&creds, DirectConfig::production()).await?;
 
     println!("Trade tape for: [${symsListRust()}]");
     println!("{:>12}  {:<8}  {:>8}  {:>8}", "Time", "Symbol", "Price", "Size");
@@ -1299,7 +1299,7 @@ use thetadatadx::SecType;
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
-    let client = ThetaDataDxClient::connect(&creds, DirectConfig::production()).await?;
+    let client = Client::connect(&creds, DirectConfig::production()).await?;
 
     let min_size: i32 = ${minSize()};
 
@@ -1337,7 +1337,7 @@ use thetadatadx::fpss::protocol::Contract;
 #[tokio::main]
 async fn main() -> Result<(), thetadatadx::Error> {
     let creds = Credentials::from_file("creds.txt")?;
-    let client = ThetaDataDxClient::connect(&creds, DirectConfig::production()).await?;
+    let client = Client::connect(&creds, DirectConfig::production()).await?;
 
     let symbol = "${sym()}";
     let exp    = "${exp()}";

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Columnar output — DataFrame / Arrow column names follow the public field names everywhere: `OptionContract` tables emit `symbol` (was the wire spelling `root`) and `InterestRateTick` tables emit `date` (was the wire spelling `created`), matching the row-object attributes.
 - HTTP server — REST responses carry the vendor's v3 field shapes for contract identity: `expiration` is an ISO `YYYY-MM-DD` string and EOD rows use the `created` / `last_trade` keys. Time-of-day values remain Eastern-Time millisecond integers paired with `date`, documented as the SDK's raw-time convention.
 - Python stub — the `StreamParseError` stub alias and the phantom `Error` exception stub are gone; the stub names match the runtime exactly.
-- The async worker-thread configuration knob is renamed to a neutral client name on every binding: Python `worker_threads`, TypeScript `setWorkerThreadsExplicit` / `workerThreads` (and the exported `WorkerThreadsSetting`), C++ `set_worker_threads_explicit` / `get_worker_threads`, and the C-ABI `thetadatadx_config_set_worker_threads_explicit` / `thetadatadx_config_get_worker_threads` (the prior names carried a runtime-internal token). The presence-plus-value ABI shape is unchanged.
+- The async worker-thread configuration knob is renamed to a neutral client name on every binding: Python `worker_threads`, TypeScript `setWorkerThreads` / `workerThreads` (and the exported `WorkerThreadsSetting`), C++ `set_worker_threads` / `get_worker_threads`, and the C-ABI `thetadatadx_config_set_worker_threads` / `thetadatadx_config_get_worker_threads` (the prior names carried a runtime-internal token). The presence-plus-value ABI shape is unchanged.
 
 ### Added
 

--- a/scripts/check_binding_parity.py
+++ b/scripts/check_binding_parity.py
@@ -1121,6 +1121,20 @@ def _collect_cpp_class_methods(cpp_hpp: pathlib.Path) -> dict[str, set[str]]:
     return out
 
 
+# The unified `Client`'s data surfaces are reached through view
+# accessors that return a cheap handle clone (`historical`, `stream`,
+# `flatFiles`). They are hand-written per binding rather than generated
+# from `endpoint_surface.toml`, so a drop or rename in one binding would
+# otherwise pass silently. The forward `[[method]]` check catches a drop
+# of a declared accessor; this roster anchors the reverse-direction scan
+# that catches a NEW symmetric view accessor added on a binding without
+# an enrolling row. Names are the canonical camelCase row spelling; the
+# scan derives the per-binding form exactly as the forward check does.
+CLIENT_VIEW_ACCESSORS: frozenset[str] = frozenset(
+    {"historical", "stream", "flatFiles"}
+)
+
+
 def _check_method_rows(
     method_rows: list[dict[str, Any]],
     py_methods: dict[str, set[str]],
@@ -1134,6 +1148,12 @@ def _check_method_rows(
     verifies the actual binding state against the declared state and
     returns a list of human-readable mismatch strings (empty when
     every row matches).
+
+    Beyond the per-row forward check, the unified `Client` view accessors
+    (`CLIENT_VIEW_ACCESSORS`) get a reverse-direction orphan scan: a view
+    accessor that exists on the `Client` class in a binding but carries no
+    enrolling `Client` `[[method]]` row trips the gate, so a future
+    accessor cannot ship on one binding untracked.
     """
     errors: list[str] = []
     for row in method_rows:
@@ -1200,6 +1220,40 @@ def _check_method_rows(
                 f"actual={actual_cpp} ({verb} -- expected `{snake}(` "
                 f"or `get_{snake}(` inside `class {cpp_class}` body in "
                 f"sdks/cpp/include/thetadatadx.hpp)"
+            )
+
+    # Reverse-direction orphan scan for the unified-client view accessors.
+    # An accessor present on the `Client` class in a binding but carrying
+    # no enrolling `Client` `[[method]]` row is undocumented drift: the
+    # symmetric `historical` / `stream` / `flatFiles` surface stays in
+    # lockstep only if every accessor each binding exposes is enrolled.
+    enrolled_client_methods = {
+        row["name"]
+        for row in method_rows
+        if row.get("class") == "Client" and row.get("name")
+    }
+    py_client = py_methods.get("Client", set())
+    ts_client = ts_methods.get("Client", set())
+    cpp_client = cpp_methods.get(_cpp_class_for("Client"), set())
+    for camel in sorted(CLIENT_VIEW_ACCESSORS):
+        if camel in enrolled_client_methods:
+            continue
+        snake = _camel_to_snake(camel)
+        present_on = sorted(
+            lang
+            for lang, seen in (
+                ("python", snake in py_client or f"get_{snake}" in py_client),
+                ("typescript", camel in ts_client),
+                ("cpp", snake in cpp_client or f"get_{snake}" in cpp_client),
+            )
+            if seen
+        )
+        if present_on:
+            errors.append(
+                f"  Client.{camel}: view accessor present on {present_on} but "
+                f"has no Client [[method]] row. Add one enrolling its "
+                f"per-binding presence so the unified-client view surface "
+                f"stays tracked."
             )
 
     return errors

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -205,6 +205,22 @@ def check_static_docs() -> None:
         if re.search(r"\b500000\b", path.read_text()):
             fail(f"{path.relative_to(ROOT)} contains stale text: '500000'")
 
+    # The interactive query builder generates copy-paste Python and Rust
+    # snippets. The emitted client identifier must be the symbol the SDK
+    # actually exports — Python `from thetadatadx import Client` /
+    # `Client(...)`, Rust `use thetadatadx::{Client, ...}` /
+    # `Client::connect(...)`. `ThetaDataDxClient` is only the C-ABI
+    # opaque-handle name; it is not a Python or Rust symbol, so a generated
+    # Python/Rust snippet that names it does not compile. Pin the real
+    # names and forbid the handle name in this component (which carries no
+    # C-ABI branch).
+    query_builder = DOCS_SITE / ".vitepress/theme/components/QueryBuilder.vue"
+    expect_contains(query_builder, "from thetadatadx import Client")
+    expect_contains(query_builder, "client = Client(creds, Config.production())")
+    expect_contains(query_builder, "use thetadatadx::{Client, Credentials, DirectConfig};")
+    expect_contains(query_builder, "Client::connect(&creds, DirectConfig::production())")
+    expect_not_contains(query_builder, "ThetaDataDxClient")
+
     expect_contains(
         ROOT / "crates/thetadatadx/endpoint_surface.toml",
         'description = "ET wall-clock time in HH:MM:SS.SSS (e.g. 09:30:00.000 for 9:30 AM ET; legacy 34200000 is also accepted)"',

--- a/scripts/check_no_re_framing.py
+++ b/scripts/check_no_re_framing.py
@@ -56,12 +56,29 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 # its doc comments to docs.rs. Generated `.rs` is included on purpose:
 # the checked-in generated tick classes render exactly like hand-written
 # source, so they must clear the same bar.
+#
+# The non-`.rs` schema descriptors below ride the crate `include` list in
+# `crates/thetadatadx/Cargo.toml`, so their comments land in the crates.io
+# tarball exactly like source. The `examples/` and `tests/` trees are not
+# packaged but are GitHub-visible, and their doc comments are read as
+# authoritative protocol notes — they clear the same bar.
 SCAN_GLOBS = (
     "crates/thetadatadx/src/**/*.rs",
     "ffi/src/**/*.rs",
     "sdks/python/src/**/*.rs",
     "sdks/typescript/src/**/*.rs",
     "sdks/typescript/src/**/*.ts",
+    # Schema / surface descriptors shipped via the crate `include` list.
+    "crates/thetadatadx/tick_schema.toml",
+    "crates/thetadatadx/endpoint_surface.toml",
+    "crates/thetadatadx/sdk_surface.toml",
+    "crates/thetadatadx/fpss_event_schema.toml",
+    "crates/thetadatadx/data/*.toml",
+    "sdks/parity.toml",
+    # GitHub-visible examples and regression tests.
+    "crates/thetadatadx/examples/**/*.rs",
+    "crates/thetadatadx/tests/**/*.rs",
+    "crates/thetadatadx/tests/**/*.toml",
 )
 
 
@@ -169,10 +186,14 @@ def _scan(root: pathlib.Path) -> list[tuple[pathlib.Path, int, str, str]]:
 def _selftest() -> int:
     """Plant RE framing in a synthetic source file and confirm the gate fires.
 
-    Three cases:
+    Four cases:
 
     * A file with `reverse-engineered the Java terminal` plus a jar-build
       provenance note — must be flagged.
+    * A shipped non-`.rs` schema descriptor (`tick_schema.toml`) carrying
+      a `jar build NNN` provenance comment — must be flagged. This is the
+      class of leak that previously evaded the `.rs`-only scan and shipped
+      in the crates.io tarball.
     * A clean file that names only the allow-listed "JVM terminal" /
       "Theta Terminal" parity reference — must pass.
     * A clean file whose factual wire description shares a line with the
@@ -184,6 +205,11 @@ def _selftest() -> int:
         "//! We reverse-engineered the Java terminal to learn this layout.\n"
         "/// Wire layout verified-live against terminal jar build `202605221`.\n"
         "/// Source: `Contract.toBytes()` in `Contract.java`.\n"
+    )
+    leaky_schema = (
+        'doc = """OHLC tick -- 9 fields.\n'
+        "Wire layout verified-live against terminal jar build `202605221`.\n"
+        '"""\n'
     )
     clean = (
         "//! Matches the JVM terminal byte-for-byte on the wire.\n"
@@ -201,6 +227,10 @@ def _selftest() -> int:
         leaky_path.parent.mkdir(parents=True, exist_ok=True)
         leaky_path.write_text(leaky, encoding="utf-8")
 
+        schema_path = root / "crates" / "thetadatadx" / "tick_schema.toml"
+        schema_path.parent.mkdir(parents=True, exist_ok=True)
+        schema_path.write_text(leaky_schema, encoding="utf-8")
+
         clean_path = root / "ffi" / "src" / "clean.rs"
         clean_path.parent.mkdir(parents=True, exist_ok=True)
         clean_path.write_text(clean, encoding="utf-8")
@@ -214,6 +244,13 @@ def _selftest() -> int:
         leaky_hits = [h for h in hits if h[0].name == "leaky.rs"]
         if not leaky_hits:
             print("selftest FAILED: the planted RE-framing line was not flagged")
+            return 1
+        schema_hits = [h for h in hits if h[0].name == "tick_schema.toml"]
+        if not schema_hits:
+            print(
+                "selftest FAILED: the planted jar-build line in the shipped "
+                "schema descriptor was not flagged"
+            )
             return 1
         if any(rel.name == "clean.rs" for (rel, _, _, _) in hits):
             print("selftest FAILED: a clean JVM-terminal file was flagged")

--- a/scripts/test_check_binding_parity.py
+++ b/scripts/test_check_binding_parity.py
@@ -746,6 +746,55 @@ def test_from_file_parity_live_sources_clean() -> None:
     assert errors == [], f"live from_file sources must be clean; got {errors!r}"
 
 
+# ─── Client view-accessor reverse-orphan ───────────────────────────
+
+
+def test_client_view_accessors_all_enrolled_passes() -> None:
+    """Every view accessor present on `Client` has an enrolling row."""
+    rows = [
+        {"class": "Client", "name": "historical", "python": True, "typescript": True, "cpp": True},
+        {"class": "Client", "name": "stream", "python": True, "typescript": True, "cpp": True},
+        {"class": "Client", "name": "flatFiles", "python": True, "typescript": True, "cpp": True},
+    ]
+    py_methods = {"Client": {"historical", "stream", "flat_files"}}
+    ts_methods = {"Client": {"historical", "stream", "flatFiles"}}
+    cpp_methods = {"Client": {"historical", "stream", "flat_files"}}
+    errors = cbp._check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+    assert errors == [], f"fully-enrolled view accessors must pass; got {errors!r}"
+
+
+def test_client_view_accessor_orphan_trips() -> None:
+    """A view accessor on `Client` with no enrolling row trips the gate."""
+    rows = [
+        {"class": "Client", "name": "historical", "python": True, "typescript": True, "cpp": True},
+        {"class": "Client", "name": "stream", "python": True, "typescript": True, "cpp": True},
+        # `flatFiles` deliberately omitted — present on the bindings below.
+    ]
+    py_methods = {"Client": {"historical", "stream", "flat_files"}}
+    ts_methods = {"Client": {"historical", "stream", "flatFiles"}}
+    cpp_methods = {"Client": {"historical", "stream", "flat_files"}}
+    errors = cbp._check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+    assert any("flatFiles" in e and "no Client [[method]] row" in e for e in errors), (
+        f"an unenrolled view accessor must trip the reverse-orphan scan; got {errors!r}"
+    )
+
+
+def test_client_view_accessors_live_sources_enrolled() -> None:
+    """The live `Client` view accessors are all enrolled and symmetric."""
+    import tomllib
+
+    data = tomllib.loads(cbp.PARITY_TOML.read_text(encoding="utf-8"))
+    rows = data.get("method", [])
+    py_methods = cbp._collect_python_class_methods(cbp.PY_SRC)
+    ts_methods = cbp._collect_typescript_class_methods(cbp.TS_SRC)
+    cpp_methods = cbp._collect_cpp_class_methods(cbp.CPP_HPP)
+    errors = cbp._check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+    accessor_errors = [e for e in errors if "view accessor" in e]
+    assert accessor_errors == [], (
+        f"live Client view accessors must be enrolled; got {accessor_errors!r}"
+    )
+
+
 # ─── Driver ────────────────────────────────────────────────────────
 
 
@@ -778,6 +827,9 @@ def main() -> int:
     _check("from-file untracked client trips", test_from_file_untracked_client_trips)
     _check("from-file FFI stem maps class name", test_from_file_ffi_stem_maps_class_name)
     _check("from-file live sources clean", test_from_file_parity_live_sources_clean)
+    _check("client view accessors all-enrolled passes", test_client_view_accessors_all_enrolled_passes)
+    _check("client view accessor orphan trips", test_client_view_accessor_orphan_trips)
+    _check("client view accessors live sources enrolled", test_client_view_accessors_live_sources_enrolled)
 
     if _fails:
         print(f"test_check_binding_parity: {len(_fails)} failure(s)")

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -438,7 +438,7 @@ cpp = true          # `ThetaDataDxStreamParseError` C struct, `thetadatadx::Stre
 
 # ─── EOD-Greek + index-price tick anchors ─────────────────────────────
 #
-# Two tick types model the verified-live wire shape on two endpoints
+# Two tick types model the captured wire shape on two endpoints
 # whose earlier routing dropped server-emitted columns:
 #
 #   * `GreeksEodTick` (39 columns) -- `option_history_greeks_eod`.
@@ -940,6 +940,34 @@ ffi = true
 # cross-binding setter contract at the field level.
 
 # ── Client (the unified entry-point client) ──
+#
+# The unified `Client` exposes its data surfaces through three view
+# accessors — `historical`, `stream`, and `flatFiles` — each returning a
+# cheap handle clone over the inner client. They are symmetric across
+# Python (`#[getter]`), TypeScript (`#[napi(getter)]`), and C++ (a member
+# accessor), and the reverse-orphan scan below fails if any binding drops
+# or renames one without the matrix recording it.
+
+[[method]]
+class = "Client"
+name = "historical"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "Client"
+name = "stream"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "Client"
+name = "flatFiles"
+python = true
+typescript = true
+cpp = true
 
 [[method]]
 class = "StreamView"

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -1676,7 +1676,21 @@ class InvalidParameterError(ThetaDataError):
     Distinct from the root :class:`ThetaDataError` so a malformed-but-
     rejected argument (bad value, out-of-range number, missing required
     field) is distinguishable by class from an unrelated configuration
-    fault (config-file I/O, TOML parse), which stays on the root class.
+    fault (config-file I/O, TOML parse), which is raised as
+    :class:`ConfigError`.
+    """
+
+    ...
+
+
+@final
+class ConfigError(ThetaDataError):
+    """An environmental configuration fault.
+
+    Raised on a config-file read failure, a TOML parse error, or an
+    internal config invariant. Distinct from :class:`InvalidParameterError`
+    (a rejected user-supplied argument): a :class:`ConfigError` is the
+    environment, not the call site.
     """
 
     ...

--- a/sdks/python/src/_generated/tick_classes.rs
+++ b/sdks/python/src/_generated/tick_classes.rs
@@ -659,6 +659,8 @@ impl IndexPriceAtTimeTick {
 
 /// Interest rate tick. End-of-day interest rate (percent).
 ///
+/// Wire layout per `docs.thetadata.us/operations/interest_rate_history_eod.html`:
+///
 /// The `date` decode flows through `thetadatadx::decode::row_date`, which
 /// accepts `Number`, `Timestamp`, and `Text` cells uniformly — so this tick
 /// decodes either the documented Text-ISO shape or any future
@@ -686,6 +688,8 @@ impl InterestRateTick {
 }
 
 /// Implied volatility tick.
+///
+/// The `option_history_greeks_implied_volatility` wire columns map as:
 ///
 /// The snapshot variant (`option_snapshot_greeks_implied_volatility`) emits
 /// a 4-column subset (`ms_of_day, implied_vol, iv_error, date`); the
@@ -801,7 +805,12 @@ impl MarketValueTick {
 
 /// OHLC tick. Aggregated bar data including SIP-rule VWAP.
 ///
-/// The snapshot variants (`*_snapshot_ohlc`) omit `vwap`; the generated parser's optional-column path defaults the field to `0.0` for those endpoints, mirroring how `volume`/`count` already zero-default on quote-only intraday bars.
+/// `stock_history_ohlc`, `option_history_ohlc`, and `index_history_ohlc`
+/// emit the same 8 data columns (`timestamp,open,high,low,close,
+/// volume,count,vwap`). The snapshot variants (`*_snapshot_ohlc`) omit
+/// `vwap`; the generated parser's optional-column path defaults the
+/// field to `0.0` for those endpoints, mirroring how `volume`/`count`
+/// already zero-default on quote-only intraday bars.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
@@ -1144,7 +1153,9 @@ impl TradeGreeksAllTick {
     }
 }
 
-/// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon / lambda) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against.
+/// Per-trade first-order Greeks tick (delta / theta / vega / rho / epsilon
+/// / lambda) paired with the trade-side execution columns identifying the
+/// OPRA print each Greek was calculated against.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
@@ -1229,7 +1240,10 @@ impl TradeGreeksFirstOrderTick {
     }
 }
 
-/// Per-trade implied-volatility tick (single `implied_volatility` + `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled `IvTick`) paired with the trade-side execution columns identifying the OPRA print the IV was calculated against.
+/// Per-trade implied-volatility tick (single `implied_volatility` +
+/// `iv_error` pair, NOT the bid/mid/ask IV triple of the interval-sampled
+/// `IvTick`) paired with the trade-side execution columns identifying the
+/// OPRA print the IV was calculated against.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
@@ -1302,7 +1316,9 @@ impl TradeGreeksImpliedVolatilityTick {
     }
 }
 
-/// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma / veta) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against.
+/// Per-trade second-order Greeks tick (gamma / vanna / charm / vomma /
+/// veta) paired with the trade-side execution columns identifying the OPRA
+/// print each Greek was calculated against.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]
@@ -1385,7 +1401,10 @@ impl TradeGreeksSecondOrderTick {
     }
 }
 
-/// Per-trade third-order Greeks tick (speed / zomma / color / ultima) paired with the trade-side execution columns identifying the OPRA print each Greek was calculated against. The vendor's third-order schema does not publish `vera`.
+/// Per-trade third-order Greeks tick (speed / zomma / color / ultima)
+/// paired with the trade-side execution columns identifying the OPRA print
+/// each Greek was calculated against. The vendor's third-order schema does
+/// not publish `vera`.
 #[must_use]
 #[pyclass(module = "thetadatadx", frozen, skip_from_py_object)]
 #[derive(Clone)]


### PR DESCRIPTION
The interactive query builder generated Python and Rust snippets that named `ThetaDataDxClient` — a symbol that exists only as the C-ABI opaque handle, not as a Python or Rust export — so every generated snippet failed to compile. The Python and Rust branches now emit the real exports: `from thetadatadx import Client` with `Client(creds, config)`, and `use thetadatadx::{Client, Credentials, DirectConfig}` with `Client::connect(&creds, config)`. The component carries no C-ABI branch, so the handle name is gone from it entirely.

The tick schema descriptor and several examples, fixtures, and regression tests carried wire-layout provenance breadcrumbs that ship publicly through the crate `include` list. Every breadcrumb is replaced with neutral wording that keeps the genuinely useful layout note. The no-RE-framing gate previously scanned only the Rust source globs and so never saw these files; it now also covers the shipped schema descriptors, the parity surface, and the GitHub-visible examples and tests, and a new self-test case asserts a planted provenance line in a schema file is caught.

The docs-consistency gate now pins the client identifier the query builder emits and forbids the handle name in that component, so a future drift back to a non-existent symbol fails the gate instead of shipping green.

The unreleased worker-thread changelog entry documented method names with an `_explicit` suffix that no binding exposes. It now lists the real cross-binding names, and the docs-site changelog mirror stays byte-identical.

`ConfigError` is a real runtime Python exception but was missing from the type stub. It is added as a `ThetaDataError` leaf alongside the other configuration and parameter exceptions, so the stub exception roster matches the runtime exactly.

The unified client's `historical`, `stream`, and `flatFiles` view accessors were guarded by no gate. They are now enrolled in the cross-binding parity matrix, and the method-parity check gained a reverse-orphan scan so dropping or renaming any of them in one binding fails the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)