### PR TITLE
feat(sdk): bind the slow-callback watchdog across every binding

### DIFF
--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -1274,6 +1274,56 @@ pub unsafe extern "C" fn thetadatadx_client_panic_count(handle: *const ThetaData
     })
 }
 
+/// Set the slow-callback wall-clock threshold in microseconds on this
+/// unified handle.
+///
+/// When a user-callback invocation runs longer than `threshold_us`,
+/// `thetadatadx_client_slow_callback_count` increments and a rate-limited
+/// warning is logged. Pass `0` to disable the watchdog. The watchdog is
+/// observability-only — it never cancels or kills the callback; the
+/// counter and log let operators detect a callback that has outgrown its
+/// budget and decide how to respond.
+///
+/// No-op if the handle is null or no callback has been installed yet.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_client_set_slow_callback_threshold_us(
+    handle: *const ThetaDataDxClient,
+    threshold_us: u64,
+) {
+    ffi_boundary!((), {
+        if handle.is_null() {
+            return;
+        }
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        unsafe {
+            (*handle)
+                .inner
+                .stream()
+                .set_slow_callback_threshold(std::time::Duration::from_micros(threshold_us));
+        }
+    })
+}
+
+/// Cumulative count of user-callback invocations whose wall-clock
+/// duration exceeded the threshold set by
+/// `thetadatadx_client_set_slow_callback_threshold_us` on this unified handle.
+///
+/// Returns 0 when the watchdog is disabled (threshold 0), the handle is
+/// null, or no callback has been installed yet. Safe to call from any
+/// thread without blocking.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_client_slow_callback_count(
+    handle: *const ThetaDataDxClient,
+) -> u64 {
+    ffi_boundary!(0, {
+        if handle.is_null() {
+            return 0;
+        }
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        unsafe { (*handle).inner.stream().slow_callback_count() }
+    })
+}
+
 /// Wait for the previously-superseded streaming session to quiesce.
 ///
 /// Returns `1` once the previous `thetadatadx_client_stop_streaming` /
@@ -2383,6 +2433,64 @@ pub unsafe extern "C" fn thetadatadx_streaming_panic_count(
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         guard.as_ref().map_or(0, |c| c.panic_count())
+    })
+}
+
+/// Set the slow-callback wall-clock threshold in microseconds on this
+/// FPSS handle.
+///
+/// When a user-callback invocation runs longer than `threshold_us`,
+/// `thetadatadx_streaming_slow_callback_count` increments and a
+/// rate-limited warning is logged. Pass `0` to disable the watchdog. The
+/// watchdog is observability-only — it never cancels or kills the
+/// callback; the counter and log let operators detect a callback that has
+/// outgrown its budget and decide how to respond.
+///
+/// No-op if the handle is null or has been shut down.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_streaming_set_slow_callback_threshold_us(
+    handle: *const ThetaDataDxStreamHandle,
+    threshold_us: u64,
+) {
+    ffi_boundary!((), {
+        if handle.is_null() {
+            return;
+        }
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        let handle = unsafe { &*handle };
+        let guard = handle
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(c) = guard.as_ref() {
+            c.set_slow_callback_threshold(std::time::Duration::from_micros(threshold_us));
+        }
+    })
+}
+
+/// Cumulative count of user-callback invocations whose wall-clock
+/// duration exceeded the threshold set by
+/// `thetadatadx_streaming_set_slow_callback_threshold_us` on this FPSS
+/// handle.
+///
+/// Returns 0 when the watchdog is disabled (threshold 0), the handle is
+/// null, or has been shut down. Safe to call from any thread without
+/// blocking.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_streaming_slow_callback_count(
+    handle: *const ThetaDataDxStreamHandle,
+) -> u64 {
+    ffi_boundary!(0, {
+        if handle.is_null() {
+            return 0;
+        }
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        let handle = unsafe { &*handle };
+        let guard = handle
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.as_ref().map_or(0, |c| c.slow_callback_count())
     })
 }
 

--- a/scripts/check_binding_parity.py
+++ b/scripts/check_binding_parity.py
@@ -64,6 +64,12 @@ CPP_HPP = REPO_ROOT / "sdks" / "cpp" / "include" / "thetadatadx.hpp"
 CPP_H = REPO_ROOT / "sdks" / "cpp" / "include" / "thetadatadx.h"
 FFI_SRC = REPO_ROOT / "ffi" / "src"
 CONFIG_DIR = REPO_ROOT / "crates" / "thetadatadx" / "src" / "config"
+# Core Rust streaming surfaces whose public observability accessors must
+# each carry a parity row. The unified surface lives on the
+# `StreamSurface` view returned by `Client::stream()`; the standalone
+# surface is the `StreamingClient` FPSS client.
+CORE_CLIENT_RS = REPO_ROOT / "crates" / "thetadatadx" / "src" / "client.rs"
+CORE_FPSS_MOD_RS = REPO_ROOT / "crates" / "thetadatadx" / "src" / "fpss" / "mod.rs"
 
 
 # ─── Public-surface vocabulary guard ────────────────────────────────
@@ -365,12 +371,20 @@ def _collect_typescript_setters(ts_src: pathlib.Path) -> set[str]:
         return set()
     for rs in ts_src.rglob("*.rs"):
         text = rs.read_text(encoding="utf-8")
-        # `#[napi(js_name = "setX")]` → setter `X` (drop the `set` prefix).
-        for m in re.finditer(
-            r'#\[napi\([^)]*\bjs_name\s*=\s*"set([A-Z]\w*)"[^)]*\)\]',
-            text,
-        ):
-            setters_camel.add(m.group(1))
+        # Scope to `impl Config { ... }` blocks so a `set<X>` napi method
+        # on a non-Config class (e.g. the live `StreamView` streaming
+        # knobs like `setSlowCallbackThresholdUs`) is not mistaken for a
+        # Config knob setter. This mirrors the Python collector, which
+        # relies on `#[setter]` being a Config-property-only attribute,
+        # and the C++/FFI collectors, which intersect with the
+        # `thetadatadx_config_set_*` C ABI surface.
+        for body in _iter_impl_config_bodies(text):
+            # `#[napi(js_name = "setX")]` → setter `X` (drop the `set` prefix).
+            for m in re.finditer(
+                r'#\[napi\([^)]*\bjs_name\s*=\s*"set([A-Z]\w*)"[^)]*\)\]',
+                body,
+            ):
+                setters_camel.add(m.group(1))
     # Lift to snake_case for parity-row matching. Every camelCase
     # name renders to one or more snake-case candidates (the bare
     # snake form plus any compound-word alias rendering); the gate
@@ -1256,6 +1270,140 @@ def _check_method_rows(
                 f"stays tracked."
             )
 
