### PR TITLE
docs(reference): correct option snapshot endpoint notes

### DIFF
--- a/crates/thetadatadx/endpoint_surface.toml
+++ b/crates/thetadatadx/endpoint_surface.toml
@@ -1321,7 +1321,6 @@ template = "option_snapshot_standard"
 description = "Get the latest OHLC snapshot for an option contract."
 vendor_docstring = """
 - Retrieve a real-time last ohlc of an option contract for the trading day.
-- You might need to change the default expiration date to a different date if it is past the current date.
 """
 rest_path = "/v3/option/snapshot/ohlc"
 returns = "OhlcTicks"
@@ -1332,7 +1331,6 @@ template = "option_snapshot_trade"
 description = "Get the latest trade snapshot for an option contract."
 vendor_docstring = """
 - Retrieve the real-time last trade of an option contract.
-- You might need to change the default expiration date to a different date if it is past the current date.
 - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/trade"
@@ -1344,7 +1342,6 @@ template = "option_snapshot_standard"
 description = "Get the latest NBBO quote snapshot for an option contract."
 vendor_docstring = """
 - Retrieve a real-time last NBBO quote of an option contract.
-- You might need to change the default expiration date to a different date if it is past the current date.
 - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/quote"
@@ -1357,7 +1354,6 @@ description = "Get the latest open interest snapshot for an option contract."
 vendor_docstring = """
 - Retrieve the last open interest message of an option contract.
 - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-- You might need to change the default expiration date to a different date if it is past the current date.
 - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/open_interest"
@@ -1392,8 +1388,7 @@ template = "option_snapshot_greeks"
 description = "Get all Greeks snapshot for an option contract (from ThetaData server)."
 vendor_docstring = """
 - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-- You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-- Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/greeks/all"
@@ -1405,8 +1400,7 @@ template = "option_snapshot_greeks"
 description = "Get first-order Greeks snapshot (delta, theta, rho) for an option contract."
 vendor_docstring = """
 - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-- You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-- Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/greeks/first_order"
@@ -1418,8 +1412,7 @@ template = "option_snapshot_greeks"
 description = "Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract."
 vendor_docstring = """
 - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-- You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-- Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/greeks/second_order"
@@ -1431,8 +1424,7 @@ template = "option_snapshot_greeks"
 description = "Get third-order Greeks snapshot (speed, color, ultima) for an option contract."
 vendor_docstring = """
 - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-- You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-- Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 """
 rest_path = "/v3/option/snapshot/greeks/third_order"

--- a/docs-site/docs/reference/option/snapshot/greeks/all.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/all.md
@@ -12,8 +12,7 @@ description: "Get all Greeks snapshot for an option contract (from ThetaData ser
 Get all Greeks snapshot for an option contract (from ThetaData server).
 
 - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-- You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-- Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/snapshot/greeks/first-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/first-order.md
@@ -12,8 +12,7 @@ description: "Get first-order Greeks snapshot (delta, theta, rho) for an option 
 Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
 
 - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-- You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-- Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/snapshot/greeks/second-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/second-order.md
@@ -12,8 +12,7 @@ description: "Get second-order Greeks snapshot (gamma, vanna, charm) for an opti
 Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
 
 - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-- You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-- Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/snapshot/greeks/third-order.md
+++ b/docs-site/docs/reference/option/snapshot/greeks/third-order.md
@@ -12,8 +12,7 @@ description: "Get third-order Greeks snapshot (speed, color, ultima) for an opti
 Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
 
 - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-- You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-- Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+- Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/snapshot/ohlc.md
+++ b/docs-site/docs/reference/option/snapshot/ohlc.md
@@ -12,7 +12,6 @@ description: "Get the latest OHLC snapshot for an option contract."
 Get the latest OHLC snapshot for an option contract.
 
 - Retrieve a real-time last ohlc of an option contract for the trading day.
-- You might need to change the default expiration date to a different date if it is past the current date.
 
 <SdkTabs>
 

--- a/docs-site/docs/reference/option/snapshot/open-interest.md
+++ b/docs-site/docs/reference/option/snapshot/open-interest.md
@@ -13,7 +13,6 @@ Get the latest open interest snapshot for an option contract.
 
 - Retrieve the last open interest message of an option contract.
 - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-- You might need to change the default expiration date to a different date if it is past the current date.
 - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/snapshot/quote.md
