### PR TITLE
fix(docs): remove stray tags breaking the concurrency article build

### DIFF
--- a/docs-site/docs/articles/concurrent-requests.md
+++ b/docs-site/docs/articles/concurrent-requests.md
@@ -41,5 +41,3 @@ With a Pro subscription, eight of those requests run concurrently and the rest w
 Concurrency multiplies throughput on multi-request workloads: per-day backfills, per-contract chain pulls, anything you can split with `split_date_range`. It does nothing for one giant request, so split the request first ([Request Sizing](/articles/request-sizing)), then let your tier's slots work through the pieces.
 
 One more queue exists upstream: if the servers themselves report exhaustion, the SDK retries with backoff before surfacing an error. Long-running bulk jobs should still expect occasional retries during peak hours; see [Data Issues?](/articles/data-issues) if a job stalls beyond that.
-</content>
-</invoke>


### PR DESCRIPTION
The concurrency article ended with two stray closing tags that leaked into the file. The VitePress Vue compiler rejects them as an invalid end tag, which failed the Deploy Docs build on main after #842 merged.

Removed the stray tags; the article now ends at the upstream-queue paragraph. No content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)