+    return errors
+
+
+# ─── Core streaming observability-surface orphan check ──────────────
+#
+# The cross-binding `[[method]]` rows above gate each DECLARED method
+# against the bindings. They do not gate the reverse direction on the
+# Rust side: a public observability accessor wired onto the core
+# streaming surface (`StreamSurface` view / `StreamingClient`) that never
+# grew a parity row is invisible — the row simply does not exist, so no
+# check fires, and the accessor silently reaches none of the bindings.
+# That is exactly how a wired-but-unbound counter/threshold knob drifts.
+#
+# This check harvests the public observability accessors on the two core
+# streaming surfaces and asserts each maps to a `[[method]]` row. It is
+# scoped to the observability accessor SHAPE (cumulative counters, ring
+# telemetry, and the slow-callback threshold setter) so it never trips on
+# the lifecycle / subscription methods whose cross-binding spelling
+# legitimately diverges and which the forward rows already cover.
+
+# The core Rust class name → the parity-toml `class` field. The unified
+# streaming surface is the `StreamSurface` view returned by
+# `Client::stream()`, tracked in `parity.toml` under the binding-facing
+# `StreamView` name.
+CORE_STREAMING_CLASS_TO_ROW: dict[str, str] = {
+    "StreamSurface": "StreamView",
+    "StreamingClient": "StreamingClient",
+}
+
+# Core Rust accessor name → the canonical camelCase parity-row `name`.
+# Most accessors camelCase directly; the standalone `StreamingClient`
+# core counter is named `dropped_count` but the binding/row contract
+# spells it `droppedEventCount` (the same counter as the unified
+# surface), so it is bridged explicitly here.
+CORE_STREAMING_METHOD_RENAMES: dict[str, str] = {
+    "dropped_count": "droppedEventCount",
+    "dropped_event_count": "droppedEventCount",
+    "slow_callback_count": "slowCallbackCount",
+    "set_slow_callback_threshold": "setSlowCallbackThresholdUs",
+}
+
+# An observability accessor is one whose name matches this shape. The
+# closure is intentionally narrow: cumulative counters (`*_count`), ring
+# telemetry (`ring_*`), and the slow-callback threshold setter. Lifecycle
+# / subscription / connection methods do not match and stay governed by
+# the forward `[[method]]` rows alone.
+def _is_core_observability_accessor(name: str) -> bool:
+    if name == "record_panic":
+        # Internal `#[cfg(feature = "__internal")]` fault-injection hook,
+        # not a public client accessor.
+        return False
+    if name.endswith("_count"):
+        return True
+    if name.startswith("ring_"):
+        return True
+    if name.startswith("set_") and name.endswith("_threshold"):
+        return True
+    return False
+
+
+def _collect_core_streaming_observability_methods(
+    client_rs: pathlib.Path,
+    fpss_mod_rs: pathlib.Path,
+) -> dict[str, set[str]]:
+    """Return `{core_class: {accessor, ...}}` for the public observability
+    accessors on the core streaming surfaces.
+
+    Parses `impl StreamSurface<...> { ... }` in `client.rs` and
+    `impl StreamingClient { ... }` in `fpss/mod.rs`, collecting every
+    `pub fn <name>` whose name matches the observability shape
+    (`_is_core_observability_accessor`). `#[cfg(...)]` / `#[doc(hidden)]`
+    gated methods are skipped — they are not part of the published
+    surface a binding must mirror.
+    """
+    out: dict[str, set[str]] = {}
+    sources: list[tuple[str, pathlib.Path]] = [
+        ("StreamSurface", client_rs),
+        ("StreamingClient", fpss_mod_rs),
+    ]
+    # `impl StreamSurface<'_> {` / `impl StreamingClient {` — tolerate an
+    # optional generic / lifetime parameter list before the brace.
+    pub_fn_re = re.compile(
+        r"((?:#\[[^\]]*\]\s*)*)\bpub\s+fn\s+([a-z_][a-z0-9_]*)\s*[(<]"
+    )
+    for class_name, rs in sources:
+        if not rs.is_file():
+            continue
+        text = rs.read_text(encoding="utf-8")
+        impl_re = re.compile(
+            rf"impl\s+{class_name}\b[^{{]*\{{"
+        )
+        for header in impl_re.finditer(text):
+            body = _balanced_body(text, header.end())
+            for m in pub_fn_re.finditer(body):
+                attrs = m.group(1)
+                name = m.group(2)
+                if "cfg(" in attrs or "doc(hidden)" in attrs:
+                    continue
+                if not _is_core_observability_accessor(name):
+                    continue
+                out.setdefault(class_name, set()).add(name)
+    return out
+
+
+def _check_core_streaming_method_rows(
+    core_methods: dict[str, set[str]],
+    method_rows: list[dict[str, Any]],
+) -> list[str]:
+    """Assert every public observability accessor on the core streaming
+    surfaces carries a `[[method]]` parity row.
+
+    Closes the blind spot where a counter / threshold knob wired onto the
+    core `StreamSurface` / `StreamingClient` surface reaches none of the
+    bindings because no row enrolls it. The row's per-binding columns are
+    then gated by `_check_method_rows`; this check only asserts the row
+    EXISTS for the right class.
+    """
+    errors: list[str] = []
+    declared: set[tuple[str, str]] = {
+        (row.get("class", ""), row.get("name", "")) for row in method_rows
+    }
+    for core_class, names in sorted(core_methods.items()):
+        row_class = CORE_STREAMING_CLASS_TO_ROW.get(core_class, core_class)
+        for name in sorted(names):
+            row_name = CORE_STREAMING_METHOD_RENAMES.get(name, _snake_to_camel(name))
+            if (row_class, row_name) not in declared:
+                errors.append(
+                    f"  {core_class}::{name}: public observability accessor on "
+                    f"the core streaming surface has no `[[method]]` row "
+                    f"(expected `class = \"{row_class}\"`, `name = "
+                    f"\"{row_name}\"` in sdks/parity.toml). A wired-but-"
+                    f"unenrolled accessor reaches none of the bindings — add "
+                    f"the row and bind it on python / typescript / cpp."
+                )
     return errors
 
 
@@ -2804,6 +2952,20 @@ def main(argv: list[str] | None = None) -> int:
         method_rows, py_class_methods, ts_class_methods, cpp_class_methods
     )
 
+    # Reverse-direction orphan check on the core streaming surfaces: a
+    # public observability accessor (counter / ring telemetry / the
+    # slow-callback threshold setter) wired onto the core `StreamSurface`
+    # view or the standalone `StreamingClient` MUST carry a `[[method]]`
+    # row. Without this, a wired-but-unenrolled knob reaches none of the
+    # bindings and no forward check fires, because the row simply does not
+    # exist. This closes that blind spot at its source — the Rust surface.
+    core_streaming_methods = _collect_core_streaming_observability_methods(
+        CORE_CLIENT_RS, CORE_FPSS_MOD_RS
+    )
+    core_streaming_errors = _check_core_streaming_method_rows(
+        core_streaming_methods, method_rows
+    )
+
     # Orphan Rust pub fields (no parity row).
     orphan_errors = _check_orphan_rust_fields(rust_fields, rows)
 
@@ -2977,6 +3139,16 @@ def main(argv: list[str] | None = None) -> int:
             f"mismatch(es) (per-method `[[method]]` granularity):"
         )
         for e in method_errors:
+            print(e)
+        print()
+
+    if core_streaming_errors:
+        had_errors = True
+        print(
+            f"check_binding_parity: {len(core_streaming_errors)} core "
+            f"streaming observability accessor(s) lack a `[[method]]` row:"
+        )
+        for e in core_streaming_errors:
             print(e)
         print()
 
@@ -3619,6 +3791,116 @@ def _run_selftest() -> int:
         assert errors == [], (
             f"class-scoped TS lookup must not leak across classes; got {errors!r}"
         )
