### PR TITLE
fix: preserve error sources and align cross-binding strike and park-interval widths

### DIFF
--- a/crates/thetadatadx/src/auth/creds.rs
+++ b/crates/thetadatadx/src/auth/creds.rs
@@ -89,6 +89,7 @@ impl Credentials {
                     e
                 )),
                 message: "credentials file unreadable".to_string(),
+                source: Some(Box::new(e)),
             }
         })?);
 

--- a/crates/thetadatadx/src/error.rs
+++ b/crates/thetadatadx/src/error.rs
@@ -408,6 +408,13 @@ pub enum Error {
         kind: DecodeErrorKind,
         /// Human-readable detail for logs and `Display`.
         message: String,
+        /// Typed underlying cause when this error was bridged from a
+        /// lower layer (the per-cell decoder), so `Error::source()`
+        /// returns the original error for chain walking. `None` for
+        /// failures raised directly at this layer, whose full detail is
+        /// already carried by `kind` and `message`.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
     },
 
     /// Query returned no data rows.
@@ -439,6 +446,13 @@ pub enum Error {
         kind: ConfigErrorKind,
         /// Human-readable detail for logs and `Display`.
         message: String,
+        /// Typed underlying cause when this error was bridged from a
+        /// lower layer (the data-format encoding layer), so
+        /// `Error::source()` returns the original error for chain
+        /// walking. `None` for failures raised directly at this layer,
+        /// whose full detail is already carried by `kind` and `message`.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
     },
 
     /// HTTP error (reqwest).
@@ -516,6 +530,7 @@ impl Error {
         Self::Config {
             kind: ConfigErrorKind::InvalidValue { field, message },
             message: display,
+            source: None,
         }
     }
 
@@ -527,6 +542,7 @@ impl Error {
         Self::Config {
             kind: ConfigErrorKind::MissingField(field),
             message: display,
+            source: None,
         }
     }
 
@@ -543,6 +559,7 @@ impl Error {
                 max,
             },
             message: display,
+            source: None,
         }
     }
 
@@ -553,6 +570,7 @@ impl Error {
         Self::Config {
             kind: ConfigErrorKind::Io(message.clone()),
             message,
+            source: None,
         }
     }
 
@@ -563,6 +581,7 @@ impl Error {
         Self::Config {
             kind: ConfigErrorKind::TomlParse(message.clone()),
             message,
+            source: None,
         }
     }
 
@@ -573,6 +592,7 @@ impl Error {
         Self::Config {
             kind: ConfigErrorKind::Internal(message.clone()),
             message,
+            source: None,
         }
     }
 
@@ -586,6 +606,7 @@ impl Error {
         Self::Decode {
             kind: DecodeErrorKind::Protobuf(message.clone()),
             message,
+            source: None,
         }
     }
 
@@ -596,6 +617,7 @@ impl Error {
         Self::Decode {
             kind: DecodeErrorKind::Codec(message.clone()),
             message,
+            source: None,
         }
     }
 
@@ -607,6 +629,7 @@ impl Error {
         Self::Decode {
             kind: DecodeErrorKind::Arrow(message.clone()),
             message,
+            source: None,
         }
     }
 
@@ -623,7 +646,11 @@ impl Error {
             actual_columns,
         };
         let message = kind.to_string();
-        Self::Decode { kind, message }
+        Self::Decode {
+            kind,
+            message,
+            source: None,
+        }
     }
 
     /// Build a `Decode` error categorized as a column type mismatch.
@@ -641,7 +668,11 @@ impl Error {
             actual: actual.into(),
         };
         let message = kind.to_string();
-        Self::Decode { kind, message }
+        Self::Decode {
+            kind,
+            message,
+            source: None,
+        }
     }
 
     // ─── Decompress constructors ────────────────────────────────────────
@@ -710,9 +741,18 @@ impl From<crate::tdbe::error::Error> for Error {
         // these failures reflect a bad caller-supplied value, never an
         // SDK-internal name.
         match err {
-            crate::tdbe::error::Error::Config(msg) => Self::config_invalid("input", msg),
             crate::tdbe::error::Error::Io(e) => Self::Io(e),
-            other => Self::config_invalid("input", other.to_string()),
+            other => {
+                let display = format!("input: {other}");
+                Self::Config {
+                    kind: ConfigErrorKind::InvalidValue {
+                        field: "input".to_string(),
+                        message: other.to_string(),
+                    },
+                    message: display,
+                    source: Some(Box::new(other)),
+                }
+            }
         }
     }
 }
