### PR TITLE
docs: fix TypeScript quickstart async usage and streaming event reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ with client.streaming(on_event) as session:
 ```typescript
 import { Contract, Client } from 'thetadatadx';
 
-const client = Client.connectFromFile('creds.txt');
 const formatContract = (contract: {
   symbol: string;
   expiration?: number;
@@ -116,28 +115,34 @@ const formatContract = (contract: {
   .filter((value) => value != null)
   .join(' ');
 
-client.stream.startStreaming((event) => {
-  if (event.kind === 'trade' && event.trade) {
-    const { contract, price, size, exchange, msOfDay, sequence, condition } = event.trade;
-    console.log(
-      `${formatContract(contract)} trade price=${price} size=${size} ` +
-      `exchange=${exchange} ms_of_day=${msOfDay} sequence=${sequence} condition=${condition}`,
-    );
-  } else if (event.kind === 'quote' && event.quote) {
-    const { contract, bid, ask, bidSize, askSize, bidExchange, askExchange, msOfDay } = event.quote;
-    console.log(
-      `${formatContract(contract)} quote bid=${bid} ask=${ask} ` +
-      `bid_size=${bidSize} ask_size=${askSize} bid_exchange=${bidExchange} ` +
-      `ask_exchange=${askExchange} ms_of_day=${msOfDay}`,
-    );
-  }
-});
+async function main() {
+  const client = await Client.connectFromFile('creds.txt');
 
-const leg = { expiration: '20260619', strike: '550', right: 'C' };
-client.stream.subscribeMany([
-  Contract.option('SPY', leg).quote(),
-  Contract.option('SPY', leg).trade(),
-]);
+  await client.stream.startStreaming((event) => {
+    if (event.kind === 'trade' && event.trade) {
+      const { contract, price, size, exchange, msOfDay, sequence, condition } = event.trade;
+      console.log(
+        `${formatContract(contract)} trade price=${price} size=${size} ` +
+        `exchange=${exchange} ms_of_day=${msOfDay} sequence=${sequence} condition=${condition}`,
+      );
+    } else if (event.kind === 'quote' && event.quote) {
+      const { contract, bid, ask, bidSize, askSize, bidExchange, askExchange, msOfDay } = event.quote;
+      console.log(
+        `${formatContract(contract)} quote bid=${bid} ask=${ask} ` +
+        `bid_size=${bidSize} ask_size=${askSize} bid_exchange=${bidExchange} ` +
+        `ask_exchange=${askExchange} ms_of_day=${msOfDay}`,
+      );
+    }
+  });
+
+  const leg = { expiration: '20260619', strike: '550', right: 'C' };
+  client.stream.subscribeMany([
+    Contract.option('SPY', leg).quote(),
+    Contract.option('SPY', leg).trade(),
+  ]);
+}
+
+await main();
 ```
 
 ### C++

--- a/docs-site/docs/articles/getting-started.md
+++ b/docs-site/docs/articles/getting-started.md
@@ -45,7 +45,7 @@ Requires Python 3.12+. Pre-built `abi3` wheels for Linux x86_64, macOS, and Wind
 npm install thetadatadx
 ```
 
-Requires Node.js 18+. Pre-built native binaries install automatically per platform.
+Requires Node.js 20+. Pre-built native binaries install automatically per platform.
 
 </template>
 

--- a/docs-site/docs/streaming/events.md
+++ b/docs-site/docs/streaming/events.md
@@ -152,7 +152,7 @@ Lifecycle and session events share the callback. The ones worth handling:
 | `market_open` / `market_close` | Session boundary notices. |
 | `disconnected` / `reconnecting` / `reconnected` | Automatic-reconnect progress; see [Reconnection & Monitoring](/streaming/reliability). |
 | `reconnects_exhausted` | The retry budget is spent; the session is down for good until you intervene. |
-| `server_error` / `error` | Server-reported or protocol-level error with a message payload. |
+| `server_error` / `parse_error` | Server-reported (`ServerError`) or protocol-level parse (`ParseError`) error with a message payload. |
 | `ping`, `restart`, `reconnected_server`, `unknown_frame`, `unknown_control` | Heartbeats, server restarts, and forward-compatibility fallbacks. |
 
 Unrecognized future event types arrive as `unknown_*` rather than being dropped, so a callback written today keeps working against newer servers.


### PR DESCRIPTION
Documentation-only fixes from the audit. No SDK source, parity surface, or changelog touched.

## TypeScript quickstart was broken

The README TypeScript quickstart called `Client.connectFromFile('creds.txt')` synchronously, then read `client.stream` and called `startStreaming(...)`. `connectFromFile` returns `Promise<Client>` and `startStreaming` returns `Promise<void>`, so the old form read `.stream` off an unresolved promise (undefined at runtime) and let connect/auth rejections escape unhandled. The snippet now lives in an `async function main()` that awaits the connect and the start-streaming call, with `await main()` at the bottom. `subscribeMany` returns `void` (synchronous per `sdks/typescript/index.d.ts`), so it is called without await. The snippet type-checks under `tsc --noEmit` as a module.

## Node version floor was inconsistent

The getting-started guide stated Node.js 18+ while the README badge said 20+. The published `engines.node` is `>= 20` (`sdks/typescript/package.json`), which is the single source of truth, so both docs now read 20+.

## Streaming event catalogue listed a non-existent kind

`docs-site/docs/streaming/events.md` listed an `error` event kind. The real discriminants are `server_error` (ServerError) and `parse_error` (ParseError), confirmed against the typed event-kind union in `sdks/typescript/index.d.ts` and the FPSS event schema. The row now reads `server_error` / `parse_error`. The file is hand-authored, not generated, so it is edited directly; `generate_docs_site --check` and `generate_sdk_surfaces --check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)