+
+    def _case_core_streaming_positive_all_enrolled() -> None:
+        """Every core observability accessor has a `[[method]]` row —
+        gate is silent. Covers the `dropped_count` -> `droppedEventCount`
+        and `set_slow_callback_threshold` -> `setSlowCallbackThresholdUs`
+        renames plus the direct camelCase mappings."""
+        core_methods = {
+            "StreamSurface": {
+                "dropped_event_count",
+                "ring_occupancy",
+                "ring_capacity",
+                "panic_count",
+                "slow_callback_count",
+                "set_slow_callback_threshold",
+            },
+            "StreamingClient": {
+                "dropped_count",
+                "ring_occupancy",
+                "ring_capacity",
+                "panic_count",
+                "slow_callback_count",
+                "set_slow_callback_threshold",
+            },
+        }
+        rows = [
+            {"class": "StreamView", "name": n}
+            for n in (
+                "droppedEventCount",
+                "ringOccupancy",
+                "ringCapacity",
+                "panicCount",
+                "slowCallbackCount",
+                "setSlowCallbackThresholdUs",
+            )
+        ] + [
+            {"class": "StreamingClient", "name": n}
+            for n in (
+                "droppedEventCount",
+                "ringOccupancy",
+                "ringCapacity",
+                "panicCount",
+                "slowCallbackCount",
+                "setSlowCallbackThresholdUs",
+            )
+        ]
+        errors = _check_core_streaming_method_rows(core_methods, rows)
+        assert errors == [], (
+            f"fully-enrolled core observability surface must be silent; got {errors!r}"
+        )
+
+    def _case_core_streaming_negative_unenrolled_getter() -> None:
+        """A wired core counter with no `[[method]]` row trips the gate —
+        the exact blind spot this check closes."""
+        core_methods = {"StreamSurface": {"slow_callback_count"}}
+        rows: list[dict[str, Any]] = []  # no enrolling row
+        errors = _check_core_streaming_method_rows(core_methods, rows)
+        assert any("slow_callback_count" in e and "slowCallbackCount" in e for e in errors), (
+            f"unenrolled core counter must trip the gate; got {errors!r}"
+        )
+
+    def _case_core_streaming_negative_unenrolled_setter() -> None:
+        """A wired core threshold setter with no row trips, mapped to the
+        unit-suffixed binding row name."""
+        core_methods = {"StreamingClient": {"set_slow_callback_threshold"}}
+        rows: list[dict[str, Any]] = []
+        errors = _check_core_streaming_method_rows(core_methods, rows)
+        assert any("setSlowCallbackThresholdUs" in e for e in errors), (
+            f"unenrolled core setter must trip the gate; got {errors!r}"
+        )
+
+    def _case_core_streaming_internal_hook_ignored() -> None:
+        """`record_panic` (the internal fault-injection hook) is not an
+        observability accessor, so the harvester never surfaces it and it
+        never needs a row. The predicate is the filter; assert it
+        directly. Lifecycle / subscription methods are likewise excluded."""
+        assert not _is_core_observability_accessor("record_panic"), (
+            "record_panic must be excluded from the observability surface"
+        )
+        for non_obs in ("subscribe", "stop_streaming", "reconnect", "is_streaming"):
+            assert not _is_core_observability_accessor(non_obs), (
+                f"{non_obs} must not be treated as an observability accessor"
+            )
+        # The shape predicate accepts the genuine observability accessors.
+        for obs in (
+            "dropped_count",
+            "ring_occupancy",
+            "panic_count",
+            "slow_callback_count",
+            "set_slow_callback_threshold",
+        ):
+            assert _is_core_observability_accessor(obs), (
+                f"{obs} must be treated as an observability accessor"
+            )
+
+    _case(
+        "core-streaming positive — every observability accessor enrolled",
+        _case_core_streaming_positive_all_enrolled,
+    )
+    _case(
+        "core-streaming negative — unenrolled counter trips",
+        _case_core_streaming_negative_unenrolled_getter,
+    )
+    _case(
+        "core-streaming negative — unenrolled threshold setter trips",
+        _case_core_streaming_negative_unenrolled_setter,
+    )
+    _case(
+        "core-streaming positive — internal record_panic hook ignored",
+        _case_core_streaming_internal_hook_ignored,
+    )
 
     _case("method positive — declared and present on all three bindings", _case_method_positive_all_three)
     _case("method negative — declared Python but missing in source", _case_method_python_missing)

