### PR TITLE
fix(python): raise StreamError, not RuntimeError, on a partial reconnect

### DIFF
--- a/sdks/python/src/fpss_client.rs
+++ b/sdks/python/src/fpss_client.rs
@@ -846,7 +846,11 @@ impl StreamingClient {
             };
             py.detach(move || inner.restore_subscriptions(&per_contract, &full_stream))
         };
-        outcome.map_err(|e| PyRuntimeError::new_err(format!("reconnect succeeded but {e}")))
+        // Route the partial-restore failure through the typed-exception
+        // mapper so a `PartialReconnect` surfaces as `StreamError` — the
+        // same leaf the unified `StreamView.reconnect` raises — rather
+        // than a bare `RuntimeError` that `except StreamError` misses.
+        outcome.map_err(to_py_err)
     }
 
     /// Block until every superseded streaming session's event ring


### PR DESCRIPTION
The standalone `StreamingClient.reconnect` wrapped a partial-restore failure (core `PartialReconnect`) in a bare `PyRuntimeError`, so `except thetadatadx.StreamError` missed it — while the unified `StreamView.reconnect` routes the identical condition through `to_py_err` and raises `StreamError`. Routes it through `to_py_err` so both surfaces raise the same typed leaf. Cross-binding error-parity fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)