### PR TITLE
fix(ffi): guard reconnect callback against panics and pin hand-written ABI struct layouts

### DIFF
--- a/docs-site/docs/migration/v12-to-v13.md
+++ b/docs-site/docs/migration/v12-to-v13.md
@@ -427,7 +427,7 @@ Per binding:
 - **Python** — `ContractRef.strike` is `Optional[float]` dollars; `strike_dollars` is removed.
 - **TypeScript** — the streaming `Contract.strike` is `number` dollars; `strikeDollars` is removed. `Contract.option(...)` accepts `number | string`.
 - **Rust** — the codec struct field is renamed `Contract.strike_thousandths` (the wire encoding, unit in the name); read dollars via `strike_dollars()`.
-- **C** — `ThetaDataDxContract.strike` is `double` dollars. Offset (24) and struct size (32) are unchanged (the field widens into former tail padding); recompile against the new header. The streaming-contract strike accessor is `thetadatadx_contract_strike_dollars(contract, &out)`, mirroring the C++ `thetadatadx::strike(c)` helper.
+- **C** — `ThetaDataDxContract.strike` is `double` dollars at offset 24. The struct also carries the wire-encoded `strike_thousandths` (`int32_t`) as a real trailing field at offset 32, so `sizeof(ThetaDataDxContract)` is 40 (the layout pinned in `sdks/cpp/include/fpss_layout_asserts.hpp.inc`); recompile against the new header. The streaming-contract strike accessor is `thetadatadx_contract_strike_dollars(contract, &out)`, mirroring the C++ `thetadatadx::strike(c)` helper.
 - **WS server** — subscribe payloads take `"strike"` as a JSON number in dollars (`550` or `550.5`); the contract JSON in every outgoing frame emits dollars. Clients that sent thousandths must divide by 1000.
 - **Flat files** — decoded rows (`FlatFileRow.strike`, the Python/TS row dicts, the Arrow projection) carry dollars; the on-disk CSV/JSONL writers keep the vendor's file format.
 

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -1730,8 +1730,27 @@ pub unsafe extern "C" fn thetadatadx_config_set_reconnect_callback(
         unsafe impl Sync for CallbackCtx {}
         impl CallbackCtx {
             fn invoke(&self, reason: i32, attempt: u32) -> i64 {
-                // SAFETY: `self.cb` is the caller-registered function pointer and `self.user_data` the matching context; the registration contract guarantees both stay valid and thread-safe while any client built from the config is alive.
-                unsafe { (self.cb)(reason, attempt, self.user_data) }
+                // The decision callback runs on the streaming I/O thread,
+                // not on a `ffi_boundary!`-guarded entry point, so a panic
+                // here would unwind across the C ABI on a foreign thread.
+                // Catch it and fall back to the stop decision (`-1`), the
+                // same defence the stream dispatcher applies per
+                // invocation, so a panicking decision callback ends the
+                // reconnect loop instead of aborting the process.
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    // SAFETY: `self.cb` is the caller-registered function pointer and `self.user_data` the matching context; the registration contract guarantees both stay valid and thread-safe while any client built from the config is alive.
+                    unsafe { (self.cb)(reason, attempt, self.user_data) }
+                }));
+                match result {
+                    Ok(delay_ms) => delay_ms,
+                    Err(_) => {
+                        tracing::error!(
+                            target: "thetadatadx::ffi",
+                            "reconnect decision callback panicked; stopping reconnect attempts",
+                        );
+                        -1
+                    }
+                }
             }
         }
         let ctx = CallbackCtx { cb, user_data };

