### PR TITLE
fix: correct documentation examples and align config template with code defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThetaDataDx
 
-High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Python, TypeScript, C++, and Rust** — one Rust engine under all four. Pull US stock, option, index, and rate data three ways: point-in-time **history**, real-time **streaming**, and whole-universe **flat files**, all from a single authenticated client. Connects straight to ThetaData — no Java terminal, no JVM.
+High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Python, TypeScript, C++, and Rust** — one Rust engine under all four. Pull US stock, option, index, and rate data three ways: point-in-time **history**, real-time **streaming**, and whole-universe **flat files**, all from a single authenticated client. Connects straight to ThetaData — nothing to install and run locally.
 
 [![Rust CI](https://github.com/userFRM/ThetaDataDx/actions/workflows/ci.yml/badge.svg)](https://github.com/userFRM/ThetaDataDx/actions/workflows/ci.yml)
 [![Python SDK](https://github.com/userFRM/ThetaDataDx/actions/workflows/python.yml/badge.svg)](https://github.com/userFRM/ThetaDataDx/actions/workflows/python.yml)
@@ -25,10 +25,10 @@ High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Py
 
 ## Features
 
-- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Complete coverage** — stocks, options, indices, and rates across 65 typed endpoints.
 - **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
 - **DataFrames built in** — every result chains straight to Polars, pandas, or Arrow over a zero-copy boundary.
-- **Greeks without a round-trip** — 23 Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **Greeks without a round-trip** — first- through third-order Black-Scholes Greeks and an implied-volatility solver, computed locally.
 - **The same surface in every language** — identical methods and identical typed errors, Python through Rust.
 - **No terminal to run** — a direct connection to ThetaData; nothing to install and babysit locally.
 
@@ -224,13 +224,13 @@ with client.streaming(on_event) as session:
 
 ## Endpoint coverage
 
-61 typed endpoints across stocks, options, indices, the market calendar, and
+65 typed endpoints across stocks, options, indices, the market calendar, and
 interest rates, plus real-time streaming and a local Greeks calculator.
 
 | Category | Endpoints | Examples |
 |---|---|---|
-| Stock | 14 | EOD, OHLC, trades, quotes, snapshots, at-time |
-| Option | 34 | Every stock surface plus five Greeks tiers, open interest, contract lists |
+| Stock | 16 | EOD, OHLC, trades, quotes, snapshots, at-time |
+| Option | 36 | Every stock surface plus five Greeks tiers, open interest, contract lists |
 | Index | 9 | EOD, OHLC, price, snapshots |
 | Calendar | 3 | Market open/close, holidays, early closes |
 | Interest rate | 1 | EOD rate history |

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -1,6 +1,6 @@
 # thetadatadx
 
-The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — from one async client. Connects straight to ThetaData; no Java terminal, no JVM, no local proxy.
+The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — from one async client. Connects straight to ThetaData; nothing to install and run locally, no local proxy.
 
 [![Crates.io](https://img.shields.io/crates/v/thetadatadx.svg?logo=rust)](https://crates.io/crates/thetadatadx)
 [![docs.rs](https://img.shields.io/docsrs/thetadatadx?logo=docsdotrs)](https://docs.rs/thetadatadx)
@@ -12,9 +12,9 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ## Features
 
-- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Complete coverage** — stocks, options, indices, and rates across 65 typed endpoints.
 - **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
-- **Greeks without a round-trip** — 23 Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **Greeks without a round-trip** — first- through third-order Black-Scholes Greeks and an implied-volatility solver, computed locally.
 - **Buffer or stream** — every history builder yields a `Vec<Tick>` on `.await`, or chunk-by-chunk via `.stream(handler)`.
 - **Typed errors** — one `Error` enum across every transport, plus a dedicated `FpssError` for the streaming path.
 - **DataFrames on demand** — opt into the `polars` / `arrow` features for a zero-copy conversion off any result.
@@ -64,7 +64,7 @@ async fn main() -> Result<(), thetadatadx::Error> {
 }
 ```
 
-61 typed endpoints span stocks, options, indices, the market calendar, and interest rates. Each builder accepts `.await` for a buffered `Vec<Tick>`, or `.stream(handler)` for chunk-by-chunk delivery — the right choice for multi-day backfills, where it holds peak memory flat instead of materialising the whole response.
+65 typed endpoints span stocks, options, indices, the market calendar, and interest rates. Each builder accepts `.await` for a buffered `Vec<Tick>`, or `.stream(handler)` for chunk-by-chunk delivery — the right choice for multi-day backfills, where it holds peak memory flat instead of materialising the whole response.
 
 ## Streaming
 
@@ -148,7 +148,7 @@ use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::fpss::{StreamingClient, StreamEvent};
 
 let creds = Credentials::from_file("creds.txt")?;
-let hosts = DirectConfig::production().fpss.hosts;
+let hosts = DirectConfig::production().streaming.hosts;
 let client = StreamingClient::builder(&creds, &hosts).ring_size(8192).build()?;
 
 client.subscribe(Contract::stock("AAPL").quote())?;
@@ -179,7 +179,7 @@ let path = thetadatadx::flatfile_request(
 
 ## Greeks calculator
 
-A full Black-Scholes calculator — 23 Greeks plus an implied-volatility solver — runs locally, no request required.
+A full Black-Scholes calculator — first- through third-order Greeks plus an implied-volatility solver — runs locally, no request required.
 
 ## DataFrames
 

--- a/crates/thetadatadx/config.default.toml
+++ b/crates/thetadatadx/config.default.toml
@@ -35,15 +35,20 @@ hosts = [
 # Connection timeout per server attempt (ms)
 connect_timeout = 2000
 
-# Read timeout — how long to wait for data before considering disconnected (ms)
-read_timeout = 10000
+# Read timeout — how long to wait for data before the link is considered
+# dead (ms). The server heartbeats every ~100 ms on a quiet session, so this
+# default is ~30 missed heartbeats: a dead link is declared quickly.
+read_timeout = 3000
 
-# Heartbeat interval (ms). The streaming protocol requires pings every 100ms.
-ping_interval = 100
+# Client heartbeat interval (ms). The server's own ~100 ms heartbeat is the
+# primary liveness signal; this client ping proves write-side health at a
+# 4 Hz cadence without adding inbound-frame pressure on a recovering upstream.
+ping_interval = 250
 
-# Reconnect wait after involuntary disconnect (ms)
-# FPSSClient.RECONNECT_DELAY_MS = 2000 at runtime in the Java terminal.
-reconnect_wait = 2000
+# Initial reconnect wait after an involuntary disconnect (ms). The auto-
+# reconnect driver doubles this per consecutive attempt up to its cap, then
+# applies jitter so a fleet does not reconnect in lockstep.
+reconnect_wait = 250
 
 # Reconnect wait after TooManyRequests (ms). ThetaData enforces rate limits.
 reconnect_wait_rate_limited = 130000

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -1288,6 +1288,80 @@ mod tests {
         }
 
         #[test]
+        fn config_default_toml_matches_production_defaults() {
+            // The shipped template fills every tuning knob explicitly, and
+            // `#[serde(default)]` only backfills absent keys — so any value
+            // written here OVERRIDES the code default the moment an operator
+            // copies the file. Pin every parsed value to
+            // `DirectConfig::production()` so the template can never silently
+            // drift from the in-code defaults.
+            let default_toml = include_str!("../../config.default.toml");
+            let config = DirectConfig::from_toml_str(default_toml).unwrap();
+            let prod = DirectConfig::production();
+
+            // Historical (gRPC).
+            assert_eq!(config.historical.host, prod.historical.host);
+            assert_eq!(config.historical.port, prod.historical.port);
+            assert_eq!(config.historical.tls, prod.historical.tls);
+            assert_eq!(
+                config.historical.keepalive_secs,
+                prod.historical.keepalive_secs
+            );
+            assert_eq!(
+                config.historical.keepalive_timeout_secs,
+                prod.historical.keepalive_timeout_secs
+            );
+            assert_eq!(
+                config.historical.max_message_size,
+                prod.historical.max_message_size
+            );
+            assert_eq!(
+                config.historical.window_size_kb,
+                prod.historical.window_size_kb
+            );
+            assert_eq!(
+                config.historical.connection_window_size_kb,
+                prod.historical.connection_window_size_kb
+            );
+            assert_eq!(
+                config.historical.concurrent_requests,
+                prod.historical.concurrent_requests
+            );
+
+            // Streaming (TCP).
+            assert_eq!(config.streaming.hosts, prod.streaming.hosts);
+            assert_eq!(
+                config.streaming.connect_timeout_ms,
+                prod.streaming.connect_timeout_ms
+            );
+            assert_eq!(config.streaming.timeout_ms, prod.streaming.timeout_ms);
+            assert_eq!(
+                config.streaming.ping_interval_ms,
+                prod.streaming.ping_interval_ms
+            );
+            assert_eq!(config.streaming.ring_size, prod.streaming.ring_size);
+            assert_eq!(config.streaming.flush_mode, prod.streaming.flush_mode);
+            assert_eq!(config.streaming.wait_strategy, prod.streaming.wait_strategy);
+            assert_eq!(
+                config.streaming.wait_spin_iters,
+                prod.streaming.wait_spin_iters
+            );
+            assert_eq!(
+                config.streaming.wait_yield_iters,
+                prod.streaming.wait_yield_iters
+            );
+            assert_eq!(config.streaming.wait_park_us, prod.streaming.wait_park_us);
+            assert_eq!(config.streaming.consumer_cpu, prod.streaming.consumer_cpu);
+
+            // Reconnect cadence.
+            assert_eq!(config.reconnect.wait_ms, prod.reconnect.wait_ms);
+            assert_eq!(
+                config.reconnect.wait_rate_limited_ms,
+                prod.reconnect.wait_rate_limited_ms
+            );
+        }
+
+        #[test]
         fn config_default_toml_uses_canonical_section_names() {
             // The deserializer binds `[historical]` / `[streaming]`; the
             // internal vendor names `[mdds]` / `[fpss]` deserialize to

--- a/docs-site/docs/articles/concurrent-requests.md
+++ b/docs-site/docs/articles/concurrent-requests.md
@@ -27,7 +27,7 @@ from thetadatadx import AsyncClient
 client = AsyncClient.from_file("creds.txt")
 
 async def pull(day):
-    return await client.historical.stock_history_trade_async("AAPL", day)
+    return await client.stock_history_trade_async("AAPL", day)
 
 results = asyncio.run(asyncio.gather(*(pull(d) for d in days)))
 ```

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -5,7 +5,7 @@ description: Install the SDK, save your credentials, and make your first request
 
 # Getting Started
 
-ThetaDataDx connects directly to ThetaData's servers — no Java terminal process to install or babysit. Pick a language, install, save your credentials, and make a request.
+ThetaDataDx connects directly to ThetaData's servers — nothing to install and babysit locally. Pick a language, install, save your credentials, and make a request.
 
 ## 1. Install
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -610,7 +610,7 @@ code does not change.
   accessor) is removed: the post-SSOT pipeline has exactly one queue
   (the event queue sized by `ring_size`), so a separate
   event-channel-depth knob is dead. TOML configs that set
-  `[fpss] queue_depth = ...` should switch to `ring_size`.
+  `[streaming] queue_depth = ...` should switch to `ring_size`.
 - The cross-language response-shape agreement validator
   (`scripts/validate_agreement.py`) now consumes a TypeScript
   shape manifest alongside the Python / CLI / C++ runtime artifacts.

--- a/docs-site/docs/cli.md
+++ b/docs-site/docs/cli.md
@@ -26,7 +26,7 @@ thetadatadx option list_expirations SPY
 thetadatadx option list_strikes SPY 20250321
 
 # EOD Greeks for one pinned contract
-thetadatadx option history_greeks_eod SPY 20250321 570 C 20250303 20250306
+thetadatadx option history_greeks_eod SPY 20250321 20250303 20250306 570 C
 
 # Snapshot quotes for several symbols
 thetadatadx stock snapshot_quote AAPL,MSFT,GOOGL

--- a/docs-site/docs/examples/bulk-backfill.md
+++ b/docs-site/docs/examples/bulk-backfill.md
@@ -39,7 +39,7 @@ Every endpoint has a `<endpoint>_builder(...)` factory whose `.stream(...)` / `.
 ```rust
 let days = ["20250303", "20250304", "20250305"];
 for day in days {
-    client.historical.stock_history_trade("AAPL", day)
+    client.historical().stock_history_trade("AAPL", day)
         .stream(|chunk| {
             // &[TradeTick] — persist, then the chunk is dropped.
             write_parquet(chunk);

--- a/docs-site/docs/server/index.md
+++ b/docs-site/docs/server/index.md
@@ -9,7 +9,7 @@ description: Run the local HTTP REST and WebSocket server speaking the v3 route 
 
 ## Download and run
 
-Prebuilt binaries are attached to each [GitHub Release](https://github.com/userFRM/ThetaDataDx/releases). No Rust toolchain and no Java terminal are required — download the archive for your platform, unpack it, and run the binary.
+Prebuilt binaries are attached to each [GitHub Release](https://github.com/userFRM/ThetaDataDx/releases). No Rust toolchain and nothing else to install locally — download the archive for your platform, unpack it, and run the binary.
 
 The binaries are not code-signed yet, so each operating system asks for a one-time confirmation the first time you launch one.
 

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -1,6 +1,6 @@
 # thetadatadx (C++)
 
-The C++ SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; no Java terminal, no JVM, no local proxy.
+The C++ SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; nothing to install and run locally, no local proxy.
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/userFRM/ThetaDataDx/blob/main/LICENSE)
 [![C++](https://img.shields.io/badge/C%2B%2B-17-00599C.svg?logo=cplusplus&logoColor=white)](https://isocpp.org)
@@ -12,10 +12,10 @@ The C++ SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, op
 
 ## Features
 
-- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Complete coverage** — stocks, options, indices, and rates across 65 typed endpoints.
 - **Three access modes** — point-in-time history, real-time streaming, and bulk flat-file downloads.
 - **Typed structs, no JSON** — every endpoint returns a `std::vector` of decoded structs; prices arrive as `double`.
-- **Greeks without a round-trip** — 23 Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **Greeks without a round-trip** — first- through third-order Black-Scholes Greeks and an implied-volatility solver, computed locally.
 - **RAII throughout** — clients own their connections and clean up on scope exit; methods throw on failure.
 - **Header plus one library** — a single `thetadatadx.hpp` over a prebuilt C ABI shared library.
 
@@ -157,7 +157,7 @@ fpss.subscribe(thetadatadx::SecType::option().full_trades());   // the callback 
 
 ## Greeks calculator
 
-A full Black-Scholes calculator — 23 Greeks plus an implied-volatility solver — runs locally, no connection required:
+A full Black-Scholes calculator — first- through third-order Greeks plus an implied-volatility solver — runs locally, no connection required:
 
 ```cpp
 auto g = thetadatadx::all_greeks(450.0, 455.0, 0.05, 0.015, 30.0 / 365.0, 8.50, "C");
@@ -191,12 +191,12 @@ The flat-file distribution serves a fixed set of datasets: option `trade_quote` 
 
 ## Endpoint coverage
 
-61 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming and the local Greeks calculator.
+65 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming and the local Greeks calculator.
 
 | Category | Endpoints | Examples |
 |---|---|---|
-| Stock | 14 | EOD, OHLC, trades, quotes, snapshots, at-time |
-| Option | 34 | Every stock surface plus five Greeks tiers, open interest, contract lists |
+| Stock | 16 | EOD, OHLC, trades, quotes, snapshots, at-time |
+| Option | 36 | Every stock surface plus five Greeks tiers, open interest, contract lists |
 | Index | 9 | EOD, OHLC, price, snapshots |
 | Calendar | 3 | Market open/close, holidays, early closes |
 | Interest rate | 1 | EOD rate history |

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,6 +1,6 @@
 # thetadatadx (Python)
 
-The Python SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; no Java terminal, no JVM, no local proxy.
+The Python SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; nothing to install and run locally, no local proxy.
 
 [![PyPI](https://img.shields.io/pypi/v/thetadatadx?logo=python&logoColor=white)](https://pypi.org/project/thetadatadx)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/userFRM/ThetaDataDx/blob/main/LICENSE)
@@ -13,10 +13,10 @@ The Python SDK for [ThetaData](https://thetadata.us) market data. Pull US stock,
 
 ## Features
 
-- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Complete coverage** — stocks, options, indices, and rates across 65 typed endpoints.
 - **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
 - **DataFrames built in** — every result chains straight to Polars, pandas, or Arrow over a zero-copy boundary.
-- **Greeks without a round-trip** — 23 Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **Greeks without a round-trip** — first- through third-order Black-Scholes Greeks and an implied-volatility solver, computed locally.
 - **Typed all the way down** — every tick is a typed object with attribute access and IDE completion, not a dict.
 - **No terminal to run** — a direct connection to ThetaData; nothing to install and babysit locally.
 
@@ -60,7 +60,7 @@ for tick in eod:
     print(f"{tick.date}: O={tick.open:.2f} H={tick.high:.2f} "
           f"L={tick.low:.2f} C={tick.close:.2f} V={tick.volume}")
 
-bars = client.historical.stock_history_ohlc("AAPL", "20240315", "1m")   # 1-minute bars
+bars = client.historical.stock_history_ohlc("AAPL", "20240315", interval="1m")   # 1-minute bars
 exps = client.historical.option_list_expirations("SPY")
 strikes = client.historical.option_list_strikes("SPY", exps[0])
 ```
@@ -164,6 +164,21 @@ with client.streaming(on_event) as session:
     time.sleep(60)   # the callback runs on the streaming thread — keep it fast
 ```
 
+Watch feed health from the main thread without touching the callback. The session resolves the client's observability getters directly: `millis_since_last_event()` is the staleness clock (a steadily growing value is the earliest sign of a wedged link), `ring_occupancy()` against `ring_capacity()` shows how close the consumer is to falling behind, and `dropped_event_count()` is the cumulative tally of events shed on a full ring:
+
+```python
+with client.streaming(on_event) as session:
+    session.subscribe(SecType.OPTION.full_trades())
+    while True:
+        time.sleep(5)
+        stale_ms = session.millis_since_last_event()   # None until the first frame
+        print(
+            f"stale={stale_ms}ms "
+            f"ring={session.ring_occupancy()}/{session.ring_capacity()} "
+            f"dropped={session.dropped_event_count()}"
+        )
+```
+
 > [!TIP]
 > The `with client.streaming(callback)` block opens the session on entry and drains
 > it cleanly on exit, so the callback has stopped firing by the time the block
@@ -173,7 +188,7 @@ with client.streaming(on_event) as session:
 
 ## Greeks calculator
 
-A full Black-Scholes calculator — 23 Greeks plus an implied-volatility solver — runs locally, no request required:
+A full Black-Scholes calculator — first- through third-order Greeks plus an implied-volatility solver — runs locally, no request required:
 
 ```python
 from thetadatadx import all_greeks, implied_volatility
@@ -210,7 +225,7 @@ The flat-file distribution serves a fixed set of datasets: option `trade_quote` 
 
 ## Endpoint coverage
 
-61 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming and the local Greeks calculator.
+65 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming and the local Greeks calculator.
 
 | Category | Endpoints | Examples |
 |---|---|---|

--- a/sdks/python/examples/historical.py
+++ b/sdks/python/examples/historical.py
@@ -14,7 +14,7 @@ print(f"  ... {len(eod)} total days\n")
 
 # Intraday 1-minute bars
 print("=== AAPL 1-min OHLC (Mar 15, 2024) ===")
-bars = client.historical.stock_history_ohlc("AAPL", "20240315", interval="60000")
+bars = client.historical.stock_history_ohlc("AAPL", "20240315", interval="1m")
 for bar in bars[:5]:
     print(f"  {bar.ms_of_day}ms: O={bar.open:.2f} H={bar.high:.2f} "
           f"L={bar.low:.2f} C={bar.close:.2f}")

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,6 +1,6 @@
 # thetadatadx (TypeScript / Node.js)
 
-The Node.js SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; no Java terminal, no JVM, no local proxy.
+The Node.js SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, option, index, and rate data three ways — point-in-time **history**, real-time **streaming**, and whole-universe **flat files** — all from a single authenticated client. Connects straight to ThetaData; nothing to install and run locally, no local proxy.
 
 [![npm](https://img.shields.io/npm/v/thetadatadx?logo=npm)](https://www.npmjs.com/package/thetadatadx)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/userFRM/ThetaDataDx/blob/main/LICENSE)
@@ -13,7 +13,7 @@ The Node.js SDK for [ThetaData](https://thetadata.us) market data. Pull US stock
 
 ## Features
 
-- **Complete coverage** — stocks, options, indices, and rates across 61 typed endpoints.
+- **Complete coverage** — stocks, options, indices, and rates across 65 typed endpoints.
 - **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
 - **Fully typed** — every endpoint, tick, and streaming event ships with hand-checked `.d.ts` declarations.
 - **Greeks on demand** — five tiers of Black-Scholes Greeks and implied volatility, served straight from the option endpoints.
@@ -52,7 +52,7 @@ Every historical method resolves a `Promise` of typed tick objects off the runti
 const eod = await client.historical.stockHistoryEOD('AAPL', '20240101', '20240301');
 console.log(eod.length, eod[0].close);
 
-const bars = await client.historical.stockHistoryOHLC('AAPL', '20240315', { interval: '60000' });
+const bars = await client.historical.stockHistoryOHLC('AAPL', '20240315', { interval: '1m' });
 const exps = await client.historical.optionListExpirations('SPY');
 
 // Optional parameters — including a per-call timeout — ride in the trailing options object
@@ -188,17 +188,17 @@ The flat-file distribution serves a fixed set of datasets: option `trade_quote` 
 
 ## Endpoint coverage
 
-61 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming.
+65 typed endpoints across stocks, options, indices, the market calendar, and interest rates, plus real-time streaming.
 
 | Category | Endpoints | Examples |
 |---|---|---|
-| Stock | 14 | EOD, OHLC, trades, quotes, snapshots, at-time |
-| Option | 34 | Every stock surface plus five Greeks tiers, open interest, contract lists |
+| Stock | 16 | EOD, OHLC, trades, quotes, snapshots, at-time |
+| Option | 36 | Every stock surface plus five Greeks tiers, open interest, contract lists |
 | Index | 9 | EOD, OHLC, price, snapshots |
 | Calendar | 3 | Market open/close, holidays, early closes |
 | Interest rate | 1 | EOD rate history |
 
-Every endpoint is a camelCase method on `Client`. The full method list with JSDoc lives in `index.d.ts` and the [API reference](https://userfrm.github.io/ThetaDataDx/reference/).
+Every endpoint is a camelCase method on `client.historical`. The full method list with JSDoc lives in `index.d.ts` and the [API reference](https://userfrm.github.io/ThetaDataDx/reference/).
 
 ## Errors
 

--- a/sdks/typescript/examples/historical.ts
+++ b/sdks/typescript/examples/historical.ts
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
   // Intraday 1-minute bars.
   console.log("=== AAPL 1-min OHLC (Mar 15, 2024) ===");
   const bars = await client.historical.stockHistoryOHLC("AAPL", "20240315", {
-    interval: "60000",
+    interval: "1m",
   });
   for (const bar of bars.slice(0, 5)) {
     console.log(

--- a/sdks/typescript/scripts/run_doc_examples.mjs
+++ b/sdks/typescript/scripts/run_doc_examples.mjs
@@ -1,13 +1,25 @@
-// Gate 3 (issue #546) - TypeScript side: doctest gate.
+// TypeScript doc-example gate.
 //
-// Extracts tsdoc `@example` / fenced-code blocks from `index.d.ts`
-// and runs each one through `tsx` so the example actually
-// compiles and executes against the published surface.
+// Type-checks the fenced code examples in the published surface against
+// `index.d.ts`, so a broken snippet fails the gate instead of shipping.
+// Two sources are scanned:
 //
-// Today `index.d.ts` carries zero `@example` blocks (the napi-rs
-// emitter doesn't pass them through from the Rust source); the
-// script exits 0 with a "no examples found" note so the wiring is
-// in place for the moment we start documenting on the TS side.
+//   1. `index.d.ts` JSDoc — fenced blocks live inside `/** ... */` comments,
+//      so every line is prefixed with ` * `. The fence regex only matches
+//      column-0 fences, so the leading ` * ` gutter is stripped first;
+//      without that step the extractor matched zero blocks and the gate was
+//      inert (which is how broken JSDoc shipped unnoticed).
+//   2. `README.md` — the package's primary worked examples.
+//
+// Examples read as a narrative: a block that opens with its own `import`
+// starts a self-contained unit, and any following fenced block that carries
+// no import is a continuation that reuses the same `client` (and other
+// bindings). Blocks are therefore grouped into units — each unit begins at an
+// import-bearing block and absorbs the bare continuation fragments after it —
+// and every unit is emitted as one module (imports hoisted, bodies run inside
+// one async IIFE so top-level `await` is legal) and type-checked with
+// `tsc --noEmit`. Bare `import ... from "thetadatadx"` / "@thetadatadx/sdk"
+// is re-homed onto the local `index.d.ts` declarations.
 
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -17,47 +29,191 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const dtsPath = resolve(here, "..", "index.d.ts");
+const pkgRoot = resolve(here, "..");
+const dtsPath = resolve(pkgRoot, "index.d.ts");
+const readmePath = resolve(pkgRoot, "README.md");
 
-const text = readFileSync(dtsPath, "utf-8");
+// Module specifier that resolves the local declarations.
+const LOCAL_MODULE = dtsPath.replace(/\\/g, "/").replace(/\.d\.ts$/, "");
 
 const FENCE_RE = /```(?:ts|typescript|javascript|js)\n([\s\S]*?)\n```/g;
-const examples = [];
-for (const match of text.matchAll(FENCE_RE)) {
-  examples.push(match[1].trim());
+
+// Strip the leading ` * ` (JSDoc gutter) from every line so fences nested in
+// `/** ... */` comments line up at column 0 for FENCE_RE.
+function stripJsDocGutter(text) {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/^\s*\* ?/, ""))
+    .join("\n");
 }
 
-if (examples.length === 0) {
-  console.log(
-    "run_doc_examples: no fenced-code examples found in index.d.ts. " +
-      "Gate is wired but inactive - adding `@example` tsdoc blocks " +
-      "to the napi-rs source will start exercising them here."
+function extractBlocks(source, { stripGutter }) {
+  const haystack = stripGutter ? stripJsDocGutter(source) : source;
+  const blocks = [];
+  for (const match of haystack.matchAll(FENCE_RE)) {
+    blocks.push(match[1].trim());
+  }
+  return blocks;
+}
+
+// Re-home bare package imports / requires onto the local declarations.
+function rehome(line) {
+  return line.replace(
+    /(["'])(?:thetadatadx|@thetadatadx\/sdk)\1/g,
+    `"${LOCAL_MODULE}"`
   );
-  process.exit(0);
+}
+
+const IMPORT_RE = /^\s*import\s/;
+
+function isImportLine(line) {
+  return (
+    /^\s*import\s.+\sfrom\s.+$/.test(line) ||
+    /^\s*import\s+["'].+["'];?\s*$/.test(line)
+  );
+}
+
+const REQUIRE_RE = /\brequire\s*\(/;
+
+// A block opens a fresh unit if it pulls in its own bindings — via an ESM
+// `import` or a CommonJS `require(...)`. Blocks with neither are continuation
+// fragments that reuse the open unit's context.
+function blockOpensUnit(block) {
+  return block.split("\n").some((l) => IMPORT_RE.test(l) || REQUIRE_RE.test(l));
+}
+
+// Group blocks into compilation units: a block with its own import opens a
+// unit; bare continuation blocks attach to the open unit. A leading bare
+// block (no import yet) opens its own unit.
+function groupUnits(blocks) {
+  const units = [];
+  for (const block of blocks) {
+    if (units.length === 0 || blockOpensUnit(block)) {
+      units.push([block]);
+    } else {
+      units[units.length - 1].push(block);
+    }
+  }
+  return units;
+}
+
+// Emit one compilable module from a unit's blocks: hoist every `import`
+// (de-duplicated) to the top, then run the rest inside one async IIFE so a
+// top-level `await` type-checks.
+function emitUnit(blocks) {
+  const imports = new Map();
+  const bodies = [];
+  for (const block of blocks) {
+    const bodyLines = [];
+    for (const raw of block.split("\n")) {
+      const line = rehome(raw);
+      if (isImportLine(line)) {
+        imports.set(line.trim(), true);
+      } else {
+        bodyLines.push(line);
+      }
+    }
+    bodies.push(bodyLines.join("\n"));
+  }
+  const importBlock = [...imports.keys()].join("\n");
+  const bodyBlock = bodies.join("\n\n");
+
+  // Continuation fragments reuse a `client` declared in an earlier prose
+  // block that is not part of this unit. When the unit uses `client` but
+  // never declares it, supply an ambient binding typed as `Client` so the
+  // fragment's method calls are still checked against the real surface
+  // (rather than failing on an undeclared name and checking nothing).
+  const declaresClient = /\b(?:const|let|var)\s+client\b/.test(bodyBlock);
+  const usesClient = /\bclient\b/.test(bodyBlock);
+  const ambient =
+    usesClient && !declaresClient
+      ? `import type { Client as __DocClient } from "${LOCAL_MODULE}";\ndeclare const client: __DocClient;\n`
+      : "";
+
+  return `${importBlock}\n${ambient}\nasync function __doc_example__() {\n${bodyBlock}\n}\nvoid __doc_example__;\nexport {};\n`;
+}
+
+const sources = [
+  { label: "index.d.ts", blocks: extractBlocks(readFileSync(dtsPath, "utf-8"), { stripGutter: true }) },
+  { label: "README.md", blocks: extractBlocks(readFileSync(readmePath, "utf-8"), { stripGutter: false }) },
+];
+
+const totalBlocks = sources.reduce((n, s) => n + s.blocks.length, 0);
+if (totalBlocks === 0) {
+  console.error(
+    "run_doc_examples: no fenced-code examples found in index.d.ts or README.md. " +
+      "The extractor matched nothing — that is the exact bug this gate guards against, " +
+      "so fail loudly rather than pass an empty gate."
+  );
+  process.exit(1);
 }
 
 const scratch = mkdtempSync(join(tmpdir(), "thetadatadx-doc-"));
 try {
-  let failed = 0;
-  for (let i = 0; i < examples.length; i++) {
-    const body = examples[i];
-    const filePath = join(scratch, `example-${i}.mjs`);
-    const prelude = "import * as thetadatadx from \"thetadatadx\";\n";
-    writeFileSync(filePath, prelude + body, "utf-8");
-    const result = spawnSync("npx", ["tsx", filePath], {
-      cwd: resolve(here, ".."),
-      stdio: "inherit",
+  // Optional peer dependencies referenced by examples (e.g. apache-arrow)
+  // are not installed for the gate; declare them as `any`-typed modules so an
+  // example exercising the integration still type-checks its own surface
+  // usage instead of failing on the unresolved peer.
+  const shimsPath = join(scratch, "peer-shims.d.ts");
+  writeFileSync(
+    shimsPath,
+    ['declare module "apache-arrow";', ""].join("\n"),
+    "utf-8"
+  );
+
+  const files = [shimsPath];
+  for (const { label, blocks } of sources) {
+    if (blocks.length === 0) continue;
+    const slug = label.replace(/[^a-z0-9]+/gi, "_");
+    groupUnits(blocks).forEach((unit, i) => {
+      const filePath = join(scratch, `${slug}_unit${i}.ts`);
+      writeFileSync(filePath, emitUnit(unit), "utf-8");
+      files.push(filePath);
     });
-    if (result.status !== 0) {
-      console.error(`example #${i} (from index.d.ts) failed`);
-      failed += 1;
-    }
   }
-  if (failed > 0) {
-    console.error(`${failed} of ${examples.length} doc example(s) failed`);
+
+  // A standalone tsconfig keeps the example check off the package's own
+  // `include` list and sidesteps tsc's "files on the command line ignore
+  // tsconfig" diagnostic.
+  const tsconfigPath = join(scratch, "tsconfig.json");
+  writeFileSync(
+    tsconfigPath,
+    JSON.stringify(
+      {
+        compilerOptions: {
+          noEmit: true,
+          strict: true,
+          skipLibCheck: true,
+          target: "ES2022",
+          module: "ES2022",
+          moduleResolution: "node",
+          esModuleInterop: true,
+          ignoreDeprecations: "6.0",
+          typeRoots: [resolve(pkgRoot, "node_modules", "@types").replace(/\\/g, "/")],
+          types: ["node"],
+        },
+        files,
+      },
+      null,
+      2
+    ),
+    "utf-8"
+  );
+
+  const tsc = resolve(pkgRoot, "node_modules", ".bin", "tsc");
+  const result = spawnSync(tsc, ["--project", tsconfigPath], {
+    cwd: pkgRoot,
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    console.error(
+      `doc-example type-check failed across ${totalBlocks} extracted example block(s) ` +
+        `from ${sources.filter((s) => s.blocks.length).map((s) => s.label).join(", ")}`
+    );
     process.exit(1);
   }
-  console.log(`ok: ${examples.length} doc example(s) executed cleanly`);
+  console.log(`ok: ${totalBlocks} doc example block(s) type-checked cleanly`);
 } finally {
   rmSync(scratch, { recursive: true, force: true });
 }


### PR DESCRIPTION
## What

A batch of documentation-accuracy and config-template defects.

### Examples that did not compile / run against the real surface

- **Python OHLC** (`sdks/python/README.md`): `interval` is keyword-only on `stock_history_ohlc`, but the example passed it positionally. Now `interval="1m"`.
- **Async concurrency** (`docs-site/docs/articles/concurrent-requests.md`): `AsyncClient` surfaces `*_async` methods directly and has no `historical` view. Now `await client.stock_history_trade_async(...)`.
- **Rust backfill** (`docs-site/docs/examples/bulk-backfill.md`): `historical` is a method on the Rust client. Now `client.historical().stock_history_trade(...)`.
- **CLI EOD Greeks** (`docs-site/docs/cli.md`): required positional order is `symbol expiration start_date end_date`, with `strike` / `right` optional after. Reordered to match the generated reference page.
- **Rust streaming** (`crates/thetadatadx/README.md`): the config field is `streaming`, not `fpss`. Now `DirectConfig::production().streaming.hosts`.

### Config template overriding production defaults

`config.default.toml` shipped three values that overrode the production defaults the moment a client copied it (the loader only backfills absent keys). Corrected to match `DirectConfig::production()` exactly:

| Knob | Was | Now (production default) |
|---|---|---|
| `read_timeout` (`streaming.timeout_ms`) | `10000` | `3000` |
| `ping_interval` (`streaming.ping_interval_ms`) | `100` | `250` |
| `reconnect_wait` (`reconnect.wait_ms`) | `2000` | `250` |

The comments that leaked runtime internals are rewritten to describe each knob on its own terms. A new test, `config_default_toml_matches_production_defaults` (in `config_file_tests`), asserts every value parsed from the shipped template equals the corresponding `DirectConfig::production()` default, so the template can never silently drift again.

### Endpoint counts (recounted from `endpoint_surface.toml`)

65 typed endpoints total: **16** stock, **36** option, **9** index, **3** calendar, **1** interest rate. Corrected the headline total and the per-category table in the root README and the per-SDK READMEs.

### Accuracy + observability

- Replaced the unsourceable Greeks count with an accurate "first- through third-order Greeks" phrasing (the result struct mixes Greek and non-Greek fields).
- Fixed the TypeScript "every endpoint is a camelCase method on `Client`" sentence to `client.historical`.
- Added a feed-health snippet to the Python streaming docs using the documented observability getters (`millis_since_last_event()`, `ring_occupancy()` / `ring_capacity()`, `dropped_event_count()`).
- Standardized the OHLC `interval` examples on the duration-string form across Python and TypeScript.

### Doc-example gate that validated nothing

`sdks/typescript/scripts/run_doc_examples.mjs` used a column-0 fence regex, so it never matched the fenced blocks inside JSDoc comments and checked zero examples. It now strips the JSDoc gutter, also scans `README.md`, groups narrative blocks into compilable units, and type-checks each through `tsc --noEmit`. It now extracts 13 example blocks.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo test -p thetadatadx --lib --features config-file config_file_tests` — 22 passed, including the new drift-guard test.
- `python3 scripts/check_docs_consistency.py` — ok (also synced the one-line `[fpss]` / `[streaming]` drift between `CHANGELOG.md` and the docs-site copy that the gate flagged).
- The fixed TypeScript doc-example gate now extracts and type-checks real examples.

### Expected and tracked

The reactivated TypeScript doc-example gate now surfaces pre-existing bugs in the generated `index.d.ts` JSDoc — a wrong package name in a `require(...)` example and unresolved `Credentials` / `Client` references plus an untyped callback parameter. Those are fixes to the generated declarations and are handled in a separate change; they are not edited here. The gate failing on them is the intended new signal, not a regression introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)