### PR TITLE
fix(server): emit every wire column on REST/WS ticks and gate full open interest to options

### DIFF
--- a/tools/server/src/format.rs
+++ b/tools/server/src/format.rs
@@ -188,6 +188,7 @@ pub fn ohlc_ticks_to_json(ticks: &[OhlcTick]) -> Vec<sonic_rs::Value> {
                 "close": t.close,
                 "volume": t.volume,
                 "count": t.count,
+                "vwap": t.vwap,
                 "date": t.date
             });
             insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
@@ -204,10 +205,18 @@ pub fn trade_ticks_to_json(ticks: &[TradeTick]) -> Vec<sonic_rs::Value> {
             let mut row = sonic_rs::json!({
                 "ms_of_day": t.ms_of_day,
                 "sequence": t.sequence,
-                "size": t.size,
+                "ext_condition1": t.ext_condition1,
+                "ext_condition2": t.ext_condition2,
+                "ext_condition3": t.ext_condition3,
+                "ext_condition4": t.ext_condition4,
                 "condition": t.condition,
-                "price": t.price,
+                "size": t.size,
                 "exchange": t.exchange,
+                "price": t.price,
+                "condition_flags": t.condition_flags,
+                "price_flags": t.price_flags,
+                "volume_type": t.volume_type,
+                "records_back": t.records_back,
                 "date": t.date
             });
             insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);
@@ -697,8 +706,15 @@ pub fn iv_ticks_to_json(ticks: &[IvTick]) -> Vec<sonic_rs::Value> {
         .map(|t| {
             let mut row = sonic_rs::json!({
                 "ms_of_day": t.ms_of_day,
+                "bid": t.bid,
+                "bid_implied_volatility": t.bid_implied_volatility,
+                "midpoint": t.midpoint,
                 "implied_volatility": t.implied_volatility,
+                "ask": t.ask,
+                "ask_implied_volatility": t.ask_implied_volatility,
                 "iv_error": t.iv_error,
+                "underlying_ms_of_day": t.underlying_ms_of_day,
+                "underlying_price": t.underlying_price,
                 "date": t.date
             });
             insert_contract_id_fields(&mut row, t.expiration, t.strike, t.right);

--- a/tools/server/src/ws/subscribe.rs
+++ b/tools/server/src/ws/subscribe.rs
@@ -586,6 +586,13 @@ fn subscription_plan(
         "OHLC" => Ok(per_contract(SubscriptionKind::Trade)),
         "OPEN_INTEREST" => Ok(per_contract(SubscriptionKind::OpenInterest)),
         "FULL_TRADES" => Ok(full(FullSubscriptionKind::Trades)),
+        // Open interest is an option-only concept; stocks and indices carry
+        // none, so a security-type-wide open-interest stream over them would
+        // never publish. Reject the pairing rather than acknowledge a feed
+        // that can never deliver.
+        "FULL_OPEN_INTEREST" if sec_type != "OPTION" => Err(format!(
+            "'FULL_OPEN_INTEREST' is only available for sec_type 'OPTION', got: '{sec_type}'"
+        )),
         "FULL_OPEN_INTEREST" => Ok(full(FullSubscriptionKind::OpenInterest)),
         other => Err(format!(
             "unknown req_type: '{other}' (accepted: {})",
@@ -777,6 +784,17 @@ mod tests {
                 kind: FullSubscriptionKind::OpenInterest,
             }]
         );
+    }
+
+    /// Open interest is option-only; a security-type-wide open-interest
+    /// stream over stocks or indices is rejected rather than acknowledged.
+    #[test]
+    fn plan_rejects_full_open_interest_for_non_option() {
+        for sec_type in ["STOCK", "INDEX"] {
+            let err = subscription_plan("FULL_OPEN_INTEREST", sec_type, &[]).unwrap_err();
+            assert!(err.contains("OPTION"), "names the only valid sec_type: {err}");
+            assert!(err.contains(sec_type), "echoes the rejected sec_type: {err}");
+        }
     }
 
     /// `right=Both` produces two contracts; the plan installs one


### PR DESCRIPTION
## What

REST and WebSocket JSON renderers must carry every wire column the tick type defines. Three formatters projected only a partial column set, silently dropping data the endpoint had already returned, and one subscription path acknowledged a feed that can never publish.

## Fixes

**Trade ticks (`trade_ticks_to_json`).** Emitted only 7 of the 15 TradeTick columns, dropping `ext_condition1..4`, `condition_flags`, `price_flags`, `volume_type`, and `records_back`. Now emits all 15 in schema order, matching the full `trade_quote_ticks_to_json` sibling. Affects stock/option `history_trade`, `snapshot_trade`, and `at_time_trade`.

**Implied volatility ticks (`iv_ticks_to_json`).** Emitted the 4-column snapshot subset (`ms_of_day`, `implied_volatility`, `iv_error`, `date`) on the full 11-column history shape, dropping `bid`, `bid_implied_volatility`, `midpoint`, `ask`, `ask_implied_volatility`, `underlying_ms_of_day`, and `underlying_price`. The `option_history_greeks_implied_volatility` response now carries every field the IvTick struct holds; the snapshot endpoint's missing columns already zero-default through the parser, so the full-field shape stays correct there too.

**OHLC ticks (`ohlc_ticks_to_json`).** Unconditionally dropped `vwap`, which `*_history_ohlc` carries. Now emits it.

**Full open interest subscription (`ws/subscribe.rs`).** Open interest is option-only; the flat-file gate rejects stock/index open interest. `FULL_OPEN_INTEREST` over a non-OPTION sec_type previously mapped to a `Stock`/`Index` full subscription and replied SUBSCRIBED for a feed that can never publish. It now returns an error reply for any sec_type other than OPTION, mirroring the unknown-req-type rejection path.

## Verification

- `cargo check` clean
- `cargo clippy -- -D warnings` clean
- `cargo test` — 108 passed (added `plan_rejects_full_open_interest_for_non_option`)
- `cargo fmt --all -- --check` clean
- `scripts/check_binding_parity.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)