### PR TITLE
ci: run config-file tests and add per-entry bench thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,14 @@ jobs:
       # raw transport layer against synthetic frames. Without this flag
       # those tests silently skip and the endpoint-routing / decoder /
       # pool-bench coverage is lost.
-      - run: cargo test --workspace --locked --features thetadatadx/__test-helpers
+      #
+      # `config-file` is enabled alongside it so the TOML-config test
+      # module (`#[cfg(feature = "config-file")]` in `config/mod.rs`)
+      # actually compiles and runs. Without it those tests are excluded
+      # entirely, so a sample config that silently drops a section — or a
+      # test asserting an override that never applies — passes by never
+      # executing.
+      - run: cargo test --workspace --locked --features thetadatadx/__test-helpers,thetadatadx/config-file
       # Gate 3 (#546) - Rust side: doctests run as part of `cargo test
       # --workspace` above, but invoking `--doc` explicitly verifies
       # the FFI crate's `extern "C"` doc examples compile + run on
@@ -271,6 +278,8 @@ jobs:
           # captured locally and we do not bless a value against the
           # GitHub-hosted runner without one observed sample.
           cargo bench -p thetadatadx --bench bench_fpss_event --locked -- --quick
+      - name: Validate the regression gate's own threshold logic
+        run: python3 scripts/check_bench_regression.py --selftest
       - name: Compare against checked-in baseline
         # Threshold tightened from 100% (a 2x slowdown passed) to 25%.
         # The baseline JSON is recaptured against the GH-hosted runner

--- a/crates/thetadatadx/benches/baseline/criterion.json
+++ b/crates/thetadatadx/benches/baseline/criterion.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "comment": "Gate 10 (#553) baseline. Calibrated against the GitHub-hosted runner perf profile (PR #566, 2026-05-21). Threshold stays at 25% so a real regression past this baseline trips CI. The loader in `scripts/check_bench_regression.py` ignores `_meta` and the per-entry `_captured_on` field; only `criterion_path` + `p50_ns` are gated."
+    "comment": "Baseline calibrated against the GitHub-hosted runner perf profile. The global threshold is 25% so a real regression past this baseline trips CI. The loader in `scripts/check_bench_regression.py` ignores `_meta` and the per-entry `_captured_on` field and gates on `criterion_path` + `p50_ns`. An entry may add `threshold_pct` to set its own tolerance: wider for a known high-variance workload, tighter for a critical hot path. It replaces the global gate for that entry, and the `comment` field records why."
   },
   "_captured_on": "2026-05-21",
   "streaming_channels/direct_callback/100k_events": {
@@ -9,11 +9,15 @@
   },
   "streaming_channels/disruptor_consumer_panic_isolated/100k_events": {
     "p50_ns": 2116315.6,
-    "criterion_path": "streaming_channels_disruptor_consumer_panic_isolated/100k_events"
+    "criterion_path": "streaming_channels_disruptor_consumer_panic_isolated/100k_events",
+    "threshold_pct": 40,
+    "comment": "Multi-thread, ~2.1ms workload whose p50 swings with hosted-runner CPU contention; observed clean-PR runs land near +26% under load. The 40% tolerance absorbs that scheduler variance while still catching a genuine ~1.4x regression."
   },
   "streaming_channels/disruptor_cross_thread/100k_events": {
     "p50_ns": 2151760.2,
-    "criterion_path": "streaming_channels_disruptor_cross_thread/100k_events"
+    "criterion_path": "streaming_channels_disruptor_cross_thread/100k_events",
+    "threshold_pct": 40,
+    "comment": "Multi-thread, ~2.2ms cross-thread workload with the same hosted-runner contention variance as its sibling; same 40% tolerance for the same reason."
   },
   "StreamEvent::clone/Quote": {
     "p50_ns": 21.9,

--- a/scripts/check_bench_regression.py
+++ b/scripts/check_bench_regression.py
@@ -46,6 +46,38 @@ import pathlib
 import sys
 
 
+def effective_threshold(entry: dict, global_threshold: float) -> float:
+    """Resolve the regression tolerance for one baseline entry.
+
+    A per-entry `threshold_pct` replaces the global gate — wider for a
+    known high-variance workload, tighter for a critical hot path. Any
+    non-numeric or absent value falls back to the global threshold.
+    """
+    value = entry.get("threshold_pct")
+    return float(value) if isinstance(value, (int, float)) else global_threshold
+
+
+def _selftest() -> int:
+    cases = [
+        ({}, 25.0, 25.0),
+        ({"threshold_pct": 40}, 25.0, 40.0),
+        ({"threshold_pct": 10}, 25.0, 10.0),
+        ({"threshold_pct": 40.5}, 25.0, 40.5),
+        ({"threshold_pct": None}, 25.0, 25.0),
+        ({"threshold_pct": "nope"}, 25.0, 25.0),
+    ]
+    for entry, global_t, expected in cases:
+        got = effective_threshold(entry, global_t)
+        if got != expected:
+            sys.stderr.write(
+                f"selftest FAIL: effective_threshold({entry}, {global_t}) "
+                f"= {got}, expected {expected}\n"
+            )
+            return 1
+    print(f"check_bench_regression --selftest: {len(cases)} passed, 0 failed")
+    return 0
+
+
 def load_baseline(path: pathlib.Path) -> dict:
     if not path.is_file():
         sys.stderr.write(
@@ -100,7 +132,15 @@ def main() -> int:
             "percentage threshold; filters sub-nanosecond runner jitter"
         ),
     )
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="run the threshold-resolution self-test and exit",
+    )
     args = parser.parse_args()
