### PR TITLE
docs: sync the changelog mirror with the canonical section name

### DIFF
--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -610,7 +610,7 @@ code does not change.
   accessor) is removed: the post-SSOT pipeline has exactly one queue
   (the event queue sized by `ring_size`), so a separate
   event-channel-depth knob is dead. TOML configs that set
-  `[fpss] queue_depth = ...` should switch to `ring_size`.
+  `[streaming] queue_depth = ...` should switch to `ring_size`.
 - The cross-language response-shape agreement validator
   (`scripts/validate_agreement.py`) now consumes a TypeScript
   shape manifest alongside the Python / CLI / C++ runtime artifacts.


### PR DESCRIPTION
The `[fpss] queue_depth` → `[streaming] queue_depth` scrub updated `CHANGELOG.md` but not its `docs-site/docs/changelog.md` mirror, so the two diverged (failing the docs-consistency gate) and the dead `[fpss]` name still rendered in the published changelog. Copy the canonical file over the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)