### PR TITLE
fix(contract): guard the OCC-21 repair slice against non-ASCII input

### DIFF
--- a/crates/thetadatadx/src/fpss/protocol/contract.rs
+++ b/crates/thetadatadx/src/fpss/protocol/contract.rs
@@ -798,7 +798,15 @@ impl std::str::FromStr for Contract {
         // (digits, right byte, strike width) still surface their exact
         // errors with the repaired input in the message.
         const OCC21_SUFFIX_LEN: usize = 15; // YYMMDD(6) + right(1) + strike(8)
-        if trimmed.len() == Self::OCC21_LEN - 1 && trimmed.len() > OCC21_SUFFIX_LEN {
+        // `trimmed.len()` is a byte count, so a non-ASCII input can reach
+        // this length with `split` (byte index 5) landing mid-codepoint;
+        // slicing there would panic. OCC-21 identifiers are ASCII by spec,
+        // so require ASCII before the byte slices and let anything else
+        // fall through to the bare-root validator for a clean error.
+        if trimmed.len() == Self::OCC21_LEN - 1
+            && trimmed.len() > OCC21_SUFFIX_LEN
+            && trimmed.is_ascii()
+        {
             let split = trimmed.len() - OCC21_SUFFIX_LEN;
             let root_slice = trimmed[..split].trim_end_matches(' ');
             let suffix = &trimmed[split..];
@@ -1249,6 +1257,23 @@ mod tests {
         assert!(
             err.contains("APPLETREESARECUTEST"),
             "expected error to include the offending input, got: {err}"
+        );
+    }
+
+    #[test]
+    fn from_str_non_ascii_at_repair_length_does_not_panic() {
+        use std::str::FromStr;
+        // 20 bytes via a multi-byte codepoint whose continuation byte
+        // lands on the byte-5 split the repair heuristic slices at.
+        // Before the ASCII guard this panicked on a non-char-boundary
+        // slice; now it must fall through to the bare-root validator and
+        // return a clean error.
+        let input = "ABCDé260417C0055000"; // 'é' is two bytes -> 20 bytes total
+        assert_eq!(input.len(), 20);
+        let err = Contract::from_str(input).unwrap_err().to_string();
+        assert!(
+            err.contains("Contract::from_str"),
+            "expected Contract::from_str-prefixed error, got: {err}"
         );
     }
 

--- a/crates/thetadatadx/src/fpss/protocol/contract.rs
+++ b/crates/thetadatadx/src/fpss/protocol/contract.rs
@@ -798,6 +798,7 @@ impl std::str::FromStr for Contract {
         // (digits, right byte, strike width) still surface their exact
         // errors with the repaired input in the message.
         const OCC21_SUFFIX_LEN: usize = 15; // YYMMDD(6) + right(1) + strike(8)
+
         // `trimmed.len()` is a byte count, so a non-ASCII input can reach
         // this length with `split` (byte index 5) landing mid-codepoint;
         // slicing there would panic. OCC-21 identifiers are ASCII by spec,


### PR DESCRIPTION
## What

`Contract::from_str` repairs a 20-byte OCC-21 identifier by peeling the trailing 15-char suffix and re-padding the root, slicing the input at byte index 5. The length guard tests the byte count (`trimmed.len()`), so a non-ASCII input could reach 20 bytes with the split landing inside a multi-byte codepoint. Slicing on a non-char-boundary panics, so `"ABCDé260417C0055000".parse::<Contract>()` aborted instead of returning an error.

## Fix

OCC-21 identifiers are ASCII by spec (the strict 21-char `parse_occ21` already enforces this before its own slices). Require `trimmed.is_ascii()` before the repair slices; non-ASCII input falls through to the bare-root validator, which returns a clean `Contract::from_str` error naming the offending input. Adds a regression test for the previously-panicking string.

## Test

`cargo test -p thetadatadx --lib fpss::protocol::contract` — 45 pass including the new `from_str_non_ascii_at_repair_length_does_not_panic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)