### PR TITLE
fix(typescript): add @types/node so the doc-example gate type-checks

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -12,7 +12,8 @@
         "typescript": "6.0.3"
       },
       "devDependencies": {
-        "@napi-rs/cli": "^3.6.2"
+        "@napi-rs/cli": "^3.6.2",
+        "@types/node": "20.19.42"
       },
       "engines": {
         "node": ">= 20"
@@ -1570,6 +1571,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/node": {
+      "version": "20.19.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
+      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1904,6 +1915,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -27,7 +27,8 @@
     "version": "napi version"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^3.6.2"
+    "@napi-rs/cli": "^3.6.2",
+    "@types/node": "20.19.42"
   },
   "optionalDependencies": {
     "thetadatadx-darwin-arm64": "12.0.0",


### PR DESCRIPTION
## Why

Main's `TypeScript SDK` workflow is red: the doc-example gate (`run_doc_examples.mjs`, reactivated to extract 13 examples) compiles the snippets with a tsconfig that sets `types: ["node"]` over `node_modules/@types`, but `@types/node` was only an **unhoisted transitive** dependency — so tsc fails with `TS2688: Cannot find type definition file for 'node'` and the gate (hence the Build job) fails.

## Fix

Add `@types/node@^20` (matching `engines.node >= 20` / CI node 20) as a direct devDependency so it resolves at the top level.

## Verified

`npm ci` → `node scripts/run_doc_examples.mjs` → `ok: 13 doc example block(s) type-checked cleanly` (was TS2688).

🤖 Generated with [Claude Code](https://claude.com/claude-code)