### PR TITLE
refactor(config): derive historical concurrency from subscription tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The bring-your-own wait-strategy trait and presets used by the Rust generic streaming-drain escape hatch are re-exported under `thetadatadx::streaming::wait`, so a caller naming a custom wait strategy refers only to crate-owned paths and never adds an internal dependency to their own manifest. The zero-cost generic override is unchanged; only the path it is named through moved onto the crate's own surface.
 - The flat-file request-type and contract security-type fields render as stable wire tokens (`trade_quote`, `open_interest`, `eod`, `STOCK`, `OPTION`, `INDEX`, `RATE`) on the JSON, WebSocket, and fluent client surfaces instead of an internal variant identifier, so the token a client parses against is decoupled from the implementation and cannot shift under an internal rename. Output is identical to the prior rendering for every current value.
 
+### Removed
+
+- The `concurrent_requests` configuration knob is removed from the public client API on every binding; historical request concurrency is now derived automatically from the account's subscription tier (Free=1, Value=2, Standard=4, Pro=8) and sized into the connection pool at connect time, so there is no value to set, clamp, or migrate.
+
 ### Fixed
 
 - The TypeScript surface no longer renders internal runtime types in its public type declarations: the streaming callback and the namespace-handle doc comments described their plumbing in terms of internal wrappers, which the generated `index.d.ts` shipped to clients. The docs now describe the behavior on its own terms, so the published declarations carry only the client-facing surface.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,10 +76,10 @@ FPSS credential length fields are read as unsigned integers (matching Java's
 
 ### Concurrent Request Limiting
 
-HistoricalClient enforces a semaphore (`mdds_concurrent_requests`) that limits the number of
-in-flight gRPC requests. The default is dynamically derived from the user's subscription
-tier (`2^tier`), matching the Java terminal's concurrency model. This prevents runaway
-request storms from overwhelming the upstream MDDS server or triggering server-side rate
+The SDK caps the number of in-flight historical requests with an internal semaphore. The cap
+is derived automatically from the account's subscription tier at connect time and is not
+user-configurable. This respects the server-side per-tier concurrency limit and prevents
+runaway request storms from overwhelming the upstream server or triggering server-side rate
 limiting.
 
 ### Unknown Compression Rejection

--- a/crates/thetadatadx/src/config/mdds.rs
+++ b/crates/thetadatadx/src/config/mdds.rs
@@ -1,19 +1,14 @@
 //! Historical (gRPC) sub-configuration.
 //!
-//! `concurrent_requests` is the throughput knob for large historical
-//! pulls (multi-day backfills, wide `strike_range`, `interval = 1s` /
-//! `tick`):
+//! Holds the per-channel gRPC tuning for the historical transport:
+//! message-size ceiling, keepalive cadence, HTTP/2 flow-control
+//! windows, connect/request deadlines, and the buffered-response warn
+//! threshold.
 //!
-//! | Workload                                        | `concurrent_requests` |
-//! |-------------------------------------------------|-----------------------|
-//! | One-shot single-day single-strike query         | `1`                   |
-//! | Multi-day backfill, narrow strike scope (sr<10) | `4` (PRO)             |
-//! | Wide `strike_range` or `1s`/`tick` interval bulk| `8` (PRO max)         |
-//! | Server-side tier caps                           | FREE=1 / VALUE=2 / STANDARD=4 / PRO=8 |
-//!
-//! `concurrent_requests` is clamped to the resolved subscription
-//! tier cap at connect time (a setting of `32` on a PRO tier opens
-//! 8 channels and emits a `tracing::warn!`).
+//! Channel-pool concurrency is **not** a tuning knob here: it is
+//! resolved internally from the subscription tier returned by Nexus
+//! auth at connect time, so the live pool always stays inside the
+//! server-side per-tier ceiling without any caller input.
 //!
 //! See `docs-site/docs/configuration.md` for the per-binding setter
 //! samples.
@@ -31,13 +26,6 @@ pub struct HistoricalConfig {
     /// Whether to use TLS for the historical connection.
     /// Always `true` in production (standard gRPC-over-TLS on port 443).
     pub tls: bool,
-
-    /// Max concurrent in-flight gRPC requests.
-    ///
-    /// The JVM terminal caps this at `2^subscription_tier` (Free=1, Value=2,
-    /// Standard=4, Pro=8). Set to 0 to auto-detect from the subscription tier
-    /// returned by Nexus auth.
-    pub concurrent_requests: usize,
 
     /// Max inbound gRPC message size in bytes.
     ///
@@ -121,25 +109,6 @@ pub struct HistoricalConfig {
     /// effectively disables it too (no realistic response reaches
     /// that size).
     pub warn_on_buffered_threshold_bytes: usize,
-
-    /// Bypass the subscription-tier clamp on `concurrent_requests`.
-    ///
-    /// **Test-only escape hatch.** ThetaData enforces a server-side
-    /// cap on concurrent in-flight gRPC requests per subscription
-    /// tier (Free=1 / Value=2 / Standard=4 / Pro=8). The SDK normally
-    /// clamps `concurrent_requests` to this cap at connect time so
-    /// the user gets a clear `tracing::warn!` rather than opaque
-    /// upstream rejections on the (N+1)-th channel. Setting this to
-    /// `true` skips the clamp — only useful for tests that need to
-    /// reproduce the over-provisioning failure mode against a stubbed
-    /// auth response.
-    ///
-    /// **Do not enable in production.** The server will reject
-    /// channels above the tier cap; the SDK's clamp is the friendly
-    /// boundary that surfaces the problem locally instead of letting
-    /// it leak into per-RPC retry storms.
-    #[doc(hidden)]
-    pub override_tier_clamp: bool,
 }
 
 impl HistoricalConfig {
@@ -150,7 +119,6 @@ impl HistoricalConfig {
             host: "mdds-01.thetadata.us".to_string(),
             port: 443,
             tls: true,
-            concurrent_requests: 0,
             max_message_size: 4 * 1024 * 1024,
             keepalive_secs: 30,
             keepalive_timeout_secs: 10,
@@ -169,7 +137,6 @@ impl HistoricalConfig {
             // operator-visible "you are on the wrong API for this
             // workload" signal at this boundary.
             warn_on_buffered_threshold_bytes: 100 * 1024 * 1024,
-            override_tier_clamp: false,
         }
     }
 }

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -521,11 +521,6 @@ impl DirectConfig {
     pub fn historical_tls(&self) -> bool {
         self.historical.tls
     }
-    /// Historical concurrent in-flight requests budget.
-    #[must_use]
-    pub fn historical_concurrent_requests(&self) -> usize {
-        self.historical.concurrent_requests
-    }
     /// Historical max inbound message size, in bytes.
     #[must_use]
     pub fn historical_max_message_size(&self) -> usize {
@@ -787,7 +782,6 @@ mod config_file {
         /// override to the same number as the default is still honoured as
         /// an explicit choice rather than read as unset.
         max_message_size_mb: Option<usize>,
-        concurrent_requests: usize,
     }
 
     impl GrpcSection {
@@ -815,7 +809,6 @@ mod config_file {
                 // remains the single source of truth unless the operator
                 // sets this MB-denominated override explicitly.
                 max_message_size_mb: None,
-                concurrent_requests: prod.historical.concurrent_requests,
             }
         }
     }
@@ -878,7 +871,6 @@ mod config_file {
         /// [grpc]
         /// window_size_kb = 64
         /// connection_window_size_kb = 64
-        /// concurrent_requests = 0  # 0 = auto from tier
         /// ```
         ///
         /// # Errors
@@ -971,7 +963,6 @@ mod config_file {
             out.historical.host = cf.historical.host;
             out.historical.port = cf.historical.port;
             out.historical.tls = cf.historical.tls;
-            out.historical.concurrent_requests = cf.grpc.concurrent_requests;
             out.historical.max_message_size = max_message_size;
             out.historical.keepalive_secs = cf.historical.keepalive_time_secs;
             out.historical.keepalive_timeout_secs = cf.historical.keepalive_timeout_secs;
@@ -1225,12 +1216,10 @@ mod tests {
                 [grpc]
                 window_size_kb = 128
                 connection_window_size_kb = 256
-                concurrent_requests = 4
             "#;
             let config = DirectConfig::from_toml_str(toml).unwrap();
             assert_eq!(config.historical.window_size_kb, 128);
             assert_eq!(config.historical.connection_window_size_kb, 256);
-            assert_eq!(config.historical.concurrent_requests, 4);
         }
 
         #[test]
@@ -1427,10 +1416,6 @@ mod tests {
             assert_eq!(
                 config.historical.connection_window_size_kb,
                 prod.historical.connection_window_size_kb
-            );
-            assert_eq!(
-                config.historical.concurrent_requests,
-                prod.historical.concurrent_requests
             );
 
             // Streaming (TCP).
@@ -1662,10 +1647,12 @@ mod tests {
     #[test]
     fn historical_defaults_match_production_baseline() {
         let mdds = crate::config::HistoricalConfig::production_defaults();
-        // Tier clamp on by default — the override is an internal
-        // escape hatch only enabled by tests that need to reproduce
-        // the over-provisioning failure mode.
-        assert!(!mdds.override_tier_clamp);
+        // The buffered-response warn fires at 100 MiB by default, and
+        // the per-request deadline is the 300s ceiling. Channel-pool
+        // concurrency carries no default here — it is resolved from
+        // the subscription tier at connect time.
+        assert_eq!(mdds.warn_on_buffered_threshold_bytes, 100 * 1024 * 1024);
+        assert_eq!(mdds.request_timeout_secs, 300);
     }
 
     // ── RetryPolicy / env var tests ──────────────────────────────────

--- a/crates/thetadatadx/src/mdds/client.rs
+++ b/crates/thetadatadx/src/mdds/client.rs
@@ -121,7 +121,7 @@ impl HistoricalClient {
         let port = config.historical.port;
         tracing::debug!(host = %host, port, tls = config.historical.tls, "connecting to MDDS");
 
-        let pool_size = effective_pool_size(&config, &auth_resp);
+        let pool_size = effective_pool_size(&auth_resp);
         let channels =
             open_channel_pool(&host, port, config.historical.tls, pool_size, &config).await?;
         tracing::info!(
@@ -137,16 +137,12 @@ impl HistoricalClient {
         // The request semaphore must match the resolved channel pool
         // size so the (N+1)-th in-flight RPC can never claim a permit
         // before there's a channel free to carry it. `pool_size`
-        // already reflects the tier-clamped, auto-detected resolution
-        // from `effective_pool_size`; reusing it keeps the semaphore
-        // and the channel count strictly coupled.
+        // already reflects the tier-derived resolution from
+        // `effective_pool_size`; reusing it keeps the semaphore and
+        // the channel count strictly coupled.
         let request_semaphore = Arc::new(tokio::sync::Semaphore::new(pool_size));
 
-        tracing::debug!(
-            mdds_concurrent_requests = pool_size,
-            auto_detected = config.historical.concurrent_requests == 0,
-            "request semaphore initialized"
-        );
+        tracing::debug!(pool_size, "request semaphore initialized");
 
         let stock_tier = auth_resp
             .user
@@ -314,62 +310,26 @@ impl HistoricalClient {
     }
 }
 
-/// Pool sizing — `concurrent_requests` from `DirectConfig` is the
-/// explicit caller intent, **clamped to the subscription tier cap**.
-/// Subscription tier supplies the default when `concurrent_requests = 0`
-/// and the upper bound when it's set explicitly.
+/// Channel-pool sizing — resolved purely from the subscription tier.
 ///
-/// # Why clamp explicit caller intent
+/// The server enforces a hard per-tier cap on concurrent in-flight
+/// gRPC requests (Free=1 / Value=2 / Standard=4 / Pro=8). The SDK
+/// sizes the channel pool to exactly that cap so the live pool always
+/// stays inside the server-side ceiling — there is no caller-supplied
+/// concurrency knob to over-provision and trip per-RPC
+/// `ResourceExhausted` rejections.
 ///
-/// ThetaData enforces a hard server-side cap on concurrent in-flight
-/// gRPC requests per tier (Free=1 / Value=2 / Standard=4 / Pro=8).
-/// Without the clamp, a caller asking for `concurrent_requests = 32`
-/// on a Pro tier opens 32 channels; the (Pro_cap + 1)-th RPC then
-/// fails with an upstream `ResourceExhausted` per-stream rejection,
-/// which the SDK retries on a different channel, producing a confusing
-/// "everything fails intermittently" symptom. Clamping locally
-/// surfaces the misconfiguration as a `tracing::warn!` on connect and
-/// keeps the live pool inside the tier's headroom.
+/// # Resolution
 ///
-/// The `override_tier_clamp` escape hatch on `HistoricalConfig` bypasses
-/// the clamp — test-only, used to reproduce the over-provisioning
-/// failure mode against a stubbed auth response.
-///
-/// # Resolution ladder
-///
-/// 1. `concurrent_requests > 0` ∧ `from_tier > 0` ∧ `!override` →
-///    `min(from_config, from_tier)` (clamp + warn if `from_config > from_tier`)
-/// 2. `concurrent_requests > 0` ∧ (`from_tier = 0` ∨ `override`) →
-///    `from_config` (no tier reference available, or operator bypass)
-/// 3. `concurrent_requests = 0` ∧ `from_tier > 0` → `from_tier` (auto-detect)
-/// 4. `concurrent_requests = 0` ∧ `from_tier = 0` → `DEFAULT_POOL_SIZE`
-fn effective_pool_size(
-    config: &DirectConfig,
-    auth_resp: &crate::auth::nexus::AuthResponse,
-) -> usize {
+/// 1. tier resolved from the auth response → that tier's cap.
+/// 2. no tier on the auth response (anonymous channel, dev harness)
+///    → `DEFAULT_POOL_SIZE`.
+fn effective_pool_size(auth_resp: &crate::auth::nexus::AuthResponse) -> usize {
     const DEFAULT_POOL_SIZE: usize = 4;
-    let from_config = config.historical.concurrent_requests;
     let from_tier = auth_resp
         .user
         .as_ref()
         .map_or(0, crate::auth::nexus::AuthUser::max_concurrent_requests);
-    if from_config > 0 {
-        // Explicit caller intent — clamp to tier cap so a configured
-        // value above the server-side ceiling does not produce
-        // confusing per-RPC `ResourceExhausted` rejections downstream.
-        // The escape hatch (`override_tier_clamp`) bypasses the clamp
-        // for tests that need to reproduce the misconfiguration.
-        if from_tier > 0 && !config.historical.override_tier_clamp && from_config > from_tier {
-            tracing::warn!(
-                configured = from_config,
-                tier_cap = from_tier,
-                "mdds.concurrent_requests exceeds subscription tier cap — clamping to tier cap; \
-                 set HistoricalConfig.override_tier_clamp = true to bypass (tests only)"
-            );
-            return from_tier;
-        }
-        return from_config.max(1);
-    }
     if from_tier > 0 {
         from_tier
     } else {
@@ -519,11 +479,10 @@ mod pool_size_tests {
     use crate::auth::nexus::AuthResponse;
     #[cfg(feature = "__internal")]
     use crate::auth::nexus::AuthUser;
-    use crate::config::DirectConfig;
 
     /// Build an AuthResponse whose user reports the given subscription
-    /// wire bytes. `AuthUser::max_concurrent_requests` maps those into
-    /// `2^tier` — the same shape the JVM terminal uses.
+    /// wire byte. `AuthUser::max_concurrent_requests` maps that into
+    /// the per-tier cap (`2^tier`).
     #[cfg(feature = "__internal")]
     fn auth_with_tier(stock_sub: Option<i32>) -> AuthResponse {
         AuthResponse {
@@ -541,95 +500,24 @@ mod pool_size_tests {
 
     #[cfg(feature = "__internal")]
     #[test]
-    fn explicit_below_tier_cap_honoured() {
-        // Caller asks for exactly 1 channel; auth response carries a
-        // Pro tier (subscription byte 3 -> 2^3 = 8 concurrent). The
-        // explicit caller intent is below the tier cap, so honour it
-        // exactly without inflating.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.concurrent_requests = 1;
-        let auth = auth_with_tier(Some(3));
-        assert_eq!(effective_pool_size(&config, &auth), 1);
-    }
-
-    #[cfg(feature = "__internal")]
-    #[test]
-    fn auto_detect_falls_back_to_tier_when_config_is_zero() {
-        // Caller signals "auto-detect" with concurrent_requests = 0;
-        // tier (subscription byte 2 -> 4 concurrent) supplies the
-        // default.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.concurrent_requests = 0;
-        let auth = auth_with_tier(Some(2));
-        assert_eq!(effective_pool_size(&config, &auth), 4);
+    fn pool_size_tracks_tier_cap() {
+        // The pool is sized to exactly the tier cap: Free=1, Value=2,
+        // Standard=4, Pro=8 (subscription wire bytes 0..=3).
+        for (sub_byte, expected) in [(0, 1), (1, 2), (2, 4), (3, 8)] {
+            let auth = auth_with_tier(Some(sub_byte));
+            assert_eq!(effective_pool_size(&auth), expected);
+        }
     }
 
     #[test]
-    fn auto_detect_falls_back_to_default_when_no_tier() {
-        // Auto-detect + no auth user — hardcoded `4` is the last
-        // resort.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.concurrent_requests = 0;
+    fn pool_size_falls_back_to_default_when_no_tier() {
+        // No auth user (anonymous channel, dev harness) — the
+        // hardcoded `4` is the last resort.
         let auth = AuthResponse {
             session_id: "session".to_string(),
             user: None,
             session_created: None,
         };
-        assert_eq!(effective_pool_size(&config, &auth), 4);
-    }
-
-    #[cfg(feature = "__internal")]
-    #[test]
-    fn explicit_above_tier_cap_clamped() {
-        // Caller asks for 32 channels but tier is Free (byte 0 -> 1
-        // concurrent). The clamp folds the configured value to the
-        // tier cap so the per-RPC `ResourceExhausted` rejections
-        // never surface — the local warn is the SDK's friendly
-        // boundary against the server-side cap.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.concurrent_requests = 32;
-        let auth = auth_with_tier(Some(0));
-        assert_eq!(effective_pool_size(&config, &auth), 1);
-    }
-
-    #[cfg(feature = "__internal")]
-    #[test]
-    fn explicit_above_pro_cap_clamped_to_pro() {
-        // Pro tier permits 8. Caller asks for 16. Clamp to 8.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.concurrent_requests = 16;
-        let auth = auth_with_tier(Some(3));
-        assert_eq!(effective_pool_size(&config, &auth), 8);
-    }
-
-    #[cfg(feature = "__internal")]
-    #[test]
-    fn override_tier_clamp_bypasses_clamp() {
-        // The internal escape hatch lets tests reproduce the
-        // over-provisioning failure mode against a stubbed Free-tier
-        // auth response. With the override on, the configured value
-        // passes through unmodified — useful for asserting downstream
-        // behaviour against an explicitly mis-sized pool.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.concurrent_requests = 16;
-        config.historical.override_tier_clamp = true;
-        let auth = auth_with_tier(Some(0));
-        assert_eq!(effective_pool_size(&config, &auth), 16);
-    }
-
-    #[test]
-    fn no_tier_response_does_not_clamp() {
-        // Auth response carries no tier (anonymous channel, dev
-        // harness, etc.). The clamp arm is skipped entirely — the
-        // configured value passes through. The default-pool fallback
-        // only triggers for `concurrent_requests = 0`.
-        let mut config = DirectConfig::production_defaults();
-        config.historical.concurrent_requests = 16;
-        let auth = AuthResponse {
-            session_id: "session".to_string(),
-            user: None,
-            session_created: None,
-        };
-        assert_eq!(effective_pool_size(&config, &auth), 16);
+        assert_eq!(effective_pool_size(&auth), 4);
     }
 }

--- a/docs-site/docs/articles/concurrent-requests.md
+++ b/docs-site/docs/articles/concurrent-requests.md
@@ -1,11 +1,11 @@
 ---
 title: Concurrent Requests
-description: How many historical requests run in parallel per subscription tier, and how to use that budget.
+description: How many historical requests run in parallel per subscription tier.
 ---
 
 # Concurrent Requests
 
-Your requests are not rate-limited, but the number of requests **in flight at once** is capped by your subscription tier on each asset class:
+Your requests are not rate-limited, but the number of historical requests **in flight at once** is capped by your subscription tier on each asset class:
 
 | Tier | Concurrent requests |
 |---|---:|
@@ -14,11 +14,13 @@ Your requests are not rate-limited, but the number of requests **in flight at on
 | Standard | 4 |
 | Pro | 8 |
 
-## What the SDK does for you
+## It's automatic
 
-Every historical call acquires a permit from a client-side semaphore sized to your tier's cap, detected at connect time. Fire as many calls in parallel as you like — async tasks in Rust and Python, threads, a process-wide backfill loop — and anything beyond the cap **queues in order and drains as slots free**. You never receive a rejection for over-parallelism; the burst is absorbed as latency, not errors.
+There is no knob to set. At connect time the SDK reads your tier from authentication and sizes its historical connection pool to match. A Pro account gets eight in-flight slots, Free gets one, and so on. You don't pass a value, you don't tune anything, and there's nothing to get wrong.
 
-That means the idiomatic pattern is simply to launch your whole batch:
+Every historical call quietly takes a slot from that pool. Fire as many calls in parallel as you like, whether that's async tasks in Rust and Python, threads, or a process-wide backfill loop. Anything beyond your tier's slot count **queues in order and drains as slots free**. You never get a rejection for over-parallelism; the burst is absorbed as latency, not errors.
+
+So the idiomatic pattern is simply to launch your whole batch and let the pool pace it:
 
 ```python
 import asyncio
@@ -32,19 +34,12 @@ async def pull(day):
 results = asyncio.run(asyncio.gather(*(pull(d) for d in days)))
 ```
 
-With a Pro subscription, eight of those requests run concurrently and the rest wait their turn.
-
-## Tuning the cap down (or trying to exceed it)
-
-`concurrent_requests` on the configuration object overrides the auto-detected value — useful for capping a shared account's footprint from one process. Values above your tier cap are clamped back to the cap at connect time, with a single warning log naming both numbers, because the servers reject the excess anyway.
-
-```python
-cfg = Config.production()
-cfg.concurrent_requests = 2   # be a polite tenant on a shared account
-```
+With a Pro subscription, eight of those requests run concurrently and the rest wait their turn. On Free, they run one at a time. Same code either way.
 
 ## When parallelism pays
 
-Concurrency multiplies throughput on multi-request workloads: per-day backfills, per-contract chain pulls, anything you can split with `split_date_range`. It does nothing for one giant request — split the request first ([Request Sizing](/articles/request-sizing)), then spend your tier's slots on the pieces.
+Concurrency multiplies throughput on multi-request workloads: per-day backfills, per-contract chain pulls, anything you can split with `split_date_range`. It does nothing for one giant request, so split the request first ([Request Sizing](/articles/request-sizing)), then let your tier's slots work through the pieces.
 
 One more queue exists upstream: if the servers themselves report exhaustion, the SDK retries with backoff before surfacing an error. Long-running bulk jobs should still expect occasional retries during peak hours; see [Data Issues?](/articles/data-issues) if a job stalls beyond that.
+</content>
+</invoke>

--- a/docs-site/docs/articles/configuration.md
+++ b/docs-site/docs/articles/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Environments, retries, timeouts, concurrency, and the streaming knobs.
+description: Environments, retries, timeouts, and the streaming knobs.
 ---
 
 # Configuration
@@ -32,7 +32,6 @@ In Rust the same fields live on `DirectConfig` struct sub-configs (`config.retry
 |---|---|---|
 | Request deadlines | `timeout_ms` per request (builder / kwarg) | Hard per-call deadline; expiry raises a timeout error and frees the slot. |
 | Retries | `retry_initial_delay_ms`, `retry_max_delay_ms`, `retry_max_attempts`, `retry_jitter`, `retry_max_elapsed_secs` | Backoff schedule for transient historical-request faults. |
-| Concurrency | `concurrent_requests` | Parallel historical requests; auto-set from your tier. See [Concurrent Requests](/articles/concurrent-requests). |
 | Streaming reconnect | `reconnect_policy`, `reconnect_max_attempts`, `reconnect_wait_ms`, `reconnect_wait_max_ms`, `reconnect_jitter`, `reconnect_stable_window_secs`, … | Automatic streaming reconnection. See [Reconnection & Monitoring](/streaming/reliability). |
 | Streaming latency | `flush_mode` (`"batched"` default / `"immediate"`), `streaming_ring_size`, `streaming_timeout_ms`, keepalive fields | Write-path flush behavior and event-buffer capacity. |
 | Flat files | `flatfiles_max_attempts`, `flatfiles_initial_backoff_secs`, `flatfiles_max_backoff_secs`, `flatfiles_jitter` | Retry budget for bulk downloads. |
@@ -40,6 +39,8 @@ In Rust the same fields live on `DirectConfig` struct sub-configs (`config.retry
 | Runtime | `worker_threads` | Async worker-thread count for embedded bindings (0 = auto). |
 
 Every field above is available on all four language surfaces under the naming convention shown earlier; unknown values fail at configuration time, not at first request.
+
+Historical request concurrency is not in this table because it isn't configurable. The SDK sizes its historical connection pool automatically from your subscription tier at connect time. See [Concurrent Requests](/articles/concurrent-requests).
 
 ## Config file (Rust)
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The bring-your-own wait-strategy trait and presets used by the Rust generic streaming-drain escape hatch are re-exported under `thetadatadx::streaming::wait`, so a caller naming a custom wait strategy refers only to crate-owned paths and never adds an internal dependency to their own manifest. The zero-cost generic override is unchanged; only the path it is named through moved onto the crate's own surface.
 - The flat-file request-type and contract security-type fields render as stable wire tokens (`trade_quote`, `open_interest`, `eod`, `STOCK`, `OPTION`, `INDEX`, `RATE`) on the JSON, WebSocket, and fluent client surfaces instead of an internal variant identifier, so the token a client parses against is decoupled from the implementation and cannot shift under an internal rename. Output is identical to the prior rendering for every current value.
 
+### Removed
+
+- The `concurrent_requests` configuration knob is removed from the public client API on every binding; historical request concurrency is now derived automatically from the account's subscription tier (Free=1, Value=2, Standard=4, Pro=8) and sized into the connection pool at connect time, so there is no value to set, clamp, or migrate.
+
 ### Fixed
 
 - The TypeScript surface no longer renders internal runtime types in its public type declarations: the streaming callback and the namespace-handle doc comments described their plumbing in terms of internal wrappers, which the generated `index.d.ts` shipped to clients. The docs now describe the behavior on its own terms, so the published declarations carry only the client-facing surface.

--- a/docs-site/docs/migration/v11-to-v12.md
+++ b/docs-site/docs/migration/v11-to-v12.md
@@ -19,7 +19,7 @@ walks the changes a downstream caller actually has to make.
 | FPSS streaming (TS) | `client.startStreamingIter()` | `client.startStreaming(cb)` |
 | FPSS streaming (C ABI) | `thetadatadx_client_start_streaming_iter` + iter API | `thetadatadx_client_set_callback` |
 | REST fallback | `Config::with_rest_fallback(...)` | Removed — the library speaks the gRPC + FPSS + flat-file wire protocols directly |
-| Decode pipeline knobs | `decode_threads` / `decode_queue_depth` / `decoder_ring_size` (every binding) | Removed — delete the setter calls; concurrency is sized by `concurrent_requests` alone |
+| Decode pipeline knobs | `decode_threads` / `decode_queue_depth` / `decoder_ring_size` (every binding) | Removed — delete the setter calls; historical concurrency is now sized automatically from your subscription tier |
 | Engine internals | `use thetadatadx::mdds::...` from a downstream crate | Gated behind `features = ["__internal"]`; not a stable surface |
 
 ## FPSS streaming reshape
@@ -130,20 +130,22 @@ the REST escape hatch can either:
 ## Decode pipeline knobs removed
 
 The two-stage decode pipeline these knobs tuned no longer exists:
-per-chunk decode runs inline on each request task, and the only
-concurrency control is `concurrent_requests`. `decode_threads`,
-`decode_queue_depth`, and `decoder_ring_size` are removed from every
-binding — delete the setter calls (and any getter reads); there is no
-replacement value to migrate.
+per-chunk decode runs inline on each request task, and historical
+concurrency is now sized automatically from your subscription tier at
+connect time. `decode_threads`, `decode_queue_depth`, and
+`decoder_ring_size` are removed from every binding — delete the setter
+calls (and any getter reads); there is no replacement value to migrate.
 
-- Rust: `config.mdds.decode_threads = Some(8);` → delete; size with `config.mdds.concurrent_requests` instead.
-- Python: `cfg.decode_threads = 8` → delete; keep `cfg.concurrent_requests`.
-- TypeScript: `cfg.setDecodeThreads(8)` → delete; keep `cfg.setConcurrentRequests(8)`.
-- C ABI: `thetadatadx_config_set_decode_threads(cfg, 8)` → delete; keep `thetadatadx_config_set_concurrent_requests(cfg, 8)`.
-- C++: `cfg.set_decode_threads(8)` → delete; keep `cfg.set_concurrent_requests(8)`.
+- Rust: `config.mdds.decode_threads = Some(8);` → delete; nothing replaces it.
+- Python: `cfg.decode_threads = 8` → delete; nothing replaces it.
+- TypeScript: `cfg.setDecodeThreads(8)` → delete; nothing replaces it.
+- C ABI: `thetadatadx_config_set_decode_threads(cfg, 8)` → delete; nothing replaces it.
+- C++: `cfg.set_decode_threads(8)` → delete; nothing replaces it.
 
 The same applies to the `decode_queue_depth` and `decoder_ring_size`
 variants of each setter, including the `_explicit` C ABI forms.
+Historical request concurrency is no longer a configuration field on any
+binding; see [Concurrent Requests](/articles/concurrent-requests).
 
 ## Engine internals are now gated
 

--- a/docs-site/docs/public/llms.txt
+++ b/docs-site/docs/public/llms.txt
@@ -4,9 +4,9 @@
 
 / — ThetaDataDx: SDK for ThetaData market data — historical, streaming, and bulk flat files in Rust, Python, TypeScript, and C++.
 /articles/ai-llms — Building with AI / LLMs: Machine-readable entry points for coding assistants and LLM agents.
-/articles/concurrent-requests — Concurrent Requests: How many historical requests run in parallel per subscription tier, and how to use that budget.
+/articles/concurrent-requests — Concurrent Requests: How many historical requests run in parallel per subscription tier.
 /articles/conditions — Trade & Quote Conditions: Condition code mapping for the condition fields on trade and quote rows.
-/articles/configuration — Configuration: Environments, retries, timeouts, concurrency, and the streaming knobs.
+/articles/configuration — Configuration: Environments, retries, timeouts, and the streaming knobs.
 /articles/data-issues — Data Issues?: A short checklist before filing a data problem.
 /articles/error-codes — Error Codes: The typed error surface across all four SDKs and the server's error envelope.
 /articles/exchanges — Exchanges: Exchange code mapping for the exchange fields on trade and quote rows.

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -2538,49 +2538,7 @@ pub unsafe extern "C" fn thetadatadx_config_get_historical_port(
     })
 }
 
-// ── Historical pool sizing ───────────────────────────────────────────────
-
-/// Set the number of concurrent in-flight gRPC requests on a config
-/// handle.
-///
-/// `n = 0` (default) auto-detects from the Nexus subscription tier
-/// (Free=1 / Value=2 / Standard=4 / Pro=8). Explicit values above
-/// the tier cap are clamped at connect time with a `tracing::warn!`.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_set_concurrent_requests(
-    config: *mut ThetaDataDxConfig,
-    n: u32,
-) {
-    ffi_boundary!((), {
-        let config = require_config_mut!(config);
-        config.inner.historical.concurrent_requests = n as usize;
-    })
-}
-
-/// Read the configured concurrent in-flight gRPC request count. Writes
-/// the value into `*out_n` (`0` = auto-detect from the subscription
-/// tier). A stored value above `u32::MAX` saturates to `u32::MAX`.
-/// Returns `0` on success, `-1` if either pointer is null.
-#[no_mangle]
-pub unsafe extern "C" fn thetadatadx_config_get_concurrent_requests(
-    config: *const ThetaDataDxConfig,
-    out_n: *mut u32,
-) -> i32 {
-    ffi_boundary!(-1, {
-        if config.is_null() || out_n.is_null() {
-            set_error("config or out-parameter pointer is null");
-            return -1;
-        }
-        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
-        let config = unsafe { &*config };
-        let value = u32::try_from(config.inner.historical.concurrent_requests).unwrap_or(u32::MAX);
-        // SAFETY: out pointer checked non-null above; caller pins the storage for the call duration.
-        unsafe {
-            *out_n = value;
-        }
-        0
-    })
-}
+// ── Historical tuning ────────────────────────────────────────────────────
 
 /// Set the `warn_on_buffered_threshold_bytes` ceiling on a config
 /// handle. Streaming endpoints log a `tracing::warn!` when a
@@ -2762,36 +2720,6 @@ mod pool_sizing_tests {
     //! `HistoricalConfig` to confirm the value round-tripped.
 
     #[test]
-    fn concurrent_requests_round_trips() {
-        let cfg = super::thetadatadx_config_production();
-        assert!(!cfg.is_null());
-        // SAFETY: handle just returned by thetadatadx_config_production.
-        unsafe {
-            let mut current: u32 = 99;
-            super::thetadatadx_config_set_concurrent_requests(cfg, 8);
-            assert_eq!((*cfg).inner.historical.concurrent_requests, 8);
-            assert_eq!(
-                super::thetadatadx_config_get_concurrent_requests(cfg, &mut current),
-                0
-            );
-            assert_eq!(current, 8);
-            super::thetadatadx_config_set_concurrent_requests(cfg, 0);
-            assert_eq!((*cfg).inner.historical.concurrent_requests, 0);
-            assert_eq!(
-                super::thetadatadx_config_get_concurrent_requests(cfg, &mut current),
-                0
-            );
-            assert_eq!(current, 0);
-            // Null-pointer guard on the getter returns -1.
-            assert_eq!(
-                super::thetadatadx_config_get_concurrent_requests(std::ptr::null(), &mut current),
-                -1
-            );
-            super::thetadatadx_config_free(cfg);
-        }
-    }
-
-    #[test]
     fn flush_mode_round_trips() {
         let cfg = super::thetadatadx_config_production();
         assert!(!cfg.is_null());
@@ -2926,7 +2854,7 @@ mod pool_sizing_tests {
         // documented FFI contract — the call must return without
         // crashing. The test exercises that null-tolerance branch.
         unsafe {
-            super::thetadatadx_config_set_concurrent_requests(std::ptr::null_mut(), 4);
+            super::thetadatadx_config_set_request_timeout_secs(std::ptr::null_mut(), 4);
         }
     }
 }
@@ -3090,9 +3018,10 @@ mod reconnect_setter_tests {
     #[test]
     fn reconnect_setters_compose_with_pool_sizing_setters() {
         // Cross-binding interleaved-survival contract: reconnect setter
-        // calls and pool-sizing setter calls on the same `ThetaDataDxConfig`
-        // must land in `inner` independently and persist. Mirrors the
-        // Python `test_reconnect_setter_state_survives_interleaved_calls`,
+        // calls and historical tuning setter calls on the same
+        // `ThetaDataDxConfig` must land in `inner` independently and
+        // persist. Mirrors the Python
+        // `test_reconnect_setter_state_survives_interleaved_calls`,
         // TypeScript `Pool-sizing setter state survives interleaved
         // reconnect setter calls`, and C++ `Reconnect setters compose
         // with pool-sizing setters` cases.
@@ -3100,8 +3029,8 @@ mod reconnect_setter_tests {
         assert!(!cfg.is_null());
         // SAFETY: handle just returned by thetadatadx_config_production.
         unsafe {
-            // Apply pool-sizing knobs.
-            super::thetadatadx_config_set_concurrent_requests(cfg, 8);
+            // Apply a historical tuning knob.
+            super::thetadatadx_config_set_warn_on_buffered_threshold_bytes(cfg, 8 * 1024 * 1024);
 
             // Apply reconnect knobs.
             super::thetadatadx_config_set_reconnect_policy(cfg, 0);
@@ -3109,9 +3038,9 @@ mod reconnect_setter_tests {
             super::thetadatadx_config_set_reconnect_max_rate_limited_attempts(cfg, 3);
             super::thetadatadx_config_set_reconnect_stable_window_secs(cfg, 60);
 
-            // Pool-sizing mutations survived the reconnect setter sequence.
+            // Historical tuning mutations survived the reconnect setter sequence.
             let mdds = &(*cfg).inner.historical;
-            assert_eq!(mdds.concurrent_requests, 8);
+            assert_eq!(mdds.warn_on_buffered_threshold_bytes, 8 * 1024 * 1024);
 
             // Reconnect mutations landed on `Auto(limits)`.
             let thetadatadx::ReconnectPolicy::Auto(limits) = &(*cfg).inner.reconnect.policy else {

--- a/scripts/check_doc_defaults.py
+++ b/scripts/check_doc_defaults.py
@@ -24,9 +24,8 @@ This gate closes that gap by construction:
 * Exit non-zero with ``file:line`` for every mismatch.
 
 A field whose default is genuinely environment-dependent (no single
-literal — e.g. ``concurrent_requests = 0`` meaning "auto-detect from the
-subscription tier") is registered with an explicit skip reason rather
-than forced into a false match.
+literal) is registered with an explicit skip reason rather than forced
+into a false match.
 
 Run::
 
@@ -744,18 +743,7 @@ def build_surfaces() -> list[Surface]:
             "streaming.keepalive_interval_secs", _re(r"^\s*streaming_keepalive_interval_secs:")
         ),
         SurfaceField("streaming.keepalive_retries", _re(r"^\s*streaming_keepalive_retries:")),
-        SurfaceField("historical.concurrent_requests", _re(r"^\s*concurrent_requests:")),
     ]
-    # `concurrent_requests` has no single-literal default: the
-    # constructor seeds `0`, which is the "auto-detect from the
-    # subscription tier returned by Nexus auth" sentinel rather than a
-    # caller-facing fixed value. Every surface documents it as
-    # "0 = auto-detect", not "Default 0"; the gate registers the field
-    # so the skip is explicit rather than silently absent, but does not
-    # demand a literal match against the sentinel.
-    pyi.skips["historical.concurrent_requests"] = (
-        "default 0 is the auto-detect-from-tier sentinel, not a fixed literal"
-    )
     surfaces.append(pyi)
 
     return surfaces
@@ -892,7 +880,6 @@ impl Default for RetryPolicy {
 impl MddsConfig {
     pub fn production_defaults() -> Self {
         Self {
-            concurrent_requests: 0,
             max_message_size: 4 * 1024 * 1024,
             keepalive_secs: 30,
             keepalive_timeout_secs: 10,
@@ -900,7 +887,6 @@ impl MddsConfig {
             connection_window_size_kb: 64,
             connect_timeout_secs: 10,
             warn_on_buffered_threshold_bytes: 100 * 1024 * 1024,
-            override_tier_clamp: false,
         }
     }
 }

--- a/sdks/cpp/include/thetadatadx.h
+++ b/sdks/cpp/include/thetadatadx.h
@@ -1881,24 +1881,6 @@ void thetadatadx_config_set_historical_port(ThetaDataDxConfig* config, uint16_t 
 int32_t thetadatadx_config_get_historical_port(const ThetaDataDxConfig* config, uint16_t* out_port);
 
 /**
- * Set the number of concurrent in-flight gRPC requests.
- * @param config Config handle to mutate; no-op when NULL.
- * @param n 0 (default) auto-detects the cap from the subscription
- *          entitlement; a positive value is an explicit cap, clamped to
- *          the entitlement cap at connect time with a logged warning if
- *          exceeded.
- */
-void thetadatadx_config_set_concurrent_requests(ThetaDataDxConfig* config, uint32_t n);
-
-/**
- * Read the current concurrent in-flight gRPC request count.
- * @param config Config handle to read.
- * @param out_n Receives the count on success (0 = auto-detect).
- * @return 0 on success, -1 if either pointer is null.
- */
-int32_t thetadatadx_config_get_concurrent_requests(const ThetaDataDxConfig* config, uint32_t* out_n);
-
-/**
  * Set the warn_on_buffered_threshold_bytes ceiling on a config.
  *
  * Buffered (non-streaming) endpoints log a warning when a response's

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -1353,31 +1353,7 @@ public:
         return port;
     }
 
-    // ── Historical pool sizing ──
-
-    /**
-     * Set the number of concurrent in-flight gRPC requests.
-     *
-     * @p n = 0 (default) auto-detects from the Nexus subscription tier
-     * (Free=1 / Value=2 / Standard=4 / Pro=8). Explicit values above
-     * the tier cap are clamped at connect time with a warn.
-     */
-    void set_concurrent_requests(std::uint32_t n) {
-        thetadatadx_config_set_concurrent_requests(handle_.get(), n);
-    }
-
-    /**
-     * Read the current concurrent in-flight gRPC request count.
-     *
-     * Returns the configured value (`0` = auto-detect from the tier),
-     * or `0` on a null handle (matching the C ABI's `-1` failure
-     * mapping at the boundary).
-     */
-    std::uint32_t get_concurrent_requests() const {
-        std::uint32_t n = 0;
-        thetadatadx_config_get_concurrent_requests(handle_.get(), &n);
-        return n;
-    }
+    // ── Historical tuning ──
 
     /**
      * Set the warn_on_buffered_threshold_bytes ceiling.

--- a/sdks/cpp/tests/config_pool_sizing.cpp
+++ b/sdks/cpp/tests/config_pool_sizing.cpp
@@ -1,8 +1,8 @@
-// Historical pool-sizing setter + getter on thetadatadx::Config.
+// Historical tuning setters + getters on thetadatadx::Config.
 //
-// Offline test pinning the contract that `set_concurrent_requests` and
-// the `get_concurrent_requests()` readback getter on the `thetadatadx::Config`
-// C++ wrapper round-trip through the underlying C ABI.
+// Offline test pinning the contract that the historical tuning setters
+// and readback getters on the `thetadatadx::Config` C++ wrapper
+// round-trip through the underlying C ABI.
 
 #include <cstdint>
 
@@ -10,21 +10,6 @@
 
 #include "thetadatadx.h"
 #include "thetadatadx.hpp"
-
-TEST_CASE("Config concurrent_requests setter + getter round-trip", "[config][pool_sizing][offline]") {
-    auto cfg = thetadatadx::Config::production();
-    // The readback getter mirrors the Python `Config.concurrent_requests`
-    // and TypeScript `concurrentRequests` surfaces, so a value set
-    // through the C++ wrapper reads back through the same wrapper.
-    cfg.set_concurrent_requests(0);
-    REQUIRE(cfg.get_concurrent_requests() == 0u);
-    cfg.set_concurrent_requests(1);
-    REQUIRE(cfg.get_concurrent_requests() == 1u);
-    cfg.set_concurrent_requests(8);
-    REQUIRE(cfg.get_concurrent_requests() == 8u);
-    cfg.set_concurrent_requests(32);
-    REQUIRE(cfg.get_concurrent_requests() == 32u);
-}
 
 TEST_CASE("Config historical request_timeout_secs setter + getter round-trip",
           "[config][pool_sizing][offline]") {

--- a/sdks/cpp/tests/config_reconnect.cpp
+++ b/sdks/cpp/tests/config_reconnect.cpp
@@ -84,14 +84,16 @@ TEST_CASE("Reconnect setters under Manual policy are silent no-ops",
     REQUIRE_NOTHROW(cfg.set_reconnect_stable_window_secs(120));
 }
 
-TEST_CASE("Reconnect setters compose with pool-sizing setters",
+TEST_CASE("Reconnect setters compose with historical tuning setters",
           "[config][reconnect][offline]") {
-    // Interleaved reconnect setter and pool-sizing setter calls on
-    // the same `thetadatadx::Config` must not interfere with each other.
+    // Interleaved reconnect setter and historical tuning setter calls
+    // on the same `thetadatadx::Config` must not interfere with each
+    // other.
     auto cfg = thetadatadx::Config::production();
     cfg.set_reconnect_policy(0);
     cfg.set_reconnect_max_attempts(7);
     cfg.set_reconnect_max_rate_limited_attempts(77);
     cfg.set_reconnect_stable_window_secs(120);
-    REQUIRE_NOTHROW(cfg.set_concurrent_requests(4));
+    REQUIRE_NOTHROW(cfg.set_warn_on_buffered_threshold_bytes(8 * 1024 * 1024));
+    REQUIRE(cfg.get_warn_on_buffered_threshold_bytes() == 8u * 1024u * 1024u);
 }

--- a/sdks/cpp/tests/flatfiles_config.cpp
+++ b/sdks/cpp/tests/flatfiles_config.cpp
@@ -83,21 +83,23 @@ TEST_CASE("Config::set_flatfiles_read_timeout_secs round-trips via getter",
     }
 }
 
-TEST_CASE("FlatFiles setters compose with pool-sizing setters",
+TEST_CASE("FlatFiles setters compose with historical tuning setters",
           "[config][flatfiles][offline]") {
-    // Interleaved flatfiles setter and pool-sizing setter calls on
-    // the same `thetadatadx::Config` must not interfere with each other.
+    // Interleaved flatfiles setter and historical tuning setter calls
+    // on the same `thetadatadx::Config` must not interfere with each
+    // other.
     auto cfg = thetadatadx::Config::production();
     REQUIRE_NOTHROW(cfg.set_flatfiles_max_attempts(7));
     REQUIRE_NOTHROW(cfg.set_flatfiles_initial_backoff_secs(3));
     REQUIRE_NOTHROW(cfg.set_flatfiles_max_backoff_secs(12));
     REQUIRE_NOTHROW(cfg.set_flatfiles_connect_timeout_secs(20));
     REQUIRE_NOTHROW(cfg.set_flatfiles_read_timeout_secs(45));
-    REQUIRE_NOTHROW(cfg.set_concurrent_requests(4));
+    REQUIRE_NOTHROW(cfg.set_warn_on_buffered_threshold_bytes(8 * 1024 * 1024));
 
     REQUIRE(cfg.get_flatfiles_max_attempts() == 7u);
     REQUIRE(cfg.get_flatfiles_initial_backoff_secs() == 3u);
     REQUIRE(cfg.get_flatfiles_max_backoff_secs() == 12u);
     REQUIRE(cfg.get_flatfiles_connect_timeout_secs() == 20u);
     REQUIRE(cfg.get_flatfiles_read_timeout_secs() == 45u);
+    REQUIRE(cfg.get_warn_on_buffered_threshold_bytes() == 8u * 1024u * 1024u);
 }

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -270,15 +270,11 @@ cpp = true
 # ─── HistoricalConfig cross-binding setters ────────────────────────────
 #
 # Tuning knobs on the historical sub-config exposed across every binding.
-# `concurrent_requests` / `warn_on_buffered_threshold_bytes` are bound
+# `warn_on_buffered_threshold_bytes` / `request_timeout_secs` are bound
 # via `Config.<name>` (Python), `Config.set<Name>` (TypeScript napi),
 # `thetadatadx::Config::set_<name>` (C++ forwarder over the C ABI).
-
-[[class]]
-name = "HistoricalConfig.concurrent_requests"
-python = true
-typescript = true
-cpp = true
+# Channel-pool concurrency is intentionally absent: it is resolved
+# internally from the subscription tier, not exposed as a caller knob.
 
 [[class]]
 name = "HistoricalConfig.warn_on_buffered_threshold_bytes"
@@ -576,14 +572,6 @@ issue = "#595"
 
 [[class]]
 name = "HistoricalConfig.connect_timeout_secs"
-python = false
-typescript = false
-cpp = false
-rust_only = true
-issue = "#595"
-
-[[class]]
-name = "HistoricalConfig.override_tier_clamp"
 python = false
 typescript = false
 cpp = false
@@ -1498,28 +1486,19 @@ python = true
 typescript = true
 cpp = true
 
-# The `flushMode` / `deriveOhlcvc` / `concurrentRequests` readback
-# getters are exposed on every binding: Python (`Config.flush_mode` /
-# `.derive_ohlcvc` / `.concurrent_requests` properties), TypeScript
-# (`Config.flushMode` / `.deriveOhlcvc` / `.concurrentRequests`
+# The `flushMode` / `deriveOhlcvc` readback getters are exposed on
+# every binding: Python (`Config.flush_mode` / `.derive_ohlcvc`
+# properties), TypeScript (`Config.flushMode` / `.deriveOhlcvc`
 # getters), C++ (`Config::get_flush_mode()` etc. over the FFI
 # `thetadatadx_config_get_*` symbols). Both the Python `#[getter]` accessors and
 # the C++ readback getters carry a uniform `get_` Rust/C++ fn prefix
 # (pyo3 strips it so the Python property name stays bare); the parity
 # gate accepts that per-language convention against the bare row. The
 # matching setters are tracked by the dotted `[[class]]` rows
-# `StreamingConfig.flush_mode` / `StreamingConfig.derive_ohlcvc` /
-# `HistoricalConfig.concurrent_requests`.
+# `StreamingConfig.flush_mode` / `StreamingConfig.derive_ohlcvc`.
 [[method]]
 class = "Config"
 name = "deriveOhlcvc"
-python = true
-typescript = true
-cpp = true
-
-[[method]]
-class = "Config"
-name = "concurrentRequests"
 python = true
 typescript = true
 cpp = true

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -103,8 +103,6 @@ class Config:
     """Hostname of the historical-data server."""
     historical_port: int
     """TCP port of the historical-data server."""
-    concurrent_requests: int
-    """Maximum in-flight historical requests. ``0`` auto-detects the cap from the subscription tier; explicit values above the tier cap are clamped at connect time with a warning."""
     warn_on_buffered_threshold_bytes: int
     """Byte ceiling above which a buffered (non-``.stream()``) historical response logs a warning pointing the caller at the streaming surface. ``0`` disables the warning; the default is ``100 * 1024 * 1024`` (100 MiB). The data is still delivered."""
     request_timeout_secs: int

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1241,35 +1241,7 @@ impl Config {
         guard.historical.port
     }
 
-    // ── Historical pool sizing ─────────────────────────────────────
-
-    /// Set the number of concurrent in-flight gRPC requests.
-    ///
-    /// ``0`` (default) auto-detects from the Nexus subscription tier:
-    /// FREE=1 / VALUE=2 / STANDARD=4 / PRO=8. Explicit values above
-    /// the tier cap are clamped to the cap at connect time with a
-    /// ``tracing::warn!`` — set ``override_tier_clamp = True`` to
-    /// bypass (tests only).
-    ///
-    /// Examples
-    /// --------
-    /// Multi-day backfill on a PRO subscription::
-    ///
-    ///     cfg = Config.production()
-    ///     cfg.concurrent_requests = 8
-    ///     client = Client(creds, cfg)
-    #[setter]
-    fn set_concurrent_requests(&self, n: usize) {
-        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.historical.concurrent_requests = n;
-    }
-
-    /// Current `concurrent_requests` setting (``0`` = auto-detect).
-    #[getter]
-    fn get_concurrent_requests(&self) -> usize {
-        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        guard.historical.concurrent_requests
-    }
+    // ── Historical tuning ──────────────────────────────────────────
 
     /// Set the warning threshold (in bytes) for buffered (non-streaming)
     /// historical responses. Endpoints whose decoded total exceeds this

--- a/sdks/python/tests/test_config_pool_sizing.py
+++ b/sdks/python/tests/test_config_pool_sizing.py
@@ -1,11 +1,11 @@
-"""Historical pool-sizing setter on `Config`.
+"""Historical tuning setters on `Config`.
 
-Locks the contract that the ``concurrent_requests`` property exposed
-by ``Config`` round-trips through the pyo3 binding to the underlying
-Rust ``HistoricalConfig`` correctly.
+Locks the contract that the historical tuning properties exposed by
+``Config`` (such as ``request_timeout_secs``) round-trip through the
+pyo3 binding to the underlying Rust ``HistoricalConfig`` correctly.
 
-Live behaviour (the tier clamp at connect time, the auto-detect
-default = 0 sentinels) is covered by the Rust unit tests under
+Live behaviour (the per-tier connection-pool concurrency limit
+resolved at connect time) is covered by the Rust unit tests under
 ``mdds::client::pool_size_tests``; this file pins only the Python
 surface contract.
 """
@@ -18,31 +18,6 @@ import importlib
 def _import_module():
     """Import the freshly-built native module from ``maturin develop``."""
     return importlib.import_module("thetadatadx")
-
-
-# ─── concurrent_requests ────────────────────────────────────────────
-
-
-def test_concurrent_requests_defaults_to_auto_detect_sentinel():
-    """`concurrent_requests = 0` is the auto-detect sentinel.
-
-    The Rust core resolves the value at connect time off the Nexus
-    subscription tier. Production defaults keep the sentinel so the
-    most common user (`Config.production()` + connect) never has to
-    set it.
-    """
-    mod = _import_module()
-    cfg = mod.Config.production()
-    assert cfg.concurrent_requests == 0
-
-
-def test_concurrent_requests_round_trips():
-    """`concurrent_requests = N` round-trips through the binding."""
-    mod = _import_module()
-    cfg = mod.Config.production()
-    for n in (1, 2, 4, 8, 16):
-        cfg.concurrent_requests = n
-        assert cfg.concurrent_requests == n
 
 
 # ─── request_timeout_secs ───────────────────────────────────────────

--- a/sdks/python/tests/test_config_reconnect.py
+++ b/sdks/python/tests/test_config_reconnect.py
@@ -160,9 +160,9 @@ def test_reconnect_setter_state_survives_interleaved_calls():
     must not interfere with each other.
 
     Mirrors the TS ``Reconnect setters are independent`` case: the
-    reconnect setters have no getters, so we assert via the
-    pool-sizing getters that the pool-sizing state survives a
-    reconnect setter sequence.
+    reconnect setters have no getters, so we assert via a historical
+    tuning getter that that state survives a reconnect setter
+    sequence.
     """
     mod = _import_module()
     cfg = mod.Config.production()
@@ -170,8 +170,8 @@ def test_reconnect_setter_state_survives_interleaved_calls():
     cfg.reconnect_max_attempts = 7
     cfg.reconnect_max_rate_limited_attempts = 77
     cfg.reconnect_stable_window_secs = 120
-    cfg.concurrent_requests = 4
-    assert cfg.concurrent_requests == 4
+    cfg.warn_on_buffered_threshold_bytes = 8 * 1024 * 1024
+    assert cfg.warn_on_buffered_threshold_bytes == 8 * 1024 * 1024
     # Reconnect policy getter still reads the policy we set.
     assert cfg.reconnect_policy == "auto"
 

--- a/sdks/python/tests/test_flatfiles_config.py
+++ b/sdks/python/tests/test_flatfiles_config.py
@@ -156,8 +156,8 @@ def test_flatfiles_field_setters_compose_into_consistent_config() -> None:
 
 
 def test_flatfiles_setter_state_survives_interleaved_calls() -> None:
-    """Interleaved flatfile setter and pool-sizing setter calls must
-    not interfere with each other. Mirrors the TS / C++ contract.
+    """Interleaved flatfile setter and historical tuning setter calls
+    must not interfere with each other. Mirrors the TS / C++ contract.
     """
     mod = _import_module()
     cfg = mod.Config.production()
@@ -166,8 +166,8 @@ def test_flatfiles_setter_state_survives_interleaved_calls() -> None:
     cfg.flatfiles_max_backoff_secs = 12
     cfg.flatfiles_connect_timeout_secs = 20
     cfg.flatfiles_read_timeout_secs = 45
-    cfg.concurrent_requests = 4
-    assert cfg.concurrent_requests == 4
+    cfg.warn_on_buffered_threshold_bytes = 8 * 1024 * 1024
+    assert cfg.warn_on_buffered_threshold_bytes == 8 * 1024 * 1024
     assert cfg.flatfiles_max_attempts == 7
     assert cfg.flatfiles_initial_backoff_secs == 3
     assert cfg.flatfiles_max_backoff_secs == 12

--- a/sdks/typescript/__tests__/config_pool_sizing.test.mjs
+++ b/sdks/typescript/__tests__/config_pool_sizing.test.mjs
@@ -1,12 +1,13 @@
-// Historical pool-sizing setter on `Config`.
+// Historical tuning setters on `Config`.
 //
-// Locks the contract that the `concurrentRequests` property exposed
-// by the `Config` napi class round-trips through napi-rs to the
-// underlying Rust `HistoricalConfig` correctly.
+// Locks the contract that the historical tuning properties exposed by
+// the `Config` napi class (such as `requestTimeoutSecs`) round-trip
+// through napi-rs to the underlying Rust `HistoricalConfig` correctly.
 //
-// Live behaviour (the tier clamp at connect time) is covered by the
-// Rust unit tests under `mdds::client::pool_size_tests`; this file
-// pins only the JS surface contract.
+// Live behaviour (the per-tier connection-pool concurrency limit
+// resolved at connect time) is covered by the Rust unit tests under
+// `mdds::client::pool_size_tests`; this file pins only the JS surface
+// contract.
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -19,21 +20,6 @@ try {
 }
 
 const { Config } = mod;
-
-describe('Config.concurrentRequests', () => {
-  it('defaults to 0 (auto-detect sentinel)', () => {
-    const cfg = Config.production();
-    assert.equal(cfg.concurrentRequests, 0);
-  });
-
-  it('round-trips through the setter', () => {
-    const cfg = Config.production();
-    for (const n of [1, 2, 4, 8, 16]) {
-      cfg.setConcurrentRequests(n);
-      assert.equal(cfg.concurrentRequests, n);
-    }
-  });
-});
 
 describe('Config.requestTimeoutSecs', () => {
   it('defaults to 300n (5-minute per-request deadline)', () => {

--- a/sdks/typescript/__tests__/config_reconnect.test.mjs
+++ b/sdks/typescript/__tests__/config_reconnect.test.mjs
@@ -108,18 +108,19 @@ describe('Config.setReconnectStableWindowSecs', () => {
 });
 
 describe('Pool-sizing setter state survives interleaved reconnect setter calls', () => {
-  it('reconnect setters do not interfere with pool-sizing getters', () => {
+  it('reconnect setters do not interfere with historical tuning getters', () => {
     // The reconnect setters expose no getters, so the contract
     // we can verify is: after interleaving reconnect setter
-    // calls with pool-sizing setter calls, the pool-sizing
-    // getters still observe the values that were last written.
+    // calls with historical tuning setter calls, the historical
+    // tuning getters still observe the values that were last
+    // written.
     const cfg = Config.production();
     cfg.setReconnectPolicy('auto');
     cfg.setReconnectMaxAttempts(7);
     cfg.setReconnectMaxRateLimitedAttempts(77);
     cfg.setReconnectStableWindowSecs(120n);
-    cfg.setConcurrentRequests(4);
-    assert.equal(cfg.concurrentRequests, 4);
+    cfg.setWarnOnBufferedThresholdBytes(8n * 1024n * 1024n);
+    assert.equal(cfg.warnOnBufferedThresholdBytes, 8n * 1024n * 1024n);
   });
 });
 

--- a/sdks/typescript/__tests__/flatfiles_config.test.mjs
+++ b/sdks/typescript/__tests__/flatfiles_config.test.mjs
@@ -119,20 +119,20 @@ describe('Config.setFlatfilesReadTimeoutSecs', () => {
   });
 });
 
-describe('FlatFiles setter state survives interleaved pool-sizing calls', () => {
-  it('FlatFiles setter mutations land independently of pool-sizing mutations', () => {
+describe('FlatFiles setter state survives interleaved historical tuning calls', () => {
+  it('FlatFiles setter mutations land independently of historical tuning mutations', () => {
     const cfg = Config.production();
     cfg.setFlatfilesMaxAttempts(7);
     cfg.setFlatfilesInitialBackoffSecs(3n);
     cfg.setFlatfilesMaxBackoffSecs(12n);
     cfg.setFlatfilesConnectTimeoutSecs(20n);
     cfg.setFlatfilesReadTimeoutSecs(45n);
-    cfg.setConcurrentRequests(4);
+    cfg.setWarnOnBufferedThresholdBytes(8n * 1024n * 1024n);
     assert.equal(cfg.flatfilesMaxAttempts, 7);
     assert.equal(cfg.flatfilesInitialBackoffSecs, 3n);
     assert.equal(cfg.flatfilesMaxBackoffSecs, 12n);
     assert.equal(cfg.flatfilesConnectTimeoutSecs, 20n);
     assert.equal(cfg.flatfilesReadTimeoutSecs, 45n);
-    assert.equal(cfg.concurrentRequests, 4);
+    assert.equal(cfg.warnOnBufferedThresholdBytes, 8n * 1024n * 1024n);
   });
 });

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -75,16 +75,6 @@ export declare class Config {
   /** Stage streaming config (port 20100, unstable testing servers). */
   static stage(): Config
   /**
-   * Set the number of concurrent in-flight gRPC requests.
-   *
-   * `0` (default) auto-detects from the Nexus subscription tier
-   * (Free=1 / Value=2 / Standard=4 / Pro=8). Explicit values above
-   * the tier cap are clamped at connect time with a warn.
-   */
-  setConcurrentRequests(n: number): void
-  /** Current `concurrent_requests` setting (`0` = auto-detect). */
-  get concurrentRequests(): number
-  /**
    * Set the warning threshold (in bytes) for buffered (non-streaming)
    * historical responses. Endpoints whose decoded total exceeds this
    * value log a warning pointing the caller at the

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -99,32 +99,7 @@ impl Config {
         guard.clone()
     }
 
-    // ── historical pool sizing ───────────────────────────────────────────
-
-    /// Set the number of concurrent in-flight gRPC requests.
-    ///
-    /// `0` (default) auto-detects from the Nexus subscription tier
-    /// (Free=1 / Value=2 / Standard=4 / Pro=8). Explicit values above
-    /// the tier cap are clamped at connect time with a warn.
-    #[napi(js_name = "setConcurrentRequests")]
-    pub fn set_concurrent_requests(&self, n: u32) -> napi::Result<()> {
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        guard.historical.concurrent_requests = n as usize;
-        Ok(())
-    }
-
-    /// Current `concurrent_requests` setting (`0` = auto-detect).
-    #[napi(getter, js_name = "concurrentRequests")]
-    pub fn concurrent_requests(&self) -> napi::Result<u32> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
-        Ok(u32::try_from(guard.historical.concurrent_requests).unwrap_or(u32::MAX))
-    }
+    // ── historical tuning ────────────────────────────────────────────────
 
     /// Set the warning threshold (in bytes) for buffered (non-streaming)
     /// historical responses. Endpoints whose decoded total exceeds this


### PR DESCRIPTION
## What

Historical request concurrency is a server-enforced, per-tier limit (Free=1, Value=2, Standard=4, Pro=8), not a client choice. This removes the `concurrent_requests` knob and the `override_tier_clamp` escape hatch from the public configuration surface across every binding, and sizes the gRPC channel pool purely from the subscription tier resolved at connect time.

## Why

Exposing concurrency as a settable knob let a caller open more channels than the account is allowed, after which the (cap+1)-th request failed upstream with `ResourceExhausted` and retried elsewhere, surfacing as confusing intermittent failures. With the pool sized to the tier by construction, the live pool can never exceed the server-side ceiling and there is nothing for a caller to misconfigure.

## Changes

- Core: drop `HistoricalConfig.concurrent_requests` and `override_tier_clamp`; `effective_pool_size` now resolves from the tier alone (tier cap, else default of 4). Drop the `historical_concurrent_requests` accessor and the `[grpc] concurrent_requests` TOML field.
- Bindings: remove the C ABI `set`/`get_concurrent_requests` symbols, the Python and TypeScript setters/getters, and the C++ forwarders. Cross-binding compose tests retarget to the `warn_on_buffered_threshold_bytes` historical knob.
- Parity: drop the `HistoricalConfig.concurrent_requests` and `override_tier_clamp` rows and the `concurrentRequests` getter row.
- Docs: the concurrency article now documents automatic tier sizing instead of an override; configuration and migration docs updated to match.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (0 failures), Python and TypeScript binding crates `cargo check`, plus the parity, doc-defaults, and version-sync gates all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)