--- a/sdks/cpp/include/abi_struct_layout_asserts.hpp.inc
+++ b/sdks/cpp/include/abi_struct_layout_asserts.hpp.inc
@@ -1,0 +1,94 @@
+// Layout guards for the hand-written `#[repr(C)]` ABI structs that are
+// not emitted from a schema (so no generated assert covers them). The
+// generated tick and FPSS event structs are pinned in
+// `tick_layout_asserts.hpp.inc` and `fpss_layout_asserts.hpp.inc`; the
+// structs below are declared by hand on both sides, so these
+// hand-written asserts are the only thing that fails the build if a
+// field width, padding gap, or member order drifts from the Rust
+// definitions in `ffi/src` (`types.rs`, `streaming.rs`, `flatfiles.rs`).
+//
+// Sizes and offsets are the LP64 layout (x86_64 / aarch64 Linux, macOS)
+// of the matching `#[repr(C)]` structs.
+
+// ── ThetaDataDxOptionContract (ffi/src/types.rs) ──
+// symbol (const char*) @0, expiration (int32_t) @8, 4-byte pad,
+// strike (double) @16, right (uint32_t) @24, 4-byte tail pad → 32 bytes.
+static_assert(offsetof(ThetaDataDxOptionContract, symbol) == 0,
+              "ThetaDataDxOptionContract::symbol offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxOptionContract, expiration) == 8,
+              "ThetaDataDxOptionContract::expiration offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxOptionContract, strike) == 16,
+              "ThetaDataDxOptionContract::strike offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxOptionContract, right) == 24,
+              "ThetaDataDxOptionContract::right offset drifted from Rust");
+static_assert(sizeof(ThetaDataDxOptionContract) == 32,
+              "ThetaDataDxOptionContract total size drifted from Rust");
+
+// ── ThetaDataDxOptionContractArray (ffi/src/types.rs) ──
+static_assert(offsetof(ThetaDataDxOptionContractArray, data) == 0,
+              "ThetaDataDxOptionContractArray::data offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxOptionContractArray, len) == 8,
+              "ThetaDataDxOptionContractArray::len offset drifted from Rust");
+static_assert(sizeof(ThetaDataDxOptionContractArray) == 16,
+              "ThetaDataDxOptionContractArray total size drifted from Rust");
+
+// ── ThetaDataDxStringArray (ffi/src/types.rs) ──
+static_assert(offsetof(ThetaDataDxStringArray, data) == 0,
+              "ThetaDataDxStringArray::data offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxStringArray, len) == 8,
+              "ThetaDataDxStringArray::len offset drifted from Rust");
+static_assert(sizeof(ThetaDataDxStringArray) == 16,
+              "ThetaDataDxStringArray total size drifted from Rust");
+
+// ── ThetaDataDxSubscription (ffi/src/streaming.rs) ──
+static_assert(offsetof(ThetaDataDxSubscription, kind) == 0,
+              "ThetaDataDxSubscription::kind offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxSubscription, contract) == 8,
+              "ThetaDataDxSubscription::contract offset drifted from Rust");
+static_assert(sizeof(ThetaDataDxSubscription) == 16,
+              "ThetaDataDxSubscription total size drifted from Rust");
+
+// ── ThetaDataDxSubscriptionArray (ffi/src/streaming.rs) ──
+static_assert(offsetof(ThetaDataDxSubscriptionArray, data) == 0,
+              "ThetaDataDxSubscriptionArray::data offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxSubscriptionArray, len) == 8,
+              "ThetaDataDxSubscriptionArray::len offset drifted from Rust");
+static_assert(sizeof(ThetaDataDxSubscriptionArray) == 16,
+              "ThetaDataDxSubscriptionArray total size drifted from Rust");
+
+// ── ThetaDataDxSubscriptionRequest (ffi/src/streaming.rs) ──
+// scope (int32_t) @0, kind (int32_t) @4, then six pointer fields packed
+// 8 bytes apart with no interior padding → 48 bytes.
+static_assert(offsetof(ThetaDataDxSubscriptionRequest, scope) == 0,
+              "ThetaDataDxSubscriptionRequest::scope offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxSubscriptionRequest, kind) == 4,
+              "ThetaDataDxSubscriptionRequest::kind offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxSubscriptionRequest, symbol) == 8,
+              "ThetaDataDxSubscriptionRequest::symbol offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxSubscriptionRequest, expiration) == 16,
+              "ThetaDataDxSubscriptionRequest::expiration offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxSubscriptionRequest, strike) == 24,
+              "ThetaDataDxSubscriptionRequest::strike offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxSubscriptionRequest, right) == 32,
+              "ThetaDataDxSubscriptionRequest::right offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxSubscriptionRequest, sec_type) == 40,
+              "ThetaDataDxSubscriptionRequest::sec_type offset drifted from Rust");
+static_assert(sizeof(ThetaDataDxSubscriptionRequest) == 48,
+              "ThetaDataDxSubscriptionRequest total size drifted from Rust");
+
+// ── ThetaDataDxArrowBytes (ffi/src/types.rs) ──
+static_assert(offsetof(ThetaDataDxArrowBytes, data) == 0,
+              "ThetaDataDxArrowBytes::data offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxArrowBytes, len) == 8,
+              "ThetaDataDxArrowBytes::len offset drifted from Rust");
+static_assert(sizeof(ThetaDataDxArrowBytes) == 16,
+              "ThetaDataDxArrowBytes total size drifted from Rust");
+
+// ── ThetaDataDxFlatFileBytes (ffi/src/flatfiles.rs) ──
+// Layout-identical to ThetaDataDxArrowBytes by contract.
+static_assert(offsetof(ThetaDataDxFlatFileBytes, data) == 0,
+              "ThetaDataDxFlatFileBytes::data offset drifted from Rust");
+static_assert(offsetof(ThetaDataDxFlatFileBytes, len) == 8,
+              "ThetaDataDxFlatFileBytes::len offset drifted from Rust");
+static_assert(sizeof(ThetaDataDxFlatFileBytes) == 16,
+              "ThetaDataDxFlatFileBytes total size drifted from Rust");

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -147,6 +147,11 @@ using TradeQuoteTick = ThetaDataDxTradeQuoteTick;
 // Generated layout guards for the FPSS event C mirror structs.
 #include "fpss_layout_asserts.hpp.inc"
 
