### PR TITLE
fix(ts): make flat-file methods async so they never block the event loop

### DIFF
--- a/docs-site/docs/articles/flat-files.md
+++ b/docs-site/docs/articles/flat-files.md
@@ -42,7 +42,7 @@ client.flatfile_to_path("OPTION", "TRADE_QUOTE", "20250303", "trade_quotes.csv",
 <template #typescript>
 
 ```typescript
-const rows = client.flatFiles.optionTradeQuote('20250303');
+const rows = await client.flatFiles.optionTradeQuote('20250303');
 const ipc = rows.toArrowIpc();   // feed into apache-arrow `tableFromIPC`
 ```
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -171,17 +171,17 @@ import { tableFromIPC } from 'apache-arrow';   // peer dependency
 
 const client = Client.connectFromFile('creds.txt');
 
-const rows = client.flatFiles.optionTradeQuote('20260428');
+const rows = await client.flatFiles.optionTradeQuote('20260428');
 console.log(rows.len());
 
 const table = tableFromIPC(rows.toArrowIpc());
 // Or skip Arrow entirely: const json = JSON.parse(rows.toJson());
 
 // Generic dispatcher when security type / request type come from config
-const oi = client.flatFiles.request('OPTION', 'OPEN_INTEREST', '20260428');
+const oi = await client.flatFiles.request('OPTION', 'OPEN_INTEREST', '20260428');
 
 // Or write the raw vendor file straight to disk
-client.flatFileToPath('OPTION', 'TRADE_QUOTE', '20260428', '/tmp/option-trade-quote', 'csv');
+await client.flatFileToPath('OPTION', 'TRADE_QUOTE', '20260428', '/tmp/option-trade-quote', 'csv');
 ```
 
 The flat-file distribution serves a fixed set of datasets: option `trade_quote` / `open_interest` / `eod` and stock `trade_quote` / `eod`. Available `flatFiles.*` methods: `optionTradeQuote`, `optionOpenInterest`, `optionEod`, `stockTradeQuote`, `stockEod`, plus `request(secType, reqType, date)`. The generic `request(...)` and `flatFileToPath(...)` paths reject an unserved `(security, request)` pair with a typed invalid-parameter error.

--- a/sdks/typescript/__tests__/native_typed_errors.test.mjs
+++ b/sdks/typescript/__tests__/native_typed_errors.test.mjs
@@ -300,7 +300,7 @@ describe('FLATFILES enum-parse input-validation parity (native)', () => {
       return;
     }
 
-    assert.throws(
+    await assert.rejects(
       () => client.flatFiles.request('BOGUS', 'QUOTE', '20260102'),
       (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
       'an unknown flat-file sec_type must reclassify to InvalidParameterError, matching the Python ValueError',
@@ -316,7 +316,7 @@ describe('FLATFILES enum-parse input-validation parity (native)', () => {
       return;
     }
 
-    assert.throws(
+    await assert.rejects(
       () => client.flatFileToPath('OPTION', 'BOGUS', '20260102', '/tmp/thetadatadx-test.csv'),
       (err) => err instanceof mod.InvalidParameterError && err instanceof mod.ThetaDataError,
       'an unknown flat-file req_type must reclassify to InvalidParameterError',

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -48,7 +48,7 @@ export declare class Client {
    * Returns the final on-disk path with the format extension
    * auto-appended if missing.
    */
-  flatFileToPath(secType: string, reqType: string, date: string, path: string, format?: string | undefined | null): string
+  flatFileToPath(secType: string, reqType: string, date: string, path: string, format?: string | undefined | null): Promise<string>
 }
 
 /**
@@ -687,20 +687,20 @@ export declare class FlatFileRowList {
  */
 export declare class FlatFilesNamespace {
   /** Option trade-with-quote flat file for the given `YYYYMMDD` date. */
-  optionTradeQuote(date: string): FlatFileRowList
+  optionTradeQuote(date: string): Promise<FlatFileRowList>
   /** Option open-interest flat file for the given `YYYYMMDD` date. */
-  optionOpenInterest(date: string): FlatFileRowList
+  optionOpenInterest(date: string): Promise<FlatFileRowList>
   /** Option end-of-day flat file for the given `YYYYMMDD` date. */
-  optionEod(date: string): FlatFileRowList
+  optionEod(date: string): Promise<FlatFileRowList>
   /** Stock trade-with-quote flat file for the given `YYYYMMDD` date. */
-  stockTradeQuote(date: string): FlatFileRowList
+  stockTradeQuote(date: string): Promise<FlatFileRowList>
   /** Stock end-of-day flat file for the given `YYYYMMDD` date. */
-  stockEod(date: string): FlatFileRowList
+  stockEod(date: string): Promise<FlatFileRowList>
   /**
    * Generic dispatcher — `secType` and `reqType` accept `"OPTION"` /
    * `"QUOTE"` style strings.
    */
-  request(secType: string, reqType: string, date: string): FlatFileRowList
+  request(secType: string, reqType: string, date: string): Promise<FlatFileRowList>
 }
 
 /**

--- a/sdks/typescript/src/flatfile_methods.rs
+++ b/sdks/typescript/src/flatfile_methods.rs
@@ -24,7 +24,7 @@ use serde_json::{json, Map as JsonMap, Value as JsonValue};
 
 use thetadatadx::flatfiles::{self, FlatFileFormat, FlatFileRow, FlatFileValue, ReqType, SecType};
 
-use crate::{runtime, to_napi_err};
+use crate::{spawn_endpoint_task, to_napi_err};
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -63,7 +63,14 @@ fn parse_flatfile_format(fmt: Option<&str>) -> napi::Result<FlatFileFormat> {
     }
 }
 
-fn pull_decoded(
+/// Pull and decode a flat-file blob off the libuv thread.
+///
+/// A flat-file pull is a full-day blob download — seconds of network
+/// transfer and a large decode. Running it on the runtime's execution
+/// thread via [`spawn_endpoint_task`] keeps the Node event loop free for
+/// the whole call, matching every historical endpoint. Callers are
+/// `async fn`s, so napi-rs returns a JS `Promise` resolved off-thread.
+async fn pull_decoded(
     client: &Arc<thetadatadx::Client>,
     sec: SecType,
     req: ReqType,
@@ -71,9 +78,7 @@ fn pull_decoded(
 ) -> napi::Result<Vec<FlatFileRow>> {
     let client = Arc::clone(client);
     let date = date.to_string();
-    runtime()
-        .block_on(async move { client.flatfile_request_decoded(sec, req, &date).await }) // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
-        .map_err(to_napi_err)
+    spawn_endpoint_task(async move { client.flatfile_request_decoded(sec, req, &date).await }).await
 }
 
 // ── FlatFileRowList ────────────────────────────────────────────────────
@@ -171,43 +176,44 @@ pub struct FlatFilesNamespace {
 impl FlatFilesNamespace {
     /// Option trade-with-quote flat file for the given `YYYYMMDD` date.
     #[napi(js_name = "optionTradeQuote")]
-    pub fn option_trade_quote(&self, date: String) -> napi::Result<FlatFileRowList> {
-        let rows = pull_decoded(&self.client, SecType::Option, ReqType::TradeQuote, &date)?;
+    pub async fn option_trade_quote(&self, date: String) -> napi::Result<FlatFileRowList> {
+        let rows = pull_decoded(&self.client, SecType::Option, ReqType::TradeQuote, &date).await?;
         Ok(FlatFileRowList { rows })
     }
 
     /// Option open-interest flat file for the given `YYYYMMDD` date.
     #[napi(js_name = "optionOpenInterest")]
-    pub fn option_open_interest(&self, date: String) -> napi::Result<FlatFileRowList> {
-        let rows = pull_decoded(&self.client, SecType::Option, ReqType::OpenInterest, &date)?;
+    pub async fn option_open_interest(&self, date: String) -> napi::Result<FlatFileRowList> {
+        let rows =
+            pull_decoded(&self.client, SecType::Option, ReqType::OpenInterest, &date).await?;
         Ok(FlatFileRowList { rows })
     }
 
     /// Option end-of-day flat file for the given `YYYYMMDD` date.
     #[napi(js_name = "optionEod")]
-    pub fn option_eod(&self, date: String) -> napi::Result<FlatFileRowList> {
-        let rows = pull_decoded(&self.client, SecType::Option, ReqType::Eod, &date)?;
+    pub async fn option_eod(&self, date: String) -> napi::Result<FlatFileRowList> {
+        let rows = pull_decoded(&self.client, SecType::Option, ReqType::Eod, &date).await?;
         Ok(FlatFileRowList { rows })
     }
 
     /// Stock trade-with-quote flat file for the given `YYYYMMDD` date.
     #[napi(js_name = "stockTradeQuote")]
-    pub fn stock_trade_quote(&self, date: String) -> napi::Result<FlatFileRowList> {
-        let rows = pull_decoded(&self.client, SecType::Stock, ReqType::TradeQuote, &date)?;
+    pub async fn stock_trade_quote(&self, date: String) -> napi::Result<FlatFileRowList> {
+        let rows = pull_decoded(&self.client, SecType::Stock, ReqType::TradeQuote, &date).await?;
         Ok(FlatFileRowList { rows })
     }
 
     /// Stock end-of-day flat file for the given `YYYYMMDD` date.
     #[napi(js_name = "stockEod")]
-    pub fn stock_eod(&self, date: String) -> napi::Result<FlatFileRowList> {
-        let rows = pull_decoded(&self.client, SecType::Stock, ReqType::Eod, &date)?;
+    pub async fn stock_eod(&self, date: String) -> napi::Result<FlatFileRowList> {
+        let rows = pull_decoded(&self.client, SecType::Stock, ReqType::Eod, &date).await?;
         Ok(FlatFileRowList { rows })
     }
 
     /// Generic dispatcher — `secType` and `reqType` accept `"OPTION"` /
     /// `"QUOTE"` style strings.
     #[napi]
-    pub fn request(
+    pub async fn request(
         &self,
         sec_type: String,
         req_type: String,
@@ -215,7 +221,7 @@ impl FlatFilesNamespace {
     ) -> napi::Result<FlatFileRowList> {
         let sec = parse_flatfile_sec_type(&sec_type)?;
         let req = parse_flatfile_req_type(&req_type)?;
-        let rows = pull_decoded(&self.client, sec, req, &date)?;
+        let rows = pull_decoded(&self.client, sec, req, &date).await?;
         Ok(FlatFileRowList { rows })
     }
 }
@@ -238,7 +244,7 @@ impl Client {
     /// Returns the final on-disk path with the format extension
     /// auto-appended if missing.
     #[napi(js_name = "flatFileToPath")]
-    pub fn flat_file_to_path(
+    pub async fn flat_file_to_path(
         &self,
         sec_type: String,
         req_type: String,
@@ -251,13 +257,12 @@ impl Client {
         let fmt = parse_flatfile_format(format.as_deref())?;
         let client = Arc::clone(&self.client);
         let path_buf = std::path::PathBuf::from(path);
-        let final_path = runtime()
-            .block_on(async move {
-                client
-                    .flatfile_request(sec, req, &date, &path_buf, fmt)
-                    .await
-            }) // VOCAB-OK: tokio Runtime::block_on in NAPI bridge
-            .map_err(to_napi_err)?;
+        let final_path = spawn_endpoint_task(async move {
+            client
+                .flatfile_request(sec, req, &date, &path_buf, fmt)
+                .await
+        })
+        .await?;
         Ok(final_path.to_string_lossy().into_owned())
     }
 }


### PR DESCRIPTION
## What

The TypeScript flat-file methods ran a full-day blob download synchronously on the single libuv thread, freezing all concurrent JS for the duration of the call. This converts them to async so the work runs off-thread and the event loop stays free.

## Why

A flat-file pull is a full-day blob download — seconds of network transfer and a large decode. The methods previously drove that work through a blocking runtime call from inside a synchronous napi method, so the download executed on the libuv thread: timers stalled, queued promises could not advance, and concurrent requests made no progress until the pull finished.

Every other data-fetch method on the binding already spawns its blocking work off the libuv thread via the shared `spawn_endpoint_task` path and returns a JS Promise. The flat-file surface was the lone synchronous holdout. This brings it to parity with the rest of the async surface.

## Change

`optionTradeQuote`, `optionOpenInterest`, `optionEod`, `stockTradeQuote`, `stockEod`, the generic `request`, and `flatFileToPath` are now async. They spawn the blocking pull off the libuv thread through the same `spawn_endpoint_task` path the historical endpoints use; napi-rs returns a Promise resolved off-thread. `index.d.ts` is regenerated and now declares these methods returning `Promise<...>`.

## Breaking change

The flat-file methods now return a `Promise` instead of resolving synchronously — callers must `await` them. Acceptable pre-release. Tests and the TypeScript docs/README examples are updated to `await`.

## Verification

- `cargo check` (napi crate): clean
- `npm run build`: ok, `index.d.ts` shows `Promise<...>`
- `npm test`: 166 pass, 0 fail
- `cargo fmt --all -- --check`: clean
- `python3 scripts/check_binding_parity.py`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)