### PR TITLE
fix(sdk): expose the flat-files surface on the TypeScript HistoricalClient

### DIFF
--- a/sdks/typescript/__tests__/mdds_client.test.mjs
+++ b/sdks/typescript/__tests__/mdds_client.test.mjs
@@ -101,9 +101,13 @@ describe('HistoricalClient carries the historical surface', () => {
     // The `connect` / `connectFromFile` static factories are lifecycle
     // constructors that live only on the standalone client; the
     // `HistoricalView` is reached through `client.historical` and has no
-    // constructor of its own. Exclude them so the comparison pins the
-    // generated data-fetch surface.
-    const LIFECYCLE = new Set(['connect', 'connectFromFile']);
+    // constructor of its own. The flat-files surface is a hand-written
+    // client-level member that lives on the unified `Client` itself, not on
+    // its `client.historical` view, so it is mirrored onto `HistoricalClient`
+    // directly and pinned against the unified `Client` in its own block
+    // above. Exclude both so this comparison pins the generated data-fetch
+    // surface.
+    const LIFECYCLE = new Set(['connect', 'connectFromFile', 'flatFileToPath']);
     // Every data-fetch method the MDDS-only client exposes must also exist
     // on the unified client's `client.historical` view — the historical
     // surface is generated identically onto both, so the MDDS set is a
@@ -115,6 +119,61 @@ describe('HistoricalClient carries the historical surface', () => {
         `HistoricalClient method ${name} is missing from HistoricalView — the two historical surfaces have drifted`
       );
     }
+  });
+});
+
+describe('HistoricalClient exposes the flat-files surface its contract promises', () => {
+  // The class docstring states the historical / list / snapshot / at-time /
+  // flat-files surface is identical to the unified client. The flat-file
+  // entry points must therefore be reachable here, matching the unified
+  // `Client` and the Python `HistoricalClient`, which delegates to its
+  // wrapped client. A historical-only handle opens the same data channel,
+  // so the namespace and the to-path writer are client-agnostic.
+  const FLATFILE_GETTER = 'flatFiles';
+  const FLATFILE_METHOD = 'flatFileToPath';
+
+  it('declares the flatFiles getter in index.d.ts', () => {
+    assert.match(
+      mddsBlock[0],
+      /get flatFiles\(\): FlatFilesNamespace/,
+      'HistoricalClient must declare the flatFiles getter in index.d.ts'
+    );
+  });
+
+  it('declares the flatFileToPath method in index.d.ts', () => {
+    const methods = methodNames(mddsBlock[0]);
+    assert.ok(
+      methods.has(FLATFILE_METHOD),
+      'HistoricalClient must declare flatFileToPath in index.d.ts'
+    );
+  });
+
+  it('exposes both flat-file members on the loaded addon prototype', () => {
+    const proto = mod.HistoricalClient.prototype;
+    const descriptor = Object.getOwnPropertyDescriptor(proto, FLATFILE_GETTER);
+    assert.equal(
+      typeof descriptor?.get,
+      'function',
+      'HistoricalClient.flatFiles must be an accessor on the prototype'
+    );
+    assert.equal(
+      typeof proto[FLATFILE_METHOD],
+      'function',
+      'HistoricalClient.flatFileToPath must be a method on the prototype'
+    );
+  });
+
+  it('matches the unified Client flat-file surface (control)', () => {
+    const clientBlock = dts.match(/export declare class Client \{[\s\S]*?\n\}/);
+    assert.match(
+      clientBlock[0],
+      /get flatFiles\(\): FlatFilesNamespace/,
+      'the unified Client must retain the flatFiles getter'
+    );
+    assert.ok(
+      methodNames(clientBlock[0]).has(FLATFILE_METHOD),
+      'the unified Client must retain flatFileToPath'
+    );
   });
 });
 

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -1565,6 +1565,18 @@ export declare class HistoricalClient {
   stockHistoryOHLCRange(symbol: string, startDate: string | Date, endDate: string | Date, options?: StockHistoryOhlcRangeOptions | undefined | null): Promise<Array<OhlcTick>>
   /** Stream `stock_history_ohlc_range` rows into `callback` without materialising the full response in memory. `callback(chunk: OhlcTick[]) => void` is invoked once per server chunk; the chunk is freed before the next is fetched, so peak memory tracks a single chunk rather than the whole result. This is the memory-bounded companion to the `stockHistoryOHLCRange` method — prefer it for multi-day or full-universe pulls. The returned Promise resolves when the stream drains and rejects (typed like the buffered method) on a wire or decode error. Cancelling the Promise drops the in-flight request. `options` carries the same optional builder parameters and `timeoutMs` as the buffered method; the `callback` is the trailing argument. */
   stockHistoryOHLCRangeStream(symbol: string, startDate: string | Date, endDate: string | Date, options: StockHistoryOhlcRangeOptions | undefined | null, callback: ((arg: Array<OhlcTick>) => void)): Promise<void>
+  /**
+   * FLATFILES namespace handle. Cheap — shares the underlying client connection.
+   * The historical-only client opens the same data channel as the unified
+   * client, so the full flat-file surface is reachable here unchanged.
+   */
+  get flatFiles(): FlatFilesNamespace
+  /**
+   * Pull a flat-file blob and write the requested format to `path`.
+   * Returns the final on-disk path with the format extension
+   * auto-appended if missing.
+   */
+  flatFileToPath(secType: string, reqType: string, date: string, path: string, format?: string | undefined | null): Promise<string>
 }
 
 /**

--- a/sdks/typescript/src/flatfile_methods.rs
+++ b/sdks/typescript/src/flatfile_methods.rs
@@ -228,11 +228,52 @@ impl FlatFilesNamespace {
 
 // ── Client napi extension ─────────────────────────────────────────
 
-use crate::Client;
+use crate::{Client, HistoricalClient};
 
 #[napi]
 impl Client {
     /// FLATFILES namespace handle. Cheap — shares the underlying client connection.
+    #[napi(getter, js_name = "flatFiles")]
+    pub fn flat_files(&self) -> FlatFilesNamespace {
+        FlatFilesNamespace {
+            client: Arc::clone(&self.client),
+        }
+    }
+
+    /// Pull a flat-file blob and write the requested format to `path`.
+    /// Returns the final on-disk path with the format extension
+    /// auto-appended if missing.
+    #[napi(js_name = "flatFileToPath")]
+    pub async fn flat_file_to_path(
+        &self,
+        sec_type: String,
+        req_type: String,
+        date: String,
+        path: String,
+        format: Option<String>,
+    ) -> napi::Result<String> {
+        let sec = parse_flatfile_sec_type(&sec_type)?;
+        let req = parse_flatfile_req_type(&req_type)?;
+        let fmt = parse_flatfile_format(format.as_deref())?;
+        let client = Arc::clone(&self.client);
+        let path_buf = std::path::PathBuf::from(path);
+        let final_path = spawn_endpoint_task(async move {
+            client
+                .flatfile_request(sec, req, &date, &path_buf, fmt)
+                .await
+        })
+        .await?;
+        Ok(final_path.to_string_lossy().into_owned())
+    }
+}
+
+// ── HistoricalClient napi extension ────────────────────────────────
+
+#[napi]
+impl HistoricalClient {
+    /// FLATFILES namespace handle. Cheap — shares the underlying client connection.
+    /// The historical-only client opens the same data channel as the unified
+    /// client, so the full flat-file surface is reachable here unchanged.
     #[napi(getter, js_name = "flatFiles")]
     pub fn flat_files(&self) -> FlatFilesNamespace {
         FlatFilesNamespace {


### PR DESCRIPTION
The standalone `HistoricalClient` documents a historical / list / snapshot / at-time / flat-files surface identical to the unified client, but the `flatFiles` getter and `flatFileToPath` writer were implemented only on the unified `Client`. A historical-only handle therefore resolved `flatFiles` to `undefined` at runtime, breaking the contract its own docstring promises and diverging from the Python `HistoricalClient`, which delegates to its wrapped client and reaches the flat-files surface.

The invariant: `HistoricalClient` exposes the flat-files surface its contract promises, matching the Python binding and the unified client.

The historical-only handle opens the same data channel and holds the same client core, so the `FlatFilesNamespace` and the to-path writer are client-agnostic. Both members are mirrored onto `HistoricalClient` so the documented surface is reachable. The regenerated `index.d.ts` now declares `get flatFiles()` and `flatFileToPath` on the class, and the structural contract test pins the flat-files surface on `HistoricalClient` against the unified `Client`.

Verification: `cargo check` and `cargo fmt --all -- --check` clean; `npm run build` regenerates `index.d.ts` with the new members; `npm test` passes (170/170); the binding parity gate is clean with no new row required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)