+// Layout guards for the hand-written ABI structs (option contract,
+// subscription, arrow / flat-file byte buffers, string + array
+// wrappers) that no schema generator covers.
+#include "abi_struct_layout_asserts.hpp.inc"
+
 // OptionContract uses std::string for symbol to avoid use-after-free.
 // The C FFI ThetaDataDxOptionContract uses a raw char* that is freed with the array,
 // so we deep-copy the string during conversion.


### PR DESCRIPTION
Three defense-in-depth fixes across the C ABI crate, the C++ binding, and the migration doc.

## Reconnect callback panic guard

The decision callback installed by `thetadatadx_config_set_reconnect_callback` is invoked from the streaming I/O thread, outside any `ffi_boundary!` guard. A panic in a consumer decision callback (for example a PyO3 consumer of the C ABI) would unwind across the C boundary on a foreign thread. The stream-callback path already wraps each invocation in `catch_unwind`; the reconnect path did not. This wraps the callback invocation in `catch_unwind` and falls back to the stop decision (`-1`) on panic, so a panicking callback ends the reconnect loop instead of aborting the process. Mirrors the existing stream dispatcher behaviour.

## Layout guards for hand-written ABI structs

The generated tick and FPSS event structs are pinned with `static_assert` offset and size guards, but several hand-written `repr(C)` ABI structs had no compile-time drift guard: `ThetaDataDxOptionContract` (which has a non-obvious 4-byte pad before `strike`), `ThetaDataDxSubscription`, `ThetaDataDxSubscriptionRequest`, `ThetaDataDxArrowBytes` / `ThetaDataDxFlatFileBytes`, `ThetaDataDxStringArray`, and the `{data, len}` array wrappers. Layouts matched the Rust definitions but nothing failed the build on drift. A new `abi_struct_layout_asserts.hpp.inc` adds `offsetof` and `sizeof` asserts for each, included alongside the existing generated guards. The expected offsets and sizes were read from the actual `repr(C)` layouts in `ffi/src`, and confirmed to fire on a deliberately perturbed offset (not tautological).

## Migration doc correction

The `ThetaDataDxContract` migration note stated the struct size (32) was unchanged. The authoritative layout is 40 bytes, with `strike` (double) at offset 24 and `strike_thousandths` (int32_t) a real trailing field at offset 32, matching the machine-asserted layout in `sdks/cpp/include/fpss_layout_asserts.hpp.inc`. The prose now states the correct numbers.

## Verification

- `cargo build -p thetadatadx-ffi` clean (debug and release)
- `cargo fmt --all -- --check` clean
- `cargo clippy -p thetadatadx-ffi -- -D warnings` clean
- `cargo test -p thetadatadx-ffi` all pass
- `g++ -std=c++17 -fsyntax-only -I sdks/cpp/include` against `thetadatadx.hpp` clean with the new asserts active; a perturbed offset was confirmed to fail the build
- `scripts/check_c_abi_completeness.py` clean against the release `.so` (326 symbols, bidirectional parity)
- `scripts/check_safety_comment_boilerplate.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)