+
+    if args.selftest:
+        return _selftest()
 
     baseline = load_baseline(args.baseline)
     failures: list[tuple[str, float, float, float]] = []
@@ -131,7 +171,14 @@ def main() -> int:
 
         abs_delta = current_p50 - float(baseline_p50)
         delta_pct = abs_delta / float(baseline_p50) * 100.0
-        over_pct = delta_pct > args.threshold
+        # A bench may carry its own `threshold_pct` to set a tolerance that
+        # differs from the global gate — wider for a known high-variance
+        # workload (a multi-thread bench whose p50 swings with runner CPU
+        # contention), or tighter for a critical hot path. It replaces the
+        # global `--threshold` for that entry; the reason is documented on
+        # the entry itself. Absent the field, the global gate applies.
+        eff_threshold = effective_threshold(entry, args.threshold)
+        over_pct = delta_pct > eff_threshold
         regressed = over_pct and abs_delta > args.abs_floor_ns
         # `NOISE` marks a bench that cleared the percentage gate but not the
         # absolute floor — a sub-nanosecond move we refuse to treat as real.
@@ -140,7 +187,7 @@ def main() -> int:
             f"{status:<11} {bench_id:<60} "
             f"baseline {baseline_p50:>12.1f} ns  "
             f"current {current_p50:>12.1f} ns  "
-            f"delta {delta_pct:+.2f}%"
+            f"delta {delta_pct:+.2f}%  limit {eff_threshold:.0f}%"
         )
         if regressed:
             failures.append((bench_id, float(baseline_p50), current_p50, delta_pct))
@@ -156,7 +203,8 @@ def main() -> int:
 
     if failures:
         sys.stderr.write(
-            f"\n{len(failures)} bench(es) regressed beyond the {args.threshold:.1f}% threshold:\n"
+            f"\n{len(failures)} bench(es) regressed beyond their threshold "
+            f"(global {args.threshold:.1f}%, per-entry overrides as noted):\n"
         )
         for bench_id, base, cur, delta in failures:
             sys.stderr.write(


### PR DESCRIPTION
## Why

Two CI-coverage gaps surfaced while landing the recent fixes:

1. **The `config-file` test module never ran.** The workspace `Test` job ran with only `thetadatadx/__test-helpers`, so the `#[cfg(feature = "config-file")]` config test module in `config/mod.rs` compiled out entirely. That is how a sample config silently dropping a section — and four tests asserting overrides that never applied — sat green until a manual run surfaced them.
2. **The bench gate flaked on unrelated PRs.** Every tracked bench was compared against one global 25% threshold. Two multi-thread streaming benches (`disruptor_consumer_panic_isolated`, `disruptor_cross_thread`, ~2.1–2.2ms) swing with hosted-runner CPU contention and tipped just past 25% (+25.8%, +26.9%) on PRs that never touched the hot path.

## What

- **Enable `config-file` on the Test step** (`--features thetadatadx/__test-helpers,thetadatadx/config-file`) so the 15 config tests run on every PR. Verified they execute and pass under that exact feature set.
- **Per-entry `threshold_pct` in the bench baseline.** An entry may set its own tolerance — wider for a known high-variance workload, tighter for a critical hot path — replacing the global gate for that entry, with a `comment` field recording why. The two disruptor benches get 40% (still catches a genuine ~1.4x regression); everything else stays on the global 25%.
- **`--selftest`** on `check_bench_regression.py` validating the threshold-resolution logic, wired into the gate job so the gate's own logic is exercised in CI.

## Test

- `cargo test -p thetadatadx --lib --features thetadatadx/__test-helpers,thetadatadx/config-file config_file_tests` — 15 pass.
- `python3 scripts/check_bench_regression.py --selftest` — 6 pass.
- Baseline JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)