### PR TITLE
docs: correct TS await usage and the Python endpoint table

### DIFF
--- a/sdks/README.md
+++ b/sdks/README.md
@@ -114,9 +114,9 @@ npm run build
 ```typescript
 import { Client } from 'thetadatadx';
 
-const client = await Client.connectFromFile('creds.txt');
+const client = Client.connectFromFile('creds.txt');
 
-const eod = client.historical.stockHistoryEOD('AAPL', '20240101', '20240315');
+const eod = await client.historical.stockHistoryEOD('AAPL', '20240101', '20240315');
 ```
 
 Requires Node.js 18+. See [sdks/typescript/README.md](typescript/README.md) for full documentation.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -229,8 +229,8 @@ The flat-file distribution serves a fixed set of datasets: option `trade_quote` 
 
 | Category | Endpoints | Examples |
 |---|---|---|
-| Stock | 14 | EOD, OHLC, trades, quotes, snapshots, at-time |
-| Option | 34 | Every stock surface plus five Greeks tiers, open interest, contract lists |
+| Stock | 16 | EOD, OHLC, trades, quotes, snapshots, at-time |
+| Option | 36 | Every stock surface plus five Greeks tiers, open interest, contract lists |
 | Index | 9 | EOD, OHLC, price, snapshots |
 | Calendar | 3 | Market open/close, holidays, early closes |
 | Interest rate | 1 | EOD rate history |


### PR DESCRIPTION
Three README accuracy fixes found while verifying the published surface:

- `sdks/README.md` — the TypeScript quick-start awaited the synchronous `Client.connectFromFile(...)` (returns `Client`, not a Promise) and omitted `await` on the Promise-returning `stockHistoryEOD(...)`, so the snippet's `eod` was a pending promise rather than rows. Removed the wrong `await`, added the missing one (valid top-level await in the ESM snippet).
- `sdks/python/README.md` — the per-category endpoint table read Stock 14 / Option 34, disagreeing with the "65 typed endpoints" total on the same page and the real counts; corrected to Stock 16 / Option 36 (16+36+9+3+1 = 65).

🤖 Generated with [Claude Code](https://claude.com/claude-code)