### PR TITLE
docs: align streaming ms_of_day label and document json-raw format

### DIFF
--- a/crates/thetadatadx/build_support_bin/fpss_events/ffi_rust.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/ffi_rust.rs
@@ -140,7 +140,7 @@ fn fpss_column_doc(name: &str) -> String {
         "market_bid" => "Calculated market bid (dollars), nudged from the quote bid.",
         "market_price" => "Integer midpoint of `market_bid` / `market_ask` (dollars).",
         "message" => "Human-readable error text from the server.",
-        "ms_of_day" => "Milliseconds since midnight (exchange-local) when the event was recorded.",
+        "ms_of_day" => "Milliseconds since midnight Eastern Time when the event was recorded.",
         "open" => "Opening price of the bar.",
         "open_interest" => "Number of outstanding open contracts.",
         "payload" => "Raw frame payload bytes, preserved for diagnostics.",

--- a/crates/thetadatadx/src/fpss/events.rs
+++ b/crates/thetadatadx/src/fpss/events.rs
@@ -52,7 +52,7 @@ pub enum StreamData {
         /// when the server has not yet sent the matching
         /// `ContractAssigned` frame.
         contract: Arc<Contract>,
-        /// Milliseconds since midnight (exchange-local) when the quote was recorded.
+        /// Milliseconds since midnight Eastern Time when the quote was recorded.
         ms_of_day: i32,
         /// Number of contracts/shares resting at the bid.
         bid_size: i32,
@@ -83,7 +83,7 @@ pub enum StreamData {
         /// when the matching `ContractAssigned` frame has not yet
         /// arrived.
         contract: Arc<Contract>,
-        /// Milliseconds since midnight (exchange-local) when the trade printed.
+        /// Milliseconds since midnight Eastern Time when the trade printed.
         ms_of_day: i32,
         /// Exchange sequence number for ordering trades within the day.
         sequence: i32,
@@ -124,7 +124,7 @@ pub enum StreamData {
         /// when the matching `ContractAssigned` frame has not yet
         /// arrived.
         contract: Arc<Contract>,
-        /// Milliseconds since midnight (exchange-local) when the open interest was recorded.
+        /// Milliseconds since midnight Eastern Time when the open interest was recorded.
         ms_of_day: i32,
         /// Number of outstanding open contracts.
         open_interest: i32,
@@ -143,7 +143,7 @@ pub enum StreamData {
         /// when the matching `ContractAssigned` frame has not yet
         /// arrived.
         contract: Arc<Contract>,
-        /// Milliseconds since midnight (exchange-local) at the bar's open.
+        /// Milliseconds since midnight Eastern Time at the bar's open.
         ms_of_day: i32,
         /// Opening price of the bar.
         open: f64,
@@ -177,7 +177,7 @@ pub enum StreamData {
         /// when the matching `ContractAssigned` frame has not yet
         /// arrived.
         contract: Arc<Contract>,
-        /// Milliseconds since midnight (exchange-local) when the market value was computed.
+        /// Milliseconds since midnight Eastern Time when the market value was computed.
         ms_of_day: i32,
         /// Calculated market bid (dollars), nudged from the quote bid.
         market_bid: f64,

--- a/docs-site/docs/cli.md
+++ b/docs-site/docs/cli.md
@@ -44,7 +44,7 @@ Commands mirror the endpoint names, and every parameter — required and optiona
 |---|---|---|
 | `--creds <path>` | `creds.txt` | Credentials file. |
 | `--config <preset>` | `production` | `production` or `dev`. |
-| `--format <fmt>` | `table` | `table`, `json`, or `csv`. |
+| `--format <fmt>` | `table` | `table`, `json`, `json-raw`, or `csv`. `json-raw` emits dates as raw `YYYYMMDD` integers (and `ms_of_day` as raw milliseconds) instead of the ISO-formatted values `json` produces. |
 
 ## Scripting
 

--- a/ffi/src/fpss_event_structs.rs
+++ b/ffi/src/fpss_event_structs.rs
@@ -105,7 +105,7 @@ strike: 0.0,
 pub struct ThetaDataDxStreamMarketValue {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
-    /// Milliseconds since midnight (exchange-local) when the event was recorded.
+    /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Calculated market bid (dollars), nudged from the quote bid.
     pub market_bid: f64,
@@ -124,7 +124,7 @@ pub struct ThetaDataDxStreamMarketValue {
 pub struct ThetaDataDxStreamOhlcvc {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
-    /// Milliseconds since midnight (exchange-local) when the event was recorded.
+    /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Opening price of the bar.
     pub open: f64,
@@ -149,7 +149,7 @@ pub struct ThetaDataDxStreamOhlcvc {
 pub struct ThetaDataDxStreamOpenInterest {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
-    /// Milliseconds since midnight (exchange-local) when the event was recorded.
+    /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Number of outstanding open contracts.
     pub open_interest: i32,
@@ -164,7 +164,7 @@ pub struct ThetaDataDxStreamOpenInterest {
 pub struct ThetaDataDxStreamQuote {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
-    /// Milliseconds since midnight (exchange-local) when the event was recorded.
+    /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Number of contracts/shares resting at the bid.
     pub bid_size: i32,
@@ -193,7 +193,7 @@ pub struct ThetaDataDxStreamQuote {
 pub struct ThetaDataDxStreamTrade {
     /// Contract this event refers to.
     pub contract: ThetaDataDxContract,
-    /// Milliseconds since midnight (exchange-local) when the event was recorded.
+    /// Milliseconds since midnight Eastern Time when the event was recorded.
     pub ms_of_day: i32,
     /// Exchange sequence number for ordering trades within the day.
     pub sequence: i32,

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -425,7 +425,7 @@ class Quote:
     contract: ContractRef
     """The contract this quote is for."""
     ms_of_day: int
-    """Milliseconds since exchange-local midnight when the quote was recorded."""
+    """Milliseconds since midnight Eastern Time when the quote was recorded."""
     bid_size: int
     """Number of contracts or shares resting at the bid."""
     bid_exchange: int
@@ -464,7 +464,7 @@ class Trade:
     contract: ContractRef
     """The contract this trade is for."""
     ms_of_day: int
-    """Milliseconds since exchange-local midnight when the trade printed."""
+    """Milliseconds since midnight Eastern Time when the trade printed."""
     sequence: int
     """Exchange sequence number ordering trades within the day."""
     ext_condition1: int
@@ -513,7 +513,7 @@ class OpenInterest:
     contract: ContractRef
     """The contract this open-interest tick is for."""
     ms_of_day: int
-    """Milliseconds since exchange-local midnight when the open interest was recorded."""
+    """Milliseconds since midnight Eastern Time when the open interest was recorded."""
     open_interest: int
     """Number of outstanding open contracts."""
     date: int
@@ -538,7 +538,7 @@ class Ohlcvc:
     contract: ContractRef
     """The contract this bar is for."""
     ms_of_day: int
-    """Milliseconds since exchange-local midnight at the bar's open."""
+    """Milliseconds since midnight Eastern Time at the bar's open."""
     open: float
     """Opening price of the bar in dollars."""
     high: float

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -119,6 +119,7 @@ thetadatadx iv 450 450 0.05 0.015 0.082 8.5 call
 ```bash
 thetadatadx stock history_eod AAPL 20240101 20240301                  # pretty table (default)
 thetadatadx stock history_eod AAPL 20240101 20240301 --format json     # JSON array
+thetadatadx stock history_eod AAPL 20240101 20240301 --format json-raw # JSON with raw YYYYMMDD integer dates
 thetadatadx stock history_eod AAPL 20240101 20240301 --format csv      # CSV
 ```
 
@@ -128,7 +129,7 @@ thetadatadx stock history_eod AAPL 20240101 20240301 --format csv      # CSV
 |------|---------|-------------|
 | `--creds <path>` | `creds.txt` | Credentials file |
 | `--config <preset>` | `production` | `production` or `dev` |
-| `--format <fmt>` | `table` | `table`, `json`, or `csv` |
+| `--format <fmt>` | `table` | `table`, `json`, `json-raw`, or `csv`; `json-raw` emits dates as raw `YYYYMMDD` integers instead of the ISO values `json` produces |
 | `--timeout-ms <ms>` | | Per-call deadline in milliseconds; on expiry the in-flight request is cancelled |
 
 ## Endpoint coverage


### PR DESCRIPTION
Two documentation label-accuracy fixes for the streaming surface and the CLI.

## Streaming `ms_of_day` label

The streaming `ms_of_day` field was documented as "exchange-local" in the Rust event structs and FFI structs but "Eastern Time" on the docs page and in every tick schema. Same field, two labels. The field is an unconverted `i32` that already carries Eastern Time (US exchange-local time equals ET), so this is a wording fix with no behavioral or data change. All four surfaces now read "Milliseconds since midnight Eastern Time".

The FFI struct comment is emitted by the schema-driven generator, so the correction lives in the emitter source and the checked-in generated file was regenerated from it. The generated-file consistency check passes.

## CLI `--format` `json-raw`

The CLI accepts four `--format` values — `table`, `json`, `json-raw`, `csv` — but the docs and README enumerated only three, leaving `json-raw` undiscoverable. `json-raw` is output-significant: it emits dates as raw `YYYYMMDD` integers (and `ms_of_day` as raw milliseconds) instead of the ISO-formatted values `json` produces. Added it, with a short note on its semantics, to both `docs-site/docs/cli.md` and `tools/cli/README.md`. The CLI's own inline `--format` help already enumerated `json-raw` with its semantics, so no code change was needed there.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo build -p thetadatadx` and `-p thetadatadx-ffi` build
- `generate_sdk_surfaces --check` and `generate_docs_site --check` both report generated files match
- `python3 scripts/check_docs_consistency.py` reports ok
- No `exchange-local` string remains anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)