### PR TITLE
fix(python): release the GIL across blocking FPSS streaming I/O

### DIFF
--- a/crates/thetadatadx/build_support_bin/sdk_surface/python.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/python.rs
@@ -155,7 +155,7 @@ fn python_streaming_method(method: &MethodSpec) -> String {
             // attribute lookup.
             writeln!(
                 out,
-                "    pub(crate) fn {}(&self, callback: Py<PyAny>) -> PyResult<()> {{",
+                "    pub(crate) fn {}(&self, py: Python<'_>, callback: Py<PyAny>) -> PyResult<()> {{",
                 method.name
             )
             .unwrap();
@@ -313,7 +313,12 @@ fn python_streaming_method(method: &MethodSpec) -> String {
                  references past a teardown the application has already\n\
                  observed.",
             );
-            writeln!(out, "    fn {}(&self) -> PyResult<()> {{", method.name).unwrap();
+            writeln!(
+                out,
+                "    fn {}(&self, py: Python<'_>) -> PyResult<()> {{",
+                method.name
+            )
+            .unwrap();
             out.push_str(include_str!("templates/python/reconnect_body.rs.tmpl"));
         }
         MethodKind::AwaitDrain => {

--- a/crates/thetadatadx/build_support_bin/sdk_surface/templates/python/reconnect_body.rs.tmpl
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/templates/python/reconnect_body.rs.tmpl
@@ -18,13 +18,23 @@
         let dispatch_cb = Arc::clone(&callback_arc);
         let panic_recorder = Arc::clone(&self.client);
 
+        // Never hold the GIL across the blocking network reconnect.
+        // `reconnect_streaming_scoped` tears the old session down, opens a
+        // fresh FPSS TLS connection, re-runs the `CREDENTIALS` handshake,
+        // and paces the saved-subscription replay (sleeping
+        // `replay_pace_ms` between bursts) — all synchronously on the
+        // calling thread. The whole call is released from the interpreter
+        // lock via `py.detach` so a sibling Python thread keeps running
+        // while the reconnect is in flight. The reconnect path and its
+        // `Result` are pure Rust; `to_py_err` maps the failure AFTER the
+        // GIL is re-acquired.
+        //
         // GIL once per batch, not per event — see `start_streaming`. The
-        // scope holds the GIL across each batch drain and releases it
-        // across the idle wait; the per-event `Python::attach` is the
-        // cheap reentrant fast path.
-        self.client
-            .stream()
-            .reconnect_streaming_scoped(
+        // dispatcher scope holds the GIL across each batch drain and
+        // releases it across the idle wait; the per-event
+        // `Python::attach` is the cheap reentrant fast path.
+        py.detach(|| {
+            self.client.stream().reconnect_streaming_scoped(
                 move |event: &fpss::StreamEvent| {
                     Python::attach(|py| {
                         // Borrowed `&StreamEvent` → typed pyclass in one
@@ -46,7 +56,8 @@
                 },
                 |drain| Python::attach(|_py| drain()),
             )
-            .map_err(to_py_err)?;
+        })
+        .map_err(to_py_err)?;
 
         // Replace the stored callable with a freshly owned handle so
         // the next reconnect / shutdown sees the same state shape.

--- a/crates/thetadatadx/build_support_bin/sdk_surface/templates/python/start_streaming_body.rs.tmpl
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/templates/python/start_streaming_body.rs.tmpl
@@ -25,15 +25,26 @@
         // `catch_unwind`, so the core counter is only bumped here.
         let panic_recorder = Arc::clone(&self.client);
 
-        // GIL once per batch, not per event. `start_streaming_scoped`
-        // brackets each consumer batch drain in the `Python::attach`
-        // scope below, so the GIL is acquired once and held across every
-        // event in the batch, then released across the idle inter-batch
-        // wait. The per-event `Python::attach` is then the cheap
-        // reentrant fast path (the GIL is already held by the scope), not
-        // a full acquire-from-detached every event — which is what lifts
-        // sustained drain throughput. The no-GIL discipline holds: the
-        // lock never spans the blocking wait.
+        // Never hold the GIL across the blocking network connect.
+        // `start_streaming_scoped` performs the FPSS TLS socket connect
+        // and the `CREDENTIALS` handshake synchronously on the calling
+        // thread before it spawns the dispatcher, so the whole call is
+        // released from the interpreter lock via `py.detach`. A sibling
+        // Python thread keeps running while the handshake is in flight.
+        // The connect path and the resulting `Result` are pure Rust — no
+        // Python object is touched inside the detached region; the typed
+        // exception mapping (`to_py_err`) runs AFTER the GIL is
+        // re-acquired, leaving the error surface unchanged.
+        //
+        // GIL once per batch, not per event. The dispatcher scope below
+        // re-acquires the GIL via `Python::attach` for each consumer
+        // batch drain, holds it across every event in the batch, then
+        // releases it across the idle inter-batch wait. The per-event
+        // `Python::attach` is the cheap reentrant fast path (the GIL is
+        // already held by the scope), not a full acquire-from-detached
+        // every event — which is what lifts sustained drain throughput.
+        // The no-GIL discipline holds: the lock never spans the blocking
+        // connect and never spans the idle wait.
         //
         // The consumer is not the FPSS TLS reader thread; a slow Python
         // callback at most fills the streaming ring and bumps
@@ -45,9 +56,8 @@
         // Python exceptions raised by the callback are caught via `call1`
         // returning `Err` and are also counted on `panic_count()` via
         // `panic_recorder.record_panic()` below.
-        self.client
-            .stream()
-            .start_streaming_scoped(
+        py.detach(|| {
+            self.client.stream().start_streaming_scoped(
                 move |event: &fpss::StreamEvent| {
                     Python::attach(|py| {
                         // Convert the borrowed `&StreamEvent` straight to its
@@ -77,7 +87,8 @@
                 },
                 |drain| Python::attach(|_py| drain()),
             )
-            .map_err(to_py_err)?;
+        })
+        .map_err(to_py_err)?;
 
         // The dispatcher closure already captured a clone of
         // `callback_arc` (via `dispatch_cb`), so the Arc ref-count is

--- a/sdks/python/src/_generated/streaming_methods.rs
+++ b/sdks/python/src/_generated/streaming_methods.rs
@@ -42,7 +42,7 @@ impl StreamView {
     /// `catch_unwind` boundary and routed through
     /// `PyErr::write_unraisable` (visible in `sys.stderr` and
     /// the unraisable hook); each one bumps `panic_count()`.
-    pub(crate) fn start_streaming(&self, callback: Py<PyAny>) -> PyResult<()> {
+    pub(crate) fn start_streaming(&self, py: Python<'_>, callback: Py<PyAny>) -> PyResult<()> {
         // Hold the user callable in a `Mutex<Option<Py<PyAny>>>` so
         // `stop_streaming` can drop it without leaking a Python
         // reference, and so a subsequent `start_streaming` /
@@ -70,15 +70,26 @@ impl StreamView {
         // `catch_unwind`, so the core counter is only bumped here.
         let panic_recorder = Arc::clone(&self.client);
 
-        // GIL once per batch, not per event. `start_streaming_scoped`
-        // brackets each consumer batch drain in the `Python::attach`
-        // scope below, so the GIL is acquired once and held across every
-        // event in the batch, then released across the idle inter-batch
-        // wait. The per-event `Python::attach` is then the cheap
-        // reentrant fast path (the GIL is already held by the scope), not
-        // a full acquire-from-detached every event — which is what lifts
-        // sustained drain throughput. The no-GIL discipline holds: the
-        // lock never spans the blocking wait.
+        // Never hold the GIL across the blocking network connect.
+        // `start_streaming_scoped` performs the FPSS TLS socket connect
+        // and the `CREDENTIALS` handshake synchronously on the calling
+        // thread before it spawns the dispatcher, so the whole call is
+        // released from the interpreter lock via `py.detach`. A sibling
+        // Python thread keeps running while the handshake is in flight.
+        // The connect path and the resulting `Result` are pure Rust — no
+        // Python object is touched inside the detached region; the typed
+        // exception mapping (`to_py_err`) runs AFTER the GIL is
+        // re-acquired, leaving the error surface unchanged.
+        //
+        // GIL once per batch, not per event. The dispatcher scope below
+        // re-acquires the GIL via `Python::attach` for each consumer
+        // batch drain, holds it across every event in the batch, then
+        // releases it across the idle inter-batch wait. The per-event
+        // `Python::attach` is the cheap reentrant fast path (the GIL is
+        // already held by the scope), not a full acquire-from-detached
+        // every event — which is what lifts sustained drain throughput.
+        // The no-GIL discipline holds: the lock never spans the blocking
+        // connect and never spans the idle wait.
         //
         // The consumer is not the FPSS TLS reader thread; a slow Python
         // callback at most fills the streaming ring and bumps
@@ -90,9 +101,8 @@ impl StreamView {
         // Python exceptions raised by the callback are caught via `call1`
         // returning `Err` and are also counted on `panic_count()` via
         // `panic_recorder.record_panic()` below.
-        self.client
-            .stream()
-            .start_streaming_scoped(
+        py.detach(|| {
+            self.client.stream().start_streaming_scoped(
                 move |event: &fpss::StreamEvent| {
                     Python::attach(|py| {
                         // Convert the borrowed `&StreamEvent` straight to its
@@ -122,7 +132,8 @@ impl StreamView {
                 },
                 |drain| Python::attach(|_py| drain()),
             )
-            .map_err(to_py_err)?;
+        })
+        .map_err(to_py_err)?;
 
         // The dispatcher closure already captured a clone of
         // `callback_arc` (via `dispatch_cb`), so the Arc ref-count is
@@ -178,7 +189,7 @@ impl StreamView {
     /// to enforce the explicit handoff and avoid retaining captured
     /// references past a teardown the application has already
     /// observed.
-    fn reconnect(&self) -> PyResult<()> {
+    fn reconnect(&self, py: Python<'_>) -> PyResult<()> {
         // `reconnect` re-registers the previously installed callback
         // on a fresh FPSS connection. We require a prior
         // `start_streaming(callback)` so the Python surface stays
@@ -199,13 +210,23 @@ impl StreamView {
         let dispatch_cb = Arc::clone(&callback_arc);
         let panic_recorder = Arc::clone(&self.client);
 
+        // Never hold the GIL across the blocking network reconnect.
+        // `reconnect_streaming_scoped` tears the old session down, opens a
+        // fresh FPSS TLS connection, re-runs the `CREDENTIALS` handshake,
+        // and paces the saved-subscription replay (sleeping
+        // `replay_pace_ms` between bursts) — all synchronously on the
+        // calling thread. The whole call is released from the interpreter
+        // lock via `py.detach` so a sibling Python thread keeps running
+        // while the reconnect is in flight. The reconnect path and its
+        // `Result` are pure Rust; `to_py_err` maps the failure AFTER the
+        // GIL is re-acquired.
+        //
         // GIL once per batch, not per event — see `start_streaming`. The
-        // scope holds the GIL across each batch drain and releases it
-        // across the idle wait; the per-event `Python::attach` is the
-        // cheap reentrant fast path.
-        self.client
-            .stream()
-            .reconnect_streaming_scoped(
+        // dispatcher scope holds the GIL across each batch drain and
+        // releases it across the idle wait; the per-event
+        // `Python::attach` is the cheap reentrant fast path.
+        py.detach(|| {
+            self.client.stream().reconnect_streaming_scoped(
                 move |event: &fpss::StreamEvent| {
                     Python::attach(|py| {
                         // Borrowed `&StreamEvent` → typed pyclass in one
@@ -227,7 +248,8 @@ impl StreamView {
                 },
                 |drain| Python::attach(|_py| drain()),
             )
-            .map_err(to_py_err)?;
+        })
+        .map_err(to_py_err)?;
 
         // Replace the stored callable with a freshly owned handle so
         // the next reconnect / shutdown sees the same state shape.

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1729,9 +1729,14 @@ impl StreamView {
     /// client.stream.subscribe(option.trade())
     /// client.stream.subscribe(SecType.OPTION.full_trades())
     /// ```
-    fn subscribe(&self, sub: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn subscribe(&self, py: Python<'_>, sub: &Bound<'_, PyAny>) -> PyResult<()> {
+        // `coerce_subscription` reads the Python object, so it runs with
+        // the GIL held; the subscribe is a blocking wire write, so the
+        // GIL is released across it. Never hold the GIL across blocking
+        // network I/O.
         let inner = fluent::coerce_subscription(sub)?;
-        self.client.stream().subscribe(inner).map_err(to_py_err)
+        py.detach(|| self.client.stream().subscribe(inner))
+            .map_err(to_py_err)
     }
 
     /// Bulk-subscribe a list / iterable of `Subscription` values.
@@ -1739,23 +1744,25 @@ impl StreamView {
     /// Stops at the first error and re-raises it; previously-installed
     /// subscriptions are NOT rolled back (the upstream streaming
     /// protocol does not support batched transactions).
-    fn subscribe_many(&self, subs: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn subscribe_many(&self, py: Python<'_>, subs: &Bound<'_, PyAny>) -> PyResult<()> {
+        // Coerce the list under the GIL, then release it across the
+        // blocking wire writes — never hold the GIL across network I/O.
         let list = fluent::coerce_subscription_list(subs)?;
-        self.client.stream().subscribe_many(list).map_err(to_py_err)
+        py.detach(|| self.client.stream().subscribe_many(list))
+            .map_err(to_py_err)
     }
 
     /// Polymorphic unsubscribe — fluent counterpart to `subscribe(sub)`.
-    fn unsubscribe(&self, sub: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn unsubscribe(&self, py: Python<'_>, sub: &Bound<'_, PyAny>) -> PyResult<()> {
         let inner = fluent::coerce_subscription(sub)?;
-        self.client.stream().unsubscribe(inner).map_err(to_py_err)
+        py.detach(|| self.client.stream().unsubscribe(inner))
+            .map_err(to_py_err)
     }
 
     /// Bulk-unsubscribe a list / iterable of `Subscription` values.
-    fn unsubscribe_many(&self, subs: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn unsubscribe_many(&self, py: Python<'_>, subs: &Bound<'_, PyAny>) -> PyResult<()> {
         let list = fluent::coerce_subscription_list(subs)?;
-        self.client
-            .stream()
-            .unsubscribe_many(list)
+        py.detach(|| self.client.stream().unsubscribe_many(list))
             .map_err(to_py_err)
     }
 }

--- a/sdks/python/src/streaming_session.rs
+++ b/sdks/python/src/streaming_session.rs
@@ -57,7 +57,7 @@ impl StreamableHandle {
     /// `StreamView` surface, so the `Unified` arm dispatches through it.
     pub(crate) fn start_streaming(&self, py: Python<'_>, callback: Py<PyAny>) -> PyResult<()> {
         match self {
-            Self::Unified(handle) => handle.borrow(py).stream().start_streaming(callback),
+            Self::Unified(handle) => handle.borrow(py).stream().start_streaming(py, callback),
             Self::Fpss(handle) => handle.borrow(py).start_streaming(py, callback),
         }
     }

--- a/sdks/python/tests/test_docstring_examples.py
+++ b/sdks/python/tests/test_docstring_examples.py
@@ -1,4 +1,4 @@
-"""Gate 3 (issue #546) - Python side: doctest gate.
+"""Python-side doctest gate.
 
 Scans the Rust source under `sdks/python/src/` for triple-slash doc
 comments containing `>>>` blocks, extracts them, and runs each block
@@ -10,10 +10,11 @@ sometimes loses the `>>>` prefix. The Rust source is the source of
 truth for what we documented; if the example there doesn't run, that
 is the bug.
 
-A doctest gate caught the v10.0.0 `Contract` regression after the
-fact - the docstring example referenced `Contract.stock("AAPL")` but
-the pyclass wasn't registered. Future regressions of the same shape
-fail here instead of in production.
+This gate exists because a docstring example can reference a symbol the
+module never registered — e.g. `Contract.stock("AAPL")` documented while
+the pyclass was unregistered. Running every documented example keeps the
+docs and the compiled surface in lockstep, so that class of regression
+fails here instead of in a user's session.
 """
 
 from __future__ import annotations

--- a/sdks/python/tests/test_error_parity.py
+++ b/sdks/python/tests/test_error_parity.py
@@ -1,4 +1,4 @@
-"""Cross-binding error-class parity — Python surface (issue #681).
+"""Cross-binding error-class parity — Python surface.
 
 Pins the canonical typed-exception vocabulary so it stays identical to
 the TypeScript / C++ / C ABI leaf sets: a `NotFound` status raises

--- a/sdks/python/tests/test_fluent_contract_example.py
+++ b/sdks/python/tests/test_fluent_contract_example.py
@@ -1,4 +1,4 @@
-"""Regression test for the v10.0.0 fluent `Contract` builder (#557).
+"""Regression test for the fluent `Contract` builder.
 
 Asserts that the example documented in `fluent.rs:7-10`:
 
@@ -69,8 +69,7 @@ def test_contract_class_is_fluent_builder(thetadatadx_mod) -> None:
     for method in ("stock", "option", "index", "quote", "trade", "open_interest"):
         assert hasattr(cls, method), (
             f"thetadatadx.Contract is missing fluent method {method!r}; "
-            f"is the event payload shadowing the fluent builder again? "
-            f"See #557."
+            f"is the event payload shadowing the fluent builder again?"
         )
 
 

--- a/sdks/python/tests/test_fpss_control_variants.py
+++ b/sdks/python/tests/test_fpss_control_variants.py
@@ -143,7 +143,7 @@ def test_data_classes_still_exported(thetadatadx_mod):
     surfaced as `event.contract.symbol` / `event.contract.strike`. It is
     distinct from the fluent `Contract` builder (which lives at
     `thetadatadx.Contract` and exposes `.stock()` / `.option()` factory
-    methods); see #557 for the collision-rename background.
+    methods). The two identifiers must never collapse to one Python name.
     """
     for variant in ("Quote", "Trade", "Ohlcvc", "OpenInterest", "ContractRef"):
         cls = getattr(thetadatadx_mod, variant, None)

--- a/sdks/python/tests/test_fresh_install_smoke.py
+++ b/sdks/python/tests/test_fresh_install_smoke.py
@@ -1,9 +1,9 @@
-"""Gate 8 (issue #551): fresh-install smoke test.
+"""Fresh-install smoke test.
 
 Acts like a first-time user typing `pip install thetadatadx` then
 `from thetadatadx import <X>` for every documented top-level export.
-Catches "documented but unreachable" regressions of the class that bit
-production on v10.0.0 (issue #557).
+Catches "documented but unreachable" regressions — a name that the docs
+promise but the compiled module never registers.
 
 The CI workflow runs this against a wheel freshly installed into an
 isolated venv — see `python.yml::build`. The test deliberately uses

--- a/sdks/python/tests/test_interest_rate.py
+++ b/sdks/python/tests/test_interest_rate.py
@@ -1,12 +1,13 @@
 """Regression coverage for the `InterestRateTick` schema fix.
 
-Before this PR the `tick_schema.toml` definition advertised three fields
-(`ms_of_day`, `rate`, `date`) but the upstream v3 server actually emits
-two columns: an ISO-date `created` header and a `rate` percent value.
-Every live `interest_rate_history_eod` call therefore failed inside the
-decoder with `expected: "Number|Timestamp", got Text`.
+The `tick_schema.toml` definition must match what the upstream v3 server
+actually emits for interest-rate EOD: two columns, an ISO-date `created`
+header and a `rate` percent value — not a fictitious `ms_of_day` field. A
+schema that advertises `ms_of_day` makes every live
+`interest_rate_history_eod` call fail inside the decoder with
+`expected: "Number|Timestamp", got Text`.
 
-The fix is cross-binding by design — the Python `InterestRateTick`
+The schema is cross-binding by design — the Python `InterestRateTick`
 pyclass is regenerated from `tick_schema.toml`, so the shape of the
 pyclass itself is the single source of truth this test pins. Liveness
 of the decode is covered upstream in
@@ -54,8 +55,8 @@ def test_interest_rate_tick_rejects_removed_ms_of_day_kw(InterestRateTick) -> No
     """Pin the breaking change: `ms_of_day` was a fictitious field
     (server never sent it) and has been removed. A keyword call that
     targets the removed field must raise `TypeError` — the wheel is
-    explicitly NOT backward-compatible with v10.x `InterestRateTick(
-    ms_of_day=...)` call sites."""
+    explicitly NOT backward-compatible with any `InterestRateTick(
+    ms_of_day=...)` call site."""
     with pytest.raises(TypeError):
         InterestRateTick(ms_of_day=34_200_000, rate=4.36, date=20250428)
 

--- a/sdks/python/tests/test_module_exports.py
+++ b/sdks/python/tests/test_module_exports.py
@@ -1,10 +1,10 @@
-"""Gate 1 (issue #544): every `#[pyclass]` declared in the Python SDK's
-Rust source must end up registered on the compiled module.
+"""Every `#[pyclass]` declared in the Python SDK's Rust source must end
+up registered on the compiled module.
 
-Production user on v10.0.0 hit `ImportError` for `from thetadatadx import
-Contract` because the pyclass was defined but never registered via
-`m.add_class::<...>()`. This test parametrises one assertion per pyclass
-so the failure points at the missing name, not a generic "drift" message.
+A pyclass can be defined but never registered via `m.add_class::<...>()`,
+which surfaces to users as `ImportError` on `from thetadatadx import <X>`.
+This test parametrises one assertion per pyclass so the failure points at
+the missing name, not a generic "drift" message.
 
 False positives — types that are pyclasses for FFI-internal reasons but
 deliberately not exposed at the Python module level — go in

--- a/sdks/python/tests/test_no_pyclass_name_collisions.py
+++ b/sdks/python/tests/test_no_pyclass_name_collisions.py
@@ -1,4 +1,4 @@
-"""Regression guard for the v10.0.0 `Contract` collision (#557).
+"""Regression guard against `#[pyclass]` Python-name collisions.
 
 Two pyclasses registered under the same Python name silently shadow each
 other — `m.add_class` is last-write-wins, so whichever helper runs second
@@ -66,8 +66,8 @@ def test_no_pyclass_name_collisions() -> None:
     assert not collisions, (
         "Multiple #[pyclass] structs register the same Python name. "
         "pyo3's m.add_class is last-write-wins, so the second registration "
-        "silently shadows the first — see v10.0.0 #557 for the prior "
-        "Contract-collision incident. Fix by adding an explicit "
+        "silently shadows the first, dropping the earlier registration's "
+        "methods from the user-facing surface. Fix by adding an explicit "
         '`name = "..."` attribute to disambiguate.\n'
         f"Collisions: {collisions}"
     )

--- a/sdks/python/tests/test_util_helpers.py
+++ b/sdks/python/tests/test_util_helpers.py
@@ -1,4 +1,4 @@
-"""Cross-language utility helpers — Python binding parity tests (issue #424).
+"""Cross-language utility helpers — Python binding parity tests.
 
 Verifies the `thetadatadx.util` submodule exposes the same lookup surface
 as the Rust core (`thetadatadx::utils::{conditions, exchange, sequences}`).


### PR DESCRIPTION
The unified StreamView streaming lifecycle held the interpreter lock across the blocking FPSS network connect. start_streaming runs the TLS socket connect plus the CREDENTIALS handshake synchronously on the calling thread, and reconnect additionally tears the old session down and paces the saved-subscription replay; both blocked every other Python thread for the duration. The invariant: the GIL is never held across blocking network I/O, so a sibling Python thread keeps running while a handshake or reconnect is in flight.

Both paths now run inside py.detach. The blocking core call runs detached from the interpreter lock, re-acquiring only to map the typed exception and to store the Python callback handle. The dispatcher scope still re-acquires the GIL per batch via Python::attach, so the no-GIL discipline holds end to end: the lock spans neither the blocking connect nor the idle inter-batch wait. This matches the standalone StreamingClient, which already detaches the identical core calls.

streaming_methods.rs is generated from the Python streaming generator, so the fix lives in the generator and its body templates and is regenerated; the hand-written StreamView subscribe / unsubscribe family in lib.rs now detaches each blocking wire write the same way.

Also reworded version-era and issue-reference tokens in Python test docstrings to state the invariant under test rather than the release or tracking number that surfaced it.

Verification: sdks/python cargo check passes; generator --check is drift-clean; cargo fmt --all -- --check clean; check_binding_parity.py clean; both streaming paths and the subscribe family grep-confirmed to route every blocking core call through py.detach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)