### PR TITLE
fix(core): make IV solve total, calendar type authoritative, validate cadence/timeouts

### DIFF
--- a/crates/thetadatadx/src/config/flatfiles.rs
+++ b/crates/thetadatadx/src/config/flatfiles.rs
@@ -124,6 +124,16 @@ impl Default for FlatFilesConfig {
 pub mod bounds {
     /// Allowed range for [`super::FlatFilesConfig::max_attempts`].
     pub const MAX_ATTEMPTS: std::ops::RangeInclusive<u32> = 1..=100;
+
+    /// Allowed range (secs) for [`super::FlatFilesConfig::connect_timeout_secs`].
+    /// A connect timeout must be positive (a `0` timeout fails every connect
+    /// instantly); capped at five minutes.
+    pub const CONNECT_TIMEOUT_SECS: std::ops::RangeInclusive<u64> = 1..=300;
+
+    /// Allowed range (secs) for [`super::FlatFilesConfig::read_timeout_secs`].
+    /// A read timeout must be positive; capped at one hour for large
+    /// flat-file pulls.
+    pub const READ_TIMEOUT_SECS: std::ops::RangeInclusive<u64> = 1..=3_600;
 }
 
 #[cfg(test)]

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -61,8 +61,8 @@ pub use fpss::{
 pub use mdds::HistoricalConfig;
 pub use metrics::MetricsConfig;
 pub use reconnect::{
-    ReconnectAttemptClass, ReconnectAttemptLimits, ReconnectConfig, ReconnectPolicy,
-    RATE_LIMITED_JITTER_WINDOW,
+    bounds as reconnect_bounds, ReconnectAttemptClass, ReconnectAttemptLimits, ReconnectConfig,
+    ReconnectPolicy, RATE_LIMITED_JITTER_WINDOW,
 };
 pub use retry::RetryPolicy;
 pub use runtime::RuntimeConfig;
@@ -376,6 +376,75 @@ impl DirectConfig {
                 ),
             ));
         }
+        // Reconnect cadence trio: the rate-limited and server-restart floors
+        // must be positive delays, and the replay pace must stay within band.
+        // A `0` cadence would busy-loop the reconnect driver; bands are
+        // band-checked up front the same way the streaming knobs are.
+        if !reconnect_bounds::WAIT_RATE_LIMITED_MS.contains(&self.reconnect.wait_rate_limited_ms) {
+            return Err(Error::config_out_of_range(
+                "reconnect.wait_rate_limited_ms",
+                to_i64(self.reconnect.wait_rate_limited_ms),
+                to_i64(*reconnect_bounds::WAIT_RATE_LIMITED_MS.start()),
+                to_i64(*reconnect_bounds::WAIT_RATE_LIMITED_MS.end()),
+            ));
+        }
+        if !reconnect_bounds::WAIT_SERVER_RESTART_MS
+            .contains(&self.reconnect.wait_server_restart_ms)
+        {
+            return Err(Error::config_out_of_range(
+                "reconnect.wait_server_restart_ms",
+                to_i64(self.reconnect.wait_server_restart_ms),
+                to_i64(*reconnect_bounds::WAIT_SERVER_RESTART_MS.start()),
+                to_i64(*reconnect_bounds::WAIT_SERVER_RESTART_MS.end()),
+            ));
+        }
+        if !reconnect_bounds::REPLAY_PACE_MS.contains(&self.reconnect.replay_pace_ms) {
+            return Err(Error::config_out_of_range(
+                "reconnect.replay_pace_ms",
+                to_i64(self.reconnect.replay_pace_ms),
+                to_i64(*reconnect_bounds::REPLAY_PACE_MS.start()),
+                to_i64(*reconnect_bounds::REPLAY_PACE_MS.end()),
+            ));
+        }
+        // Auto-reconnect per-class attempt budgets: every class budget must
+        // be at least one attempt so the driver can make forward progress and
+        // within band so a typo cannot spin effectively forever. Only the
+        // `Auto` policy carries budgets; `Manual` / `Custom` have none to
+        // check.
+        if let ReconnectPolicy::Auto(limits) = &self.reconnect.policy {
+            for (field, value) in [
+                ("reconnect.max_attempts", limits.max_attempts),
+                (
+                    "reconnect.max_rate_limited_attempts",
+                    limits.max_rate_limited_attempts,
+                ),
+                (
+                    "reconnect.max_server_restart_attempts",
+                    limits.max_server_restart_attempts,
+                ),
+            ] {
+                if !reconnect_bounds::ATTEMPT_BUDGET.contains(&value) {
+                    return Err(Error::config_out_of_range(
+                        field,
+                        i64::from(value),
+                        i64::from(*reconnect_bounds::ATTEMPT_BUDGET.start()),
+                        i64::from(*reconnect_bounds::ATTEMPT_BUDGET.end()),
+                    ));
+                }
+            }
+        }
+        // Historical retry policy: the backoff ceiling cannot sit below the
+        // initial delay (mirrors the flatfiles `max_backoff >= initial_backoff`
+        // invariant), or the exponential ladder would start above its own cap.
+        if self.retry.max_delay < self.retry.initial_delay {
+            return Err(Error::config_invalid(
+                "retry.max_delay",
+                format!(
+                    "max_delay ({:?}) must be >= initial_delay ({:?})",
+                    self.retry.max_delay, self.retry.initial_delay
+                ),
+            ));
+        }
         // Validate ring_size eagerly so a bad config fails fast rather
         // than waiting for the connect attempt. Re-validation happens
         // at `StreamingClient::connect` for callers that bypass `validate`.
