### PR TITLE
feat(sdk): even up streaming observability surface across every binding

### DIFF
--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -716,6 +716,25 @@ impl Client {
         }
     }
 
+    /// Whether the live streaming session is currently authenticated.
+    ///
+    /// Distinct from [`Self::is_streaming`]: a `Live` slot can hold a
+    /// streaming client whose authenticated flag has been cleared after a
+    /// server disconnect, before the caller has issued a reconnect. A
+    /// panicked dispatcher folds back to `false` here too, so the failed
+    /// state is uniformly visible across every status reader rather than
+    /// reporting "authenticated with no deliveries". Returns `false`
+    /// before streaming starts and after it stops.
+    pub(crate) fn is_authenticated(&self) -> bool {
+        match &**self.state.load() {
+            StreamingSlot::Live { client } => {
+                let session = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+                client.is_authenticated() && !matches!(*session, DispatcherSession::Failed { .. })
+            }
+            StreamingSlot::Idle | StreamingSlot::Stopped => false,
+        }
+    }
+
     /// Whether a prior streaming session has registered its drain flag
     /// for [`Self::await_drain`] to poll on.
     ///
@@ -1634,6 +1653,17 @@ impl StreamSurface<'_> {
     #[must_use]
     pub fn is_streaming(&self) -> bool {
         self.0.is_streaming()
+    }
+
+    /// Whether the live streaming session is currently authenticated.
+    ///
+    /// Distinct from [`Self::is_streaming`]: the session can be live yet
+    /// briefly unauthenticated mid-reconnect (the authenticated flag is
+    /// cleared on disconnect and restored on a successful re-auth).
+    /// Returns `false` before streaming starts and after it stops.
+    #[must_use]
+    pub fn is_authenticated(&self) -> bool {
+        self.0.is_authenticated()
     }
 
     /// Wait for every retired streaming session to drain. Returns `false`

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -975,6 +975,27 @@ pub unsafe extern "C" fn thetadatadx_client_is_streaming(handle: *const ThetaDat
     })
 }
 
+/// Check if the live streaming session is authenticated on the unified
+/// client.
+///
+/// Distinct from `thetadatadx_client_is_streaming`: the session can be live
+/// yet briefly unauthenticated mid-reconnect. Returns 1 when
+/// authenticated, 0 otherwise (including a null handle, before streaming
+/// starts, and after it stops).
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_client_is_authenticated(
+    handle: *const ThetaDataDxClient,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if handle.is_null() {
+            return 0;
+        }
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        let handle = unsafe { &*handle };
+        i32::from(handle.inner.stream().is_authenticated())
+    })
+}
+
 /// Get active subscriptions as a typed array. Returns null on error.
 ///
 /// Caller must free the result with `thetadatadx_subscription_array_free`.
@@ -1801,6 +1822,43 @@ pub unsafe extern "C" fn thetadatadx_streaming_set_callback(
     })
 }
 
+/// Check if the standalone FPSS streaming connection is currently open.
+///
+/// Distinct from `thetadatadx_streaming_is_authenticated`: the connection
+/// can be open yet briefly unauthenticated mid-reconnect. A panicked
+/// dispatcher folds back to `0` so the failed state is uniformly visible
+/// across status readers. Returns 1 when streaming, 0 otherwise
+/// (including a null handle and after shutdown).
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_streaming_is_streaming(
+    handle: *const ThetaDataDxStreamHandle,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if handle.is_null() {
+            return 0;
+        }
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        let handle = unsafe { &*handle };
+        let inner_guard = handle
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if inner_guard.as_ref().is_none() {
+            return 0;
+        }
+        let session = handle.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        if let FfpssDispatcherSession::Failed { reason } = &*session {
+            tracing::debug!(
+                target: "thetadatadx::ffi",
+                reason = %reason,
+                "thetadatadx_streaming_is_streaming: dispatcher failed",
+            );
+            return 0;
+        }
+        1
+    })
+}
+
 /// Check if the FPSS client is currently authenticated.
 ///
 /// Returns 1 if authenticated, 0 if not (or if handle is null).
@@ -1872,6 +1930,47 @@ pub unsafe extern "C" fn thetadatadx_streaming_active_subscriptions(
             subs.into_iter()
                 .map(|(kind, contract)| (kind.kind_str().to_string(), format!("{contract}"))),
         )
