### PR TITLE
chore: drop the vendor Java namespace from the proto and a doc comment

### DIFF
--- a/crates/thetadatadx/proto/mdds.proto
+++ b/crates/thetadatadx/proto/mdds.proto
@@ -2,9 +2,6 @@ syntax = "proto3";
 
 import "google/protobuf/struct.proto";
 
-option java_multiple_files = true;
-option java_package = "net.thetadata.grpc";
-
 // Production MDDS routes on BetaEndpoints.BetaThetaTerminal/<method>.
 // Do not rename without confirming the server has been updated.
 package BetaEndpoints;

--- a/crates/thetadatadx/src/flatfiles/datatype.rs
+++ b/crates/thetadatadx/src/flatfiles/datatype.rs
@@ -2,8 +2,8 @@
 //!
 //! The first FLATFILES chunk header encodes the per-column schema as an
 //! array of `i32` codes — one per column — describing the FIT-decoded row
-//! layout. The codes are stable identifiers from the vendor's
-//! `net.thetadata.enums.DataType` enum (e.g. `MS_OF_DAY=1`, `OPEN_INTEREST=121`).
+//! layout. The codes are the vendor's stable wire identifiers for each
+//! column data type (e.g. `MS_OF_DAY=1`, `OPEN_INTEREST=121`).
 //!
 //! For each code we need three pieces of information when emitting CSV
 //! or JSONL:


### PR DESCRIPTION
Two source-level references named an internal vendor Java namespace on the public surface:

- `crates/thetadatadx/proto/mdds.proto` carried `option java_multiple_files` / `option java_package = "net.thetadata.grpc"` — dead Java-codegen directives (no Java is generated) that named an internal package. Removed; the generated Rust is unchanged (prost ignores these options), and the crate builds.
- `crates/thetadatadx/src/flatfiles/datatype.rs` described the column codes as coming from the vendor's `net.thetadata.enums.DataType` enum. Reworded to describe them as the vendor's stable wire identifiers for each column data type, without naming an internal class.

The wire-required `package BetaEndpoints;` and the service path stay — they are the live gRPC routing the server expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)