--- a/sdks/cpp/examples/fpss_smoke.cpp
+++ b/sdks/cpp/examples/fpss_smoke.cpp
@@ -180,7 +180,7 @@ int main(int argc, char** argv) {
 
         const int total = total_events.load(std::memory_order_relaxed);
         const int data = data_events.load(std::memory_order_relaxed);
-        const uint64_t dropped = fpss.dropped_events();
+        const uint64_t dropped = fpss.dropped_event_count();
 
         std::cout << "summary: total=" << total
                   << " data=" << data

--- a/sdks/cpp/include/thetadatadx.h
+++ b/sdks/cpp/include/thetadatadx.h
@@ -2289,6 +2289,24 @@ char* thetadatadx_streaming_last_connected_addr(const ThetaDataDxStreamHandle* h
  *          callback has been installed yet. */
 uint64_t thetadatadx_streaming_panic_count(const ThetaDataDxStreamHandle* h);
 
+/** Set the slow-callback wall-clock threshold in microseconds. When a
+ *  callback invocation runs longer than threshold_us,
+ *  thetadatadx_streaming_slow_callback_count increments and a rate-limited
+ *  warning is logged. Pass 0 to disable. Observability-only: the watchdog
+ *  never cancels the callback. No-op on a null or shut-down handle.
+ *  @param h The streaming handle.
+ *  @param threshold_us The wall-clock threshold in microseconds, or 0 to
+ *          disable the watchdog. */
+void thetadatadx_streaming_set_slow_callback_threshold_us(const ThetaDataDxStreamHandle* h, uint64_t threshold_us);
+
+/** Cumulative count of user-callback invocations whose wall-clock duration
+ *  exceeded the threshold set via
+ *  thetadatadx_streaming_set_slow_callback_threshold_us.
+ *  @param h The streaming handle.
+ *  @return The slow-callback count, or 0 if the watchdog is disabled, the
+ *          handle is null, or has been shut down. */
+uint64_t thetadatadx_streaming_slow_callback_count(const ThetaDataDxStreamHandle* h);
+
 /** Shut down the streaming client. Terminal: every subsequent
  *  set_callback / reconnect / shutdown call on this handle returns -1
  *  with a clear thetadatadx_last_error() string. The handle remains valid for
@@ -2540,6 +2558,25 @@ char* thetadatadx_client_last_connected_addr(const ThetaDataDxClient* handle);
  *  @return The contained-failure count, or 0 if the handle is null or no
  *          callback has been installed yet. */
 uint64_t thetadatadx_client_panic_count(const ThetaDataDxClient* handle);
+
+/** Set the slow-callback wall-clock threshold in microseconds on the unified
+ *  handle. When a callback invocation runs longer than threshold_us,
+ *  thetadatadx_client_slow_callback_count increments and a rate-limited warning
+ *  is logged. Pass 0 to disable. Observability-only: the watchdog never
+ *  cancels the callback. No-op on a null handle or before a callback is
+ *  installed.
+ *  @param handle The unified handle.
+ *  @param threshold_us The wall-clock threshold in microseconds, or 0 to
+ *          disable the watchdog. */
+void thetadatadx_client_set_slow_callback_threshold_us(const ThetaDataDxClient* handle, uint64_t threshold_us);
+
+/** Cumulative count of user-callback invocations whose wall-clock duration
+ *  exceeded the threshold set via
+ *  thetadatadx_client_set_slow_callback_threshold_us.
+ *  @param handle The unified handle.
+ *  @return The slow-callback count, or 0 if the watchdog is disabled, the
+ *          handle is null, or no callback has been installed yet. */
+uint64_t thetadatadx_client_slow_callback_count(const ThetaDataDxClient* handle);
 
 /** Free a unified client handle. Calls thetadatadx_client_stop_streaming
  *  internally, then waits up to 5 seconds for the registered callback to

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -1484,7 +1484,7 @@ using StreamEvent = ThetaDataDxStreamEvent;
 // from the streaming reader through a bounded ring to a dedicated consumer
 // thread, which invokes `fn` inside an isolation boundary. The reader
 // thread never blocks on user code; on ring overflow events are dropped
-// and counted via `dropped_events()`.
+// and counted via `dropped_event_count()`.
 //
 // The StreamingClient owns the `std::function`. A free `extern "C"` shim retrieves
 // the stored function from the registered `void* ctx` and invokes it with
@@ -1569,7 +1569,7 @@ public:
      *  `fn` runs on the consumer thread inside an isolation boundary, never
      *  on the streaming reader. The reader thread cannot be blocked by
      *  user code: on ring overflow events are dropped and counted via
-     *  `dropped_events()`. Throws on registration failure.
+     *  `dropped_event_count()`. Throws on registration failure.
      *
      *  ## Callback storage + thread affinity
      *
@@ -1608,8 +1608,10 @@ public:
     /** Cumulative count of streaming events the TLS reader could not
      *  publish into the bounded ring because the consumer fell behind
      *  and the ring was full. Returns 0 when no callback has been
-     *  installed yet. Safe to call on a moved-from client. */
-    uint64_t dropped_events() const {
+     *  installed yet. Safe to call on a moved-from client. Mirrors the
+     *  unified Stream::dropped_event_count() spelling so the same counter
+     *  reads identically on both C++ streaming surfaces. */
+    uint64_t dropped_event_count() const {
         return handle_ ? thetadatadx_streaming_dropped_events(handle_.get()) : 0;
     }
 
@@ -1617,7 +1619,7 @@ public:
      *  event ring but not yet drained into the registered callback —
      *  the in-flight depth between the I/O thread and the dispatcher.
      *  Rising occupancy that approaches ring_capacity() predicts
-     *  drops before dropped_events() moves; sampling never blocks the
+     *  drops before dropped_event_count() moves; sampling never blocks the
      *  feed and is safe from any thread. Returns 0 when no session is
      *  live. Safe to call on a moved-from client. */
     uint64_t ring_occupancy() const {
@@ -1640,6 +1642,26 @@ public:
      *  installed yet. Safe to call from any thread without blocking. */
     uint64_t panic_count() const {
         return handle_ ? thetadatadx_streaming_panic_count(handle_.get()) : 0;
+    }
+
+    /** Set the slow-callback wall-clock threshold in microseconds. When a
+     *  callback invocation runs longer than threshold_us,
+     *  slow_callback_count() increments and a rate-limited warning is
+     *  logged. Pass 0 to disable. Observability-only: the watchdog never
+     *  cancels the callback. No-op on a moved-from or shut-down client. */
+    void set_slow_callback_threshold_us(uint64_t threshold_us) const {
+        if (handle_) {
+            thetadatadx_streaming_set_slow_callback_threshold_us(handle_.get(), threshold_us);
+        }
+    }
+
+    /** Cumulative count of user-callback invocations whose wall-clock
+     *  duration exceeded the threshold set via
+     *  set_slow_callback_threshold_us(). Returns 0 when the watchdog is
+     *  disabled or no session is live. Safe to call on a moved-from
+     *  client. */
+    uint64_t slow_callback_count() const {
+        return handle_ ? thetadatadx_streaming_slow_callback_count(handle_.get()) : 0;
     }
 
     /** Milliseconds since the most recent inbound streaming frame of
@@ -2098,6 +2120,28 @@ public:
     /// Python / TypeScript `client.stream.panic_count` placement.
     uint64_t panic_count() const {
         return handle_ ? thetadatadx_client_panic_count(handle_) : 0;
+    }
+
+    /// Set the slow-callback wall-clock threshold in microseconds. When a
+    /// callback invocation runs longer than threshold_us,
+    /// slow_callback_count() increments and a rate-limited warning is logged.
+    /// Pass 0 to disable. Observability-only: the watchdog never cancels the
+    /// callback. No-op when no callback has been installed yet. Mirrors the
+    /// Python / TypeScript `client.stream.set_slow_callback_threshold_us`
+    /// placement.
+    void set_slow_callback_threshold_us(uint64_t threshold_us) const {
+        if (handle_) {
+            thetadatadx_client_set_slow_callback_threshold_us(handle_, threshold_us);
+        }
+    }
+
+    /// Cumulative count of user-callback invocations whose wall-clock duration
+    /// exceeded the threshold set via set_slow_callback_threshold_us(). Returns
+    /// 0 when the watchdog is disabled or no callback has been installed yet.
+    /// Mirrors the Python / TypeScript `client.stream.slow_callback_count`
+    /// placement.
+    uint64_t slow_callback_count() const {
+        return handle_ ? thetadatadx_client_slow_callback_count(handle_) : 0;
     }
 
     /// Snapshot the currently-active full-stream subscriptions (the entire

--- a/sdks/cpp/tests/fpss.cpp
+++ b/sdks/cpp/tests/fpss.cpp
@@ -35,6 +35,33 @@ TEST_CASE("StreamingClient is move-constructible", "[fpss][offline]") {
     STATIC_REQUIRE_FALSE(std::is_copy_assignable_v<thetadatadx::StreamingClient>);
 }
 
+TEST_CASE("StreamingClient binds the observability surface",
+          "[fpss][offline]") {
+    // Pin the diagnostic accessors so a delete or rename fires at compile
+    // time. The standalone client uses the same `dropped_event_count()`
+    // spelling as the unified `Stream` view (the counter is identical on
+    // both surfaces), plus the slow-callback watchdog getter/setter.
+    using SC = thetadatadx::StreamingClient;
+    // dropped_event_count() -> uint64_t
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().dropped_event_count()), uint64_t>);
+    // ring_occupancy() / ring_capacity() -> uint64_t
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().ring_occupancy()), uint64_t>);
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().ring_capacity()), uint64_t>);
+    // panic_count() -> uint64_t
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().panic_count()), uint64_t>);
+    // slow_callback_count() -> uint64_t
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().slow_callback_count()), uint64_t>);
+    // set_slow_callback_threshold_us(uint64_t) -> void
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().set_slow_callback_threshold_us(uint64_t{})),
+        void>);
+}
+
 TEST_CASE("StreamingClient registers a callback and receives at least one event",
           "[fpss][live]") {
     const auto creds_path = env_or_empty("THETADATADX_LIVE_CREDS");

--- a/sdks/cpp/tests/thetadatadx_client.cpp
+++ b/sdks/cpp/tests/thetadatadx_client.cpp
@@ -97,6 +97,13 @@ TEST_CASE("Stream binds the full FPSS surface",
     // panic_count() lives on the `client.stream()` view -> uint64_t
     STATIC_REQUIRE(std::is_same_v<
         decltype(std::declval<const SV&>().panic_count()), uint64_t>);
+    // slow_callback_count() lives on the `client.stream()` view -> uint64_t
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SV&>().slow_callback_count()), uint64_t>);
+    // set_slow_callback_threshold_us(uint64_t) -> void
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SV&>().set_slow_callback_threshold_us(uint64_t{})),
+        void>);
 }
 
 TEST_CASE("Client end-to-end push-callback cycle", "[unified][live]") {
@@ -114,6 +121,11 @@ TEST_CASE("Client end-to-end push-callback cycle", "[unified][live]") {
     auto stream = client.stream();
     REQUIRE_FALSE(stream.is_streaming());
     REQUIRE(stream.dropped_event_count() == 0);
+    // Slow-callback watchdog: 0 before streaming; the threshold setter
+    // round-trips as a no-throw configuration call (microseconds; 0
+    // disables).
+    REQUIRE(stream.slow_callback_count() == 0);
+    REQUIRE_NOTHROW(stream.set_slow_callback_threshold_us(1000));
 
     std::atomic<uint64_t> events{0};
     stream.set_callback([&](const thetadatadx::StreamEvent& /*event*/) {

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1146,6 +1146,20 @@ cpp = true
 
 [[method]]
 class = "StreamView"
+name = "slowCallbackCount"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "StreamView"
+name = "setSlowCallbackThresholdUs"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "StreamView"
 name = "millisSinceLastEvent"
 python = true
 typescript = true
@@ -1274,13 +1288,6 @@ class = "StreamingClient"
 name = "droppedEventCount"
 python = true
 typescript = true
-cpp = false  # C++ method is `dropped_events`, declared separately below
-
-[[method]]
-class = "StreamingClient"
-name = "droppedEvents"
-python = false
-typescript = false
 cpp = true
 
 [[method]]
@@ -1300,6 +1307,20 @@ cpp = true
 [[method]]
 class = "StreamingClient"
 name = "panicCount"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "StreamingClient"
+name = "slowCallbackCount"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "StreamingClient"
+name = "setSlowCallbackThresholdUs"
 python = true
 typescript = true
 cpp = true

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -1083,6 +1083,25 @@ class StreamView:
         """
         ...
 
+    def set_slow_callback_threshold_us(self, threshold_us: int) -> None:
+        """Set the slow-callback wall-clock threshold in microseconds.
+
+        When a callback invocation runs longer than ``threshold_us``,
+        :meth:`slow_callback_count` increments and a rate-limited
+        warning is logged. Pass ``0`` to disable the watchdog (the
+        default). Observability only: the watchdog never cancels the
+        callback. No-op when streaming has not started.
+        """
+        ...
+
+    def slow_callback_count(self) -> int:
+        """Cumulative count of user-callback invocations whose
+        wall-clock duration exceeded the threshold set by
+        :meth:`set_slow_callback_threshold_us`. 0 when the watchdog is
+        disabled or streaming has not started.
+        """
+        ...
+
 
 @final
 class Client:
@@ -1437,6 +1456,25 @@ class StreamingClient:
 
         The fixed denominator for :meth:`ring_occupancy`; 0 when
         streaming is not active.
+        """
+        ...
+
+    def set_slow_callback_threshold_us(self, threshold_us: int) -> None:
+        """Set the slow-callback wall-clock threshold in microseconds.
+
+        When a callback invocation runs longer than ``threshold_us``,
+        :meth:`slow_callback_count` increments and a rate-limited
+        warning is logged. Pass ``0`` to disable the watchdog (the
+        default). Observability only: the watchdog never cancels the
+        callback. No-op when no session is live.
+        """
+        ...
+
+    def slow_callback_count(self) -> int:
+        """Cumulative count of user-callback invocations whose
+        wall-clock duration exceeded the threshold set by
+        :meth:`set_slow_callback_threshold_us`. 0 when the watchdog is
+        disabled or no session is live.
         """
         ...
 

--- a/sdks/python/src/fpss_client.rs
+++ b/sdks/python/src/fpss_client.rs
@@ -606,6 +606,30 @@ impl StreamingClient {
         guard.as_ref().map_or(0, |c| c.panic_count())
     }
 
+    /// Set the slow-callback wall-clock threshold in microseconds.
+    ///
+    /// When a callback invocation runs longer than ``threshold_us``,
+    /// :meth:`slow_callback_count` increments and a rate-limited warning
+    /// is logged. Pass ``0`` to disable the watchdog (the default).
+    /// Observability only: the watchdog never cancels or kills the
+    /// callback. No-op when no session is live.
+    fn set_slow_callback_threshold_us(&self, threshold_us: u64) {
+        let guard = self.lock_inner();
+        if let Some(c) = guard.as_ref() {
+            c.set_slow_callback_threshold(std::time::Duration::from_micros(threshold_us));
+        }
+    }
+
+    /// Cumulative count of user-callback invocations whose wall-clock
+    /// duration exceeded the threshold set by
+    /// :meth:`set_slow_callback_threshold_us`. Returns 0 when the
+    /// watchdog is disabled or no session is live. Safe to read from any
+    /// thread.
+    fn slow_callback_count(&self) -> u64 {
+        let guard = self.lock_inner();
+        guard.as_ref().map_or(0, |c| c.slow_callback_count())
+    }
+
     /// Milliseconds since the most recent inbound streaming frame of
     /// any kind (data tick, heartbeat, control), or ``None`` when no
     /// session is live or no frame has been received yet. The

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1663,6 +1663,33 @@ impl StreamView {
     fn panic_count(&self) -> u64 {
         self.client.stream().panic_count()
     }
+
+    /// Set the slow-callback wall-clock threshold in microseconds.
+    ///
+    /// When a callback invocation runs longer than ``threshold_us``,
+    /// :meth:`slow_callback_count` increments and a rate-limited warning
+    /// is logged. Pass ``0`` to disable the watchdog (the default).
+    ///
+    /// Observability only: the watchdog never cancels or kills the
+    /// callback. The counter and log let operators detect a callback
+    /// that has outgrown its budget and decide how to respond. No-op
+    /// when streaming has not started.
+    fn set_slow_callback_threshold_us(&self, threshold_us: u64) {
+        self.client
+            .stream()
+            .set_slow_callback_threshold(std::time::Duration::from_micros(threshold_us));
+    }
+
+    /// Cumulative count of user-callback invocations whose wall-clock
+    /// duration exceeded the threshold set by
+    /// :meth:`set_slow_callback_threshold_us`. Returns 0 when the
+    /// watchdog is disabled or streaming has not started. Mirrors the
+    /// `slow_callback_count()` getter on the standalone
+    /// [`crate::fpss_client::StreamingClient`] and the upstream
+    /// [`thetadatadx::Client::slow_callback_count`].
+    fn slow_callback_count(&self) -> u64 {
+        self.client.stream().slow_callback_count()
+    }
 }
 
 // ── Fluent contract-first API on the unified client ──────────────────────
@@ -1786,6 +1813,8 @@ pub(crate) const ALLOWED_UNIFIED_PROXY_METHODS: &[&str] = &[
     "panic_count",
     "ring_occupancy",
     "ring_capacity",
+    "slow_callback_count",
+    "set_slow_callback_threshold_us",
     // FLATFILES namespace getter.
     "flat_files",
     // NOTE: `session_uuid` / `subscription_info` are NOT on
@@ -1821,6 +1850,8 @@ const STREAM_VIEW_PROXY_METHODS: &[&str] = &[
     "panic_count",
     "ring_occupancy",
     "ring_capacity",
+    "slow_callback_count",
+    "set_slow_callback_threshold_us",
 ];
 
 /// Hand-written `#[pymethods]` entries on `Client` outside
@@ -1846,7 +1877,8 @@ const HANDWRITTEN_UNIFIED_PYMETHODS: &[&str] = &[
     // `StreamView` surface (lib.rs).
     "active_full_subscriptions",
     // Diagnostic getters — `dropped_event_count`, `panic_count`,
-    // `ring_occupancy`, and `ring_capacity` all live on the
+    // `ring_occupancy`, `ring_capacity`, and `slow_callback_count`, plus
+    // the slow-callback threshold setter, all live on the
     // `client.stream` `StreamView` surface (lib.rs). All forward to the
     // core `thetadatadx::Client` accessors so the counts match every
     // other binding.
@@ -1854,6 +1886,8 @@ const HANDWRITTEN_UNIFIED_PYMETHODS: &[&str] = &[
     "panic_count",
     "ring_occupancy",
     "ring_capacity",
+    "slow_callback_count",
+    "set_slow_callback_threshold_us",
 ];
 
 /// `const fn` byte-equal helper for the compile-time guard below.

--- a/sdks/python/src/mdds_client.rs
+++ b/sdks/python/src/mdds_client.rs
@@ -86,6 +86,8 @@ pub(crate) const FPSS_TOUCHING_METHODS: &[&str] = &[
     "active_full_subscriptions",
     "dropped_event_count",
     "panic_count",
+    "slow_callback_count",
+    "set_slow_callback_threshold_us",
     // Hand-written `#[pymethods]` entries on `Client` /
     // sibling streaming pyclasses. These factories return a
     // streaming-session pyclass (sync, sync-iter, or asyncio) — the

--- a/sdks/python/tests/test_slow_callback.py
+++ b/sdks/python/tests/test_slow_callback.py
@@ -1,0 +1,113 @@
+"""
+Slow-callback watchdog accessibility + round-trip test.
+
+Pins the contract that ``client.stream.slow_callback_count()`` is
+callable across the streaming lifecycle (pre-start / post-start /
+post-reconnect / post-stop), is non-negative everywhere, and that
+``client.stream.set_slow_callback_threshold_us(threshold_us)`` round-trips
+as a no-throw configuration call. The threshold crosses the binding
+boundary as microseconds (the core watchdog measures user-callback
+wall-clock against it); pass 0 to disable the watchdog.
+
+The counter and threshold live on the live streaming client, forwarded
+through ``thetadatadx::Client::slow_callback_count`` /
+``set_slow_callback_threshold`` and the PyO3 wrapper. Because the state
+lives on the live client, ``reconnect()`` (which calls
+``stop_streaming() + start_streaming()`` internally) rebuilds the client
+and resets the count to 0; ``stop_streaming()`` clears the slot and the
+getter returns 0 in that state.
+
+This shape mirrors the TypeScript binding's
+``__tests__/slow_callback.test.mjs`` and the C++
+``tests/thetadatadx_client.cpp`` slow-callback coverage to keep the
+public contract identical across SDKs.
+
+Gated on ``THETADATADX_TEST_CREDS=path/to/creds.txt`` because ``Client``
+needs a live FPSS handshake. Tests skip silently on developer machines
+that haven't wired creds.
+
+What this test does NOT assert: that the counter actually *increments*
+on a genuinely slow callback. Synthesizing a guaranteed-over-budget
+invocation requires a full FPSS mock harness that is out of scope here;
+the watchdog is observability-only and never cancels the callback.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    """Build a real `Client` or skip the test."""
+    creds_path = os.environ.get("THETADATADX_TEST_CREDS")
+    if not creds_path:
+        pytest.skip(
+            "set THETADATADX_TEST_CREDS=path/to/creds.txt to enable this live test"
+        )
+    try:
+        import thetadatadx
+    except ImportError:
+        pytest.skip(
+            "thetadatadx native extension not built "
+            "-- run `maturin develop` from sdks/python/"
+        )
+
+    creds = thetadatadx.Credentials.from_file(creds_path)
+    config = thetadatadx.Config.production()
+    client = thetadatadx.Client(creds, config)
+    yield client
+    try:
+        client.stream.stop_streaming()
+    except Exception:
+        pass
+
+
+def _noop_callback(_event):
+    """Minimal callback for lifecycle tests; does no work."""
+
+
+def test_slow_callback_count_callable_before_streaming(client):
+    """The getter must be callable before `start_streaming(callback)`
+    and return 0 -- the streaming slot is empty, so the wrapper
+    forwards 0 from the unified client.
+    """
+    count = client.stream.slow_callback_count()
+    assert isinstance(count, int)
+    assert count == 0
+
+
+def test_set_slow_callback_threshold_us_noop_before_streaming(client):
+    """The threshold setter is a no-op before a session is live and must
+    not raise. The watchdog count stays 0.
+    """
+    client.stream.set_slow_callback_threshold_us(2_500)
+    assert client.stream.slow_callback_count() == 0
+    # Passing 0 disables the watchdog.
+    client.stream.set_slow_callback_threshold_us(0)
+
+
+def test_slow_callback_lifecycle_round_trip(client):
+    """The setter round-trips and the counter stays callable across the
+    full lifecycle: pre-start / post-start / post-reconnect / post-stop.
+    The value is non-negative everywhere; it is NOT monotone across
+    reconnect because reconnect rebuilds the FPSS client and zeros it.
+    """
+    client.stream.start_streaming(_noop_callback)
+    # Configure a 1 ms budget on the live session.
+    client.stream.set_slow_callback_threshold_us(1_000)
+    post_start = client.stream.slow_callback_count()
+    assert isinstance(post_start, int)
+    assert post_start >= 0
+
+    client.stream.reconnect()
+    post_reconnect = client.stream.slow_callback_count()
+    assert isinstance(post_reconnect, int)
+    assert post_reconnect >= 0
+
+    client.stream.stop_streaming()
+    post_stop = client.stream.slow_callback_count()
+    assert isinstance(post_stop, int)
+    assert post_stop >= 0

--- a/sdks/python/tests/test_standalone_clients.py
+++ b/sdks/python/tests/test_standalone_clients.py
@@ -68,6 +68,8 @@ BLOCKED_FPSS_METHODS = (
     "active_full_subscriptions",
     "dropped_event_count",
     "panic_count",
+    "slow_callback_count",
+    "set_slow_callback_threshold_us",
 )
 
 
@@ -270,6 +272,12 @@ def test_fpss_client_no_mdds_channel() -> None:
     # No drops, no panics on a never-started session.
     assert fpss.dropped_event_count() == 0
     assert fpss.panic_count() == 0
+    # The slow-callback watchdog reads 0 and the threshold setter is a
+    # no-op before a session is live (no live client to configure).
+    assert fpss.slow_callback_count() == 0
+    fpss.set_slow_callback_threshold_us(5_000)
+    assert fpss.slow_callback_count() == 0
+    fpss.set_slow_callback_threshold_us(0)
     assert fpss.is_streaming() is False
     assert fpss.is_authenticated() is False, (
         "StreamingClient must not be authenticated before start_streaming*"

--- a/sdks/typescript/__tests__/fpss_client.test.mjs
+++ b/sdks/typescript/__tests__/fpss_client.test.mjs
@@ -78,6 +78,8 @@ describe('StreamingClient carries the full streaming surface', () => {
     'ringOccupancy',
     'ringCapacity',
     'panicCount',
+    'slowCallbackCount',
+    'setSlowCallbackThresholdUs',
     'millisSinceLastEvent',
     'lastEventReceivedAtUnixNanos',
     'lastConnectedAddr',

--- a/sdks/typescript/__tests__/slow_callback.test.mjs
+++ b/sdks/typescript/__tests__/slow_callback.test.mjs
@@ -1,0 +1,77 @@
+// Slow-callback watchdog accessibility + round-trip test.
+//
+// The watchdog counter forwards to
+// `thetadatadx::Client::slow_callback_count` and is surfaced to JS as
+// `client.stream.slowCallbackCount(): bigint`. The threshold setter
+// forwards to `set_slow_callback_threshold` and crosses the boundary as
+// microseconds via `client.stream.setSlowCallbackThresholdUs(bigint)`.
+// Pass `0n` to disable the watchdog. It is observability-only: the
+// watchdog never cancels the callback.
+//
+// This test pins the contract: the getter is callable before streaming,
+// after `startStreaming(callback)`, after a subsequent `reconnect()`,
+// and after `stopStreaming()`; the value is non-negative across the
+// cycle; the setter round-trips without throwing.
+//
+// Gated on THETADATADX_TEST_CREDS=/path/to/creds.txt — the underlying
+// `Client.connectFromFile(...)` needs a live FPSS handshake. Skips
+// silently on dev machines without creds.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+let mod;
+try {
+  mod = await import('../index.js');
+} catch {
+  console.error('FAIL: native addon not built; run `npm run build` first');
+  process.exit(1);
+}
+
+describe('client.stream slow-callback watchdog', () => {
+  it('getter is callable and setter round-trips across the lifecycle', async () => {
+    const credsPath = process.env.THETADATADX_TEST_CREDS;
+    if (!credsPath) {
+      console.log(
+        'SKIP: set THETADATADX_TEST_CREDS=/path/to/creds.txt to enable this live test'
+      );
+      return;
+    }
+
+    const client = mod.Client.connectFromFile(credsPath);
+
+    // Pre-stream: the FPSS client does not exist yet, so the count is 0.
+    // The threshold setter is a no-op in this state and must not throw.
+    const pre = client.stream.slowCallbackCount();
+    assert.equal(typeof pre, 'bigint', 'slowCallbackCount() must return bigint');
+    assert.equal(pre, 0n, 'pre-stream count must be 0 -- nothing has run slow');
+    client.stream.setSlowCallbackThresholdUs(2_500n);
+    assert.equal(client.stream.slowCallbackCount(), 0n);
+
+    let received = 0n;
+    client.stream.startStreaming(() => {
+      received += 1n;
+    });
+    // Configure a 1 ms budget on the live session.
+    client.stream.setSlowCallbackThresholdUs(1_000n);
+    const postStart = client.stream.slowCallbackCount();
+    assert.equal(typeof postStart, 'bigint');
+    assert.ok(postStart >= 0n);
+
+    client.stream.reconnect();
+    const postReconnect = client.stream.slowCallbackCount();
+    assert.equal(typeof postReconnect, 'bigint');
+    // reconnect rebuilds the FPSS client and zeroes the counter; assert
+    // non-negative rather than monotone (monotone is not promised).
+    assert.ok(postReconnect >= 0n);
+
+    client.stream.stopStreaming();
+    const postStop = client.stream.slowCallbackCount();
+    assert.equal(typeof postStop, 'bigint');
+    assert.ok(postStop >= 0n);
+
+    // Disabling the watchdog round-trips too.
+    client.stream.setSlowCallbackThresholdUs(0n);
+    assert.equal(typeof received, 'bigint');
+  });
+});

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -2687,8 +2687,9 @@ export declare class StreamView {
    */
   panicCount(): bigint
   /**
-   * Set the slow-callback wall-clock threshold in microseconds. When a
-   * callback invocation runs longer than `thresholdUs`,
+   * Set the slow-callback wall-clock threshold in microseconds.
+   *
+   * When a callback invocation runs longer than `thresholdUs`,
    * `slowCallbackCount()` increments and a rate-limited warning is
    * logged. Pass `0n` to disable the watchdog (the default).
    * Observability only: the watchdog never cancels the callback. No-op

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -2524,6 +2524,23 @@ export declare class StreamingClient {
    */
   panicCount(): bigint
   /**
+   * Set the slow-callback wall-clock threshold in microseconds. When a
+   * callback invocation runs longer than `thresholdUs`,
+   * `slowCallbackCount()` increments and a rate-limited warning is
+   * logged. Pass `0n` to disable the watchdog (the default).
+   * Observability only: the watchdog never cancels the callback. No-op
+   * when no session is live. Accepts `bigint` for the full 64-bit
+   * unsigned range.
+   */
+  setSlowCallbackThresholdUs(thresholdUs: bigint): void
+  /**
+   * Cumulative count of user-callback invocations whose wall-clock
+   * duration exceeded the threshold set by `setSlowCallbackThresholdUs()`.
+   * Returns `0n` when the watchdog is disabled or no session is live.
+   * Returned as `bigint` for the full 64-bit unsigned range.
+   */
+  slowCallbackCount(): bigint
+  /**
    * Milliseconds since the most recent inbound streaming frame of any
    * kind (data tick, heartbeat, control), or `null` when no session is
    * live or no frame has been received yet. The operator-facing
@@ -2669,6 +2686,24 @@ export declare class StreamView {
    * (Number would top out at 2^53).
    */
   panicCount(): bigint
+  /**
+   * Set the slow-callback wall-clock threshold in microseconds. When a
+   * callback invocation runs longer than `thresholdUs`,
+   * `slowCallbackCount()` increments and a rate-limited warning is
+   * logged. Pass `0n` to disable the watchdog (the default).
+   * Observability only: the watchdog never cancels the callback. No-op
+   * before `startStreaming`. Accepts `bigint` for the full 64-bit
+   * unsigned range.
+   */
+  setSlowCallbackThresholdUs(thresholdUs: bigint): void
+  /**
+   * Cumulative count of user-callback invocations whose wall-clock
+   * duration exceeded the threshold set by `setSlowCallbackThresholdUs()`.
+   * Returns `0n` when the watchdog is disabled or before `startStreaming`.
+   * The value matches every other binding (C ABI, Python, C++). Returned
+   * as `bigint` for the full 64-bit unsigned range.
+   */
+  slowCallbackCount(): bigint
   /**
    * Snapshot of full-stream subscriptions (e.g. `OPTION` /
    * `full_trades`, `OPTION` / `full_open_interest`).

--- a/sdks/typescript/src/fpss_client.rs
+++ b/sdks/typescript/src/fpss_client.rs
@@ -546,6 +546,36 @@ impl StreamingClient {
         napi::bindgen_prelude::BigInt::from(guard.as_ref().map_or(0, |c| c.panic_count()))
     }
 
+    /// Set the slow-callback wall-clock threshold in microseconds. When a
+    /// callback invocation runs longer than `thresholdUs`,
+    /// `slowCallbackCount()` increments and a rate-limited warning is
+    /// logged. Pass `0n` to disable the watchdog (the default).
+    /// Observability only: the watchdog never cancels the callback. No-op
+    /// when no session is live. Accepts `bigint` for the full 64-bit
+    /// unsigned range.
+    #[napi(js_name = "setSlowCallbackThresholdUs")]
+    pub fn set_slow_callback_threshold_us(
+        &self,
+        threshold_us: napi::bindgen_prelude::BigInt,
+    ) -> napi::Result<()> {
+        let (_signed, value, _lossless) = threshold_us.get_u64();
+        let guard = self.lock_inner();
+        if let Some(c) = guard.as_ref() {
+            c.set_slow_callback_threshold(std::time::Duration::from_micros(value));
+        }
+        Ok(())
+    }
+
+    /// Cumulative count of user-callback invocations whose wall-clock
+    /// duration exceeded the threshold set by `setSlowCallbackThresholdUs()`.
+    /// Returns `0n` when the watchdog is disabled or no session is live.
+    /// Returned as `bigint` for the full 64-bit unsigned range.
+    #[napi(js_name = "slowCallbackCount")]
+    pub fn slow_callback_count(&self) -> napi::bindgen_prelude::BigInt {
+        let guard = self.lock_inner();
+        napi::bindgen_prelude::BigInt::from(guard.as_ref().map_or(0, |c| c.slow_callback_count()))
+    }
+
     /// Milliseconds since the most recent inbound streaming frame of any
     /// kind (data tick, heartbeat, control), or `null` when no session is
     /// live or no frame has been received yet. The operator-facing

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -622,6 +622,36 @@ impl StreamView {
         napi::bindgen_prelude::BigInt::from(self.client.stream().panic_count())
     }
 
+    /// Set the slow-callback wall-clock threshold in microseconds.
+    ///
+    /// When a callback invocation runs longer than `thresholdUs`,
+    /// `slowCallbackCount()` increments and a rate-limited warning is
+    /// logged. Pass `0n` to disable the watchdog (the default).
+    /// Observability only: the watchdog never cancels the callback. No-op
+    /// before `startStreaming`. Accepts `bigint` for the full 64-bit
+    /// unsigned range.
+    #[napi(js_name = "setSlowCallbackThresholdUs")]
+    pub fn set_slow_callback_threshold_us(
+        &self,
+        threshold_us: napi::bindgen_prelude::BigInt,
+    ) -> napi::Result<()> {
+        let (_signed, value, _lossless) = threshold_us.get_u64();
+        self.client
+            .stream()
+            .set_slow_callback_threshold(std::time::Duration::from_micros(value));
+        Ok(())
+    }
+
+    /// Cumulative count of user-callback invocations whose wall-clock
+    /// duration exceeded the threshold set by `setSlowCallbackThresholdUs()`.
+    /// Returns `0n` when the watchdog is disabled or before `startStreaming`.
+    /// The value matches every other binding (C ABI, Python, C++). Returned
+    /// as `bigint` for the full 64-bit unsigned range.
+    #[napi(js_name = "slowCallbackCount")]
+    pub fn slow_callback_count(&self) -> napi::bindgen_prelude::BigInt {
+        napi::bindgen_prelude::BigInt::from(self.client.stream().slow_callback_count())
+    }
+
     /// Snapshot of full-stream subscriptions (e.g. `OPTION` /
     /// `full_trades`, `OPTION` / `full_open_interest`).
     ///


### PR DESCRIPTION
## What

The slow-callback watchdog ships on both core streaming surfaces — the unified `Stream` view and the standalone `StreamingClient` — but reached none of the Python, TypeScript, C++, or C-ABI bindings, and `sdks/parity.toml` carried no row for it. This brings it to full cross-binding parity, on both surfaces, mirroring the existing `dropped_event_count` observability metric exactly.

## Surface

`slow_callback_count()` (getter) and the threshold setter are now exposed on every binding, on both the unified streaming view and the standalone client:

- C ABI: `thetadatadx_client_slow_callback_count` / `thetadatadx_client_set_slow_callback_threshold_us` and the `thetadatadx_streaming_*` pair (forwarding into the same core accessors every higher binding wraps).
- Python: `client.stream.slow_callback_count()` / `set_slow_callback_threshold_us(...)` and the same pair on the standalone `StreamingClient`, plus `.pyi` stubs.
- TypeScript: `slowCallbackCount()` / `setSlowCallbackThresholdUs(...)` on `StreamView` and `StreamingClient`, plus `.d.ts` declarations.
- C++: `slow_callback_count()` / `set_slow_callback_threshold_us(...)` on the unified `Stream` and the standalone `StreamingClient`.

The threshold crosses the boundary as **microseconds**: callback budgets are commonly sub-millisecond and the core watchdog measures wall-clock at nanosecond resolution, so the `_us` suffix matches the convention every other duration-valued knob already follows. The watchdog is observability-only — it counts over-budget invocations and logs (rate-limited), and never cancels or kills the callback.

## Guard blind spot

`scripts/check_binding_parity.py` gated each declared parity row against the bindings but never gated the reverse direction on the Rust side, so an observability accessor wired onto the core streaming surface with no parity row reached no binding and tripped no check — exactly how this gap existed. Added a reverse-direction scan that harvests the public observability accessors (cumulative counters, ring telemetry, the threshold setter) on the core `StreamSurface` / `StreamingClient` impls and asserts each carries a `[[method]]` row. Covered by four new selftest cases (positive all-enrolled, unenrolled getter, unenrolled setter, internal-hook excluded). Also scoped the TypeScript Config setter-set collector to `impl Config` blocks so a live-surface setter is not mistaken for a Config knob.

## C++ counter rename

The standalone `StreamingClient` exposed `dropped_events()` while the unified `Stream` exposed `dropped_event_count()` for the same counter. Renamed the `StreamingClient` C++ wrapper method to `dropped_event_count()` on both surfaces (the underlying C symbol is unchanged) and collapsed the two parity rows into one.

## Tests

- Python: `tests/test_slow_callback.py` (lifecycle + round-trip on the unified view), offline assertions added to `tests/test_standalone_clients.py`.
- TypeScript: `__tests__/slow_callback.test.mjs` plus the surface roster in `__tests__/fpss_client.test.mjs`.
- C++: `STATIC_REQUIRE` type-trait checks in `tests/fpss.cpp` and `tests/thetadatadx_client.cpp`, plus a live round-trip line.

## Verification

- `python3 scripts/check_binding_parity.py` — clean
- `python3 scripts/check_binding_parity.py --selftest` — 74 passed, 0 failed
- `python3 scripts/test_check_binding_parity.py` — all 27 cases passed
- `python3 scripts/check_c_abi_completeness.py` — clean (323 symbols, bidirectional parity)
- `cargo fmt --all -- --check` — clean
- `cargo build -p thetadatadx-ffi --release` — clean; `thetadatadx-py` and `thetadatadx-napi` compile; C++ headers pass `g++ -fsyntax-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)