+    })
+}
+
+/// Get a snapshot of currently active full-stream subscriptions.
+///
+/// Each entry's `contract` field carries the security-type discriminant
+/// (`"Stock"` / `"Option"` / `"Index"`) the full-stream subscription is
+/// bound to. The `kind` field is the snake_case full-stream kind label
+/// (`"full_trades"` / `"full_open_interest"`), matching the unified
+/// `thetadatadx_client_active_full_subscriptions` projection. Per-contract-only
+/// kinds (`Quote` / `MarketValue`) have no full-stream form and are
+/// omitted.
+///
+/// Returns a heap-allocated `ThetaDataDxSubscriptionArray` (null on error).
+/// Caller must free the result with `thetadatadx_subscription_array_free`.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_streaming_active_full_subscriptions(
+    handle: *const ThetaDataDxStreamHandle,
+) -> *mut ThetaDataDxSubscriptionArray {
+    ffi_boundary!(std::ptr::null_mut(), {
+        if handle.is_null() {
+            set_error("FPSS handle is null");
+            return ptr::null_mut();
+        }
+        // SAFETY: handle is a non-null pointer returned by the matching thetadatadx_*_new and not yet passed to thetadatadx_*_free.
+        let handle = unsafe { &*handle };
+        let guard = handle
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let client = if let Some(c) = guard.as_ref() {
+            c
+        } else {
+            set_error("FPSS client not started -- call thetadatadx_streaming_set_callback first, or has been shut down");
+            return ptr::null_mut();
+        };
+        let subs = client.active_full_subscriptions();
+        build_subscription_array(subs.into_iter().filter_map(|(kind, sec_type)| {
+            kind.full_kind_str()
+                .map(|full| (full.to_string(), format!("{sec_type:?}")))
+        }))
     })
 }
 

