### PR TITLE
fix(server): carry every Trade wire column and surface MARKET_VALUE end-to-end on the WS stream

### DIFF
--- a/tools/server/src/ws/contract_map.rs
+++ b/tools/server/src/ws/contract_map.rs
@@ -17,7 +17,8 @@ pub(super) fn lookup_event_contract(event: &StreamEvent) -> Option<Arc<Contract>
         StreamEvent::Data(StreamData::Quote { contract, .. })
         | StreamEvent::Data(StreamData::Trade { contract, .. })
         | StreamEvent::Data(StreamData::OpenInterest { contract, .. })
-        | StreamEvent::Data(StreamData::Ohlcvc { contract, .. }) => Some(Arc::clone(contract)),
+        | StreamEvent::Data(StreamData::Ohlcvc { contract, .. })
+        | StreamEvent::Data(StreamData::MarketValue { contract, .. }) => Some(Arc::clone(contract)),
         _ => None,
     }
 }

--- a/tools/server/src/ws/format.rs
+++ b/tools/server/src/ws/format.rs
@@ -91,10 +91,18 @@ pub(super) fn fpss_event_to_ws_json(
                 StreamData::Trade {
                     ms_of_day,
                     sequence,
+                    ext_condition1,
+                    ext_condition2,
+                    ext_condition3,
+                    ext_condition4,
                     condition,
                     size,
                     exchange,
                     price,
+                    condition_flags,
+                    price_flags,
+                    volume_type,
+                    records_back,
                     date,
                     received_at_ns,
                     ..
@@ -103,10 +111,18 @@ pub(super) fn fpss_event_to_ws_json(
                     sonic_rs::json!({
                         "ms_of_day": ms_of_day,
                         "sequence": sequence,
+                        "ext_condition1": ext_condition1,
+                        "ext_condition2": ext_condition2,
+                        "ext_condition3": ext_condition3,
+                        "ext_condition4": ext_condition4,
                         "condition": condition,
                         "size": size,
                         "exchange": exchange,
                         "price": price,
+                        "condition_flags": condition_flags,
+                        "price_flags": price_flags,
+                        "volume_type": volume_type,
+                        "records_back": records_back,
                         "date": date,
                         "received_at_ns": received_at_ns,
                     }),
@@ -147,6 +163,25 @@ pub(super) fn fpss_event_to_ws_json(
                     sonic_rs::json!({
                         "ms_of_day": ms_of_day,
                         "open_interest": open_interest,
+                        "date": date,
+                        "received_at_ns": received_at_ns,
+                    }),
+                ),
+                StreamData::MarketValue {
+                    ms_of_day,
+                    market_bid,
+                    market_ask,
+                    market_price,
+                    date,
+                    received_at_ns,
+                    ..
+                } => (
+                    "MARKET_VALUE",
+                    sonic_rs::json!({
+                        "ms_of_day": ms_of_day,
+                        "market_bid": market_bid,
+                        "market_ask": market_ask,
+                        "market_price": market_price,
                         "date": date,
                         "received_at_ns": received_at_ns,
                     }),
@@ -324,6 +359,112 @@ mod tests {
             date: 0,
             received_at_ns: 0,
         })
+    }
+
+    fn make_trade(contract: Arc<Contract>) -> StreamEvent {
+        StreamEvent::Data(StreamData::Trade {
+            contract,
+            ms_of_day: 1,
+            sequence: 2,
+            ext_condition1: 3,
+            ext_condition2: 4,
+            ext_condition3: 5,
+            ext_condition4: 6,
+            condition: 7,
+            size: 8,
+            exchange: 9,
+            price: 10.5,
+            condition_flags: 11,
+            price_flags: 12,
+            volume_type: 13,
+            records_back: 14,
+            date: 20260617,
+            received_at_ns: 15,
+        })
+    }
+
+    fn make_market_value(contract: Arc<Contract>) -> StreamEvent {
+        StreamEvent::Data(StreamData::MarketValue {
+            contract,
+            ms_of_day: 1,
+            market_bid: 2.5,
+            market_ask: 3.5,
+            market_price: 3.0,
+            date: 20260617,
+            received_at_ns: 4,
+        })
+    }
+
+    /// The WS Trade frame must carry every wire column the `Trade` tick
+    /// defines, matching the REST trade formatter's keys. A truncated arm
+    /// silently drops the extended-condition, flag, volume-type, and
+    /// records-back columns that downstream consumers parse.
+    #[test]
+    fn trade_frame_carries_every_wire_column() {
+        let contract = Arc::new(Contract::stock("AAPL"));
+        let event = make_trade(Arc::clone(&contract));
+        let json = fpss_event_to_ws_json(&event, Some(&contract))
+            .expect("Trade serialization must succeed");
+
+        for key in [
+            "ms_of_day",
+            "sequence",
+            "ext_condition1",
+            "ext_condition2",
+            "ext_condition3",
+            "ext_condition4",
+            "condition",
+            "size",
+            "exchange",
+            "price",
+            "condition_flags",
+            "price_flags",
+            "volume_type",
+            "records_back",
+            "date",
+        ] {
+            assert!(
+                json.contains(&format!("\"{key}\":")),
+                "Trade frame must carry the `{key}` column: {json}"
+            );
+        }
+        assert!(
+            json.contains("\"header\":{\"type\":\"TRADE\"}"),
+            "Trade frame header type: {json}"
+        );
+    }
+
+    /// MARKET_VALUE is a first-class per-contract stream: its tick must
+    /// serialize with the calculated market bid/ask/price columns rather
+    /// than being swallowed by the catch-all `None` arm.
+    #[test]
+    fn market_value_frame_serializes_calculated_columns() {
+        let contract = Arc::new(Contract::stock("SPX"));
+        let event = make_market_value(Arc::clone(&contract));
+        let json = fpss_event_to_ws_json(&event, Some(&contract))
+            .expect("MARKET_VALUE serialization must succeed");
+
+        for key in [
+            "ms_of_day",
+            "market_bid",
+            "market_ask",
+            "market_price",
+            "date",
+            "received_at_ns",
+        ] {
+            assert!(
+                json.contains(&format!("\"{key}\":")),
+                "MARKET_VALUE frame must carry the `{key}` column: {json}"
+            );
+        }
+        assert!(
+            json.contains("\"header\":{\"type\":\"MARKET_VALUE\"}"),
+            "MARKET_VALUE frame header type: {json}"
+        );
+        assert!(
+            json.contains("\"symbol\":\"SPX\""),
+            "MARKET_VALUE frame must carry its contract: {json}"
+        );
     }
 
     /// The callback thread resolves the contract directly from the

--- a/tools/server/src/ws/subscribe.rs
+++ b/tools/server/src/ws/subscribe.rs
@@ -485,6 +485,7 @@ const ACCEPTED_REQ_TYPES: &[&str] = &[
     "TRADE",
     "OHLC",
     "OPEN_INTEREST",
+    "MARKET_VALUE",
     "FULL_TRADES",
     "FULL_OPEN_INTEREST",
 ];
@@ -543,8 +544,10 @@ fn parse_right_sides(raw: Option<&str>) -> Result<Vec<bool>, String> {
 /// Translate a validated subscribe command into the FPSS subscriptions
 /// to install (or remove).
 ///
-/// - `QUOTE` / `TRADE` / `OPEN_INTEREST` map to one per-contract
-///   subscription per contract side.
+/// - `QUOTE` / `TRADE` / `OPEN_INTEREST` / `MARKET_VALUE` map to one
+///   per-contract subscription per contract side. `MARKET_VALUE` is the
+///   calculated per-contract market-value feed and has no full-stream
+///   form on the wire.
 /// - `OHLC` maps to the per-contract Trade stream: OHLCVC bars are
 ///   derived from trades, so the bar feed flows once the trade
 ///   subscription is installed. Previously this arm silently returned
@@ -585,6 +588,11 @@ fn subscription_plan(
         // underlying Trade feed is what makes the OHLC events flow.
         "OHLC" => Ok(per_contract(SubscriptionKind::Trade)),
         "OPEN_INTEREST" => Ok(per_contract(SubscriptionKind::OpenInterest)),
+        // Market value is a calculated per-contract feed with no
+        // full-stream form on the wire (like `QUOTE`); there is no
+        // `FULL_MARKET_VALUE` token, so a full market-value subscribe
+        // falls through to the `unknown req_type` error below.
+        "MARKET_VALUE" => Ok(per_contract(SubscriptionKind::MarketValue)),
         "FULL_TRADES" => Ok(full(FullSubscriptionKind::Trades)),
         // Open interest is an option-only concept; stocks and indices carry
         // none, so a security-type-wide open-interest stream over them would
@@ -747,6 +755,36 @@ mod tests {
                 "{req} maps to {kind:?}"
             );
         }
+    }
+
+    /// `req_type=MARKET_VALUE` is accepted and installs the per-contract
+    /// market-value subscription. It is a first-class per-contract stream,
+    /// not an `unknown req_type` ERROR.
+    #[test]
+    fn plan_maps_market_value_per_contract() {
+        let plan = subscription_plan("MARKET_VALUE", "OPTION", &stock_contracts()).unwrap();
+        assert_eq!(plan.len(), 1);
+        assert!(matches!(
+            &plan[0],
+            Subscription::Contract {
+                kind: SubscriptionKind::MarketValue,
+                ..
+            }
+        ));
+        assert!(
+            ACCEPTED_REQ_TYPES.contains(&"MARKET_VALUE"),
+            "MARKET_VALUE must be advertised in the accepted vocabulary"
+        );
+    }
+
+    /// Market value has no full-stream form on the wire, so there is no
+    /// `FULL_MARKET_VALUE` token: a full market-value subscribe is
+    /// rejected with the accepted-vocabulary diagnostic, mirroring the
+    /// other per-contract-only kinds.
+    #[test]
+    fn plan_rejects_full_market_value() {
+        let err = subscription_plan("FULL_MARKET_VALUE", "OPTION", &[]).unwrap_err();
+        assert!(err.contains("'FULL_MARKET_VALUE'"), "echoes the value: {err}");
     }
 
     /// OHLCVC bars are derived from trades: `req_type=OHLC` installs the


### PR DESCRIPTION
## Summary

Two HIGH WebSocket-server defects in `tools/server/src/ws/`.

The WS JSON carries every wire column the tick defines. The Trade frame previously `..`-destructured and emitted only 8 of the 15 columns the tick decodes, silently dropping `ext_condition1`, `ext_condition2`, `ext_condition3`, `ext_condition4`, `condition_flags`, `price_flags`, `volume_type`, and `records_back`. Those columns are decoded on the tick and emitted by the parallel REST trade formatter, so the WS feed served a truncated row that downstream consumers could not reconstruct. The Trade arm now emits all 15 columns under the REST formatter's exact key names.

MARKET_VALUE is a first-class per-contract stream end-to-end. The calculated market-value feed already had a fully plumbed core tick, a REST formatter, and a documented WS envelope, but was unreachable in both directions on the WS server. Three gaps are closed: the data formatter's catch-all swallowed every MarketValue tick, so a serialization arm now emits its `ms_of_day` / `market_bid` / `market_ask` / `market_price` / `date` / `received_at_ns` columns under the REST keys; the subscribe path had no `MARKET_VALUE` req_type, so a subscribe fell through to an unknown-req_type ERROR, and it now maps to a per-contract `SubscriptionKind::MarketValue` (no full-stream form, like `QUOTE`, so a full market-value subscribe is rejected); and contract resolution skipped the `MarketValue` variant, so the emitted tick now carries its contract.

## Tests

Added a Trade-frame test asserting all 15 columns serialize, a MARKET_VALUE serialization test for the calculated columns and contract, a test that a `MARKET_VALUE` subscribe is accepted (not ERROR), and a test that a full market-value subscribe is rejected.

## Verification

`cargo check`, `cargo clippy -- -D warnings`, and `cargo test` clean in `tools/server` (113 + 2 tests pass). Root `cargo fmt --all -- --check` and `python3 scripts/check_binding_parity.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)