+++ b/docs-site/docs/reference/option/snapshot/quote.md
@@ -12,7 +12,6 @@ description: "Get the latest NBBO quote snapshot for an option contract."
 Get the latest NBBO quote snapshot for an option contract.
 
 - Retrieve a real-time last NBBO quote of an option contract.
-- You might need to change the default expiration date to a different date if it is past the current date.
 - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>

--- a/docs-site/docs/reference/option/snapshot/trade.md
+++ b/docs-site/docs/reference/option/snapshot/trade.md
@@ -12,7 +12,6 @@ description: "Get the latest trade snapshot for an option contract."
 Get the latest trade snapshot for an option contract.
 
 - Retrieve the real-time last trade of an option contract.
-- You might need to change the default expiration date to a different date if it is past the current date.
 - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 
 <SdkTabs>

--- a/sdks/python/src/_generated/historical_methods.rs
+++ b/sdks/python/src/_generated/historical_methods.rs
@@ -2787,7 +2787,6 @@ impl OptionListContractsBuilder {
 /// Get the latest OHLC snapshot for an option contract.
 ///
 /// - Retrieve a real-time last ohlc of an option contract for the trading day.
-/// - You might need to change the default expiration date to a different date if it is past the current date.
 ///
 /// Defaults (upstream):
 /// - `strike`: `"*"`
@@ -2934,7 +2933,6 @@ impl OptionSnapshotOhlcBuilder {
 /// Get the latest trade snapshot for an option contract.
 ///
 /// - Retrieve the real-time last trade of an option contract.
-/// - You might need to change the default expiration date to a different date if it is past the current date.
 /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -3067,7 +3065,6 @@ impl OptionSnapshotTradeBuilder {
 /// Get the latest NBBO quote snapshot for an option contract.
 ///
 /// - Retrieve a real-time last NBBO quote of an option contract.
-/// - You might need to change the default expiration date to a different date if it is past the current date.
 /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -3216,7 +3213,6 @@ impl OptionSnapshotQuoteBuilder {
 ///
 /// - Retrieve the last open interest message of an option contract.
 /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-/// - You might need to change the default expiration date to a different date if it is past the current date.
 /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -3752,8 +3748,7 @@ impl OptionSnapshotGreeksImpliedVolatilityBuilder {
 /// Get all Greeks snapshot for an option contract (from ThetaData server).
 ///
 /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-/// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-/// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+/// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -3994,8 +3989,7 @@ impl OptionSnapshotGreeksAllBuilder {
 /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
 ///
 /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-/// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-/// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+/// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -4236,8 +4230,7 @@ impl OptionSnapshotGreeksFirstOrderBuilder {
 /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
 ///
 /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-/// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-/// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+/// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -4478,8 +4471,7 @@ impl OptionSnapshotGreeksSecondOrderBuilder {
 /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
 ///
 /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-/// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-/// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+/// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
 /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
 ///
 /// Defaults (upstream):
@@ -15968,7 +15960,6 @@ impl HistoricalView {
     /// Get the latest OHLC snapshot for an option contract.
     ///
     /// - Retrieve a real-time last ohlc of an option contract for the trading day.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -16012,7 +16003,6 @@ impl HistoricalView {
     /// Get the latest OHLC snapshot for an option contract.
     ///
     /// - Retrieve a real-time last ohlc of an option contract for the trading day.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -16088,7 +16078,6 @@ impl HistoricalView {
     /// Get the latest trade snapshot for an option contract.
     ///
     /// - Retrieve the real-time last trade of an option contract.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16129,7 +16118,6 @@ impl HistoricalView {
     /// Get the latest trade snapshot for an option contract.
     ///
     /// - Retrieve the real-time last trade of an option contract.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16201,7 +16189,6 @@ impl HistoricalView {
     /// Get the latest NBBO quote snapshot for an option contract.
     ///
     /// - Retrieve a real-time last NBBO quote of an option contract.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16246,7 +16233,6 @@ impl HistoricalView {
     /// Get the latest NBBO quote snapshot for an option contract.
     ///
     /// - Retrieve a real-time last NBBO quote of an option contract.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16324,7 +16310,6 @@ impl HistoricalView {
     ///
     /// - Retrieve the last open interest message of an option contract.
     /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16370,7 +16355,6 @@ impl HistoricalView {
     ///
     /// - Retrieve the last open interest message of an option contract.
     /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16749,8 +16733,7 @@ impl HistoricalView {
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16822,8 +16805,7 @@ impl HistoricalView {
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -16933,8 +16915,7 @@ impl HistoricalView {
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17006,8 +16987,7 @@ impl HistoricalView {
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17117,8 +17097,7 @@ impl HistoricalView {
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17190,8 +17169,7 @@ impl HistoricalView {
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17301,8 +17279,7 @@ impl HistoricalView {
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -17374,8 +17351,7 @@ impl HistoricalView {
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -953,7 +953,6 @@ export declare class HistoricalClient {
    * Get the latest OHLC snapshot for an option contract.
    *
    * - Retrieve a real-time last ohlc of an option contract for the trading day.
-   * - You might need to change the default expiration date to a different date if it is past the current date.
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -964,7 +963,6 @@ export declare class HistoricalClient {
    * Get the latest trade snapshot for an option contract.
    *
    * - Retrieve the real-time last trade of an option contract.
-   * - You might need to change the default expiration date to a different date if it is past the current date.
    * - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -976,7 +974,6 @@ export declare class HistoricalClient {
    * Get the latest NBBO quote snapshot for an option contract.
    *
    * - Retrieve a real-time last NBBO quote of an option contract.
-   * - You might need to change the default expiration date to a different date if it is past the current date.
    * - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -989,7 +986,6 @@ export declare class HistoricalClient {
    *
    * - Retrieve the last open interest message of an option contract.
    * - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-   * - You might need to change the default expiration date to a different date if it is past the current date.
    * - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1027,8 +1023,7 @@ export declare class HistoricalClient {
    * Get all Greeks snapshot for an option contract (from ThetaData server).
    *
    * - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-   * - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-   * - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1043,8 +1038,7 @@ export declare class HistoricalClient {
    * Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
    *
    * - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-   * - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-   * - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1059,8 +1053,7 @@ export declare class HistoricalClient {
    * Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
    *
    * - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-   * - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-   * - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1075,8 +1068,7 @@ export declare class HistoricalClient {
    * Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
    *
    * - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-   * - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-   * - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1775,7 +1767,6 @@ export declare class HistoricalView {
    * Get the latest OHLC snapshot for an option contract.
    *
    * - Retrieve a real-time last ohlc of an option contract for the trading day.
-   * - You might need to change the default expiration date to a different date if it is past the current date.
    *
    * Defaults (upstream):
    * - `strike`: `"*"`
@@ -1786,7 +1777,6 @@ export declare class HistoricalView {
    * Get the latest trade snapshot for an option contract.
    *
    * - Retrieve the real-time last trade of an option contract.
-   * - You might need to change the default expiration date to a different date if it is past the current date.
    * - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1798,7 +1788,6 @@ export declare class HistoricalView {
    * Get the latest NBBO quote snapshot for an option contract.
    *
    * - Retrieve a real-time last NBBO quote of an option contract.
-   * - You might need to change the default expiration date to a different date if it is past the current date.
    * - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1811,7 +1800,6 @@ export declare class HistoricalView {
    *
    * - Retrieve the last open interest message of an option contract.
    * - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-   * - You might need to change the default expiration date to a different date if it is past the current date.
    * - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1849,8 +1837,7 @@ export declare class HistoricalView {
    * Get all Greeks snapshot for an option contract (from ThetaData server).
    *
    * - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-   * - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-   * - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1865,8 +1852,7 @@ export declare class HistoricalView {
    * Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
    *
    * - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-   * - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-   * - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1881,8 +1867,7 @@ export declare class HistoricalView {
    * Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
    *
    * - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-   * - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-   * - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):
@@ -1897,8 +1882,7 @@ export declare class HistoricalView {
    * Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
    *
    * - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-   * - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-   * - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+   * - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
    * > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
    *
    * Defaults (upstream):

--- a/sdks/typescript/src/_generated/historical_methods.rs
+++ b/sdks/typescript/src/_generated/historical_methods.rs
@@ -2589,7 +2589,6 @@ impl HistoricalView {
     /// Get the latest OHLC snapshot for an option contract.
     ///
     /// - Retrieve a real-time last ohlc of an option contract for the trading day.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -2642,7 +2641,6 @@ impl HistoricalView {
     /// Get the latest trade snapshot for an option contract.
     ///
     /// - Retrieve the real-time last trade of an option contract.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -2692,7 +2690,6 @@ impl HistoricalView {
     /// Get the latest NBBO quote snapshot for an option contract.
     ///
     /// - Retrieve a real-time last NBBO quote of an option contract.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -2747,7 +2744,6 @@ impl HistoricalView {
     ///
     /// - Retrieve the last open interest message of an option contract.
     /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -2935,8 +2931,7 @@ impl HistoricalView {
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -3017,8 +3012,7 @@ impl HistoricalView {
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -3099,8 +3093,7 @@ impl HistoricalView {
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -3181,8 +3174,7 @@ impl HistoricalView {
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -7996,7 +7988,6 @@ impl HistoricalClient {
     /// Get the latest OHLC snapshot for an option contract.
     ///
     /// - Retrieve a real-time last ohlc of an option contract for the trading day.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     ///
     /// Defaults (upstream):
     /// - `strike`: `"*"`
@@ -8049,7 +8040,6 @@ impl HistoricalClient {
     /// Get the latest trade snapshot for an option contract.
     ///
     /// - Retrieve the real-time last trade of an option contract.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8099,7 +8089,6 @@ impl HistoricalClient {
     /// Get the latest NBBO quote snapshot for an option contract.
     ///
     /// - Retrieve a real-time last NBBO quote of an option contract.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8154,7 +8143,6 @@ impl HistoricalClient {
     ///
     /// - Retrieve the last open interest message of an option contract.
     /// - Open interest is reported around 06:30 ET every morning by OPRA and reflects the open interest at the end of the previous trading day.
-    /// - You might need to change the default expiration date to a different date if it is past the current date.
     /// - This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8342,8 +8330,7 @@ impl HistoricalClient {
     /// Get all Greeks snapshot for an option contract (from ThetaData server).
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8424,8 +8411,7 @@ impl HistoricalClient {
     /// Get first-order Greeks snapshot (delta, theta, rho) for an option contract.
     ///
     /// - Retrieve a real-time last greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8506,8 +8492,7 @@ impl HistoricalClient {
     /// Get second-order Greeks snapshot (gamma, vanna, charm) for an option contract.
     ///
     /// - Retrieve a real-time last second order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):
@@ -8588,8 +8573,7 @@ impl HistoricalClient {
     /// Get third-order Greeks snapshot (speed, color, ultima) for an option contract.
     ///
     /// - Retrieve a real-time last third order greeks calculation for all option contracts that lie on a provided expiration.
-    /// - You might need to change the default expiration date to a different date if it is past the current date. Some quotes are omitted in the example to reduce the space of the sample output.
-    /// - Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying.
+    /// - Set `expiration` to `*` to snapshot every expiration for the underlying in a single request.
     /// > This endpoint will return no data if the market was closed for the day. Theta Data resets the snapshot cache at midnight ET every night.
     ///
     /// Defaults (upstream):


### PR DESCRIPTION
## What

Three note lines on the option snapshot reference pages carried text that does not describe this SDK:

- "You might need to change the default expiration date to a different date if it is past the current date" — there is no default expiration here; it is a required argument. Removed (8 occurrences).
- "Some quotes are omitted in the example to reduce the space of the sample output" — refers to a sample output the generated reference pages do not render. Removed (4 occurrences).
- "Make `expiration` * if you want to get the snapshot for every expiration chain for the underlying" — reworded to state the behaviour plainly: setting `expiration` to `*` snapshots every expiration for the underlying in a single request (4 occurrences).

## How

Edited the `vendor_docstring` fields in `crates/thetadatadx/endpoint_surface.toml` and regenerated the affected reference pages and the generated binding doc comments. The wire-drift and SDK-surface gates pass against the regenerated output.

## Scope

Touches the option snapshot family (greeks all/first/second/third order, ohlc, open-interest, quote, trade). The accurate notes on those endpoints (real-time greeks calculation, market-closed behaviour, midnight cache reset) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)