--- a/ffi/tests/streaming_config_forwarding.rs
+++ b/ffi/tests/streaming_config_forwarding.rs
@@ -1,0 +1,281 @@
+//! Round-trip regression for the standalone streaming-config forwarding
+//! over the C ABI.
+//!
+//! `wait_strategy.rs` round-trips only the wait-strategy preset + the
+//! numeric wait knobs + the consumer-cpu sentinel. It never drives the
+//! rest of the streaming transport surface or the reconnect ladder, so a
+//! regression that dropped a `streaming_*` / `reconnect_*` field on the
+//! C boundary would pass that test silently. This module pins the FULL
+//! field set the higher-level bindings already cover (Python
+//! `test_config_resilience.py::test_streaming_transport_defaults_and_round_trip`
+//! + the reconnect round-trip tests; the TypeScript `config_resilience`
+//! / `config_reconnect` suites), so the C ABI stays in lockstep.
+//!
+//! Every FFI call below operates on a non-null `ThetaDataDxConfig`
+//! returned by `thetadatadx_config_production` and not yet freed, on a
+//! single thread — the contract each `unsafe extern "C"` entry point
+//! documents. The per-block `// SAFETY:` comments record that invariant.
+
+use thetadatadx_ffi::{
+    thetadatadx_config_free, thetadatadx_config_get_reconnect_jitter,
+    thetadatadx_config_get_reconnect_max_attempts,
+    thetadatadx_config_get_reconnect_max_elapsed_secs,
+    thetadatadx_config_get_reconnect_max_rate_limited_attempts,
+    thetadatadx_config_get_reconnect_max_server_restart_attempts,
+    thetadatadx_config_get_reconnect_policy, thetadatadx_config_get_reconnect_replay_burst_size,
+    thetadatadx_config_get_reconnect_replay_pace_ms,
+    thetadatadx_config_get_reconnect_stable_window_secs,
+    thetadatadx_config_get_reconnect_wait_max_ms, thetadatadx_config_get_reconnect_wait_ms,
+    thetadatadx_config_get_reconnect_wait_rate_limited_ms,
+    thetadatadx_config_get_reconnect_wait_server_restart_ms,
+    thetadatadx_config_get_streaming_connect_timeout_ms,
+    thetadatadx_config_get_streaming_data_watchdog_ms,
+    thetadatadx_config_get_streaming_host_selection,
+    thetadatadx_config_get_streaming_host_shuffle_seed,
+    thetadatadx_config_get_streaming_io_read_slice_ms,
+    thetadatadx_config_get_streaming_keepalive_idle_secs,
+    thetadatadx_config_get_streaming_keepalive_interval_secs,
+    thetadatadx_config_get_streaming_keepalive_retries,
+    thetadatadx_config_get_streaming_ping_interval_ms, thetadatadx_config_get_streaming_ring_size,
+    thetadatadx_config_get_streaming_timeout_ms, thetadatadx_config_production,
+    thetadatadx_config_set_reconnect_jitter, thetadatadx_config_set_reconnect_max_attempts,
+    thetadatadx_config_set_reconnect_max_elapsed_secs,
+    thetadatadx_config_set_reconnect_max_rate_limited_attempts,
+    thetadatadx_config_set_reconnect_max_server_restart_attempts,
+    thetadatadx_config_set_reconnect_policy, thetadatadx_config_set_reconnect_replay_burst_size,
+    thetadatadx_config_set_reconnect_replay_pace_ms,
+    thetadatadx_config_set_reconnect_stable_window_secs,
+    thetadatadx_config_set_reconnect_wait_max_ms, thetadatadx_config_set_reconnect_wait_ms,
+    thetadatadx_config_set_reconnect_wait_rate_limited_ms,
+    thetadatadx_config_set_reconnect_wait_server_restart_ms,
+    thetadatadx_config_set_streaming_connect_timeout_ms,
+    thetadatadx_config_set_streaming_data_watchdog_ms,
+    thetadatadx_config_set_streaming_host_selection,
+    thetadatadx_config_set_streaming_host_shuffle_seed,
+    thetadatadx_config_set_streaming_io_read_slice_ms,
+    thetadatadx_config_set_streaming_keepalive_idle_secs,
+    thetadatadx_config_set_streaming_keepalive_interval_secs,
+    thetadatadx_config_set_streaming_keepalive_retries,
+    thetadatadx_config_set_streaming_ping_interval_ms, thetadatadx_config_set_streaming_ring_size,
+    thetadatadx_config_set_streaming_timeout_ms,
+};
+
+#[test]
+fn streaming_transport_fields_round_trip_through_c_abi() {
+    let cfg = thetadatadx_config_production();
+    assert!(!cfg.is_null());
+
+    let mut timeout = 0u64;
+    let mut connect = 0u64;
+    let mut ping = 0u64;
+    let mut ring = 0usize;
+    let mut io_slice = 0u64;
+    let mut watchdog = 0u64;
+    let mut ka_idle = 0u64;
+    let mut ka_interval = 0u64;
+    let mut ka_retries = 0u32;
+    let mut host_policy = -1i32;
+    let mut seed_present = false;
+    let mut seed = 0u64;
+
+    // SAFETY: `cfg` is the non-null, not-yet-freed handle from
+    // `thetadatadx_config_production`, mutated/read on a single thread; every
+    // out-pointer is a live stack slot for the call.
+    unsafe {
+        // The scalar streaming knobs are infallible unit-returning
+        // setters; `host_selection` / `host_shuffle_seed` validate their
+        // input and return an `i32` status.
+        thetadatadx_config_set_streaming_timeout_ms(cfg, 10_000);
+        thetadatadx_config_set_streaming_connect_timeout_ms(cfg, 5_000);
+        thetadatadx_config_set_streaming_ping_interval_ms(cfg, 1_000);
+        thetadatadx_config_set_streaming_ring_size(cfg, 8_192);
+        thetadatadx_config_set_streaming_io_read_slice_ms(cfg, 50);
+        // 0 disables the data watchdog.
+        thetadatadx_config_set_streaming_data_watchdog_ms(cfg, 0);
+        thetadatadx_config_set_streaming_keepalive_idle_secs(cfg, 10);
+        thetadatadx_config_set_streaming_keepalive_interval_secs(cfg, 5);
+        thetadatadx_config_set_streaming_keepalive_retries(cfg, 4);
+        // Host selection: 1 = the non-default preset (round-trips a
+        // non-zero discriminant so a stuck-at-zero getter is caught).
+        assert_eq!(thetadatadx_config_set_streaming_host_selection(cfg, 1), 0);
+        // The host-shuffle seed carries the widened `(has_value, seed)`
+        // ABI shape so the `Some(_)` presence survives the boundary.
+        assert_eq!(
+            thetadatadx_config_set_streaming_host_shuffle_seed(cfg, true, 42),
+            0
+        );
+
+        assert_eq!(
+            thetadatadx_config_get_streaming_timeout_ms(cfg, &mut timeout),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_connect_timeout_ms(cfg, &mut connect),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_ping_interval_ms(cfg, &mut ping),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_ring_size(cfg, &mut ring),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_io_read_slice_ms(cfg, &mut io_slice),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_data_watchdog_ms(cfg, &mut watchdog),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_keepalive_idle_secs(cfg, &mut ka_idle),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_keepalive_interval_secs(cfg, &mut ka_interval),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_keepalive_retries(cfg, &mut ka_retries),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_host_selection(cfg, &mut host_policy),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_streaming_host_shuffle_seed(cfg, &mut seed_present, &mut seed),
+            0
+        );
+    }
+
+    assert_eq!(timeout, 10_000);
+    assert_eq!(connect, 5_000);
+    assert_eq!(ping, 1_000);
+    assert_eq!(ring, 8_192);
+    assert_eq!(io_slice, 50);
+    assert_eq!(watchdog, 0);
+    assert_eq!(ka_idle, 10);
+    assert_eq!(ka_interval, 5);
+    assert_eq!(ka_retries, 4);
+    assert_eq!(host_policy, 1);
+    assert!(seed_present);
+    assert_eq!(seed, 42);
+
+    // SAFETY: `cfg` is owned here and freed exactly once.
+    unsafe { thetadatadx_config_free(cfg) };
+}
+
+#[test]
+fn reconnect_ladder_fields_round_trip_through_c_abi() {
+    let cfg = thetadatadx_config_production();
+    assert!(!cfg.is_null());
+
+    let mut policy = -1i32;
+    let mut max_attempts = 0u32;
+    let mut max_rate_limited = 0u32;
+    let mut wait_ms = 0u64;
+    let mut wait_rate_limited = 0u64;
+    let mut wait_max = 0u64;
+    let mut wait_server_restart = 0u64;
+    let mut jitter = -1i32;
+    let mut stable_window = 0u64;
+    let mut max_elapsed = 0u64;
+    let mut max_server_restart = 0u32;
+    let mut replay_burst = 0u32;
+    let mut replay_pace = 0u64;
+
+    // SAFETY: `cfg` is the non-null, not-yet-freed handle, mutated/read on
+    // one thread; every out-pointer is a live stack slot for the call.
+    unsafe {
+        // Policy 0 = the Auto ladder. The per-class budget + wait knobs
+        // below live inside the Auto limits, so the policy must be Auto
+        // for them to forward (a Manual policy ignores the ladder fields).
+        // `policy` / `jitter` validate their discriminant and return an
+        // `i32` status; the remaining ladder knobs are infallible
+        // unit-returning setters.
+        assert_eq!(thetadatadx_config_set_reconnect_policy(cfg, 0), 0);
+        thetadatadx_config_set_reconnect_max_attempts(cfg, 7);
+        thetadatadx_config_set_reconnect_max_rate_limited_attempts(cfg, 3);
+        thetadatadx_config_set_reconnect_wait_ms(cfg, 500);
+        thetadatadx_config_set_reconnect_wait_rate_limited_ms(cfg, 2_000);
+        thetadatadx_config_set_reconnect_wait_max_ms(cfg, 30_000);
+        thetadatadx_config_set_reconnect_wait_server_restart_ms(cfg, 15_000);
+        // Jitter 1 = the non-default mode.
+        assert_eq!(thetadatadx_config_set_reconnect_jitter(cfg, 1), 0);
+        thetadatadx_config_set_reconnect_stable_window_secs(cfg, 60);
+        thetadatadx_config_set_reconnect_max_elapsed_secs(cfg, 600);
+        thetadatadx_config_set_reconnect_max_server_restart_attempts(cfg, 5);
+        thetadatadx_config_set_reconnect_replay_burst_size(cfg, 256);
+        thetadatadx_config_set_reconnect_replay_pace_ms(cfg, 10);
+
+        assert_eq!(thetadatadx_config_get_reconnect_policy(cfg, &mut policy), 0);
+        assert_eq!(
+            thetadatadx_config_get_reconnect_max_attempts(cfg, &mut max_attempts),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_max_rate_limited_attempts(cfg, &mut max_rate_limited),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_wait_ms(cfg, &mut wait_ms),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_wait_rate_limited_ms(cfg, &mut wait_rate_limited),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_wait_max_ms(cfg, &mut wait_max),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_wait_server_restart_ms(cfg, &mut wait_server_restart),
+            0
+        );
+        assert_eq!(thetadatadx_config_get_reconnect_jitter(cfg, &mut jitter), 0);
+        assert_eq!(
+            thetadatadx_config_get_reconnect_stable_window_secs(cfg, &mut stable_window),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_max_elapsed_secs(cfg, &mut max_elapsed),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_max_server_restart_attempts(
+                cfg,
+                &mut max_server_restart
+            ),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_replay_burst_size(cfg, &mut replay_burst),
+            0
+        );
+        assert_eq!(
+            thetadatadx_config_get_reconnect_replay_pace_ms(cfg, &mut replay_pace),
+            0
+        );
+    }
+
+    assert_eq!(policy, 0);
+    assert_eq!(max_attempts, 7);
+    assert_eq!(max_rate_limited, 3);
+    assert_eq!(wait_ms, 500);
+    assert_eq!(wait_rate_limited, 2_000);
+    assert_eq!(wait_max, 30_000);
+    assert_eq!(wait_server_restart, 15_000);
+    assert_eq!(jitter, 1);
+    assert_eq!(stable_window, 60);
+    assert_eq!(max_elapsed, 600);
+    assert_eq!(max_server_restart, 5);
+    assert_eq!(replay_burst, 256);
+    assert_eq!(replay_pace, 10);
+
+    // SAFETY: `cfg` is owned here and freed exactly once.
+    unsafe { thetadatadx_config_free(cfg) };
+}

