### PR TITLE
ci(typescript): publish pre-release versions under the npm next tag

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -179,7 +179,9 @@ jobs:
               if npm view "${pkg_name}@${pkg_version}" version 2>/dev/null; then
                 echo "⏭ ${pkg_name}@${pkg_version} already published"
               else
-                npm publish "$dir" --access public
+                dist_tag=latest
+                case "$pkg_version" in *-*) dist_tag=next;; esac
+                npm publish "$dir" --access public --tag "$dist_tag"
               fi
             fi
           done
@@ -192,5 +194,7 @@ jobs:
           if npm view "thetadatadx@${pkg_version}" version 2>/dev/null; then
             echo "⏭ thetadatadx@${pkg_version} already published"
           else
-            npm publish --provenance --access public
+            dist_tag=latest
+            case "$pkg_version" in *-*) dist_tag=next;; esac
+            npm publish --provenance --access public --tag "$dist_tag"
           fi


### PR DESCRIPTION
## What

A bare `npm publish` assigns the `latest` dist-tag. Publishing a pre-release (13.0.0-rc.1) that way would move `latest` to the release candidate, so `npm install thetadatadx` would serve the rc over the last stable release.

This derives the dist-tag from the package version: any version with a pre-release suffix (contains a `-`) publishes under `next`; stable versions publish under `latest`. Applied to both the platform package loop and the root package.

## Why now

Required before tagging v13.0.0-rc.1 — without it the rc would ship as `latest` to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)