### PR TITLE
fix(tdbe): correct sequence telemetry across the full counter cycle

### DIFF
--- a/crates/thetadatadx/src/flatfiles/index.rs
+++ b/crates/thetadatadx/src/flatfiles/index.rs
@@ -243,6 +243,17 @@ fn parse_one_entry(cur: &mut Cursor<&[u8]>, sec: SecType) -> Result<IndexEntry, 
         }
     };
 
+    // The entry-size prefix frames the contract-identity block exactly; the
+    // location triple that follows is outside it. A cursor that has not
+    // consumed every framed byte means the layout drifted from what we
+    // decoded, so reject rather than silently skip the remainder.
+    let consumed = e.position() as usize;
+    if consumed != entry_size {
+        return Err(Error::decode_codec(format!(
+            "flatfiles INDEX: entry framed {entry_size} bytes but decoded {consumed}"
+        )));
+    }
+
     // Location: i32 volume, i64 start, i64 end. Volume is unused by the
     // SDK; we drop it but consume the bytes to advance the cursor.
     let _volume = read_i32(cur)?;
@@ -405,6 +416,27 @@ mod tests {
         assert_eq!(entry.right, None);
         assert_eq!(entry.block_start, 0);
         assert_eq!(entry.block_end, 100);
+    }
+
+    #[test]
+    fn over_framed_entry_size_is_rejected() {
+        // entry_size claims more bytes than the contract block decodes;
+        // the parser must reject rather than skip the unframed remainder.
+        let mut e = Vec::new();
+        e.push(3u8);
+        e.extend_from_slice(b"SPY");
+        e.extend_from_slice(&20_260_428i32.to_be_bytes()); // 8 bytes decoded
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&((e.len() + 4) as u16).to_be_bytes()); // over-framed
+        buf.extend_from_slice(&e);
+        buf.extend_from_slice(&[0u8; 4]); // padding inside the frame
+        buf.extend_from_slice(&0i32.to_be_bytes());
+        buf.extend_from_slice(&0i64.to_be_bytes());
+        buf.extend_from_slice(&100i64.to_be_bytes());
+
+        let mut iter = IndexIter::new(&buf, SecType::Stock);
+        assert!(iter.next().unwrap().is_err());
     }
 
     /// Build an INDEX byte stream for one option entry.