@@ -722,8 +762,15 @@ impl From<crate::decode::DecodeError> for Error {
         // Per-cell decode failures surface through the same channel as
         // protobuf decode failures so callers pattern-match a single
         // `Error::Decode` variant. The `Codec` kind is the closest fit
-        // for FIE/FIT-cell type-mismatch failures.
-        Self::decode_codec(err.to_string())
+        // for FIE/FIT-cell type-mismatch failures. The typed cause is
+        // retained as the error source so chain walkers reach the
+        // per-cell detail without parsing the `Display` string.
+        let message = err.to_string();
+        Self::Decode {
+            kind: DecodeErrorKind::Codec(message.clone()),
+            message,
+            source: Some(Box::new(err)),
+        }
     }
 }
 
@@ -731,8 +778,11 @@ impl From<crate::grpc::Status> for Error {
     fn from(s: crate::grpc::Status) -> Self {
         // The transport carries the canonical `grpc-status` /
         // `grpc-message` pair plus the decoded `google.rpc.RetryInfo`
-        // hint. Surface the numeric code + UTF-8 message as-is so
-        // callers get `GrpcStatusKind` pattern-matching.
+        // hint. Every field of the source status is preserved
+        // structurally — the numeric code maps to a typed
+        // `GrpcStatusKind`, the message and the backoff hint carry over
+        // verbatim — so nothing is flattened away and a source link
+        // would expose no detail the variant does not already hold.
         let kind = GrpcStatusKind::from_u32(s.code());
         Self::Grpc {
             kind,
@@ -959,6 +1009,43 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn decode_error_bridge_preserves_source() {
+        use std::error::Error as _;
+        let cause = crate::decode::DecodeError::MissingCell { column: 4 };
+        let cause_display = cause.to_string();
+        let err: Error = cause.into();
+        assert!(matches!(
+            err,
+            Error::Decode {
+                kind: DecodeErrorKind::Codec(_),
+                ..
+            }
+        ));
+        let source = err.source().expect("bridged decode error carries a source");
+        assert_eq!(source.to_string(), cause_display);
+        assert!(source
+            .downcast_ref::<crate::decode::DecodeError>()
+            .is_some());
+    }
+
+    #[test]
+    fn tdbe_error_bridge_preserves_source() {
+        use std::error::Error as _;
+        let cause = crate::tdbe::error::Error::Decode("bad nibble".into());
+        let cause_display = cause.to_string();
+        let err: Error = cause.into();
+        assert!(matches!(
+            err,
+            Error::Config {
+                kind: ConfigErrorKind::InvalidValue { .. },
+                ..
+            }
+        ));
+        let source = err.source().expect("bridged tdbe error carries a source");
+        assert_eq!(source.to_string(), cause_display);
     }
 
     #[test]

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -275,6 +275,7 @@ impl From<FpssError> for Error {
                     message: message.clone(),
                 },
                 message,
+                source: None,
             },
             FpssError::Io(message) => Error::Io(std::io::Error::other(message)),
         }
@@ -2079,6 +2080,7 @@ impl StreamingClient {
                     ),
                 },
                 message: "unsupported full-stream security type".to_string(),
+                source: None,
             });
         }
         let req_id = wire_req_id(self.next_req_id.fetch_add(1, Ordering::Relaxed));

