### PR TITLE
refactor: make the fixed-point price encoding internal

### DIFF
--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -318,6 +318,7 @@ harness = false
 [[bench]]
 name = "streaming_throughput"
 harness = false
+required-features = ["__internal"]
 
 [[bench]]
 # Drives `fpss::__test_internals::{decode_frame, DeltaState}` against
@@ -365,10 +366,10 @@ required-features = ["__test-helpers"]
 # Data-format layer micro-benchmarks. These exercise the internal `tdbe`
 # module directly: the FIT/FIE nibble codecs, the Black-Scholes Greek
 # primitives, the `Price` fixed-point conversions, the enum lookups, and
-# the tick field accessors. `bench_fit` / `bench_fie` / `bench_greeks`
-# reach the codec and full Black-Scholes surfaces re-exported behind
-# `__internal`; `bench_enums` / `bench_price` / `bench_tick` ride the
-# stable public types.
+# the tick field accessors. `bench_fit` / `bench_fie` / `bench_greeks` /
+# `bench_price` reach the codec, full Black-Scholes, and fixed-point price
+# encoding surfaces re-exported behind `__internal`; `bench_enums` /
+# `bench_tick` ride the stable public types.
 [[bench]]
 name = "bench_fit"
 harness = false
@@ -382,6 +383,7 @@ required-features = ["__internal"]
 [[bench]]
 name = "bench_price"
 harness = false
+required-features = ["__internal"]
 
 [[bench]]
 name = "bench_greeks"

--- a/crates/thetadatadx/benches/bench_price.rs
+++ b/crates/thetadatadx/benches/bench_price.rs
@@ -74,7 +74,7 @@ fn bench_price_new_1000(c: &mut Criterion) {
             let mut sum = 0i32;
             for i in 0..1000i32 {
                 let p = Price::new(black_box(15000 + i), black_box(8));
-                sum += p.value;
+                sum += p.value();
             }
             black_box(sum);
         });

--- a/crates/thetadatadx/src/flatfiles/writer.rs
+++ b/crates/thetadatadx/src/flatfiles/writer.rs
@@ -78,7 +78,7 @@ pub(crate) fn data_indices(fmt: &[DataType], price_type_idx: Option<usize>) -> V
         .collect()
 }
 
-/// Per-row PRICE_TYPE exponent for `crate::tdbe::Price` decoding.
+/// Per-row PRICE_TYPE exponent for `crate::tdbe::types::price::Price` decoding.
 ///
 /// When PRICE_TYPE is in the schema, the value at that column is the
 /// vendor `price_type` field (real price = `value * 10^(price_type - 10)`).

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -293,16 +293,25 @@ pub use crate::tdbe::types::tick::{
     TradeGreeksSecondOrderTick, TradeGreeksThirdOrderTick, TradeQuoteTick, TradeTick,
 };
 
-// ─── Enums and price wrapper ──────────────────────────────────────────────────
+// ─── Enums ────────────────────────────────────────────────────────────────────
 
 pub use crate::tdbe::types::enums::{
     DataType, Interval, RateType, RemoveReason, RequestType, Right, SecType, StreamMsgType,
     StreamResponseType, Venue, Version,
 };
-// `Price` plus the validated `PriceType` exponent, the `PriceError` its
-// fallible constructor (`Price::with_value_and_type`) returns, and the
-// `MAX_PRICE_TYPE` bound that constructor validates against — the public
-// fixed-point price surface.
+/// Variable-precision fixed-point price encoding (`value` / `price_type`
+/// mantissa-and-exponent pair) and its supporting types: the validated
+/// `PriceType` exponent, the `PriceError` its fallible constructor returns,
+/// and the `MAX_PRICE_TYPE` bound that constructor validates against.
+///
+/// This is a wire-encoding detail: a client receives decoded prices
+/// (`f64` dollars on the tick rows) and never sees, sets, or reasons about
+/// the raw `(value, price_type)` pair. The encoding therefore stays off the
+/// public API. Only available when the `__internal` feature is enabled, for
+/// workspace tools, bindings, and the data-format benches. NOT a stable
+/// public surface — external crates MUST NOT enable that feature.
+#[cfg(feature = "__internal")]
+#[doc(hidden)]
 pub use crate::tdbe::types::price::{Price, PriceError, PriceType, MAX_PRICE_TYPE};
 
 // ─── Offline Black-Scholes (Greeks + implied volatility) ─────────────────────

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -299,11 +299,11 @@ pub use crate::tdbe::types::enums::{
     DataType, Interval, RateType, RemoveReason, RequestType, Right, SecType, StreamMsgType,
     StreamResponseType, Venue, Version,
 };
-// `Price` plus the `PriceError` its fallible constructor
-// (`Price::with_value_and_type`) returns and the `MAX_PRICE_TYPE` bound
-// that constructor validates against — the public fixed-point price
-// surface.
-pub use crate::tdbe::types::price::{Price, PriceError, MAX_PRICE_TYPE};
+// `Price` plus the validated `PriceType` exponent, the `PriceError` its
+// fallible constructor (`Price::with_value_and_type`) returns, and the
+// `MAX_PRICE_TYPE` bound that constructor validates against — the public
+// fixed-point price surface.
+pub use crate::tdbe::types::price::{Price, PriceError, PriceType, MAX_PRICE_TYPE};
 
 // ─── Offline Black-Scholes (Greeks + implied volatility) ─────────────────────
 