--- a/crates/thetadatadx/src/flatfiles/types.rs
+++ b/crates/thetadatadx/src/flatfiles/types.rs
@@ -145,7 +145,7 @@ pub(crate) fn req_dataset_name(req: ReqType) -> &'static str {
 #[non_exhaustive]
 pub enum FlatFilesUnavailableReason {
     /// Server returned a `RemoveReason` ordinal during auth (e.g.
-    /// `INVALID_CREDENTIALS=1`, `ACCOUNT_ALREADY_CONNECTED=7`).
+    /// `INVALID_CREDENTIALS=0`, `ACCOUNT_ALREADY_CONNECTED=6`).
     AuthRejected {
         /// Server-supplied removal-reason ordinal explaining the rejection.
         reason_code: u16,

--- a/crates/thetadatadx/src/grpc/status.rs
+++ b/crates/thetadatadx/src/grpc/status.rs
@@ -136,7 +136,9 @@ struct RetryInfoProto {
 ///
 /// Any malformed layer — non-proto payload, missing detail — degrades
 /// to `None` rather than invalidating the status it travels with.
-/// Negative durations are rejected.
+/// Negative durations are rejected, as is a `nanos` field outside the
+/// canonical `[0, 1e9)` range — an out-of-range fractional component would
+/// otherwise inflate the resulting delay past its intended value.
 fn decode_retry_delay(raw: &[u8]) -> Option<std::time::Duration> {
     use prost::Message;
     if raw.is_empty() {
@@ -149,7 +151,7 @@ fn decode_retry_delay(raw: &[u8]) -> Option<std::time::Duration> {
         }
         let info = RetryInfoProto::decode(any.value.as_slice()).ok()?;
         let proto_delay = info.retry_delay?;
-        if proto_delay.seconds < 0 || proto_delay.nanos < 0 {
+        if proto_delay.seconds < 0 || proto_delay.nanos < 0 || proto_delay.nanos >= 1_000_000_000 {
             return None;
         }
         let secs = u64::try_from(proto_delay.seconds).ok()?;
@@ -309,6 +311,19 @@ mod tests {
             Status::from_tonic(&status).retry_delay(),
             None,
             "a negative server hint must be discarded, not wrapped"
+        );
+    }
+
+    #[test]
+    fn out_of_range_nanos_is_rejected() {
+        // A nanos field at or above 1e9 is outside the canonical Duration
+        // range; carrying it through would inflate the delay (here by ~1.5s).
+        let details = retry_info_details(0, 1_500_000_000);
+        let status = tonic::Status::with_details(tonic::Code::Unavailable, "down", details.into());
+        assert_eq!(
+            Status::from_tonic(&status).retry_delay(),
+            None,
+            "an out-of-range fractional component must be discarded, not added"
         );
     }
 

--- a/crates/thetadatadx/src/tdbe/sequences.rs
+++ b/crates/thetadatadx/src/tdbe/sequences.rs
@@ -138,18 +138,20 @@ impl SequenceTracker {
 
         let sequence = if let Some(last) = self.last {
             let absolute = if raw == 0 && last.raw == -1 {
+                // True cycle wrap: -1 -> 0 advances to the next cycle's base.
+                // This is the only crossing that increments the cycle count;
+                // the unsigned axis used by `signed_to_unsigned` places raw 0
+                // at the start of a fresh cycle.
                 is_overflow = true;
                 self.overflow_count += 1;
                 self.overflow_count * SEQUENCE_RANGE as u64
             } else if raw < 0 && last.raw >= 0 && last.raw >= SEQUENCE_MAX - 1000 {
+                // Sign-bit crossing: MAX -> MIN. On the unsigned axis this is
+                // mid-cycle (position 2^31-1 -> 2^31), contiguous, NOT a cycle
+                // boundary. Stay on the current cycle and do not increment the
+                // cycle count; the true wrap is the -1 -> 0 branch above.
                 is_overflow = true;
-                self.overflow_count += 1;
-                let base = if self.overflow_count > 0 {
-                    (self.overflow_count - 1) * SEQUENCE_RANGE as u64
-                } else {
-                    0
-                };
-                base + (SEQUENCE_RANGE + raw) as u64
+                self.overflow_count * SEQUENCE_RANGE as u64 + signed_to_unsigned(raw)
             } else if raw >= last.raw {
                 last.absolute.saturating_add((raw - last.raw) as u64)
             } else {
@@ -323,13 +325,64 @@ mod tests {
     }
 
     #[test]
-    fn tracker_overflow_detection() {
+    fn tracker_sign_bit_crossing_is_not_a_cycle() {
+        // The MAX -> MIN sign-bit crossing is mid-cycle on the unsigned axis:
+        // it is flagged as an overflow event but does not advance the cycle
+        // count, and it introduces no phantom gap.
         let mut tracker = SequenceTracker::new();
         tracker.process(SEQUENCE_MAX - 1);
-        tracker.process(SEQUENCE_MAX);
-        let update = tracker.process(SEQUENCE_MIN);
-        assert!(update.is_overflow);
-        assert_eq!(tracker.overflow_count(), 1);
+        let at_max = tracker.process(SEQUENCE_MAX);
+        let crossing = tracker.process(SEQUENCE_MIN);
+        assert!(crossing.is_overflow);
+        assert!(!crossing.is_gap);
+        assert_eq!(crossing.missing_count, 0);
+        assert_eq!(tracker.overflow_count(), 0);
+        // The absolute advances by exactly one step across the crossing.
+        assert_eq!(crossing.sequence.absolute(), at_max.sequence.absolute() + 1);
+    }
+
+    #[test]
+    fn tracker_full_cycle_no_phantom_gap() {
+        // Drive both per-cycle boundaries contiguously: the sign-bit crossing
+        // (MAX -> MIN) and the true wrap (-1 -> 0). The cycle count must reach
+        // exactly 1 across one full cycle, with no spurious gap or
+        // missing-message count at either boundary. Regression for
+        // double-counting the sign-bit crossing, which inflated the absolute
+        // by SEQUENCE_RANGE and reported a ~4.29-billion phantom gap per cycle.
+        let mut tracker = SequenceTracker::new();
+
+        // Approach and step over the sign-bit crossing, contiguously.
+        tracker.process(SEQUENCE_MAX - 1);
+        let at_max = tracker.process(SEQUENCE_MAX);
+        let crossing = tracker.process(SEQUENCE_MIN);
+        assert!(crossing.is_overflow);
+        assert!(!crossing.is_gap);
+        assert_eq!(crossing.missing_count, 0);
+        assert_eq!(crossing.sequence.absolute(), at_max.sequence.absolute() + 1);
+        // The sign-bit crossing is mid-cycle: no cycle increment yet.
+        assert_eq!(tracker.overflow_count(), 0);
+
+        // Continue contiguously to -1 (one before the true wrap). Anchored at
+        // raw 0 so the absolute axis is sign-correct, then walk the final
+        // pre-wrap values.
+        tracker.process(-3);
+        tracker.process(-2);
+        let minus_one = tracker.process(-1);
+
+        // The true wrap (-1 -> 0) is the sole cycle-advancing boundary: it
+        // increments the cycle count and stays contiguous on the absolute
+        // axis (no phantom gap, no missing messages).
+        let overflow_before = tracker.overflow_count();
+        let gaps_before = tracker.gap_count();
+        let missing_before = tracker.missing_messages();
+        let wrap = tracker.process(0);
+        assert!(wrap.is_overflow);
+        assert!(!wrap.is_gap);
+        assert_eq!(wrap.missing_count, 0);
+        assert_eq!(wrap.sequence.absolute(), minus_one.sequence.absolute() + 1);
+        assert_eq!(tracker.overflow_count(), overflow_before + 1);
+        assert_eq!(tracker.gap_count(), gaps_before);
+        assert_eq!(tracker.missing_messages(), missing_before);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Core-crate correctness fixes from the audit.

**Sequence telemetry correct across the full cycle.** `SequenceTracker` now uses one consistent cycle model for both overflow branches. The sign-bit crossing (`MAX -> MIN`) is mid-cycle on the unsigned axis used by `signed_to_unsigned` — contiguous, not a cycle boundary — so it no longer advances the cycle count; only the true wrap (`-1 -> 0`) does. Previously both branches incremented the cycle count, so across a single counter cycle the absolute was inflated by a full range and the gap check reported a phantom missing-message count of one whole range. The crossing is still flagged as an overflow event for telemetry, but the cycle count and absolute are now correct end to end.

**Retry delay bounded.** `decode_retry_delay` rejects a `RetryInfo` `nanos` field outside the canonical `[0, 1e9)` range in addition to negative values, so an out-of-range fractional component can no longer inflate the resulting `Duration`.

**INDEX entry-size framing enforced.** `parse_one_entry` rejects an over-framed entry-size prefix: the prefix frames the contract-identity block exactly, so a cursor that has not consumed every framed byte signals layout drift and surfaces as a decode error rather than silently skipping the remainder.

**Doc matches wire.** `FlatFilesUnavailableReason` doc now cites the canonical wire mapping (`InvalidCredentials=0`, `AccountAlreadyConnected=6`). The classifier was already correct; only the comment was wrong.

## Tests

- `tracker_sign_bit_crossing_is_not_a_cycle` — the crossing is flagged but does not advance the cycle count and introduces no gap.
- `tracker_full_cycle_no_phantom_gap` — drives both per-cycle boundaries and asserts the cycle count advances exactly once with no phantom gap or missing-message count.
- `out_of_range_nanos_is_rejected` — a `nanos` value at/above 1e9 yields no retry hint.
- `over_framed_entry_size_is_rejected` — an over-framed entry-size prefix is rejected.

The `HEADER_ALIASES` precedence-pinning test was deferred: the table is a static slice whose first-match behavior is already exercised, and a dedicated ordering test would add brittle coupling without new coverage.

## Verification

- `cargo check -p thetadatadx` clean
- `cargo clippy -p thetadatadx --all-targets --features __internal -- -D warnings` clean
- targeted `sequences`, `grpc::status`, `flatfiles` tests pass
- `cargo fmt --all -- --check` clean
- `python3 scripts/check_binding_parity.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
