### PR TITLE
release: bump the workspace to 13.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [13.0.0-rc.1] - 2026-06-17
 
 ### Breaking changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "arrow-ipc",
  "disruptor",

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "12"
+thetadatadx = "13.0.0-rc.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -23,14 +23,14 @@ The Rust SDK for [ThetaData](https://thetadata.us) market data. Pull US stock, o
 
 ```toml
 [dependencies]
-thetadatadx = "12"
+thetadatadx = "13.0.0-rc.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 
 Opt into DataFrame ergonomics with the `polars` or `arrow` feature:
 
 ```toml
-thetadatadx = { version = "12", features = ["polars"] }
+thetadatadx = { version = "13.0.0-rc.1", features = ["polars"] }
 ```
 
 ## Quick start

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -16,7 +16,7 @@ ThetaDataDx connects directly to ThetaData's servers — nothing to install and 
 ```toml
 # Cargo.toml
 [dependencies]
-thetadatadx = "12"
+thetadatadx = "13.0.0-rc.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [13.0.0-rc.1] - 2026-06-17
 
 ### Breaking changes
 

--- a/docs-site/docs/examples/dataframes.md
+++ b/docs-site/docs/examples/dataframes.md
@@ -37,7 +37,7 @@ minute_mid = df.set_index("ts")["mid"].resample("1min").last()
 In Rust, the optional `frames` feature adds `.to_polars()` / `.to_arrow()` on tick slices:
 
 ```toml
-thetadatadx = { version = "12", features = ["frames"] }
+thetadatadx = { version = "13.0.0-rc.1", features = ["frames"] }
 ```
 
 ```rust

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -51,9 +51,15 @@ SUB_LOCK_MANIFESTS = [
 
 
 def parse_semver(value: str) -> tuple[int, int, int]:
-    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", value)
+    # Accept an optional SemVer pre-release / build suffix (e.g.
+    # `13.0.0-rc.1`) so a release candidate can be bumped with the same
+    # tool. The numeric core is returned; the suffix rides through on the
+    # version strings the bump writes. Cargo and npm take `-rc.1` as-is;
+    # maturin normalises it to the PEP 440 form, and CMake (operator-set)
+    # carries the numeric core.
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.\-]+)?", value)
     if not match:
-        sys.exit(f"not a semver MAJOR.MINOR.PATCH: '{value}'")
+        sys.exit(f"not a semver MAJOR.MINOR.PATCH[-prerelease]: '{value}'")
     return int(match.group(1)), int(match.group(2)), int(match.group(3))
 
 

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -133,7 +133,7 @@ def check_static_docs() -> None:
     # enforces this against `crates/thetadatadx/Cargo.toml` canonically.
     expect_contains(
         DOCS_SITE / "articles/getting-started.md",
-        'thetadatadx = "12"',
+        'thetadatadx = "13.0.0-rc.1"',
     )
     expect_contains(
         DOCS_SITE / "mcp.md",

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -176,18 +176,23 @@ def main() -> int:
                 f"{package_json_version(platform_pkg)}, expected {canonical}"
             )
 
-    # U4 closure: CMake project version must match the canonical
-    # crates Cargo version exactly.
+    # CMake project version must match the canonical crates Cargo
+    # version. CMake's `project(... VERSION ...)` only accepts a numeric
+    # `major.minor.patch`, so on a pre-release (e.g. `13.0.0-rc.1`) it
+    # carries the numeric base (`13.0.0`); compare against that base, not
+    # the full pre-release string. A normal release has no suffix, so the
+    # base equals the canonical version.
+    canonical_base = canonical.split("-", 1)[0]
     cmake_version = cmake_project_version(CMAKE_LISTS)
     if cmake_version is None:
         failures.append(
             f"{CMAKE_LISTS.relative_to(ROOT)}: could not parse "
             "`project(... VERSION ...)` value"
         )
-    elif cmake_version != canonical:
+    elif cmake_version != canonical_base:
         failures.append(
             f"{CMAKE_LISTS.relative_to(ROOT)} VERSION is "
-            f"{cmake_version}, expected {canonical}"
+            f"{cmake_version}, expected {canonical_base}"
         )
 
     # U5 closure: documentation pins must match the canonical major.

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 # `VERSION` tracks the C++ binding alongside the Rust Cargo manifests
 # (`Cargo.toml`, `crates/*/Cargo.toml`, `tools/*/Cargo.toml`) and the
 # TypeScript `package.json` files; all bindings carry the same version.
-project(thetadatadx-cpp VERSION 12.0.0 LANGUAGES CXX)
+project(thetadatadx-cpp VERSION 13.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "arrow",
  "libc",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "arrow-ipc",
  "chrono",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm64')
         const bindingPackageVersion = require('thetadatadx-android-arm64/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm-eabi')
         const bindingPackageVersion = require('thetadatadx-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-gnu')
         const bindingPackageVersion = require('thetadatadx-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-ia32-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-arm64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('thetadatadx-darwin-universal')
       const bindingPackageVersion = require('thetadatadx-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-x64')
         const bindingPackageVersion = require('thetadatadx-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-arm64')
         const bindingPackageVersion = require('thetadatadx-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-x64')
         const bindingPackageVersion = require('thetadatadx-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-arm64')
         const bindingPackageVersion = require('thetadatadx-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-musleabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-gnueabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-ppc64-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-s390x-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm64')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-x64')
         const bindingPackageVersion = require('thetadatadx-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '12.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 12.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "12.0.0",
+  "version": "13.0.0-rc.1",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "12.0.0",
+  "version": "13.0.0-rc.1",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "12.0.0",
+  "version": "13.0.0-rc.1",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "12.0.0",
+  "version": "13.0.0-rc.1",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -31,9 +31,9 @@
     "@types/node": "20.19.42"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "12.0.0",
-    "thetadatadx-linux-x64-gnu": "12.0.0",
-    "thetadatadx-win32-x64-msvc": "12.0.0"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.1",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.1",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.1"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "12.0.0"
+version = "13.0.0-rc.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Bumps every version declaration from `12.0.0` to the `13.0.0-rc.1` release candidate, and teaches the version tooling about pre-releases. **Not auto-merged** — this is the release bump for review before the tag is cut.

## Bumped
- 7 workspace crates + all 5 `Cargo.lock` files (root, tools/mcp, tools/server, sdks/python, sdks/typescript)
- `sdks/typescript/package.json` (`version` + the 3 `optionalDependencies` pins) + the 3 platform `package.json` + the regenerated `index.js` napi version-check strings
- `sdks/cpp/CMakeLists.txt` → `VERSION 13.0.0` (CMake's `project(VERSION)` is numeric-only; it carries the pre-release's numeric base)
- doc install pins (`README.md`, `crates/thetadatadx/README.md` ×2, getting-started, dataframes) → `"13.0.0-rc.1"` (Cargo only resolves a pre-release from an explicit pre-release pin, not a bare major)
- `CHANGELOG.md` + mirror: `[Unreleased]` → `## [13.0.0-rc.1] - 2026-06-17`

## Tooling (the repo had never cut a pre-release)
- `bump_version.py`: `parse_semver` now accepts a SemVer pre-release suffix (`-rc.1`)
- `check_version_sync.py`: compares the CMake numeric base against the canonical version, so a pre-release no longer falsely trips the gate
- `check_docs_consistency.py`: the getting-started pin tracks the new version

## Verified
`check_version_sync.py` ok · `check_docs_consistency.py` ok · zero stray `12.0.0` in any version context · left history (the `[12.0.0]` changelog entry, `release-notes/v12.0.0.md`, `migration/v11-to-v12.md`, the Node `>=12.0.0` engine pin) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)