@@ -400,6 +469,25 @@ impl DirectConfig {
                     "max_backoff ({:?}) must be >= initial_backoff ({:?})",
                     self.flatfiles.max_backoff, self.flatfiles.initial_backoff
                 ),
+            ));
+        }
+        // Flat-file HTTP timeouts must be positive: a `0` connect or read
+        // timeout aborts every request instantly. Band-checked up front like
+        // the streaming timeouts.
+        if !flatfiles_bounds::CONNECT_TIMEOUT_SECS.contains(&self.flatfiles.connect_timeout_secs) {
+            return Err(Error::config_out_of_range(
+                "flatfiles.connect_timeout_secs",
+                to_i64(self.flatfiles.connect_timeout_secs),
+                to_i64(*flatfiles_bounds::CONNECT_TIMEOUT_SECS.start()),
+                to_i64(*flatfiles_bounds::CONNECT_TIMEOUT_SECS.end()),
+            ));
+        }
+        if !flatfiles_bounds::READ_TIMEOUT_SECS.contains(&self.flatfiles.read_timeout_secs) {
+            return Err(Error::config_out_of_range(
+                "flatfiles.read_timeout_secs",
+                to_i64(self.flatfiles.read_timeout_secs),
+                to_i64(*flatfiles_bounds::READ_TIMEOUT_SECS.start()),
+                to_i64(*flatfiles_bounds::READ_TIMEOUT_SECS.end()),
             ));
         }
         Ok(self)
