### PR TITLE
docs: align stale snippets with the shipped API and drop provenance prose

### DIFF
--- a/crates/thetadatadx/proto/MAINTENANCE.md
+++ b/crates/thetadatadx/proto/MAINTENANCE.md
@@ -13,8 +13,8 @@ It owns normalized endpoint names, parameter semantics, REST paths, return kinds
 projection call-shapes, reusable parameter groups, and endpoint templates. The
 build validates that surface spec against the wire contract in `mdds.proto`.
 
-Earlier revisions of this crate shipped two separate proto files extracted
-from the Java terminal (`endpoints.proto` + `v3_endpoints.proto`). Those have
+Earlier revisions of this crate shipped two separate proto files
+(`endpoints.proto` + `v3_endpoints.proto`). Those have
 been superseded by the single-file definition. Do not hand-edit `mdds.proto`;
 request an updated file from ThetaData when the wire protocol changes.
 

--- a/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
+++ b/docs-site/docs/.vitepress/theme/components/QueryBuilder.vue
@@ -1227,7 +1227,7 @@ function genRust(): string {
     for d in &early { println!("  {}  closes={}", d.date, d.close_time); }`)
 
     case 'live_quote_monitor': return `${rustHeader()}
-use thetadatadx::fpss::{FpssEvent, FpssData};
+use thetadatadx::fpss::{StreamEvent, StreamData};
 use thetadatadx::fpss::protocol::Contract;
 
 #[tokio::main]
@@ -1239,8 +1239,8 @@ async fn main() -> Result<(), thetadatadx::Error> {
     println!("{:<8}  {:>8}  {:>8}  {:>8}  {:>8}", "Symbol", "Bid", "Ask", "Spread", "Mid");
     println!("{}", "-".repeat(50));
 
-    client.stream().start_streaming(|event: &FpssEvent| {
-        if let FpssEvent::Data(FpssData::Quote { contract, bid, ask, .. }) = event {
+    client.stream().start_streaming(|event: &StreamEvent| {
+        if let StreamEvent::Data(StreamData::Quote { contract, bid, ask, .. }) = event {
             let spread = ask - bid;
             let mid = (bid + ask) / 2.0;
             println!("{:<8}  {:>8.2}  {:>8.2}  {:>8.4}  {:>8.2}",
@@ -1258,7 +1258,7 @@ async fn main() -> Result<(), thetadatadx::Error> {
 }`
 
     case 'trade_tape': return `${rustHeader()}
-use thetadatadx::fpss::{FpssEvent, FpssData};
+use thetadatadx::fpss::{StreamEvent, StreamData};
 use thetadatadx::fpss::protocol::Contract;
 
 #[tokio::main]
@@ -1270,8 +1270,8 @@ async fn main() -> Result<(), thetadatadx::Error> {
     println!("{:>12}  {:<8}  {:>8}  {:>8}", "Time", "Symbol", "Price", "Size");
     println!("{}", "-".repeat(45));
 
-    client.stream().start_streaming(|event: &FpssEvent| {
-        if let FpssEvent::Data(FpssData::Trade {
+    client.stream().start_streaming(|event: &StreamEvent| {
+        if let StreamEvent::Data(StreamData::Trade {
             contract, price, size, ms_of_day, ..
         }) = event {
             let h = ms_of_day / 3_600_000;
@@ -1292,7 +1292,7 @@ async fn main() -> Result<(), thetadatadx::Error> {
 }`
 
     case 'option_flow_scanner': return `${rustHeader()}
-use thetadatadx::fpss::{FpssEvent, FpssData};
+use thetadatadx::fpss::{StreamEvent, StreamData};
 use thetadatadx::fpss::protocol::SecTypeExt;
 use thetadatadx::SecType;
 
@@ -1307,8 +1307,8 @@ async fn main() -> Result<(), thetadatadx::Error> {
     println!("{:<35}  {:>6}  {:>8}  {:>12}", "Contract", "Size", "Price", "Premium");
     println!("{}", "-".repeat(70));
 
-    client.stream().start_streaming(move |event: &FpssEvent| {
-        if let FpssEvent::Data(FpssData::Trade { contract, price, size, .. }) = event {
+    client.stream().start_streaming(move |event: &StreamEvent| {
+        if let StreamEvent::Data(StreamData::Trade { contract, price, size, .. }) = event {
             if *size >= min_size {
                 let name = format!(
                     "{} {} {} {}",
@@ -1331,7 +1331,7 @@ async fn main() -> Result<(), thetadatadx::Error> {
 }`
 
     case 'live_option_chain': return `${rustHeader()}
-use thetadatadx::fpss::{FpssEvent, FpssData};
+use thetadatadx::fpss::{StreamEvent, StreamData};
 use thetadatadx::fpss::protocol::Contract;
 
 #[tokio::main]
@@ -1342,8 +1342,8 @@ async fn main() -> Result<(), thetadatadx::Error> {
     let symbol = "${sym()}";
     let exp    = "${exp()}";
 
-    client.stream().start_streaming(|event: &FpssEvent| {
-        if let FpssEvent::Data(FpssData::Quote { contract, bid, ask, .. }) = event {
+    client.stream().start_streaming(|event: &StreamEvent| {
+        if let StreamEvent::Data(StreamData::Quote { contract, bid, ask, .. }) = event {
             let name = format!(
                 "{} {} {} {}",
                 contract.symbol,

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -39,7 +39,7 @@ Every historical endpoint is available as `thetadatadx_stock_*`, `thetadatadx_op
 
 | Function | Description |
 |----------|-------------|
-| `thetadatadx_client_set_callback` | Register the user callback on the unified handle. The event-dispatch consumer thread invokes it for every typed FPSS event under `catch_unwind`. |
+| `thetadatadx_client_set_callback` | Register the user callback on the unified handle. The streaming delivery thread invokes it for every typed FPSS event under `catch_unwind`. |
 | `thetadatadx_client_subscribe` | Polymorphic subscribe — takes `ThetaDataDxSubscriptionRequest` (per-contract or full-stream) |
 | `thetadatadx_client_unsubscribe` | Polymorphic unsubscribe — takes `ThetaDataDxSubscriptionRequest` |
 | `thetadatadx_client_is_streaming` | Check if FPSS connection is live |
@@ -54,7 +54,7 @@ Every historical endpoint is available as `thetadatadx_stock_*`, `thetadatadx_op
 | Function | Description |
 |----------|-------------|
 | `thetadatadx_streaming_connect` | Connect standalone FPSS client |
-| `thetadatadx_streaming_set_callback` | Register the user callback. The event-dispatch consumer thread invokes it for every typed FPSS event under `catch_unwind`. |
+| `thetadatadx_streaming_set_callback` | Register the user callback. The streaming delivery thread invokes it for every typed FPSS event under `catch_unwind`. |
 | `thetadatadx_streaming_subscribe` | Polymorphic subscribe — takes `ThetaDataDxSubscriptionRequest` |
 | `thetadatadx_streaming_unsubscribe` | Polymorphic unsubscribe — takes `ThetaDataDxSubscriptionRequest` |
 | `thetadatadx_streaming_is_authenticated` | Check if FPSS is authenticated |

--- a/sdks/python/tests/test_no_gil.py
+++ b/sdks/python/tests/test_no_gil.py
@@ -257,7 +257,7 @@ def test_historical_releases_gil() -> None:
             # returns the most recent quote regardless of intraday
             # state, so we exercise the network path without
             # depending on a specific session being open.
-            client.stock_snapshot_quote("AAPL")
+            client.historical.stock_snapshot_quote("AAPL")
 
     # Baseline
     t0 = time.perf_counter()

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -32,7 +32,7 @@ Prebuilt binaries are downloaded automatically for Linux x64 (glibc), macOS arm6
 
 > [!TIP]
 > Credentials can come from a `creds.txt` file (email on line 1, password on
-> line 2) via `connectFromFile`, or inline via `connect(email, password)`.
+> line 2) via `connectFromFile`, or inline via `connect(new Credentials(email, password))`.
 
 ```typescript
 import { Client } from 'thetadatadx';


### PR DESCRIPTION
Final-round audit follow-up (the LOW doc/prose nits the second auditor surfaced). None are correctness defects in product code; all are in non-shipped or doc artifacts, but they are real staleness/hygiene issues worth closing for a pristine release.

- `QueryBuilder.vue` generated Rust streaming snippets used the removed `FpssEvent` / `FpssData` names; renamed to the shipped `StreamEvent` / `StreamData` enums (re-exported from `thetadatadx::fpss`) so the generated code compiles.
- `sdks/typescript/README.md` tip advertised `connect(email, password)`; corrected to `connect(new Credentials(email, password))` to match the real signature (the code block beneath was already correct).
- `sdks/python/tests/test_no_gil.py` called `client.stock_snapshot_quote(...)` on the unified client; the snapshot endpoints now live under `client.historical`, so the gated network probe is repointed.
- `crates/thetadatadx/proto/MAINTENANCE.md` (shipped in the crate `include` list) dropped a wire-protocol provenance sentence.
- `ffi/README.md` reworded two rows to name the streaming delivery thread without internal-dispatch vocabulary.

Gates pass: `check_no_re_framing.py`, `check_public_surface_leak.py`, `check_docs_consistency.py`, `check_doc_defaults.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)