--- a/crates/thetadatadx/src/fpss/protocol/contract.rs
+++ b/crates/thetadatadx/src/fpss/protocol/contract.rs
@@ -737,8 +737,8 @@ impl std::str::FromStr for Contract {
     ///
     /// Two formats are accepted:
     ///
-    /// 1. **Bare root** (stock contract). 1..=6 ASCII uppercase letters,
-    ///    optionally including a single `.`:
+    /// 1. **Bare root** (stock contract). 1..=16 ASCII uppercase letters,
+    ///    optionally including a single `.` (e.g. `"BRK.B"`):
     ///    ```
     ///    # use std::str::FromStr;
     ///    # use thetadatadx::fpss::protocol::Contract;

--- a/crates/thetadatadx/src/fpss/protocol/wire.rs
+++ b/crates/thetadatadx/src/fpss/protocol/wire.rs
@@ -281,6 +281,7 @@ mod tests {
             Error::Config {
                 kind: crate::error::ConfigErrorKind::InvalidValue { field, .. },
                 message,
+                ..
             } => {
                 assert_eq!(field, "auth.credentials");
                 assert!(

--- a/crates/thetadatadx/tests/flatfiles_byte_match.rs
+++ b/crates/thetadatadx/tests/flatfiles_byte_match.rs
@@ -16,6 +16,12 @@
 //! fixture inside must exist — a missing CSV at that point is a hard
 //! failure. The JSONL sink re-encodes the same logical rows and is
 //! row-count smoke-tested.
+//!
+//! The comparison is column-for-column rather than a raw byte compare:
+//! the SDK emits option strikes in dollars on every client-facing
+//! surface, while the vendor reference renders the raw scaled-integer
+//! wire value (1000 wire units per dollar). That one column is compared
+//! on a common scale; every other byte must still match exactly.
 
 // Test gate sits on each #[test] via `cfg_attr(not(feature="live-tests"),
 // ignore)`. Without `--features live-tests`, the live-MDDS integration
@@ -110,6 +116,76 @@ fn resolve_fixture(filename: &str) -> Option<PathBuf> {
     resolution_to_option(resolve_fixture_inner(filename, FIXTURES_PATH_ENV))
 }
 
+/// Zero-based index of the `strike` column in the option CSV layout
+/// (`symbol,expiration,strike,right,...`). The contract prefix the
+/// vendor prepends to every option row shares this layout.
+const OPTION_STRIKE_COLUMN: usize = 2;
+
+/// Assert the SDK CSV matches the vendor CSV column-for-column, treating
+/// the strike column as semantically equal across the two scales.
+///
+/// The strike column is the one cell that legitimately differs: the SDK
+/// emits strikes in dollars (`$210.00`), while the vendor reference
+/// renders the raw wire integer (1000 wire units per dollar, so `210000`
+/// for a $210 strike). The two encode the same strike at different
+/// scales, so a byte-equal comparison of that column would always fail.
+/// Every other byte must still match exactly, so each row is compared
+/// field-by-field with the strike cell converted to a common scale
+/// (vendor wire units / 1000 == SDK dollars) and all remaining cells
+/// compared verbatim. The header row matches byte-for-byte and is
+/// compared whole.
+fn assert_option_csv_matches_vendor(ours: &[u8], theirs: &[u8], context: &str) {
+    let ours = std::str::from_utf8(ours).expect("SDK CSV is UTF-8");
+    let theirs = std::str::from_utf8(theirs).expect("vendor CSV is UTF-8");
+    let our_lines: Vec<&str> = ours.lines().collect();
+    let their_lines: Vec<&str> = theirs.lines().collect();
+    assert_eq!(
+        our_lines.len(),
+        their_lines.len(),
+        "{context}: row count mismatch SDK={} vendor={}",
+        our_lines.len(),
+        their_lines.len()
+    );
+
+    for (row_idx, (our_line, their_line)) in our_lines.iter().zip(&their_lines).enumerate() {
+        // Row 0 is the header; both sides write the identical column
+        // names, so compare it whole.
+        if row_idx == 0 {
+            assert_eq!(our_line, their_line, "{context}: header row differs");
+            continue;
+        }
+        let our_cells: Vec<&str> = our_line.split(',').collect();
+        let their_cells: Vec<&str> = their_line.split(',').collect();
+        assert_eq!(
+            our_cells.len(),
+            their_cells.len(),
+            "{context}: column count mismatch at row {row_idx}: SDK={our_line:?} vendor={their_line:?}"
+        );
+        for (col, (our_cell, their_cell)) in our_cells.iter().zip(&their_cells).enumerate() {
+            if col == OPTION_STRIKE_COLUMN {
+                let our_strike: f64 = our_cell
+                    .parse()
+                    .unwrap_or_else(|_| panic!("{context}: SDK strike {our_cell:?} not numeric"));
+                let their_wire: f64 = their_cell.parse().unwrap_or_else(|_| {
+                    panic!("{context}: vendor strike {their_cell:?} not numeric")
+                });
+                // 1000 wire units per dollar; SDK dollars are wire /
+                // 1000. Compare on the dollar scale.
+                let their_dollars = their_wire / 1_000.0;
+                assert!(
+                    (our_strike - their_dollars).abs() < 1e-9,
+                    "{context}: strike mismatch at row {row_idx}: SDK={our_strike} vendor={their_wire} (={their_dollars} dollars)"
+                );
+            } else {
+                assert_eq!(
+                    our_cell, their_cell,
+                    "{context}: cell mismatch at row {row_idx} col {col}: SDK={our_cell:?} vendor={their_cell:?}"
+                );
+            }
+        }
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg_attr(
     not(feature = "live-tests"),
@@ -166,14 +242,7 @@ async fn option_open_interest_csv_byte_matches_vendor() {
     .expect("CSV decode");
     let ours = std::fs::read(&csv_path).expect("read SDK CSV");
     let theirs = std::fs::read(&reference_path).expect("read vendor CSV");
-    assert_eq!(
-        ours.len(),
-        theirs.len(),
-        "byte length mismatch: SDK={} vendor={}",
-        ours.len(),
-        theirs.len()
-    );
-    assert_eq!(ours, theirs, "CSV content does not byte-match vendor");
+    assert_option_csv_matches_vendor(&ours, &theirs, "OPTION/OPEN_INTEREST");
 
     // Smoke-test JSONL on the same blob; assert row count equals CSV
     // rows minus the header.
@@ -271,14 +340,7 @@ async fn option_eod_csv_byte_matches_vendor() {
     .expect("CSV decode");
     let ours = std::fs::read(&csv_path).expect("read SDK CSV");
     let theirs = std::fs::read(&reference_path).expect("read vendor CSV");
-    assert_eq!(
-        ours.len(),
-        theirs.len(),
-        "byte length mismatch: SDK={} vendor={}",
-        ours.len(),
-        theirs.len()
-    );
-    assert_eq!(ours, theirs, "EOD CSV content does not byte-match vendor");
+    assert_option_csv_matches_vendor(&ours, &theirs, "OPTION/EOD");
 
     // Smoke-test JSONL on the same blob; assert row count equals CSV
     // rows minus the header.

--- a/sdks/typescript/__tests__/wait_strategy.test.mjs
+++ b/sdks/typescript/__tests__/wait_strategy.test.mjs
@@ -30,17 +30,17 @@ test("default wait tuning", () => {
   const cfg = Config.production();
   assert.equal(cfg.waitSpinIters, 100);
   assert.equal(cfg.waitYieldIters, 10);
-  assert.equal(cfg.waitParkUs, 50);
+  assert.equal(cfg.waitParkUs, 50n);
 });
 
 test("wait tuning round-trips", () => {
   const cfg = Config.production();
   cfg.setWaitSpinIters(16);
   cfg.setWaitYieldIters(2);
-  cfg.setWaitParkUs(200);
+  cfg.setWaitParkUs(200n);
   assert.equal(cfg.waitSpinIters, 16);
   assert.equal(cfg.waitYieldIters, 2);
-  assert.equal(cfg.waitParkUs, 200);
+  assert.equal(cfg.waitParkUs, 200n);
 });
 
 test("default consumer cpu is null", () => {

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -528,11 +528,16 @@ export declare class Config {
   /**
    * Set the wait-strategy park interval in microseconds (used by the
    * `"balanced"` / `"efficient"` strategies). The interval is a `u64`
-   * microsecond value, marshalled as a `bigint`:
-   * `setWaitParkUs(BigInt(50))`.
+   * microsecond value in the core, so it marshals as a `BigInt` like
+   * the other microsecond / second streaming and reconnect knobs:
+   * `setWaitParkUs(BigInt(50))`. The core clamps the effective park
+   * interval to its supported ceiling when the wait strategy is built.
    */
   setWaitParkUs(parkUs: bigint): void
-  /** Current wait-strategy park interval in microseconds. */
+  /**
+   * Current wait-strategy park interval in microseconds (returned as a
+   * `BigInt`).
+   */
   get waitParkUs(): bigint
   /**
    * Pin the streaming consumer thread to a CPU core, or `null` to

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -527,11 +527,13 @@ export declare class Config {
   get waitYieldIters(): number
   /**
    * Set the wait-strategy park interval in microseconds (used by the
-   * `"balanced"` / `"efficient"` strategies).
+   * `"balanced"` / `"efficient"` strategies). The interval is a `u64`
+   * microsecond value, marshalled as a `bigint`:
+   * `setWaitParkUs(BigInt(50))`.
    */
-  setWaitParkUs(parkUs: number): void
+  setWaitParkUs(parkUs: bigint): void
   /** Current wait-strategy park interval in microseconds. */
-  get waitParkUs(): number
+  get waitParkUs(): bigint
   /**
    * Pin the streaming consumer thread to a CPU core, or `null` to
    * leave it under the OS scheduler (default).

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -1621,25 +1621,33 @@ impl Config {
     }
 
     /// Set the wait-strategy park interval in microseconds (used by the
-    /// `"balanced"` / `"efficient"` strategies).
+    /// `"balanced"` / `"efficient"` strategies). The interval is a `u64`
+    /// microsecond value in the core, so it marshals as a `BigInt` like
+    /// the other microsecond / second streaming and reconnect knobs:
+    /// `setWaitParkUs(BigInt(50))`. The core clamps the effective park
+    /// interval to its supported ceiling when the wait strategy is built.
     #[napi(js_name = "setWaitParkUs")]
-    pub fn set_wait_park_us(&self, park_us: u32) -> napi::Result<()> {
+    pub fn set_wait_park_us(&self, park_us: napi::bindgen_prelude::BigInt) -> napi::Result<()> {
+        let value = bigint_to_u64("setWaitParkUs", &park_us)?;
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.streaming.wait_park_us = u64::from(park_us);
+        guard.streaming.wait_park_us = value;
         Ok(())
     }
 
-    /// Current wait-strategy park interval in microseconds.
+    /// Current wait-strategy park interval in microseconds (returned as a
+    /// `BigInt`).
     #[napi(getter, js_name = "waitParkUs")]
-    pub fn wait_park_us(&self) -> napi::Result<u32> {
+    pub fn wait_park_us(&self) -> napi::Result<napi::bindgen_prelude::BigInt> {
         let guard = self
             .inner
             .lock()
             .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(u32::try_from(guard.streaming.wait_park_us).unwrap_or(u32::MAX))
+        Ok(napi::bindgen_prelude::BigInt::from(
+            guard.streaming.wait_park_us,
+        ))
     }
 
     /// Pin the streaming consumer thread to a CPU core, or `null` to


### PR DESCRIPTION
A batch of small correctness and consistency fixes across the error surface, contract docs, the flat-file byte-match test, and the TypeScript binding.

## Error cause-chain preservation

The bridges from the data-format encoding layer and the per-cell decoder into the public `Error` previously flattened the typed cause to a string, so `std::error::Error::source()` returned `None` for the `Config` and `Decode` families — inconsistent with the `Io` / `Http` / `Tls` variants that carry their cause via `#[from]`. The `Config` and `Decode` variants now hold an optional `#[source]` boxed error that the `From` conversions populate with the typed cause, so chain walkers reach the original error without parsing `Display`. The credentials-file read carries its underlying `io::Error` the same way. Display output is unchanged: `kind` and `message` render exactly as before, verified by the existing kind-carried tests. The gRPC status conversion already preserves the numeric code, message, and retry hint structurally, so it gains a clarifying comment rather than a redundant source link.

## Contract::from_str rustdoc

The bare-root doc claimed `1..=6 ASCII uppercase`, but `validate_root` accepts `1..=MAX_ROOT_LEN` (16). Corrected to match the code.

## Flat-file byte-match comparison

The opt-in live byte-match compared the SDK CSV against the vendor reference as one byte block. The SDK emits option strikes in dollars on every client-facing surface while the vendor file renders the raw scaled-integer wire value (1000 wire units per dollar), so the strike column can never byte-match. The comparison is now column-for-column: the strike cell is compared on a common scale, and every other byte must still match exactly. The test stays behind its `live-tests` feature gate and the fixtures env var.

## TypeScript wait_park_us width

The napi binding typed `wait_park_us` as `u32` while the core field, and the Python, C, and C++ bindings, are all `u64`. Widened the binding to a `BigInt`, mirroring the other microsecond and second streaming and reconnect knobs, so all four bindings match the core width.

## Verification

- `cargo fmt --all -- --check` clean (core and TypeScript crate)
- `cargo test -p thetadatadx --lib` — 808 passed, including the two new `error::tests::*_bridge_preserves_source` tests
- `cargo clippy -p thetadatadx --lib -- -D warnings` clean
- `cargo check -p thetadatadx --test flatfiles_byte_match --features live-tests` compiles
- `cargo build` on the TypeScript binding crate succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)