@@ -1642,6 +1730,48 @@ mod tests {
         config.streaming.ring_size = 100; // not a power of two
         let err = config.validate().expect_err("must reject non-power-of-two");
         assert!(err.to_string().contains("ring_size"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_reconnect_rate_limited_cadence() {
+        let mut config = DirectConfig::production_defaults();
+        config.reconnect.wait_rate_limited_ms = 0;
+        let err = config.validate().expect_err("must reject zero cadence");
+        assert!(err.to_string().contains("wait_rate_limited_ms"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_reconnect_attempt_budget() {
+        let mut config = DirectConfig::production_defaults();
+        config.reconnect.policy = ReconnectPolicy::Auto(ReconnectAttemptLimits {
+            max_attempts: 0,
+            ..ReconnectAttemptLimits::default()
+        });
+        let err = config
+            .validate()
+            .expect_err("must reject zero attempt budget");
+        assert!(err.to_string().contains("max_attempts"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_flatfiles_connect_timeout() {
+        let mut config = DirectConfig::production_defaults();
+        config.flatfiles.connect_timeout_secs = 0;
+        let err = config
+            .validate()
+            .expect_err("must reject zero connect timeout");
+        assert!(err.to_string().contains("connect_timeout_secs"));
+    }
+
+    #[test]
+    fn validate_rejects_inverted_retry_delays() {
+        let mut config = DirectConfig::production_defaults();
+        config.retry.initial_delay = std::time::Duration::from_secs(60);
+        config.retry.max_delay = std::time::Duration::from_secs(1);
+        let err = config
+            .validate()
+            .expect_err("must reject inverted retry ladder");
+        assert!(err.to_string().contains("max_delay"));
     }
 
     #[test]

--- a/crates/thetadatadx/src/config/reconnect.rs
+++ b/crates/thetadatadx/src/config/reconnect.rs
@@ -310,6 +310,35 @@ impl Default for ReconnectConfig {
     }
 }
 
+/// Validation bounds for the wired reconnect cadence and auto-reconnect
+/// attempt budgets. Bands are chosen to keep the production defaults
+/// comfortably inside their range while rejecting the degenerate `0` /
+/// runaway values that would otherwise validate clean.
+pub mod bounds {
+    use std::ops::RangeInclusive;
+
+    /// Allowed range (ms) for [`super::ReconnectConfig::wait_rate_limited_ms`].
+    /// The rate-limit cooldown is upstream-instructed; it must be a positive
+    /// delay and is capped at one hour so a typo cannot strand a client.
+    pub const WAIT_RATE_LIMITED_MS: RangeInclusive<u64> = 1..=3_600_000;
+
+    /// Allowed range (ms) for [`super::ReconnectConfig::wait_server_restart_ms`].
+    /// A flat cadence between pool-bounce retries: positive, at most ten
+    /// minutes.
+    pub const WAIT_SERVER_RESTART_MS: RangeInclusive<u64> = 1..=600_000;
+
+    /// Allowed range (ms) for [`super::ReconnectConfig::replay_pace_ms`].
+    /// `0` is permitted (pause removed; bursts still flush individually);
+    /// capped at one minute.
+    pub const REPLAY_PACE_MS: RangeInclusive<u64> = 0..=60_000;
+
+    /// Allowed range for each [`super::ReconnectAttemptLimits`] per-class
+    /// attempt budget (`max_attempts`, `max_rate_limited_attempts`,
+    /// `max_server_restart_attempts`). At least one attempt; an upper cap
+    /// that still spans multi-hour outages at the slowest cadence.
+    pub const ATTEMPT_BUDGET: RangeInclusive<u32> = 1..=100_000;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/thetadatadx/src/mdds/decode/dual_type_columns.rs
+++ b/crates/thetadatadx/src/mdds/decode/dual_type_columns.rs
@@ -341,16 +341,24 @@ pub fn parse_calendar_days_v3(
             };
 
             // type: Text "open"/"full_close"/"early_close"/"weekend"
-            // (the documented v3 wire shape). `NullValue` -> the
-            // conservative closed-day fill, matching the generated
-            // parser's absent-column seed. Any other variant ->
-            // TypeMismatch. The column itself is required (guard
-            // above), so the `None` arm is unreachable but kept total.
+            // (the documented v3 wire shape). The `type` column is the
+            // sole source of both `is_open` and `status`, so a present-
+            // but-null cell on a rows-present response is malformed: a
+            // calendar row that carries no day type cannot be classified.
+            // Reject it as a typed decode error rather than coalescing to
+            // a conservative closed-day fill, matching the strict policy
+            // `row_calendar_status` applies on every other typed column.
+            // The column itself is required (guard above), so the `None`
+            // (Unset) arm is unreachable but kept total.
             let (is_open, status) = match type_idx {
                 Some(i) => match cell_type(row, i)? {
                     Some(proto::data_value::DataType::Text(s)) => calendar_type_text(s)?,
                     Some(proto::data_value::DataType::NullValue(_)) => {
-                        (false, crate::tdbe::CalendarStatus::FullClose)
+                        return Err(DecodeError::TypeMismatch {
+                            column: i,
+                            expected: "Text",
+                            observed: "Null",
+                        });
                     }
                     None => {
                         return Err(DecodeError::TypeMismatch {

--- a/crates/thetadatadx/src/mdds/decode/tests.rs
+++ b/crates/thetadatadx/src/mdds/decode/tests.rs
@@ -1451,6 +1451,25 @@ fn parse_calendar_days_v3_errors_on_unknown_type_text() {
 }
 
 #[test]
+fn parse_calendar_days_v3_errors_on_null_type_cell() {
+    // `type` is the sole source of both `is_open` and `status`. A present-
+    // but-null cell on a rows-present response cannot be classified, so it is
+    // a typed decode error rather than a silent closed-day fill.
+    let table = proto::DataTable {
+        headers: vec!["date".into(), "type".into()],
+        data_table: vec![row_of(vec![dv_number(20_260_413), dv_null()])],
+    };
+    assert_eq!(
+        parse_calendar_days_v3(&table).unwrap_err(),
+        DecodeError::TypeMismatch {
+            column: 1,
+            expected: "Text",
+            observed: "Null",
+        }
+    );
+}
+
+#[test]
 fn parse_calendar_days_v3_errors_on_invalid_open_time_text() {
     let table = proto::DataTable {
         headers: vec!["date".into(), "type".into(), "open".into()],

--- a/crates/thetadatadx/src/tdbe/greeks.rs
+++ b/crates/thetadatadx/src/tdbe/greeks.rs
@@ -540,13 +540,30 @@ fn iv_bisection(s: f64, x: f64, r: f64, q: f64, t: f64, o: f64, is_call: bool, o
     let mut end = guess;
     let mut changer = 0.2;
 
-    // Find upper bound
+    // Find upper bound: grow `end` until the model value crosses above `o`.
+    let mut bracketed = false;
     for _ in 0..32 {
         end += changer;
         if value(s, x, end, r, q, t, is_call) > o {
+            bracketed = true;
             break;
         }
         changer *= 2.0;
+    }
+    // Upper-bound bracketing failed: the model value never reaches `o` even at
+    // the largest probed vol. A Black-Scholes call value asymptotes to
+    // `s * exp(-q*t)` as vol grows without bound, so any `o` at or above that
+    // ceiling (a crossed/stale tick where the option trades above its own
+    // attainable maximum) has no implied volatility. Mirror the price-too-low
+    // intrinsic branch: report the no-IV signal (`iv == 0.0` plus the relative
+    // residual) rather than walking `guess` up to the runaway upper bound. The
+    // solve is total — an unattainable price yields the no-IV signal, never a
+    // garbage IV near the search ceiling.
+    if !bracketed {
+        let v = value(s, x, end, r, q, t, is_call);
+        out[0] = 0.0;
+        out[1] = ((v - o) / o).clamp(-100.0, 100.0);
+        return;
     }
     for _ in 0..MAX_TRIES {
         let v = value(s, x, guess, r, q, t, is_call);
@@ -1003,6 +1020,56 @@ mod tests {
         assert!(
             (iv - true_vol).abs() < 0.005,
             "IV roundtrip: expected {true_vol}, got {iv}, err={err}"
+        );
+    }
+
+    #[test]
+    fn iv_unattainable_price_above_spot_returns_no_iv_signal() {
+        // A call value asymptotes to `s * exp(-q*t)` as vol grows without bound,
+        // so a price above spot can never be matched by any positive vol. The
+        // solve must report the no-IV signal (`iv == 0.0`), never a runaway IV
+        // near the upper-bound search ceiling.
+        let (iv, _err) = implied_volatility(100.0, 100.0, 0.05, 0.0, 0.25, 1_000_000.0, "C")
+            .expect("valid right");
+        assert_eq!(
+            iv, 0.0,
+            "unattainable price (>> spot) must yield no-IV signal, got {iv}"
+        );
+    }
+
+    #[test]
+    fn iv_price_moderately_above_ceiling_returns_no_iv_signal() {
+        // Just above the attainable maximum (`s * exp(-q*t)`): still unattainable.
+        let s = 100.0;
+        let q = 0.02;
+        let ceiling = s * (-q * 0.25_f64).exp();
+        let price = ceiling * 1.05;
+        let (iv, _err) =
+            implied_volatility(s, 100.0, 0.05, q, 0.25, price, "C").expect("valid right");
+        assert_eq!(
+            iv, 0.0,
+            "price just above attainable ceiling must yield no-IV signal, got {iv}"
+        );
+    }
+
+    #[test]
+    fn iv_in_range_price_still_converges() {
+        // Regression guard: a normal, attainable price must solve unchanged.
+        let s = 100.0;
+        let x = 100.0;
+        let r = 0.05;
+        let q = 0.01;
+        let t = 0.25;
+        let true_vol = 0.30;
+        let price = value(s, x, true_vol, r, q, t, true);
+        let (iv, _err) = implied_volatility(s, x, r, q, t, price, "C").expect("valid right");
+        assert!(
+            iv > 0.0,
+            "in-range price must converge to a positive IV, got {iv}"
+        );
+        assert!(
+            (iv - true_vol).abs() < 0.005,
+            "in-range IV must recover the input vol: expected {true_vol}, got {iv}"
         );
     }
 


### PR DESCRIPTION
## Summary

Three core-crate correctness fixes in `crates/thetadatadx/`.

**IV solve is total — an unattainable price yields the no-IV signal, never a runaway.** The implied-volatility bisection grew its upper bound by doubling but broke only once the model value crossed above the target price. A Black-Scholes call value asymptotes to spot as volatility grows without bound, so a crossed or stale tick priced above its own attainable maximum never bracketed: the bound ran away to the search ceiling and the solver returned that ceiling as the implied volatility. Because the reported residual is price-relative, it shrank toward zero for large prices and masked the bad solve. The upper-bound search now records whether it bracketed; when it cannot, the solve reports the no-IV signal (`iv == 0.0` plus the relative residual) exactly as the existing price-too-low intrinsic branch does, rather than walking the guess up to the runaway ceiling.

**Calendar type is authoritative.** The v3 calendar decoder treated a present-but-null `type` cell as a conservative closed-day fill. The `type` column is the sole source of both `is_open` and `status`, so a rows-present response carrying a null `type` cell is malformed and cannot be classified. It is now a typed decode error, matching the strict policy every other typed calendar column already applies.

**validate() rejects out-of-range cadence and timeouts up front.** Validation never inspected the reconnect cadence trio (`wait_rate_limited_ms` / `wait_server_restart_ms` / `replay_pace_ms`), the auto-reconnect per-class attempt budgets, the historical retry ladder, or the flat-file connect and read timeouts, so zero and out-of-range values validated clean against the documented reject-out-of-range-up-front contract. These knobs are now band-checked the same way the streaming and flat-file attempt knobs are: cadence delays and timeouts must be positive, each attempt budget must allow at least one attempt, and the retry backoff ceiling cannot sit below the initial delay.

## Tests

New unit tests: IV on a price far above spot and just above the attainable ceiling both return the no-IV signal, and an in-range price still converges to the input vol; a null calendar `type` cell decodes to a `TypeMismatch`; zero reconnect cadence, zero attempt budget, zero flat-file connect timeout, and an inverted retry ladder are all rejected. Existing valid configs still pass.

## Verification

`cargo check`, `cargo clippy --all-targets --features __internal -D warnings`, the targeted greeks/decode/config tests (debug and the IV tests in `--release` to confirm no overflow), `cargo fmt --all -- --check`, and `check_binding_parity.py` all clean. No new error leaf was added — the null-type case reuses the existing `DecodeError::TypeMismatch`, so binding parity stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)