### PR TITLE
ci: actually run the columnar and FFI panic-boundary test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,19 @@ jobs:
       # that references a renamed symbol, say) wouldn't surface until
       # someone manually ran the doc step.
       - run: cargo test --doc --workspace --locked
+      # The DataFrame extension traits (`to_arrow` / `to_polars`) and their
+      # column / order / dtype contract live behind the `arrow` / `polars`
+      # features, which the workspace run above does not enable — so their
+      # tests would otherwise compile to an empty, silently-passing binary.
+      # Run them explicitly so a regression in the columnar surface fails CI.
+      - run: cargo test -p thetadatadx --locked --features "arrow,polars,frames,__test-helpers,config-file"
+      # The FFI unwind-safety guard (`tests/panic_boundary.rs`) is gated
+      # behind `testing-panic-boundary`. It verifies a panic crossing an
+      # `extern "C"` boundary is caught and converted to an error code
+      # instead of aborting the process — the contract every C / C++ / Go /
+      # Python caller relies on. Without this step the guard compiles to
+      # nothing and the boundary is unverified.
+      - run: cargo test -p thetadatadx-ffi --locked --features testing-panic-boundary
 
   rustdoc:
     name: Rustdoc — Gate 13 catches broken intra-doc links

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -455,6 +455,20 @@ name = "test_endpoint_routing"
 path = "tests/test_endpoint_routing.rs"
 required-features = ["__test-helpers"]
 
+# DataFrame extension-trait tests. Each is gated on its feature so the
+# test job that enables `arrow` / `polars` runs the column/order/dtype
+# contract; without the feature the target is skipped rather than
+# compiling to an empty, silently-passing binary.
+[[test]]
+name = "test_frames_arrow"
+path = "tests/test_frames_arrow.rs"
+required-features = ["arrow"]
+
+[[test]]
+name = "test_frames_polars"
+path = "tests/test_frames_polars.rs"
+required-features = ["polars"]
+
 [[bin]]
 name = "generate_sdk_surfaces"
 path = "src/bin/generate_sdk_surfaces.rs"


### PR DESCRIPTION
## Why

Two test suites compile but execute in zero CI jobs:

- `tests/test_frames_arrow.rs` (`#![cfg(feature = "arrow")]`) and `tests/test_frames_polars.rs` (`#![cfg(feature = "polars")]`) are the only tests covering the Rust-native `to_arrow` / `to_polars` column, order, and dtype contract. The workspace test job runs `--features __test-helpers,config-file` — neither enables `arrow`/`polars`, so each file compiles to an empty, silently-passing binary. The features appear only under `cargo doc`, which never runs `#[test]` functions.
- `ffi/tests/panic_boundary.rs` (`#![cfg(feature = "testing-panic-boundary")]`) verifies a `panic!` crossing `extern "C"` is caught instead of aborting the process — unverified for the same reason.

## Fix

- Register `test_frames_arrow` / `test_frames_polars` as `[[test]]` targets with `required-features = ["arrow"|"polars"]`, so they gate cleanly instead of degrading to an empty binary.
- Add explicit test steps: `cargo test -p thetadatadx --features "arrow,polars,frames,__test-helpers,config-file"` and `cargo test -p thetadatadx-ffi --features testing-panic-boundary`.

## Verified the tests now run

- frames: `test_frames_arrow` 9 passed, `test_frames_polars` 9 passed (were 0).
- panic-boundary: 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)