--- a/crates/thetadatadx/src/mdds/decode/extract.rs
+++ b/crates/thetadatadx/src/mdds/decode/extract.rs
@@ -142,7 +142,7 @@ pub fn extract_text_column(table: &proto::DataTable, header: &str) -> Vec<Option
 pub fn extract_price_column(
     table: &proto::DataTable,
     header: &str,
-) -> Vec<Option<crate::tdbe::Price>> {
+) -> Vec<Option<crate::tdbe::types::price::Price>> {
     let Some(col_idx) = resolve_column(table, header, "Price") else {
         return vec![];
     };

--- a/crates/thetadatadx/src/tdbe/mod.rs
+++ b/crates/thetadatadx/src/tdbe/mod.rs
@@ -30,20 +30,24 @@ pub mod time;
 pub mod types;
 
 // Module-root facade. The data-format layer keeps a complete, flat
-// re-export surface so internal callers reach `crate::tdbe::Price`,
-// `crate::tdbe::Error`, `crate::tdbe::CalendarStatus`, and the tick types
-// without threading the full submodule path, and so the crate root can
-// re-export from one coherent place. The crate's curated public surface
-// (see `lib.rs`) reaches several of these through the longer submodule
-// path, so `unused_imports` is allowed on the facade rather than trimming
-// it to whichever items today's callers happen to reach the short way.
+// re-export surface so internal callers reach `crate::tdbe::Error`,
+// `crate::tdbe::CalendarStatus`, and the tick types without threading the
+// full submodule path, and so the crate root can re-export from one
+// coherent place. The crate's curated public surface (see `lib.rs`) reaches
+// several of these through the longer submodule path, so `unused_imports`
+// is allowed on the facade rather than trimming it to whichever items
+// today's callers happen to reach the short way.
+//
+// The fixed-point price encoding (`types::price::Price` and friends) is
+// deliberately NOT on this facade: it is a wire-internal detail the decode
+// layer reaches through the full `types::price` leaf path, never a short
+// `crate::tdbe::Price` alias, so the encoding cannot drift onto the public
+// surface through the convenience re-export.
 #[allow(unused_imports)]
 pub use error::Error;
 #[allow(unused_imports)]
 pub use types::enums::{
     CalendarStatus, DataType, Interval, RateType, RequestType, Right, SecType, Venue, Version,
 };
-#[allow(unused_imports)]
-pub use types::price::Price;
 #[allow(unused_imports)]
 pub use types::tick::*;

--- a/crates/thetadatadx/src/tdbe/types/mod.rs
+++ b/crates/thetadatadx/src/tdbe/types/mod.rs
@@ -20,9 +20,10 @@ mod generated;
 // Flat facade for the `types` submodule. Callers and the crate root
 // reach the leaf modules (`types::tick`, `types::enums`, `types::price`)
 // directly, so `unused_imports` is allowed on the convenience surface.
+//
+// The fixed-point price encoding (`price::Price` and friends) is wire-internal
+// and stays off this facade; the decode layer reaches `types::price` directly.
 #[allow(unused_imports)]
 pub use enums::*;
-#[allow(unused_imports)]
-pub use price::{Price, PriceError, MAX_PRICE_TYPE};
 #[allow(unused_imports)]
 pub use tick::*;

--- a/crates/thetadatadx/src/tdbe/types/price.rs
+++ b/crates/thetadatadx/src/tdbe/types/price.rs
@@ -204,8 +204,8 @@ impl Price {
     ///
     /// # Errors
     ///
-    /// Returns [`crate::PriceError::PriceTypeOutOfRange`] when `price_type` is
-    /// negative or larger than [`crate::MAX_PRICE_TYPE`].
+    /// Returns [`PriceError::PriceTypeOutOfRange`] when `price_type` is
+    /// negative or larger than [`MAX_PRICE_TYPE`].
     #[inline]
     pub fn with_value_and_type(value: i32, price_type: i32) -> Result<Self, PriceError> {
         Ok(Self {

--- a/crates/thetadatadx/src/tdbe/types/price.rs
+++ b/crates/thetadatadx/src/tdbe/types/price.rs
@@ -14,8 +14,9 @@ use std::fmt;
 /// `exp = price_type - 10` ranges from -10 to +9 across the valid set
 /// (`price_type` 0 means "unset" — at the boundary, see [`Price::is_unset`]).
 /// The constant defines the upper bound for `with_value_and_type`'s
-/// range check and the matching `debug_assert!` guards on every path
-/// that indexes the `POW10_*` tables (sized 20 entries / indices 0..=19).
+/// range check and the clamp applied on every read path that indexes
+/// the `POW10_*` tables (sized 20 entries / indices 0..=19), keeping
+/// conversion and comparison total.
 pub const MAX_PRICE_TYPE: i32 = 19;
 
 /// Construction error for [`Price::with_value_and_type`].
@@ -79,25 +80,28 @@ static POW10_F64: [f64; 20] = [
 /// - type>10: value * 10^(type-10)
 #[derive(Clone, Copy, Default)]
 pub struct Price {
-    /// Mantissa. Public for backwards compatibility; prefer the typed
-    /// [`Price::value`] accessor in new code so the field can become
-    /// `pub(crate)` in a future major release.
-    pub value: i32,
+    /// Mantissa. Read via the [`Price::value`] accessor.
+    pub(crate) value: i32,
     /// Decimal type: 0 means zero, otherwise `10 - type` = fractional digits.
+    /// Read via the [`Price::price_type`] accessor.
     ///
-    /// MUST stay within `0..=19` — the `POW10_I64` / `POW10_F64` tables
-    /// have 20 entries (indices `0..=19`) and every indexing path
-    /// debug-asserts the bound. Index 19 is a reserved upper boundary:
-    /// the arithmetic only ever uses indices `0..=18` (since
-    /// `10^19` overflows `i64`, the index-19 slot stores `i64::MAX` as
-    /// an unreachable placeholder), but accepting `price_type = 19`
-    /// without rejecting it lets us widen the wire decode boundary
-    /// in one constant if a future server-side schema extends the
-    /// range.
-    /// Public for backwards compatibility; new code should construct via
-    /// [`Price::new`] (clamps) or [`Price::with_value_and_type`] (errors
-    /// out of range) so the invariant is enforced at the boundary.
-    pub price_type: i32,
+    /// Holds the `0..=MAX_PRICE_TYPE` invariant: the `POW10_I64` /
+    /// `POW10_F64` tables have 20 entries (indices `0..=19`) and the
+    /// encoded power-of-ten `exp = price_type - 10` must keep every
+    /// index in bounds. Index 19 is a reserved upper boundary — the
+    /// arithmetic only ever uses indices `0..=18` (since `10^19`
+    /// overflows `i64`, the index-19 slot stores `i64::MAX` as an
+    /// unreachable placeholder), but accepting `price_type = 19` lets
+    /// the wire decode boundary widen in one constant if a server-side
+    /// schema extends the range.
+    ///
+    /// Construct via [`Price::new`] (clamps) or
+    /// [`Price::with_value_and_type`] (errors out of range) so the
+    /// invariant is enforced at the boundary. Field access is
+    /// crate-private; every read path additionally clamps the
+    /// exponent into the table range so conversion and comparison stay
+    /// total even for an internally constructed odd value.
+    pub(crate) price_type: i32,
 }
 
 impl Price {
@@ -139,18 +143,16 @@ impl Price {
         Ok(Self { value, price_type })
     }
 
-    /// Mantissa accessor — prefer over direct field access in new code
-    /// so the field can become `pub(crate)` in a future major release
-    /// without breaking call sites.
+    /// Mantissa accessor. The raw field is crate-private so the
+    /// `0..=MAX_PRICE_TYPE` invariant cannot be bypassed by construction.
     #[inline]
     #[must_use]
     pub const fn value(&self) -> i32 {
         self.value
     }
 
-    /// Decimal-exponent accessor — prefer over direct field access in
-    /// new code so the field can become `pub(crate)` in a future major
-    /// release without breaking call sites.
+    /// Decimal-exponent accessor. The raw field is crate-private so the
+    /// `0..=MAX_PRICE_TYPE` invariant cannot be bypassed by construction.
     #[inline]
     #[must_use]
     pub const fn price_type(&self) -> i32 {
@@ -186,63 +188,56 @@ impl Price {
         self.value == 0 || self.price_type == 0
     }
 
+    /// `price_type` clamped into the valid `0..=MAX_PRICE_TYPE` range so
+    /// every `POW10_*` index stays in bounds. Construction enforces the
+    /// invariant; this keeps the read paths total even for an internally
+    /// constructed odd value, turning a would-be out-of-bounds index into
+    /// a saturated, well-defined result instead of a panic.
+    #[inline]
+    fn clamped_price_type(&self) -> i32 {
+        self.price_type.clamp(0, MAX_PRICE_TYPE)
+    }
+
     /// Convert to f64. This is lossy but useful for display/calculations.
-    // Reason: price_type is bounded to 0..=19 by new/with_value_and_type
-    // (index 19 is a reserved unreachable placeholder; see the constant
-    // doc on MAX_PRICE_TYPE), and a debug_assert below pins the
-    // invariant for hand-constructed values that bypass those
-    // constructors.
-    #[allow(clippy::cast_sign_loss)]
     #[inline]
     #[must_use]
     pub fn to_f64(&self) -> f64 {
-        if self.price_type == 0 {
+        let price_type = self.clamped_price_type();
+        if price_type == 0 {
             return 0.0;
         }
-        debug_assert!(
-            (self.price_type as usize) < POW10_F64.len(),
-            "price_type {} outside POW10_F64 table",
-            self.price_type
-        );
-        let exp = self.price_type - 10;
+        let exp = price_type - 10;
         if exp >= 0 {
-            debug_assert!(
-                (exp as usize) < POW10_F64.len(),
-                "exp {exp} outside POW10_F64 table"
-            );
-            f64::from(self.value) * POW10_F64[exp as usize]
+            // `price_type` is clamped to `0..=MAX_PRICE_TYPE` (19), so
+            // `exp` is `0..=9` — always a valid `POW10_F64` index.
+            f64::from(self.value) * POW10_F64[exp.unsigned_abs() as usize]
         } else {
-            debug_assert!(
-                ((-exp) as usize) < POW10_F64.len(),
-                "(-exp) {} outside POW10_F64 table",
-                -exp
-            );
-            f64::from(self.value) / POW10_F64[(-exp) as usize]
+            // `exp` is `-10..=-1`, so `-exp` is `1..=10` — always a valid
+            // `POW10_F64` index.
+            f64::from(self.value) / POW10_F64[exp.unsigned_abs() as usize]
         }
     }
 
     /// Normalize both prices to the same type for comparison.
-    // Reason: price_type is bounded to 0..=19, so differences are in
-    // 0..=19 (safe cast). `&self` required by PartialOrd/Ord trait
-    // implementations. Every index into POW10_I64 is guarded by a
-    // debug_assert in addition to the explicit `exp > 18` early-out
-    // (index 19 stores `i64::MAX` as an unreachable placeholder, so the
-    // early-out is what keeps the arithmetic correct).
-    #[allow(clippy::cast_sign_loss, clippy::trivially_copy_pass_by_ref)]
+    // `&self` is required by the `PartialOrd`/`Ord` trait signatures.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
     fn compare(&self, other: &Self) -> Ordering {
-        if self.price_type == other.price_type {
+        // Clamp into the valid range so every `POW10_I64` index stays in
+        // bounds even for an internally constructed odd value.
+        let self_type = self.clamped_price_type();
+        let other_type = other.clamped_price_type();
+        if self_type == other_type {
             return self.value.cmp(&other.value);
         }
         // Scale to common base using i64 to avoid overflow.
         // For exponents > 18, i64 multiplication can overflow; fall back to f64.
-        if self.price_type > other.price_type {
-            let exp = (self.price_type - other.price_type) as usize;
+        if self_type > other_type {
+            let exp = (self_type - other_type).unsigned_abs() as usize;
             if exp > 18 {
                 // Fall back to f64 comparison for very large exponent differences.
                 return self.to_f64().total_cmp(&other.to_f64());
             }
-            debug_assert!(exp < POW10_I64.len(), "exp {exp} outside POW10_I64 table");
             let scaled = i64::from(self.value).checked_mul(POW10_I64[exp]);
             match scaled {
                 Some(s) => s.cmp(&i64::from(other.value)),
@@ -250,11 +245,10 @@ impl Price {
                 None => self.to_f64().total_cmp(&other.to_f64()),
             }
         } else {
-            let exp = (other.price_type - self.price_type) as usize;
+            let exp = (other_type - self_type).unsigned_abs() as usize;
             if exp > 18 {
                 return self.to_f64().total_cmp(&other.to_f64());
             }
-            debug_assert!(exp < POW10_I64.len(), "exp {exp} outside POW10_I64 table");
             let scaled = i64::from(other.value).checked_mul(POW10_I64[exp]);
             match scaled {
                 Some(s) => i64::from(self.value).cmp(&s),
@@ -291,26 +285,19 @@ impl fmt::Debug for Price {
 }
 
 impl fmt::Display for Price {
-    // Reason: price_type is bounded to 0..=19; debug_asserts pin the
-    // invariant for the formatter paths that arithmetic-cast it to
-    // unsigned. The formatter never actually reaches an `exp` of 9
-    // (price_type 19) because `10^19` overflows i64 — the index-19 slot
-    // is an unreachable placeholder, see MAX_PRICE_TYPE.
-    #[allow(clippy::cast_sign_loss)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.price_type == 0 {
+        // Clamp into the valid range so the digit-count arithmetic below
+        // stays non-negative and bounded even for an internally
+        // constructed odd value.
+        let price_type = self.clamped_price_type();
+        if price_type == 0 {
             return write!(f, "0.0");
         }
-        debug_assert!(
-            (0..=MAX_PRICE_TYPE).contains(&self.price_type),
-            "price_type {} outside valid range",
-            self.price_type
-        );
-        if self.price_type == 10 {
+        if price_type == 10 {
             return write!(f, "{}.0", self.value);
         }
-        if self.price_type > 10 {
-            let zeros = "0".repeat((self.price_type - 10) as usize);
+        if price_type > 10 {
+            let zeros = "0".repeat((price_type - 10).unsigned_abs() as usize);
             return write!(f, "{}{}.0", self.value, zeros);
         }
 
@@ -323,7 +310,7 @@ impl fmt::Display for Price {
             format!("{}", self.value)
         };
 
-        let frac_digits = (10 - self.price_type) as usize;
+        let frac_digits = (10 - price_type).unsigned_abs() as usize;
         let padded = if abs_str.len() <= frac_digits {
             let pad = "0".repeat(frac_digits - abs_str.len() + 1);
             format!("{pad}{abs_str}")
@@ -471,13 +458,69 @@ mod tests {
         let _ = Price::new(1, i32::MAX);
     }
 
-    /// Accessors return the same value as direct field access — they
-    /// exist so the fields can become `pub(crate)` in a future major
-    /// release without breaking call sites.
+    /// Accessors return the same value as direct field access. The raw
+    /// fields are crate-private so the `0..=MAX_PRICE_TYPE` invariant
+    /// cannot be bypassed by external construction.
     #[test]
     fn accessors_match_fields() {
         let p = Price::new(15025, 8);
         assert_eq!(p.value(), p.value);
         assert_eq!(p.price_type(), p.price_type);
+    }
+
+    /// The read paths (`to_f64`, `to_string`, `compare`) stay total even
+    /// for a `price_type` outside the table range. Construction enforces
+    /// the invariant, but an internally built odd value must saturate
+    /// into the valid range rather than index a `POW10_*` table out of
+    /// bounds and panic. Covers above the table max, below the unset
+    /// boundary (negative exponent), and both table boundaries.
+    #[test]
+    fn read_paths_are_total_for_out_of_range_price_type() {
+        // Bypass the validating constructors via crate-private fields to
+        // model an out-of-range value reaching the read paths.
+        let above = Price {
+            value: 1,
+            price_type: 30,
+        };
+        let below = Price {
+            value: 1,
+            price_type: -5,
+        };
+        let lo = Price {
+            value: 1,
+            price_type: 0,
+        };
+        let hi = Price {
+            value: 1,
+            price_type: MAX_PRICE_TYPE,
+        };
+        let reference = Price::new(15025, 8);
+
+        for p in [above, below, lo, hi] {
+            // None of these may panic; all must produce a finite f64,
+            // a non-empty string, and a defined ordering.
+            let f = p.to_f64();
+            assert!(f.is_finite(), "to_f64 must be finite; got {f}");
+            assert!(!p.to_string().is_empty(), "Display must be non-empty");
+            let _ = p.cmp(&reference);
+            let _ = reference.cmp(&p);
+            let _ = p.cmp(&p);
+        }
+    }
+
+    /// In-range conversions are unchanged by the read-path guard: a
+    /// clamp that leaves valid values untouched must reproduce the exact
+    /// prior results for known `(value, price_type)` pairs.
+    #[test]
+    fn in_range_conversions_are_unchanged() {
+        // value=12345, price_type=8 -> 12345 * 10^(8-10) = 123.45
+        assert!((Price::new(12345, 8).to_f64() - 123.45).abs() < 1e-10);
+        assert_eq!(Price::new(12345, 8).to_string(), "123.45");
+        // value=5, price_type=12 -> 5 * 10^2 = 500.0
+        assert!((Price::new(5, 12).to_f64() - 500.0).abs() < 1e-10);
+        assert_eq!(Price::new(5, 12).to_string(), "500.0");
+        // value=100, price_type=10 -> 100 * 10^0 = 100.0
+        assert!((Price::new(100, 10).to_f64() - 100.0).abs() < 1e-10);
+        assert_eq!(Price::new(100, 10).to_string(), "100.0");
     }
 }

--- a/crates/thetadatadx/src/tdbe/types/price.rs
+++ b/crates/thetadatadx/src/tdbe/types/price.rs
@@ -3,9 +3,14 @@
 //! `ThetaData` encodes a price as a `(value, price_type)` pair where the real
 //! price is `value * 10^(price_type - 10)`. [`Price`] stores that pair and
 //! compares values by scaling to a common base via integer powers of ten,
-//! falling back to f64 only when the exponent gap would overflow `i64`. The
-//! `price_type` invariant (`0..=MAX_PRICE_TYPE`) keeps every `POW10_*` table
-//! index in bounds.
+//! falling back to f64 only when the exponent gap would overflow `i64`.
+//!
+//! The decimal exponent is held as a [`PriceType`] newtype whose only
+//! constructors reject anything outside `0..=MAX_PRICE_TYPE`. Because an
+//! out-of-range exponent cannot be represented, every `POW10_*` table
+//! index derived from a `PriceType` is in bounds by construction — the
+//! read paths convert and compare with no runtime range check and no
+//! possibility of a fabricated out-of-range result.
 
 use std::cmp::Ordering;
 use std::fmt;
@@ -13,13 +18,13 @@ use std::fmt;
 /// Highest valid `price_type` discriminant. The encoded power-of-ten
 /// `exp = price_type - 10` ranges from -10 to +9 across the valid set
 /// (`price_type` 0 means "unset" — at the boundary, see [`Price::is_unset`]).
-/// The constant defines the upper bound for `with_value_and_type`'s
-/// range check and the clamp applied on every read path that indexes
-/// the `POW10_*` tables (sized 20 entries / indices 0..=19), keeping
-/// conversion and comparison total.
+/// The constant bounds [`PriceType`]'s checked constructors and matches the
+/// size of the `POW10_*` tables (20 entries / indices 0..=19), so any index
+/// derived from a `PriceType` is in range by construction.
 pub const MAX_PRICE_TYPE: i32 = 19;
 
-/// Construction error for [`Price::with_value_and_type`].
+/// Construction error for [`Price::with_value_and_type`] and
+/// [`PriceType::new`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PriceError {
     /// `price_type` outside the supported `0..=MAX_PRICE_TYPE` range.
@@ -38,6 +43,81 @@ impl fmt::Display for PriceError {
 }
 
 impl std::error::Error for PriceError {}
+
+/// Validated decimal exponent for a [`Price`], constrained to
+/// `0..=MAX_PRICE_TYPE`.
+///
+/// The inner byte is private and every constructor checks the range, so an
+/// out-of-range exponent is unrepresentable. The decimal exponent
+/// `exp = price_type - 10` is therefore confined to `-10..=9`, so
+/// `exp.unsigned_abs()` is a `POW10_*` table index that is provably in
+/// bounds — the conversion and comparison paths drop every per-read range
+/// check.
+///
+/// `Default` is the in-range "unset" exponent (`0`), matching
+/// [`PriceType::UNSET`] and [`Price::ZERO`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PriceType(u8);
+
+impl PriceType {
+    /// The "unset" exponent (`price_type == 0`); see [`Price::is_unset`].
+    pub const UNSET: Self = Self(0);
+
+    /// Construct a `PriceType`, rejecting anything outside
+    /// `0..=MAX_PRICE_TYPE`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PriceError::PriceTypeOutOfRange`] when `price_type` is
+    /// negative or larger than [`MAX_PRICE_TYPE`].
+    #[inline]
+    pub const fn new(price_type: i32) -> Result<Self, PriceError> {
+        if price_type < 0 || price_type > MAX_PRICE_TYPE {
+            return Err(PriceError::PriceTypeOutOfRange(price_type));
+        }
+        // In range, so the cast to u8 is exact.
+        Ok(Self(price_type as u8))
+    }
+
+    /// Construct a `PriceType` by saturating into `0..=MAX_PRICE_TYPE`.
+    /// Values below 0 snap to 0; values above the cap snap to
+    /// [`MAX_PRICE_TYPE`]. Used by the lossy [`Price::new`] constructor.
+    #[inline]
+    #[must_use]
+    pub const fn saturating(price_type: i32) -> Self {
+        let clamped = if price_type < 0 {
+            0
+        } else if price_type > MAX_PRICE_TYPE {
+            MAX_PRICE_TYPE
+        } else {
+            price_type
+        };
+        Self(clamped as u8)
+    }
+
+    /// The exponent as `i32`, in `0..=MAX_PRICE_TYPE`.
+    #[inline]
+    #[must_use]
+    pub const fn get(self) -> i32 {
+        self.0 as i32
+    }
+}
+
+impl TryFrom<i32> for PriceType {
+    type Error = PriceError;
+
+    #[inline]
+    fn try_from(price_type: i32) -> Result<Self, Self::Error> {
+        Self::new(price_type)
+    }
+}
+
+impl From<PriceType> for i32 {
+    #[inline]
+    fn from(price_type: PriceType) -> Self {
+        price_type.get()
+    }
+}
 
 /// Precomputed powers of 10 as i64 for fast integer scaling in `Price::compare`.
 static POW10_I64: [i64; 20] = [
@@ -82,54 +162,45 @@ static POW10_F64: [f64; 20] = [
 pub struct Price {
     /// Mantissa. Read via the [`Price::value`] accessor.
     pub(crate) value: i32,
-    /// Decimal type: 0 means zero, otherwise `10 - type` = fractional digits.
-    /// Read via the [`Price::price_type`] accessor.
+    /// Decimal exponent: 0 means zero/unset, otherwise `10 - price_type`
+    /// = fractional digits. Read via the [`Price::price_type`] accessor.
     ///
-    /// Holds the `0..=MAX_PRICE_TYPE` invariant: the `POW10_I64` /
-    /// `POW10_F64` tables have 20 entries (indices `0..=19`) and the
-    /// encoded power-of-ten `exp = price_type - 10` must keep every
-    /// index in bounds. Index 19 is a reserved upper boundary — the
-    /// arithmetic only ever uses indices `0..=18` (since `10^19`
-    /// overflows `i64`, the index-19 slot stores `i64::MAX` as an
-    /// unreachable placeholder), but accepting `price_type = 19` lets
-    /// the wire decode boundary widen in one constant if a server-side
-    /// schema extends the range.
-    ///
-    /// Construct via [`Price::new`] (clamps) or
-    /// [`Price::with_value_and_type`] (errors out of range) so the
-    /// invariant is enforced at the boundary. Field access is
-    /// crate-private; every read path additionally clamps the
-    /// exponent into the table range so conversion and comparison stay
-    /// total even for an internally constructed odd value.
-    pub(crate) price_type: i32,
+    /// Typed as [`PriceType`], which can only hold `0..=MAX_PRICE_TYPE`.
+    /// The `POW10_I64` / `POW10_F64` tables have 20 entries
+    /// (indices `0..=19`); since the exponent is bounded by the type,
+    /// every read-path table access is in range without a runtime
+    /// check. Index 19 is a reserved upper boundary — the arithmetic only
+    /// ever uses indices `0..=18` (since `10^19` overflows `i64`, the
+    /// index-19 slot stores `i64::MAX` as an unreachable placeholder), but
+    /// admitting `price_type = 19` lets the wire decode boundary widen in
+    /// one constant if a server-side schema extends the range.
+    pub(crate) price_type: PriceType,
 }
 
 impl Price {
-    /// A zero price with the default price type, useful as a neutral initializer.
+    /// A zero price with the unset price type, useful as a neutral initializer.
     pub const ZERO: Self = Self {
         value: 0,
-        price_type: 0,
+        price_type: PriceType::UNSET,
     };
 
-    /// Construct a `Price` clamping `price_type` to the valid
-    /// `0..=MAX_PRICE_TYPE` range. Out-of-range values silently snap to
-    /// the boundary so existing call sites stay panic-free; new code
-    /// that needs to reject bad inputs should call
+    /// Construct a `Price`, saturating `price_type` into the valid
+    /// `0..=MAX_PRICE_TYPE` range. Out-of-range inputs snap to the nearest
+    /// boundary; callers that must reject bad inputs use
     /// [`Self::with_value_and_type`] instead.
     #[inline]
     #[must_use]
     pub fn new(value: i32, price_type: i32) -> Self {
         Self {
             value,
-            price_type: price_type.clamp(0, MAX_PRICE_TYPE),
+            price_type: PriceType::saturating(price_type),
         }
     }
 
     /// Construct a `Price` that errors when `price_type` is outside
     /// `0..=MAX_PRICE_TYPE`. The strict counterpart to [`Self::new`] —
     /// callers that own the wire decode boundary use this so a hostile
-    /// upstream value surfaces as a typed error instead of silently
-    /// clamping.
+    /// upstream value surfaces as a typed error instead of saturating.
     ///
     /// # Errors
     ///
@@ -137,10 +208,10 @@ impl Price {
     /// negative or larger than [`crate::MAX_PRICE_TYPE`].
     #[inline]
     pub fn with_value_and_type(value: i32, price_type: i32) -> Result<Self, PriceError> {
-        if !(0..=MAX_PRICE_TYPE).contains(&price_type) {
-            return Err(PriceError::PriceTypeOutOfRange(price_type));
-        }
-        Ok(Self { value, price_type })
+        Ok(Self {
+            value,
+            price_type: PriceType::new(price_type)?,
+        })
     }
 
     /// Mantissa accessor. The raw field is crate-private so the
@@ -151,12 +222,13 @@ impl Price {
         self.value
     }
 
-    /// Decimal-exponent accessor. The raw field is crate-private so the
-    /// `0..=MAX_PRICE_TYPE` invariant cannot be bypassed by construction.
+    /// Decimal-exponent accessor, in `0..=MAX_PRICE_TYPE`. The exponent is
+    /// stored as a validated [`PriceType`] so the invariant cannot be
+    /// bypassed by construction.
     #[inline]
     #[must_use]
     pub const fn price_type(&self) -> i32 {
-        self.price_type
+        self.price_type.get()
     }
 
     /// Whether this `Price` carries the "unset" sentinel
@@ -166,7 +238,7 @@ impl Price {
     #[inline]
     #[must_use]
     pub const fn is_unset(&self) -> bool {
-        self.price_type == 0
+        self.price_type.get() == 0
     }
 
     /// Whether this `Price` represents a real zero (mantissa == 0 with
@@ -175,7 +247,7 @@ impl Price {
     #[inline]
     #[must_use]
     pub const fn is_zero_value(&self) -> bool {
-        self.value == 0 && self.price_type != 0
+        self.value == 0 && self.price_type.get() != 0
     }
 
     /// Whether this `Price` represents zero by either signal — sentinel
@@ -185,36 +257,26 @@ impl Price {
     /// "no quote yet" vs "zero price" branches stay distinguishable.
     #[must_use]
     pub fn is_zero(&self) -> bool {
-        self.value == 0 || self.price_type == 0
-    }
-
-    /// `price_type` clamped into the valid `0..=MAX_PRICE_TYPE` range so
-    /// every `POW10_*` index stays in bounds. Construction enforces the
-    /// invariant; this keeps the read paths total even for an internally
-    /// constructed odd value, turning a would-be out-of-bounds index into
-    /// a saturated, well-defined result instead of a panic.
-    #[inline]
-    fn clamped_price_type(&self) -> i32 {
-        self.price_type.clamp(0, MAX_PRICE_TYPE)
+        self.value == 0 || self.price_type.get() == 0
     }
 
     /// Convert to f64. This is lossy but useful for display/calculations.
     #[inline]
     #[must_use]
     pub fn to_f64(&self) -> f64 {
-        let price_type = self.clamped_price_type();
+        let price_type = self.price_type.get();
         if price_type == 0 {
             return 0.0;
         }
         let exp = price_type - 10;
+        // `price_type` is `1..=MAX_PRICE_TYPE` here, so `exp` is `-9..=9`
+        // and `exp.unsigned_abs()` is `0..=9` — a valid `POW10_F64` index
+        // by construction.
+        let scale = POW10_F64[exp.unsigned_abs() as usize];
         if exp >= 0 {
-            // `price_type` is clamped to `0..=MAX_PRICE_TYPE` (19), so
-            // `exp` is `0..=9` — always a valid `POW10_F64` index.
-            f64::from(self.value) * POW10_F64[exp.unsigned_abs() as usize]
+            f64::from(self.value) * scale
         } else {
-            // `exp` is `-10..=-1`, so `-exp` is `1..=10` — always a valid
-            // `POW10_F64` index.
-            f64::from(self.value) / POW10_F64[exp.unsigned_abs() as usize]
+            f64::from(self.value) / scale
         }
     }
 
@@ -223,10 +285,8 @@ impl Price {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
     fn compare(&self, other: &Self) -> Ordering {
-        // Clamp into the valid range so every `POW10_I64` index stays in
-        // bounds even for an internally constructed odd value.
-        let self_type = self.clamped_price_type();
-        let other_type = other.clamped_price_type();
+        let self_type = self.price_type.get();
+        let other_type = other.price_type.get();
         if self_type == other_type {
             return self.value.cmp(&other.value);
         }
@@ -286,10 +346,9 @@ impl fmt::Debug for Price {
 
 impl fmt::Display for Price {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Clamp into the valid range so the digit-count arithmetic below
-        // stays non-negative and bounded even for an internally
-        // constructed odd value.
-        let price_type = self.clamped_price_type();
+        // `price_type` is `0..=MAX_PRICE_TYPE` by construction, so the
+        // digit-count arithmetic below stays non-negative and bounded.
+        let price_type = self.price_type.get();
         if price_type == 0 {
             return write!(f, "0.0");
         }
@@ -371,8 +430,8 @@ mod tests {
     /// invariant that the POW10 tables are correctly sized for the
     /// supported range, including the index-19 placeholder slot, and
     /// that both Display and to_f64 agree on a finite numeric value.
-    /// (Renamed from `_round_trips` -- the assertion is "no panic +
-    /// finite numeric", not a Display->parse round-trip, per S37.)
+    /// The assertion is "no panic + finite numeric", not a
+    /// `Display`->parse round-trip.
     #[test]
     fn every_valid_price_type_renders_and_converts_finitely() {
         for pt in 0..=MAX_PRICE_TYPE {
@@ -441,76 +500,83 @@ mod tests {
         assert!(!nonzero.is_zero_value());
     }
 
-    /// `Price::new`'s clamp behaviour: out-of-range `price_type`
-    /// silently snaps to the valid boundary so existing callers stay
+    /// `Price::new`'s saturating behaviour: out-of-range `price_type`
+    /// snaps to the nearest valid boundary so existing callers stay
     /// panic-free even with a hostile wire byte.
     #[test]
-    fn new_clamps_out_of_range_price_type() {
-        // Above the cap clamps to MAX_PRICE_TYPE.
-        let p = Price::new(1, 99);
-        assert_eq!(p.price_type, MAX_PRICE_TYPE);
-        // Below 0 clamps to 0.
-        let p = Price::new(1, -3);
-        assert_eq!(p.price_type, 0);
-        // i32::MIN does not panic.
-        let _ = Price::new(1, i32::MIN);
-        // i32::MAX does not panic.
-        let _ = Price::new(1, i32::MAX);
+    fn new_saturates_out_of_range_price_type() {
+        // Above the cap saturates to MAX_PRICE_TYPE.
+        assert_eq!(Price::new(1, 99).price_type(), MAX_PRICE_TYPE);
+        // Below 0 saturates to 0.
+        assert_eq!(Price::new(1, -3).price_type(), 0);
+        // Extremes do not panic and land in range.
+        assert_eq!(Price::new(1, i32::MIN).price_type(), 0);
+        assert_eq!(Price::new(1, i32::MAX).price_type(), MAX_PRICE_TYPE);
     }
 
-    /// Accessors return the same value as direct field access. The raw
-    /// fields are crate-private so the `0..=MAX_PRICE_TYPE` invariant
+    /// Accessors return the validated exponent and mantissa. The exponent
+    /// is stored as a [`PriceType`] so the `0..=MAX_PRICE_TYPE` invariant
     /// cannot be bypassed by external construction.
     #[test]
     fn accessors_match_fields() {
         let p = Price::new(15025, 8);
-        assert_eq!(p.value(), p.value);
-        assert_eq!(p.price_type(), p.price_type);
+        assert_eq!(p.value(), 15025);
+        assert_eq!(p.price_type(), 8);
+        assert_eq!(p.price_type(), p.price_type.get());
     }
 
-    /// The read paths (`to_f64`, `to_string`, `compare`) stay total even
-    /// for a `price_type` outside the table range. Construction enforces
-    /// the invariant, but an internally built odd value must saturate
-    /// into the valid range rather than index a `POW10_*` table out of
-    /// bounds and panic. Covers above the table max, below the unset
-    /// boundary (negative exponent), and both table boundaries.
+    /// `PriceType::new` / `TryFrom<i32>` accept the supported range and
+    /// reject everything else, so an out-of-range exponent is
+    /// unrepresentable — there is no read path that can observe one.
     #[test]
-    fn read_paths_are_total_for_out_of_range_price_type() {
-        // Bypass the validating constructors via crate-private fields to
-        // model an out-of-range value reaching the read paths.
-        let above = Price {
-            value: 1,
-            price_type: 30,
-        };
-        let below = Price {
-            value: 1,
-            price_type: -5,
-        };
-        let lo = Price {
-            value: 1,
-            price_type: 0,
-        };
-        let hi = Price {
-            value: 1,
-            price_type: MAX_PRICE_TYPE,
-        };
-        let reference = Price::new(15025, 8);
+    fn price_type_rejects_out_of_range() {
+        for pt in 0..=MAX_PRICE_TYPE {
+            assert_eq!(PriceType::new(pt).map(PriceType::get), Ok(pt));
+            assert_eq!(PriceType::try_from(pt).map(PriceType::get), Ok(pt));
+        }
+        for bad in [-1, MAX_PRICE_TYPE + 1, 20, 99, i32::MIN, i32::MAX] {
+            assert_eq!(
+                PriceType::new(bad),
+                Err(PriceError::PriceTypeOutOfRange(bad)),
+                "price_type {bad} must be rejected"
+            );
+            assert!(PriceType::try_from(bad).is_err());
+        }
+    }
 
-        for p in [above, below, lo, hi] {
-            // None of these may panic; all must produce a finite f64,
-            // a non-empty string, and a defined ordering.
+    /// `PriceType::saturating` snaps into range at both boundaries while
+    /// leaving in-range values untouched.
+    #[test]
+    fn price_type_saturating_clamps_to_boundaries() {
+        assert_eq!(PriceType::saturating(-100).get(), 0);
+        assert_eq!(PriceType::saturating(i32::MIN).get(), 0);
+        assert_eq!(PriceType::saturating(8).get(), 8);
+        assert_eq!(PriceType::saturating(MAX_PRICE_TYPE).get(), MAX_PRICE_TYPE);
+        assert_eq!(PriceType::saturating(1000).get(), MAX_PRICE_TYPE);
+        assert_eq!(PriceType::saturating(i32::MAX).get(), MAX_PRICE_TYPE);
+    }
+
+    /// Every representable exponent (`0..=MAX_PRICE_TYPE`) indexes the
+    /// `POW10_*` tables in bounds, and conversion stays finite — the
+    /// type-level guarantee the read paths now rely on instead of a
+    /// per-read clamp.
+    #[test]
+    fn every_price_type_indexes_tables_in_bounds() {
+        for pt in 0..=MAX_PRICE_TYPE {
+            let p = Price::new(1, pt);
             let f = p.to_f64();
-            assert!(f.is_finite(), "to_f64 must be finite; got {f}");
+            assert!(f.is_finite(), "to_f64 must be finite for price_type {pt}");
             assert!(!p.to_string().is_empty(), "Display must be non-empty");
+            let reference = Price::new(15025, 8);
             let _ = p.cmp(&reference);
             let _ = reference.cmp(&p);
             let _ = p.cmp(&p);
         }
     }
 
-    /// In-range conversions are unchanged by the read-path guard: a
-    /// clamp that leaves valid values untouched must reproduce the exact
-    /// prior results for known `(value, price_type)` pairs.
+    /// In-range conversions are unchanged by the newtype: validated
+    /// values must reproduce the exact prior results for known
+    /// `(value, price_type)` pairs.
     #[test]
     fn in_range_conversions_are_unchanged() {
         // value=12345, price_type=8 -> 12345 * 10^(8-10) = 123.45


### PR DESCRIPTION
## Summary

A price is encoded as a `(value, price_type)` mantissa-and-exponent pair where the real price is `value * 10^(price_type - 10)`. That variable-precision fixed-point encoding is a wire-transport detail. A client of this crate receives decoded prices (`f64` dollars on the tick rows, via `to_f64`), so it must never see, set, or reason about the raw `(value, price_type)` pair. This PR makes the encoding internal: it removes `Price`, `PriceType`, `PriceError`, and `MAX_PRICE_TYPE` from the public API, and it hardens the exponent so only the validated internal decode path can construct a `Price`.

## Make the encoding internal

`Price` and its supporting types were re-exported on the curated public surface (`thetadatadx::Price`, `thetadatadx::PriceType`, `thetadatadx::PriceError`, `thetadatadx::MAX_PRICE_TYPE`) and on the internal `tdbe` / `tdbe::types` facades. None of that is needed by a client: every public tick row already carries the decoded `f64` price, and no public function or binding accepts or returns a `Price`. The pair never crosses a binding boundary.

These types are now gated behind the `__internal` feature (doc-hidden, with the same "NOT a stable public surface" contract as the other wire-internal re-exports), so they stay reachable for workspace tools, bindings, and the data-format benches but are absent from the default public API and from rendered rustdoc. The decode layer reaches them through the full `tdbe::types::price` leaf path, never a short facade alias, so the encoding cannot drift back onto the public surface through a convenience re-export. The `price_type` tick-schema column is a positional wire-layout field the parser reads and discards; it was already not a client-facing struct field in any binding, so no tick row exposes the raw exponent.

## Parse, don't validate: the exponent is unrepresentable out of range

The decimal exponent is a validated `PriceType` newtype over `0..=MAX_PRICE_TYPE`. Its only constructors check the range:

- `PriceType::new(i32) -> Result<_, PriceError>` / `TryFrom<i32>` rejects out of range with a typed error.
- `PriceType::saturating(i32)` is infallible, snapping into range at the nearest boundary; it backs the lossy `Price::new`.

Because an out-of-range exponent cannot be constructed, `exp = price_type - 10` is confined to `-10..=9` and `exp.unsigned_abs()` indexes the precomputed `POW10_I64` / `POW10_F64` tables in bounds by construction. The per-read clamps in `to_f64`, `Display`, and `compare` are gone; the table access is provably in range with no runtime check and no path that can observe or fabricate a result from an out-of-range exponent. The earlier panic class is eliminated because only the validated decode boundary constructs a `Price`: the wire decode path (FPSS / MDDS) constructs through the fallible `Price::with_value_and_type`, which threads `PriceType::new` and rejects out-of-range cells exactly as before; `Price::new` keeps its saturating contract via `PriceType::saturating` so existing infallible callers stay panic-free.

## Why this is ABI-safe

`Price` is a pure-Rust internal type, with evidence:

- No `#[repr(C)]`, no layout assertion, no `bytemuck` / `zerocopy` traits on `Price`.
- No C / C++ / Python / TypeScript binding reads `Price`'s raw fields. The C ABI exposes `PriceTick`, which carries a decoded `double price`, not `Price`. The layout-assert suite covers `PriceTick`, not `Price`.
- Bindings obtain the price exclusively as the decoded `f64` via `to_f64`; the `(value, price_type)` pair never crosses a binding boundary.

So removing the public re-export and changing the field type from `i32` to `PriceType` cannot break any ABI. Verified: `thetadatadx-ffi`, `thetadatadx-py`, and `thetadatadx-napi` all build against the default-feature crate; the tick layout-assert suite (incl. `price_tick_layout`) passes unchanged.

## Tests

- `price_type_rejects_out_of_range` accepts `0..=19` and rejects `-1`, `20`, `99`, `i32::MIN`, `i32::MAX`; out-of-range is unrepresentable.
- `price_type_saturating_clamps_to_boundaries` snaps at both ends and leaves in-range values untouched.
- `every_price_type_indexes_tables_in_bounds` and `every_valid_price_type_renders_and_converts_finitely` pin that every representable exponent indexes the tables in bounds and converts finitely.
- `in_range_conversions_are_unchanged` pins `value=12345/type=8 -> 123.45`, `5/12 -> 500.0`, `100/10 -> 100.0` for both `to_f64` and `Display`.
- `with_value_and_type_enforces_range`, `accessors_match_fields`, `is_unset_vs_is_zero_value`, `new_saturates_out_of_range_price_type` retained.

Verification: `cargo fmt --all -- --check`; `cargo test -p thetadatadx --lib` (815 passed); FFI + Python + TypeScript binding crates build; binding-parity check clean; `git grep` confirms the default public surface no longer names `Price` / `PriceType` / `PriceError` / `MAX_PRICE_TYPE`.