--- a/sdks/cpp/include/thetadatadx.h
+++ b/sdks/cpp/include/thetadatadx.h
@@ -2186,6 +2186,13 @@ ThetaDataDxStreamHandle* thetadatadx_streaming_connect_from_file(const char* pat
 
 /** Polymorphic subscribe / unsubscribe — see ThetaDataDxSubscriptionRequest below. */
 
+/** Report whether the streaming connection is currently open. Distinct
+ *  from thetadatadx_streaming_is_authenticated: the connection can be open yet
+ *  briefly unauthenticated mid-reconnect.
+ *  @param h The streaming handle.
+ *  @return 1 when streaming, 0 otherwise (including after shutdown). */
+int thetadatadx_streaming_is_streaming(const ThetaDataDxStreamHandle* h);
+
 /** Report whether the streaming session is authenticated.
  *  @param h The streaming handle.
  *  @return 1 when authenticated, 0 otherwise. */
@@ -2196,6 +2203,15 @@ int thetadatadx_streaming_is_authenticated(const ThetaDataDxStreamHandle* h);
  *  @return A subscription array the caller MUST free with
  *          thetadatadx_subscription_array_free. */
 ThetaDataDxSubscriptionArray* thetadatadx_streaming_active_subscriptions(const ThetaDataDxStreamHandle* h);
+
+/** Read the active full-stream subscriptions as a typed array. Each
+ *  entry's `contract` field carries the security-type discriminant
+ *  (`"Stock"` / `"Option"` / `"Index"`); the `kind` field is the
+ *  full-stream label (`"full_trades"` / `"full_open_interest"`).
+ *  @param h The streaming handle.
+ *  @return A subscription array the caller MUST free with
+ *          thetadatadx_subscription_array_free. */
+ThetaDataDxSubscriptionArray* thetadatadx_streaming_active_full_subscriptions(const ThetaDataDxStreamHandle* h);
 
 /** User callback signature for thetadatadx_*_set_callback.
  *  `event` is valid only for the duration of the call -- copy any fields the
@@ -2476,6 +2492,13 @@ int thetadatadx_client_reconnect(const ThetaDataDxClient* handle);
  *  @param handle The unified handle.
  *  @return 1 when streaming, 0 otherwise. */
 int thetadatadx_client_is_streaming(const ThetaDataDxClient* handle);
+
+/** Report whether the live streaming session is authenticated on the
+ *  unified client. Distinct from thetadatadx_client_is_streaming: the session
+ *  can be live yet briefly unauthenticated mid-reconnect.
+ *  @param handle The unified handle.
+ *  @return 1 when authenticated, 0 otherwise. */
+int thetadatadx_client_is_authenticated(const ThetaDataDxClient* handle);
 
 /** Read the active subscriptions as a typed array.
  *  @param handle The unified handle.

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -161,6 +161,18 @@ struct Subscription {
     std::string contract;
 };
 
+/// Full-stream subscription descriptor returned by
+/// `Stream::active_full_subscriptions` /
+/// `StreamingClient::active_full_subscriptions`. `sec_type` carries the
+/// security-type discriminant (`"Stock"` / `"Option"` / `"Index"`) the
+/// full-stream subscription is bound to; `kind` is the snake_case
+/// full-stream kind label (`"full_trades"` / `"full_open_interest"`),
+/// matching the Python / TypeScript `Subscription.kind` accessor.
+struct FullSubscription {
+    std::string kind;
+    std::string sec_type;
+};
+
 // ── Greeks result (from standalone thetadatadx_all_greeks) ──
 
 /// Full set of option Greeks and Black-Scholes intermediates returned by the
@@ -1715,6 +1727,42 @@ public:
         return out;
     }
 
+    /** `true` iff the streaming connection is currently open. Distinct
+     *  from is_authenticated(): the connection can be open yet briefly
+     *  unauthenticated mid-reconnect. Returns false on a moved-from or
+     *  shut-down client. Mirrors the unified Stream::is_streaming() and
+     *  the Python / TypeScript `is_streaming` getter so the same status
+     *  reads identically on both C++ streaming surfaces. */
+    bool is_streaming() const {
+        return handle_ && thetadatadx_streaming_is_streaming(handle_.get()) == 1;
+    }
+
+    /** Snapshot the currently-active full-stream subscriptions (the
+     *  entire universe for a given sec_type + kind, not bound to a
+     *  single contract). Throws on FFI error. Mirrors the unified
+     *  Stream::active_full_subscriptions() and the Python / TypeScript
+     *  `active_full_subscriptions` placement. */
+    std::vector<FullSubscription> active_full_subscriptions() const {
+        ThetaDataDxSubscriptionArray* arr =
+            thetadatadx_streaming_active_full_subscriptions(handle_.get());
+        if (arr == nullptr) {
+            detail::throw_last_ffi_error();
+        }
+        std::vector<FullSubscription> out;
+        if (arr->data != nullptr && arr->len > 0) {
+            out.reserve(arr->len);
+            for (size_t i = 0; i < arr->len; ++i) {
+                const ThetaDataDxSubscription& s = arr->data[i];
+                out.push_back(FullSubscription{
+                    s.kind ? std::string(s.kind) : std::string(),
+                    s.contract ? std::string(s.contract) : std::string(),
+                });
+            }
+        }
+        thetadatadx_subscription_array_free(arr);
+        return out;
+    }
+
 
 private:
     // Free C-ABI shim that the dispatcher invokes. `ctx` is the
@@ -1884,17 +1932,6 @@ struct UnifiedDeleter {
     void operator()(ThetaDataDxClient* p) const {
         if (p) thetadatadx_client_free(p);
     }
-};
-
-/// Full-stream subscription descriptor returned by
-/// `Stream::active_full_subscriptions`. `sec_type` carries the
-/// security-type discriminant (`"Stock"` / `"Option"` / `"Index"`) the
-/// full-stream subscription is bound to; `kind` is the snake_case
-/// full-stream kind label (`"full_trades"` / `"full_open_interest"`),
-/// matching the Python / TypeScript `Subscription.kind` accessor.
-struct FullSubscription {
-    std::string kind;
-    std::string sec_type;
 };
 
 /// Historical-data sub-namespace returned by `Client::historical()`.
@@ -2111,6 +2148,15 @@ public:
     /// and stop_streaming / terminal close has not).
     bool is_streaming() const {
         return handle_ && thetadatadx_client_is_streaming(handle_) == 1;
+    }
+
+    /// `true` iff the live streaming session is currently authenticated.
+    /// Distinct from is_streaming(): the session can be live yet briefly
+    /// unauthenticated mid-reconnect. Mirrors the Python / TypeScript
+    /// `client.stream.is_authenticated` placement and the standalone
+    /// `StreamingClient::is_authenticated()`.
+    bool is_authenticated() const {
+        return handle_ && thetadatadx_client_is_authenticated(handle_) == 1;
     }
 
     /// Snapshot the currently-active per-contract subscriptions. Throws on

--- a/sdks/cpp/tests/fpss.cpp
+++ b/sdks/cpp/tests/fpss.cpp
@@ -60,6 +60,19 @@ TEST_CASE("StreamingClient binds the observability surface",
     STATIC_REQUIRE(std::is_same_v<
         decltype(std::declval<const SC&>().set_slow_callback_threshold_us(uint64_t{})),
         void>);
+    // is_streaming() -> bool (evened up with the unified Stream view and
+    // the Python / TypeScript standalone surface)
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().is_streaming()), bool>);
+    // is_authenticated() -> bool
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().is_authenticated()), bool>);
+    // active_full_subscriptions() -> std::vector<FullSubscription>
+    // (evened up with the unified Stream view and the Python / TypeScript
+    // standalone surface)
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SC&>().active_full_subscriptions()),
+        std::vector<thetadatadx::FullSubscription>>);
 }
 
 TEST_CASE("StreamingClient registers a callback and receives at least one event",

--- a/sdks/cpp/tests/thetadatadx_client.cpp
+++ b/sdks/cpp/tests/thetadatadx_client.cpp
@@ -85,6 +85,11 @@ TEST_CASE("Stream binds the full FPSS surface",
     // is_streaming() -> bool
     STATIC_REQUIRE(std::is_same_v<
         decltype(std::declval<const SV&>().is_streaming()), bool>);
+    // is_authenticated() -> bool (mirrors the standalone
+    // StreamingClient::is_authenticated() and the Python / TypeScript
+    // client.stream.is_authenticated placement)
+    STATIC_REQUIRE(std::is_same_v<
+        decltype(std::declval<const SV&>().is_authenticated()), bool>);
     // active_subscriptions() -> std::vector<Subscription>
     STATIC_REQUIRE(std::is_same_v<
         decltype(std::declval<const SV&>().active_subscriptions()),
@@ -120,6 +125,9 @@ TEST_CASE("Client end-to-end push-callback cycle", "[unified][live]") {
     // call observes the same session.
     auto stream = client.stream();
     REQUIRE_FALSE(stream.is_streaming());
+    // Distinct from is_streaming(): the session is not authenticated
+    // before streaming opens.
+    REQUIRE_FALSE(stream.is_authenticated());
     REQUIRE(stream.dropped_event_count() == 0);
     // Slow-callback watchdog: 0 before streaming; the threshold setter
     // round-trips as a no-throw configuration call (microseconds; 0

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1075,6 +1075,13 @@ cpp = true
 
 [[method]]
 class = "StreamView"
+name = "isAuthenticated"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "StreamView"
 name = "awaitDrain"
 python = true
 typescript = true
@@ -1231,7 +1238,7 @@ class = "StreamingClient"
 name = "isStreaming"
 python = true
 typescript = true
-cpp = false  # C++ `StreamingClient` is always live once constructed
+cpp = true
 
 [[method]]
 class = "StreamingClient"
@@ -1287,7 +1294,7 @@ class = "StreamingClient"
 name = "activeFullSubscriptions"
 python = true
 typescript = true
-cpp = false  # C++ StreamingClient surface omits the full-stream snapshot today
+cpp = true
 
 [[method]]
 class = "StreamingClient"

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -230,6 +230,11 @@ class Contract:
         ...
 
     @staticmethod
+    def index(symbol: str) -> Contract:
+        """Construct an index contract for ``symbol``."""
+        ...
+
+    @staticmethod
     def option(
         symbol: str,
         *,
@@ -932,6 +937,15 @@ class StreamView:
 
     def is_streaming(self) -> bool:
         """Return whether the streaming connection is currently active."""
+        ...
+
+    def is_authenticated(self) -> bool:
+        """Return whether the live streaming session is authenticated.
+
+        Distinct from :meth:`is_streaming`: the session can be live yet
+        briefly unauthenticated mid-reconnect. ``False`` before streaming
+        starts and after it stops.
+        """
         ...
 
     def stop_streaming(self) -> None:

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1557,6 +1557,19 @@ impl Client {
 
 #[pymethods]
 impl StreamView {
+    /// Whether the live streaming session is currently authenticated.
+    ///
+    /// Distinct from :meth:`is_streaming`: the session can be live yet
+    /// briefly unauthenticated mid-reconnect (the authenticated flag is
+    /// cleared on disconnect and restored on a successful re-auth).
+    /// Returns ``False`` before streaming starts and after it stops.
+    /// Mirrors the standalone
+    /// [`crate::fpss_client::StreamingClient::is_authenticated`] and the
+    /// C++ `Stream::is_authenticated()` getter.
+    fn is_authenticated(&self) -> bool {
+        self.client.stream().is_authenticated()
+    }
+
     /// Cumulative count of streaming events the TLS reader could not
     /// publish into the bounded ring because the consumer fell behind
     /// and the ring was full.

--- a/sdks/python/tests/test_context_manager.py
+++ b/sdks/python/tests/test_context_manager.py
@@ -81,6 +81,33 @@ def test_thetadatadx_has_streaming_factory() -> None:
     assert hasattr(mod.Client, "streaming")
 
 
+def test_unified_stream_view_exposes_is_authenticated() -> None:
+    """`client.stream.is_authenticated()` mirrors the standalone
+    `StreamingClient.is_authenticated()` on the unified surface (cross-
+    binding parity with C++ `Stream::is_authenticated()` and TypeScript
+    `StreamView.isAuthenticated`). Asserted offline on the `StreamView`
+    type alongside `is_streaming` so the cross-binding accessor cannot be
+    dropped without a test failure even when no live credentials are set.
+    """
+    mod = _import_module()
+    assert hasattr(mod, "StreamView"), "thetadatadx must export `StreamView`"
+    assert hasattr(mod.StreamView, "is_streaming"), (
+        "StreamView must expose is_streaming()"
+    )
+    assert hasattr(mod.StreamView, "is_authenticated"), (
+        "StreamView must expose is_authenticated() (cross-binding parity "
+        "with the standalone StreamingClient and the C++ / TypeScript surfaces)"
+    )
+
+
+def test_unified_stream_view_is_authenticated_false_before_start(client) -> None:
+    """Before any `start_streaming` the live slot is empty, so
+    `client.stream.is_authenticated()` reads `False` (live-gated)."""
+    assert client.stream.is_authenticated() is False, (
+        "StreamView.is_authenticated() must read False before streaming starts"
+    )
+
+
 def test_context_manager_enter_exit_lifecycle(client) -> None:
     """`with client.streaming(callback) as session:` enters by calling
     `start_streaming(callback)` and exits by calling

--- a/sdks/typescript/__tests__/typed_surface.test.mjs
+++ b/sdks/typescript/__tests__/typed_surface.test.mjs
@@ -126,6 +126,23 @@ describe('historical methods resolve off the execution thread', () => {
       'awaitDrain must stay Promise<boolean> (streaming lifecycle, not a data fetch)'
     );
   });
+
+  it('the unified StreamView exposes isAuthenticated() alongside isStreaming()', () => {
+    // Cross-binding parity: the unified surface mirrors the standalone
+    // StreamingClient.isAuthenticated() (and the C++ Stream::is_authenticated()
+    // / Python client.stream.is_authenticated()), distinct from the
+    // session-live isStreaming() signal.
+    assert.match(
+      streamBody,
+      /isStreaming\(\): boolean/,
+      'StreamView must declare isStreaming(): boolean'
+    );
+    assert.match(
+      streamBody,
+      /isAuthenticated\(\): boolean/,
+      'StreamView must declare isAuthenticated(): boolean'
+    );
+  });
 });
 
 describe('strike is dollars everywhere', () => {

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -2628,6 +2628,16 @@ export declare class StreamingClient {
  */
 export declare class StreamView {
   /**
+   * Whether the live streaming session is currently authenticated.
+   *
+   * Distinct from `isStreaming()`: the session can be live yet briefly
+   * unauthenticated mid-reconnect (the authenticated flag is cleared on
+   * disconnect and restored on a successful re-auth). Returns `false`
+   * before `startStreaming` and after `stopStreaming`. The value
+   * matches every other binding (C ABI, Python, C++).
+   */
+  isAuthenticated(): boolean
+  /**
    * Cumulative count of FPSS events that were dropped because the
    * callback fell behind and the in-flight buffer was full.
    *

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -523,6 +523,18 @@ impl Client {
 
 #[napi]
 impl StreamView {
+    /// Whether the live streaming session is currently authenticated.
+    ///
+    /// Distinct from `isStreaming()`: the session can be live yet briefly
+    /// unauthenticated mid-reconnect (the authenticated flag is cleared on
+    /// disconnect and restored on a successful re-auth). Returns `false`
+    /// before `startStreaming` and after `stopStreaming`. The value
+    /// matches every other binding (C ABI, Python, C++).
+    #[napi(js_name = "isAuthenticated")]
+    pub fn is_authenticated(&self) -> bool {
+        self.client.stream().is_authenticated()
+    }
+
     /// Cumulative count of FPSS events that were dropped because the
     /// callback fell behind and the in-flight buffer was full.
     ///


### PR DESCRIPTION
## Summary

Closes the cross-binding parity gaps on the real-time streaming surface so the unified `Stream` view and the standalone `StreamingClient` expose the same observability and status accessors on Rust, Python, TypeScript, C++, and the C ABI.

## What changed

- **`is_authenticated()` on the unified streaming surface, every binding.** It was standalone-only before. The unified `client.stream` now reports whether the live session is authenticated — distinct from the session-live `is_streaming()` signal, since a session can be live yet briefly unauthenticated mid-reconnect. New C ABI symbol `thetadatadx_client_is_authenticated` forwards the existing core auth state; Python (`StreamView.is_authenticated`), TypeScript (`StreamView.isAuthenticated`), and C++ (`Stream::is_authenticated()`) forward over it.

- **Standalone `StreamingClient` evened up on C++ / C ABI.** `is_streaming()` and `active_full_subscriptions()` were unified-only on those two surfaces while Python/TypeScript already exposed them on both. They are now present on both streaming surfaces on every binding, over the new C ABI symbols `thetadatadx_streaming_is_streaming` and `thetadatadx_streaming_active_full_subscriptions`. The C++ `FullSubscription` value type moved up beside `Subscription` so both streaming classes can return it.

- **`Contract.index(symbol)` added to the Python type stub.** It is a real, tested constructor that was missing from `__init__.pyi`.

- **C-ABI standalone streaming-config forwarding regression test.** A new `ffi/tests/streaming_config_forwarding.rs` round-trips the full streaming-transport and reconnect-ladder field set through the config boundary, matching the forwarding coverage the Python and TypeScript suites already carry. Previously only the wait-strategy preset and a few wait knobs were tested on the C ABI.

## Parity + tests

Every added accessor carries a `sdks/parity.toml` row and a round-trip / availability assertion in the matching binding test suite (Python, TypeScript, C++). The TypeScript `index.d.ts` was regenerated from the napi build, not edited by hand.

## Verification

- `check_binding_parity.py` clean; `--selftest` 74/74; `test_check_binding_parity.py` 27/27
- `cargo fmt --all -- --check` clean
- `cargo build -p thetadatadx-ffi` + Python and TypeScript binding crates compile
- `cargo build -p thetadatadx-ffi --release` then `check_c_abi_completeness.py` clean (bidirectional header/symbol parity, 328 symbols)
- C++ offline test suite: 271 assertions across 45 cases pass
- TypeScript binding tests pass; Python binding tests pass (live-gated cases skip without credentials)
- New FFI forwarding test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)