### PR TITLE
feat(server): make per-IP rate limiting opt-in, default off

### DIFF
--- a/docs-site/docs/server/index.md
+++ b/docs-site/docs/server/index.md
@@ -75,6 +75,14 @@ thetadatadx-server --creds creds.txt
 | `--no-streaming` | — | Skip streaming startup (HTTP only). |
 | `--no-ohlcvc` | — | Disable derived OHLCVC bars on the stream. |
 
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `THETADATADX_RATE_LIMIT_PER_SECOND` | — (off) | Opt into per-IP rate limiting at this many requests per second. Setting either rate-limit variable turns the limiter on; see [Security defaults](#security-defaults). |
+| `THETADATADX_RATE_LIMIT_BURST_SIZE` | — (off) | Burst size for the per-IP rate limiter. If you set only one of the two rate-limit variables, the other falls back to `20` req/s / `40` burst. |
+| `THETADATADX_WS_CLIENT_CAPACITY` | `4096` | Per-client WebSocket send-buffer capacity in events. A larger buffer trades memory for more headroom before a slow consumer starts dropping events; invalid or zero values keep the default. |
+
 ## Logging
 
 - The access log (on by default) emits one `INFO` line per request with method, URI, status, and latency.
@@ -83,6 +91,6 @@ thetadatadx-server --creds creds.txt
 
 ## Security defaults
 
-- Binds loopback by default. On non-loopback binds, a per-IP rate limit (20 req/s, burst 40) answers excess traffic with `429` and `Retry-After`; loopback binds are never rate-limited.
+- Binds loopback by default. Per-IP rate limiting is **off by default** — the server imposes no per-IP limit, matching the terminal it replaces. Operators exposing the server as a relay opt in by setting `THETADATADX_RATE_LIMIT_PER_SECOND` and/or `THETADATADX_RATE_LIMIT_BURST_SIZE`; once on, excess traffic from a single IP is answered with `429` and `Retry-After`, on both the HTTP routes and the WebSocket upgrade.
 - `POST /v3/system/shutdown` requires the `X-Shutdown-Token` header — a random token printed once to stderr at startup; there is no flag or environment variable to set it.
 - Request bodies are capped at 64 KiB and query strings at 32 parameters.

--- a/docs-site/docs/server/websocket.md
+++ b/docs-site/docs/server/websocket.md
@@ -57,4 +57,5 @@ websocat ws://127.0.0.1:25520/v1/events
 
 - **One client at a time.** A second connection takes over the stream; the first receives a Close frame (code 1000, reason `replaced by a new client connection`). Run one server instance per consumer for multi-client setups.
 - Text frames are capped at 4 KiB — far above any legitimate envelope.
+- Each connection has a per-client send buffer (default 4096 events). On a high-rate stream a slow consumer that fills the buffer starts dropping events; raise the buffer with the `THETADATADX_WS_CLIENT_CAPACITY` environment variable (trades memory for headroom). See [Environment variables](/server/#environment-variables).
 - Programmatic consumers should prefer the [SDK streaming surface](/streaming/), which adds typed events, automatic reconnect, and drop monitoring.

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -74,6 +74,12 @@ rpassword = "7.5.4"
 # `[workspace]` table (line 15) so it's an independent workspace — it
 # can't inherit via `[lints] workspace = true` from the parent repo.
 # Mirror the rules locally to keep `cargo clippy` parity.
+[dev-dependencies]
+# `util` provides `ServiceExt::oneshot`, used by the rate-limit wire tests
+# to drive the governor composition with an injected peer `ConnectInfo`
+# without binding a real socket or a live upstream client.
+tower = { version = "0.5.3", features = ["limit", "util"] }
+
 [lints.rust]
 warnings = "deny"
 unsafe_op_in_unsafe_fn = "deny"

--- a/tools/server/src/main.rs
+++ b/tools/server/src/main.rs
@@ -254,25 +254,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .allow_methods([axum::http::Method::GET, axum::http::Method::POST])
         .allow_headers(tower_http::cors::Any);
 
-    // Loopback binds skip the general per-IP rate limiter: every local
-    // client shares the same peer IP, so a parallel backtest or bulk
-    // pull would throttle itself as a group — a regression against the
-    // legacy terminal, which imposes no per-IP limit. The limiter stays
-    // on for non-loopback binds where it is a real DoS guard, and the
-    // tighter shutdown-route limiter stays on everywhere.
-    let rate_limit_general = !router::is_loopback_bind(&args.bind);
-    if !rate_limit_general {
-        tracing::info!(
-            bind = %args.bind,
-            "loopback bind: general per-IP rate limiter disabled (shutdown-route limiter stays active)"
-        );
+    // The terminal this server replaces does no per-IP rate limiting, so
+    // the default must not either: with neither rate-limit env var set the
+    // general per-IP governor is attached nowhere, regardless of the bind
+    // address. An operator exposing the server as a relay opts in by
+    // setting THETADATADX_RATE_LIMIT_PER_SECOND and/or
+    // THETADATADX_RATE_LIMIT_BURST_SIZE. The same resolved pair drives both
+    // the HTTP general governor and the WS upgrade governor; the tighter
+    // shutdown-route limiter stays active on every bind regardless.
+    let rate_limit = router::resolve_rate_limit();
+    match rate_limit {
+        Some((per_second, burst_size)) => tracing::info!(
+            per_second,
+            burst_size,
+            "general per-IP rate limiter enabled by operator (opt-in)"
+        ),
+        None => tracing::info!(
+            "general per-IP rate limiter disabled (default; shutdown-route limiter stays active)"
+        ),
     }
 
-    let http_app = router::build(state.clone(), rate_limit_general).layer(cors);
+    let http_app = router::build(state.clone(), rate_limit).layer(cors);
     let http_addr: SocketAddr = format!("{}:{}", args.bind, args.http_port).parse()?;
 
     // Step 7: Build WebSocket server.
-    let ws_app = ws::router(state.clone(), rate_limit_general);
+    let ws_app = ws::router(state.clone(), rate_limit);
     let ws_addr: SocketAddr = format!("{}:{}", args.bind, args.ws_port).parse()?;
 
     // Step 8: Start both servers concurrently.

--- a/tools/server/src/router.rs
+++ b/tools/server/src/router.rs
@@ -19,12 +19,14 @@
 //!    runtime's task slots. Requests past the cap QUEUE on the layer's
 //!    semaphore (they are not rejected) — see the doc on
 //!    [`GLOBAL_CONCURRENCY_LIMIT`].
-//! 3. `tower_governor::GovernorLayer` enforces a per-IP rate limit
-//!    (20 rps, burst 40) on every route — **only on non-loopback binds**.
-//!    On `127.0.0.1` / `::1` every local client shares one bucket, so a
-//!    parallel backtest or bulk pull rate-limits itself as a group; the
-//!    legacy terminal imposes no such limit, and a DoS guard has no
-//!    purpose against the local machine. The shutdown endpoint keeps an
+//! 3. `tower_governor::GovernorLayer` enforces a per-IP rate limit on
+//!    every route — **only when the operator opts in**. The terminal this
+//!    server replaces does no per-IP rate limiting, so the default must
+//!    not either: with neither rate-limit env var set, the general
+//!    governor layer is never attached, regardless of bind address. An
+//!    operator exposing the server as a relay opts in by setting
+//!    `THETADATADX_RATE_LIMIT_PER_SECOND` and/or
+//!    `THETADATADX_RATE_LIMIT_BURST_SIZE`. The shutdown endpoint keeps an
 //!    independent, tighter `route_layer` (~3 attempts per hour per IP) on
 //!    every bind so token-guessing costs real wall-clock time.
 //!
@@ -90,10 +92,15 @@ const GLOBAL_CONCURRENCY_LIMIT: usize = 256;
 /// client.
 const BODY_LIMIT_BYTES: usize = 64 * 1024;
 
-/// General per-IP quota: 20 requests per second with a burst of 40. Tuned
-/// for backtest fetches (bursty metadata pulls followed by idle time).
-const GENERAL_PER_SECOND: u64 = 20;
-const GENERAL_BURST_SIZE: u32 = 40;
+/// Fallback general per-IP quota applied only when the operator opts into
+/// rate limiting by setting one of the two rate-limit env vars but not the
+/// other: 20 requests per second with a burst of 40. Tuned for backtest
+/// fetches (bursty metadata pulls followed by idle time). When NEITHER env
+/// var is set, no general governor is attached at all — the terminal this
+/// server replaces does no per-IP rate limiting, so the default must not
+/// either.
+pub(crate) const GENERAL_PER_SECOND: u64 = 20;
+pub(crate) const GENERAL_BURST_SIZE: u32 = 40;
 
 /// Shutdown endpoint quota: ~3 attempts per IP per hour.
 ///
@@ -152,28 +159,67 @@ pub(crate) fn governor_error_response(error: GovernorError) -> axum::response::R
     }
 }
 
-/// Whether `bind` is a loopback address (`127.0.0.0/8`, `::1`).
+/// Opt-in per-IP rate-limit setting: `(per_second, burst_size)`.
 ///
-/// Drives the per-IP rate-limiter decision: loopback binds skip the
-/// general `GovernorLayer` because every local client shares the same
-/// peer IP and would throttle each other as a group. Unparseable values
-/// (hostnames) conservatively count as non-loopback so the limiter stays
-/// on when the reachability of the bind is unknown.
-pub(crate) fn is_loopback_bind(bind: &str) -> bool {
-    bind.parse::<std::net::IpAddr>()
-        .map(|ip| ip.is_loopback())
-        .unwrap_or(false)
+/// The general `GovernorLayer` (on both the HTTP general routes and the WS
+/// upgrade) is attached only when this is `Some`. It is `Some` only when the
+/// operator sets at least one of the two rate-limit env vars; otherwise the
+/// server runs with no general per-IP limit, matching the terminal it
+/// replaces.
+pub type RateLimit = (u64, u32);
+
+/// Environment variable names for the opt-in per-IP rate limit.
+pub(crate) const ENV_RATE_LIMIT_PER_SECOND: &str = "THETADATADX_RATE_LIMIT_PER_SECOND";
+pub(crate) const ENV_RATE_LIMIT_BURST_SIZE: &str = "THETADATADX_RATE_LIMIT_BURST_SIZE";
+
+/// Resolve the opt-in per-IP rate limit from the process environment.
+///
+/// The terminal this server replaces does no per-IP rate limiting, so the
+/// default is OFF: with NEITHER `THETADATADX_RATE_LIMIT_PER_SECOND` nor
+/// `THETADATADX_RATE_LIMIT_BURST_SIZE` set, this returns `None` and no
+/// general governor is attached anywhere. Operators exposing the server as
+/// a relay opt in by setting one or both.
+///
+/// When at least one is set the limiter is enabled; a value that is absent
+/// or unparseable falls back to the documented default constant for that
+/// field ([`GENERAL_PER_SECOND`] / [`GENERAL_BURST_SIZE`]), so a single env
+/// var is enough to turn the limiter on with sane companion settings.
+pub fn resolve_rate_limit() -> Option<RateLimit> {
+    resolve_rate_limit_from(
+        std::env::var(ENV_RATE_LIMIT_PER_SECOND).ok().as_deref(),
+        std::env::var(ENV_RATE_LIMIT_BURST_SIZE).ok().as_deref(),
+    )
+}
+
+/// Pure core of [`resolve_rate_limit`], split out so the opt-in / partial-set
+/// semantics can be tested without mutating process-global env state.
+pub(crate) fn resolve_rate_limit_from(
+    per_second: Option<&str>,
+    burst_size: Option<&str>,
+) -> Option<RateLimit> {
+    // Default-OFF: neither knob present means no governor anywhere.
+    if per_second.is_none() && burst_size.is_none() {
+        return None;
+    }
+    let per_second = per_second
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(GENERAL_PER_SECOND);
+    let burst_size = burst_size
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(GENERAL_BURST_SIZE);
+    Some((per_second, burst_size))
 }
 
 /// Build the full REST API router with routes dynamically generated from
 /// the endpoint registry plus hand-written system routes.
 ///
-/// `rate_limit_general` mounts the per-IP general rate limiter; pass
-/// `false` for loopback binds (see [`is_loopback_bind`]). The tighter
-/// shutdown-route limiter is mounted unconditionally.
+/// `rate_limit` mounts the per-IP general rate limiter only when `Some`
+/// (see [`resolve_rate_limit`]); the terminal this server replaces does no
+/// per-IP rate limiting, so the default `None` attaches no general governor.
+/// The tighter shutdown-route limiter is mounted unconditionally.
 ///
 /// Default port: 25503 (matching ThetaData v3 terminal).
-pub fn build(state: AppState, rate_limit_general: bool) -> Router {
+pub fn build(state: AppState, rate_limit: Option<RateLimit>) -> Router {
     let mut app = Router::new();
     let mut registered = 0usize;
 
@@ -235,17 +281,17 @@ pub fn build(state: AppState, rate_limit_general: bool) -> Router {
         .layer(ConcurrencyLimitLayer::new(GLOBAL_CONCURRENCY_LIMIT))
         .layer(DefaultBodyLimit::max(BODY_LIMIT_BYTES));
 
-    // Global per-IP governor (outermost rate limit), DoS guard for
-    // non-loopback binds only. On loopback every local client shares one
-    // bucket and a parallel backtest throttles itself; the legacy
-    // terminal imposes no per-IP limit there. The shutdown route's
-    // tighter governor above stays active on every bind.
-    if rate_limit_general {
+    // Global per-IP governor (outermost rate limit), an opt-in DoS guard.
+    // The terminal this server replaces does no per-IP rate limiting, so
+    // the default attaches no general governor; an operator exposing the
+    // server as a relay opts in via the rate-limit env vars. The shutdown
+    // route's tighter governor above stays active on every bind regardless.
+    if let Some((per_second, burst_size)) = rate_limit {
         let global_governor = Arc::new(
             GovernorConfigBuilder::default()
                 .key_extractor(PeerIpKeyExtractor)
-                .per_second(GENERAL_PER_SECOND)
-                .burst_size(GENERAL_BURST_SIZE)
+                .per_second(per_second)
+                .burst_size(burst_size)
                 .finish()
                 .expect("general governor config invariants hold at build time"),
         );
@@ -290,11 +336,95 @@ pub fn build(state: AppState, rate_limit_general: bool) -> Router {
 mod tests {
     use super::*;
 
+    use std::net::SocketAddr;
+
+    use axum::body::Body;
+    use axum::extract::ConnectInfo;
+    use axum::http::Request;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
     async fn body_string(resp: axum::response::Response) -> String {
         let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .expect("body collect");
         String::from_utf8(bytes.to_vec()).expect("body utf8")
+    }
+
+    /// Build a minimal router that mounts the general governor exactly as
+    /// `build()` does — same `GovernorConfigBuilder`, `PeerIpKeyExtractor`,
+    /// and `governor_error_response` — over a trivial `200 OK` route, so the
+    /// opt-in / default-off wiring can be exercised at the wire level without
+    /// constructing a live `AppState`.
+    fn governor_probe_router(rate_limit: Option<RateLimit>) -> Router {
+        let app = Router::new().route("/probe", get(|| async { StatusCode::OK }));
+        let Some((per_second, burst_size)) = rate_limit else {
+            return app;
+        };
+        let governor = Arc::new(
+            GovernorConfigBuilder::default()
+                .key_extractor(PeerIpKeyExtractor)
+                .per_second(per_second)
+                .burst_size(burst_size)
+                .finish()
+                .expect("general governor config invariants hold at build time"),
+        );
+        app.layer(GovernorLayer::new(governor).error_handler(governor_error_response))
+    }
+
+    /// Fire one `/probe` request carrying a peer `ConnectInfo` so the
+    /// `PeerIpKeyExtractor` resolves a key, returning the response status.
+    async fn probe_once(app: &Router, peer: SocketAddr) -> StatusCode {
+        let mut req = Request::builder()
+            .uri("/probe")
+            .body(Body::empty())
+            .expect("request builds");
+        req.extensions_mut().insert(ConnectInfo(peer));
+        app.clone()
+            .oneshot(req)
+            .await
+            .expect("router responds")
+            .status()
+    }
+
+    /// Default-OFF: with no rate limit resolved, a burst far exceeding the
+    /// old 20 rps / burst 40 ceiling is never `429`'d — the server imposes
+    /// no per-IP limit, matching the terminal it replaces.
+    #[tokio::test]
+    async fn no_governor_when_rate_limit_unset_never_429s_a_burst() {
+        let app = governor_probe_router(None);
+        let peer: SocketAddr = "203.0.113.7:9000".parse().unwrap();
+        for _ in 0..100 {
+            assert_eq!(
+                probe_once(&app, peer).await,
+                StatusCode::OK,
+                "default-off server must not rate-limit any request"
+            );
+        }
+    }
+
+    /// Opt-in: with a tuned ceiling, traffic up to the burst passes and the
+    /// next same-IP request in the same instant is rejected with `429`.
+    #[tokio::test]
+    async fn governor_enforces_tuned_ceiling_when_rate_limit_set() {
+        // burst_size 3 with a low refill: the 4th immediate request from the
+        // same peer must be shed.
+        let app = governor_probe_router(Some((1, 3)));
+        let peer: SocketAddr = "203.0.113.8:9000".parse().unwrap();
+
+        for n in 0..3 {
+            assert_eq!(
+                probe_once(&app, peer).await,
+                StatusCode::OK,
+                "request {n} within the burst must pass"
+            );
+        }
+        assert_eq!(
+            probe_once(&app, peer).await,
+            StatusCode::TOO_MANY_REQUESTS,
+            "request past the tuned burst must be rate-limited"
+        );
     }
 
     /// 429 rejections carry the canonical envelope, the bare JSON
@@ -356,28 +486,45 @@ mod tests {
         assert!(body.contains("limiter offline"), "{body}");
     }
 
+    /// Default-OFF: with neither env var set the limiter resolves to
+    /// `None`, so no general governor is attached on any bind — the
+    /// terminal this server replaces imposes no per-IP rate limit.
     #[test]
-    fn loopback_binds_are_detected() {
-        assert!(is_loopback_bind("127.0.0.1"));
-        assert!(is_loopback_bind("127.0.0.53"));
-        assert!(is_loopback_bind("::1"));
+    fn rate_limit_is_off_when_neither_env_var_is_set() {
+        assert_eq!(resolve_rate_limit_from(None, None), None);
     }
 
+    /// Both env vars set: the operator's tuned pair is used verbatim.
     #[test]
-    fn non_loopback_binds_keep_the_limiter() {
-        assert!(!is_loopback_bind("0.0.0.0"));
-        assert!(!is_loopback_bind("192.168.2.21"));
-        assert!(!is_loopback_bind("10.0.0.7"));
-        assert!(!is_loopback_bind("::"));
+    fn rate_limit_uses_both_operator_values_when_set() {
+        assert_eq!(resolve_rate_limit_from(Some("5"), Some("9")), Some((5, 9)));
     }
 
-    /// Unparseable binds (hostnames) conservatively count as
-    /// non-loopback: the limiter stays on when the reachability of the
-    /// bind cannot be determined from the string.
+    /// Only one of the pair set still turns the limiter ON; the absent
+    /// field falls back to its documented default constant.
     #[test]
-    fn unparseable_binds_default_to_limited() {
-        assert!(!is_loopback_bind("localhost"));
-        assert!(!is_loopback_bind(""));
-        assert!(!is_loopback_bind("example.internal"));
+    fn rate_limit_partial_set_falls_back_to_defaults() {
+        assert_eq!(
+            resolve_rate_limit_from(Some("7"), None),
+            Some((7, GENERAL_BURST_SIZE))
+        );
+        assert_eq!(
+            resolve_rate_limit_from(None, Some("11")),
+            Some((GENERAL_PER_SECOND, 11))
+        );
+    }
+
+    /// A present-but-unparseable value falls back to its default rather
+    /// than disabling the limiter the operator asked for.
+    #[test]
+    fn rate_limit_unparseable_value_falls_back_to_default() {
+        assert_eq!(
+            resolve_rate_limit_from(Some("not-a-number"), Some("9")),
+            Some((GENERAL_PER_SECOND, 9))
+        );
+        assert_eq!(
+            resolve_rate_limit_from(Some("5"), Some("oops")),
+            Some((5, GENERAL_BURST_SIZE))
+        );
     }
 }

--- a/tools/server/src/state.rs
+++ b/tools/server/src/state.rs
@@ -30,12 +30,35 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-/// Per-client channel capacity. Matches the old `broadcast::channel(4096)`.
+/// Default per-client channel capacity. Matches the old `broadcast::channel(4096)`.
 ///
 /// At ~10k events/sec peak (market open), 4096 gives ~400ms of headroom
 /// before a slow WebSocket consumer starts dropping events.  Each slot is
 /// an `Arc<str>` (~16 bytes), so 4096 slots cost ~64KB per client.
+///
+/// An operator can override this with the `THETADATADX_WS_CLIENT_CAPACITY`
+/// env var (see [`ws_client_capacity`]) — a larger buffer trades memory for
+/// more headroom against a slow consumer on a high-rate stream.
 const WS_CLIENT_CAPACITY: usize = 4096;
+
+/// Environment variable that overrides the per-client WS channel capacity.
+const ENV_WS_CLIENT_CAPACITY: &str = "THETADATADX_WS_CLIENT_CAPACITY";
+
+/// Resolve the per-client WS channel capacity from the environment, falling
+/// back to [`WS_CLIENT_CAPACITY`] when `THETADATADX_WS_CLIENT_CAPACITY` is
+/// unset, unparseable, or zero. A zero-capacity bounded `mpsc::channel`
+/// would reject every `try_send`, so it is treated as invalid and ignored.
+fn ws_client_capacity() -> usize {
+    ws_client_capacity_from(std::env::var(ENV_WS_CLIENT_CAPACITY).ok().as_deref())
+}
+
+/// Pure core of [`ws_client_capacity`], split out so the override and the
+/// fallback-on-invalid behaviour can be tested without touching env state.
+fn ws_client_capacity_from(raw: Option<&str>) -> usize {
+    raw.and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(WS_CLIENT_CAPACITY)
+}
 
 /// Connected WS clients. Each gets its own bounded mpsc sender so the FPSS
 /// callback can fan out a single `Arc<str>` (serialized once) without cloning
@@ -145,7 +168,7 @@ impl AppState {
 
     /// Register a new WS client, returning the receiver half of its channel.
     pub async fn register_ws_client(&self) -> mpsc::Receiver<Arc<str>> {
-        let (tx, rx) = mpsc::channel(WS_CLIENT_CAPACITY);
+        let (tx, rx) = mpsc::channel(ws_client_capacity());
         self.inner.ws_clients.write().await.push(tx);
         rx
     }
@@ -273,8 +296,33 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::ct_eq;
+    use super::{ct_eq, ws_client_capacity_from, WS_CLIENT_CAPACITY};
     use std::sync::Arc;
+
+    /// Unset env falls back to the compiled-in default capacity.
+    #[test]
+    fn ws_capacity_defaults_when_env_unset() {
+        assert_eq!(ws_client_capacity_from(None), WS_CLIENT_CAPACITY);
+    }
+
+    /// A valid override is read verbatim.
+    #[test]
+    fn ws_capacity_reads_env_override() {
+        assert_eq!(ws_client_capacity_from(Some("8192")), 8192);
+        assert_eq!(ws_client_capacity_from(Some("  256  ")), 256);
+    }
+
+    /// Unparseable or zero values fall back to the default rather than
+    /// producing a useless zero-capacity channel.
+    #[test]
+    fn ws_capacity_invalid_falls_back_to_default() {
+        assert_eq!(ws_client_capacity_from(Some("0")), WS_CLIENT_CAPACITY);
+        assert_eq!(
+            ws_client_capacity_from(Some("not-a-number")),
+            WS_CLIENT_CAPACITY
+        );
+        assert_eq!(ws_client_capacity_from(Some("")), WS_CLIENT_CAPACITY);
+    }
 
     /// Stand-in for the `Inner.ws_session` slot so the begin/end
     /// semantics can be pinned without constructing a live

--- a/tools/server/src/ws/mod.rs
+++ b/tools/server/src/ws/mod.rs
@@ -15,10 +15,12 @@
 //!
 //! # Hardening
 //!
-//! The WS router composes the same three layers as the REST router
+//! The WS router composes the same layers as the REST router
 //! (`router::build`): a 256-wide `ConcurrencyLimitLayer`, a 64 KiB
-//! `DefaultBodyLimit`, and a per-peer-IP `GovernorLayer` (20 rps, burst 40).
-//! On top of that, `handle_client_message` rejects any `Message::Text`
+//! `DefaultBodyLimit`, and — only when the operator opts in via the
+//! rate-limit env vars — a per-peer-IP `GovernorLayer`. The terminal this
+//! server replaces does no per-IP rate limiting, so the default attaches no
+//! governor. On top of that, `handle_client_message` rejects any `Message::Text`
 //! longer than [`WS_MAX_TEXT_BYTES`]. A legitimate subscribe / stop command
 //! is well under 200 bytes; anything larger is attack-shaped and discarded
 //! before `sonic_rs::from_str` touches it.
@@ -57,10 +59,6 @@ const WS_CONCURRENCY_LIMIT: usize = 256;
 /// multi-MB body through the axum extractor chain.
 const WS_BODY_LIMIT_BYTES: usize = 64 * 1024;
 
-/// Per-IP rate for the WS upgrade path. Matches the REST router.
-const WS_GENERAL_PER_SECOND: u64 = 20;
-const WS_GENERAL_BURST_SIZE: u32 = 40;
-
 /// Build the WebSocket router (single route: `/v1/events`).
 ///
 /// Applies the same hardening layers as `router::build`:
@@ -71,23 +69,25 @@ const WS_GENERAL_BURST_SIZE: u32 = 40;
 ///    attackers from queueing thousands of blocked upgrades.
 /// 2. `DefaultBodyLimit` caps the upgrade request body at
 ///    [`WS_BODY_LIMIT_BYTES`].
-/// 3. `GovernorLayer` keyed on the peer connect-info IP enforces
-///    [`WS_GENERAL_PER_SECOND`] rps with a burst of [`WS_GENERAL_BURST_SIZE`]
-///    — only when `rate_limit_general` is set (non-loopback binds; see
-///    `router::is_loopback_bind`). Peer-IP-only — `X-Forwarded-For` is
-///    ignored (see `router.rs` for rationale).
-pub fn router(state: AppState, rate_limit_general: bool) -> Router {
+/// 3. `GovernorLayer` keyed on the peer connect-info IP enforces the
+///    operator's tuned `(per_second, burst)` pair — only when `rate_limit`
+///    is `Some` (the operator opted in via the rate-limit env vars; see
+///    `router::resolve_rate_limit`). The same pair is applied to the HTTP
+///    general governor, keeping the two surfaces consistent. The default is
+///    no governor, matching the terminal this server replaces. Peer-IP-only
+///    — `X-Forwarded-For` is ignored (see `router.rs` for rationale).
+pub fn router(state: AppState, rate_limit: Option<crate::router::RateLimit>) -> Router {
     let mut app = Router::new()
         .route("/v1/events", get(upgrade::ws_upgrade))
         .layer(ConcurrencyLimitLayer::new(WS_CONCURRENCY_LIMIT))
         .layer(DefaultBodyLimit::max(WS_BODY_LIMIT_BYTES));
 
-    if rate_limit_general {
+    if let Some((per_second, burst_size)) = rate_limit {
         let governor = Arc::new(
             GovernorConfigBuilder::default()
                 .key_extractor(PeerIpKeyExtractor)
-                .per_second(WS_GENERAL_PER_SECOND)
-                .burst_size(WS_GENERAL_BURST_SIZE)
+                .per_second(per_second)
+                .burst_size(burst_size)
                 .finish()
                 .expect("ws governor config invariants hold at build time"),
         );

--- a/tools/server/src/ws/subscribe.rs
+++ b/tools/server/src/ws/subscribe.rs
@@ -784,7 +784,10 @@ mod tests {
     #[test]
     fn plan_rejects_full_market_value() {
         let err = subscription_plan("FULL_MARKET_VALUE", "OPTION", &[]).unwrap_err();
-        assert!(err.contains("'FULL_MARKET_VALUE'"), "echoes the value: {err}");
+        assert!(
+            err.contains("'FULL_MARKET_VALUE'"),
+            "echoes the value: {err}"
+        );
     }
 
     /// OHLCVC bars are derived from trades: `req_type=OHLC` installs the
@@ -830,8 +833,14 @@ mod tests {
     fn plan_rejects_full_open_interest_for_non_option() {
         for sec_type in ["STOCK", "INDEX"] {
             let err = subscription_plan("FULL_OPEN_INTEREST", sec_type, &[]).unwrap_err();
-            assert!(err.contains("OPTION"), "names the only valid sec_type: {err}");
-            assert!(err.contains(sec_type), "echoes the rejected sec_type: {err}");
+            assert!(
+                err.contains("OPTION"),
+                "names the only valid sec_type: {err}"
+            );
+            assert!(
+                err.contains(sec_type),
+                "echoes the rejected sec_type: {err}"
+            );
         }
     }
 


### PR DESCRIPTION
The terminal this server replaces does no per-IP rate limiting — it is local-only and never meant for outside-IP exposure. Our server had added a `tower_governor` per-IP limit (20 rps / burst 40) on the HTTP general routes and the WebSocket upgrade, auto-enabled on non-loopback binds. That imposes behavior the terminal does not have. This makes per-IP rate limiting opt-in and off by default, configurable for operators who expose the server as a relay.

## What changed

Rate limiting is now off by default on every bind. With neither rate-limit environment variable set, no general governor layer is attached anywhere — matching the terminal the server replaces. Operators opt in by setting one or both of `THETADATADX_RATE_LIMIT_PER_SECOND` (`u64`) and `THETADATADX_RATE_LIMIT_BURST_SIZE` (`u32`). The resolved `(per_second, burst)` pair is applied to both the HTTP general governor and the WebSocket upgrade governor, keeping the two surfaces consistent. If only one of the pair is set, the other falls back to the documented `20` req/s / `40` burst default, so a single variable is enough to turn the limiter on with sane companion settings.

The bind-address auto-enable (`!is_loopback_bind(bind)`) is gone. The governor decision is now purely "are the rate-limit env vars set?", so `is_loopback_bind` and its tests were removed — nothing else referenced them. The tighter shutdown-route limiter (~3 attempts per hour per IP) is unaffected and stays active on every bind.

The per-client WebSocket send-buffer capacity is now configurable via `THETADATADX_WS_CLIENT_CAPACITY` (`usize`, default `4096`); unset, unparseable, or zero values keep the default.

Docs under `docs-site/docs/server/` document the default-off behavior, the two opt-in env vars, and the capacity override. These pages are hand-maintained (not generator output); the docs-site generator `--check` still passes.

A pre-existing `cargo fmt` deviation in `tools/server/src/ws/subscribe.rs` (two assert macros) is reformatted so the workspace fmt gate passes; no logic change there.

## Verification

- `cargo check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` green (119 unit + 2 integration), including new tests: governor absent ⇒ a 100-request burst is never `429`'d; governor present ⇒ enforces the tuned ceiling; WS capacity reads the env override and falls back on invalid input
- `cargo fmt --all -- --check` clean
- `python3 scripts/check_binding_parity.py` clean
- `generate_docs_site --features config-file,__internal --locked -- --check` clean

Supersedes #868 and #869 — same env-config approach, with rate limiting default-OFF for terminal parity. Thanks @0xdefnoterr for surfacing both knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)