### PR TITLE
fix(docs): correct the C from_file snippet and clean stale surface references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ A clear and concise description of the bug.
 
 ## Endpoint / Method Affected
 
-Which API endpoint or client method is involved? (e.g., `ThetaDataDxClient::stock_history_eod`, `ThetaDataDxClient::subscribe(Contract::stock("AAPL").quote())`)
+Which API endpoint or client method is involved? (e.g., `client.historical.stock_history_eod`, `client.stream.subscribe(Contract.stock("AAPL").quote())`)
 
 ## Steps to Reproduce
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           python3 scripts/check_doc_defaults.py
 
   no-re-framing:
-    name: Source docs reverse-engineering framing
+    name: Source docs framing hygiene
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Reverse-engineering framing detector
+      - name: Source docs framing detector
         run: |
           python3 scripts/check_no_re_framing.py --selftest
           python3 scripts/check_no_re_framing.py

--- a/docs-site/docs/migration/v12-to-v13.md
+++ b/docs-site/docs/migration/v12-to-v13.md
@@ -304,7 +304,8 @@ auto client = thetadatadx::Client::from_file("creds.txt");
 ```
 
 ```c
-ThetaDataDxClient* client = thetadatadx_client_connect_from_file("creds.txt", NULL);
+ThetaDataDxConfig* cfg = thetadatadx_config_production();
+ThetaDataDxClient* client = thetadatadx_client_connect_from_file("creds.txt", cfg);
 ```
 
 ## Flat files are restricted to the vendor datasets


### PR DESCRIPTION
Closes the three findings from the final pre-tag audit of the v13 release candidate.

- The C migration snippet called `thetadatadx_client_connect_from_file("creds.txt", NULL)`, but the C ABI requires a non-null config handle (`thetadatadx_last_error()` returns "config handle is null" otherwise). It now passes `thetadatadx_config_production()`, matching the other C before/after blocks in the guide.
- The bug-report issue template referenced the removed `ThetaDataDxClient::stock_history_eod` / `::subscribe` names; it now points at `client.historical.stock_history_eod` / `client.stream.subscribe`.
- The source-docs framing CI job and step names dropped the "reverse-engineering" wording so the public Actions UI carries neutral labels. The job is not a required status check, so the rename does not affect branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)