### PR TITLE
docs: remove terminal-provenance vocabulary from public docs and gate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1460,7 +1460,7 @@ code does not change.
 ### Added
 
 - **Seven Architecture Decision Records** under `docs/architecture/`:
-  ADR-001 (Java terminal parity sourcing), ADR-002 (FPSS ring power-of-two
+  ADR-001 (JVM terminal parity sourcing), ADR-002 (FPSS ring power-of-two
   capacity), ADR-003 (MDDS `2^tier` concurrent-request mapping), ADR-004
   (Eastern-time DST cutover), ADR-005 (OCC-21 century scope, expires
   2099-12-31), ADR-006 (FPSS reconnect policy with rate-limit-aware backoff),
@@ -1681,7 +1681,7 @@ PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
   vendor surface documented in the [v2 → v3 migration guide][v3-mig].
   The wire codec is unchanged — `Contract::to_bytes` /
   `Contract::from_bytes` still serialize the field as `root` per
-  `Contract.java` parity, and the FLATFILES decoder still resolves both
+  the contract codec parity, and the FLATFILES decoder still resolves both
   v2 (`root`) and v3 (`symbol`) response columns through the existing
   `decode::HEADER_ALIASES`. Per-language renames:
 
@@ -2014,13 +2014,13 @@ PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
 ### Fixed
 
 - **`fpss::accumulator::change_price_type` now matches the JVM terminal's
-  `PriceCalcUtils.changePriceType` byte-for-byte.** v8.0.21 widened the
+  price-type rescale byte-for-byte.** v8.0.21 widened the
   multiplication through `i64` and returned the unscaled input on
-  overflow, which broke parity with the Java reference (Java `int * int`
-  silently wraps under two's-complement). The rescale now uses
-  `i32::wrapping_mul`, reproducing the JVM's exact wire bits in both
+  overflow, which broke parity with the JVM terminal (its `i32 * i32`
+  rescale silently wraps under two's-complement). The rescale now uses
+  `i32::wrapping_mul`, reproducing the JVM terminal's exact wire bits in both
   debug and release. Tests pin the wrapping result to manually-computed
-  Java-equivalent values (e.g. `2_148 * 10^6 → -2_146_967_296`).
+  reference values (e.g. `2_148 * 10^6 → -2_146_967_296`).
 - **`decode::row_number_i64` clamps `price_type` to `0..=19`** so the
   same wire cell decodes identically through `row_number_i64` and
   `row_price_f64` (the latter routes through `tdbe::Price::new`, which
@@ -2732,7 +2732,7 @@ Major release. Three headline groups land in one pass:
 ### Changed
 
 - **License switched to Apache-2.0** across every `Cargo.toml`, `package.json`, `pyproject.toml`, and the top-level `LICENSE`. `deny.toml` allowlist cleaned up accordingly.
-- **Top-level `README.md` rewritten** as a professional SDK landing page: tagline, highlights, per-SDK quickstart (Rust / Python / TypeScript / Go / C++), architecture diagram, Java parity note. Neutral technical framing throughout.
+- **Top-level `README.md` rewritten** as a professional SDK landing page: tagline, highlights, per-SDK quickstart (Rust / Python / TypeScript / Go / C++), architecture diagram, JVM terminal parity note. Neutral technical framing throughout.
 - **A consolidated parity-tracking checklist added** as the single source of truth for terminal parity — feature-by-feature table (parity / deviation / partial) covering wire protocol, authentication, control events, reconnection, FPSS streaming, tick decoding, Greeks, validation, and intentional improvements over the JVM terminal. Three earlier stand-alone parity notes folded in.
 - **Internal `docs/dev/` design notes removed** (no longer load-bearing).
 - **`DirectClient` renamed to `HistoricalClient`** (#383) — the historical-data gRPC client now carries the name of the service it actually speaks to (MDDS = Market Data Delivery Service). `use thetadatadx::DirectClient` call sites break; update to `use thetadatadx::HistoricalClient`. The `DirectConfig` associated config type keeps its name. High-level consumers of `Client` (Python / TypeScript / Go / C++ / Rust facade) are unaffected.
@@ -2817,7 +2817,7 @@ Major release. Three headline groups land in one pass:
 - **FPSS TLS: SPKI pinning replaces `NoVerifier`** (#377) — `PinnedVerifier` parses the leaf cert via `x509-parser`, computes SHA-256 over the SubjectPublicKeyInfo DER bytes, and constant-time compares (`subtle::ConstantTimeEq`) against the captured `FPSS_SPKI_SHA256` (verified identical across prod `nj-a:20000` / `nj-b:20000`, dev `:20200`, stage `:20100` — single keypair across every FPSS environment). Rejects with `CertificateError::NotValidForName` on hostname mismatch (allowlist) or `RustlsError::General("FPSS SPKI pin mismatch: ...")` on pin mismatch. `verify_tls12_signature` / `verify_tls13_signature` delegate to rustls' proper signature verification. Previously any on-path attacker terminating TLS to `nj-a.thetadata.us:20000` could present any cert and harvest the plaintext `StreamMsgType::Credentials` frame.
 - **Password `Zeroizing<String>`** (#377) — `Credentials.password` wrapped in `zeroize::Zeroizing<String>`. Every clone (`Client`, `io_loop`, reconnect re-serialise) now wipes the backing buffer on drop. Core dump / `/proc/<pid>/mem` no longer recovers the password after `Credentials` drops. `Deref<Target = str>` means call-sites are unchanged.
 - **CSV formula injection defused on `thetadatadx-server` exports** (#377) — `escape_csv_field` now prefixes cells whose first byte is `=`, `+`, `-`, `@`, or `\t` with a single-quote `'` and encloses in CSV quotes. Defuses `=cmd|'/C calc'!A1`, `@SUM(A1:A10)`, `+1+cmd|...` etc from executing in Excel downloads. Regression test covers all five payload shapes.
-- **FPSS `io_loop`: Java-parity mid-frame read retry with per-read deadline reset** (#370) — previously a mid-frame read timeout desynced the decoder. The client now retries transparently with the per-read deadline reset, matching the Java terminal's reconnect behaviour.
+- **FPSS `io_loop`: JVM-terminal-parity mid-frame read retry with per-read deadline reset** (#370) — previously a mid-frame read timeout desynced the decoder. The client now retries transparently with the per-read deadline reset, matching the JVM terminal's reconnect behaviour.
 - **WS subscribe strike / expiration use `i32::try_from`** (#377) — client-supplied expiration / strike no longer silently narrow via `as i32`. Returns `REQ_RESPONSE { response: "ERROR", ... }` with a descriptive message on overflow. Validates `exp` against `[19000101, 21000101]` YYYYMMDD bounds and `strike > 0` before building the FPSS frame (#378).
 - **`validate_generic_named` sanitises parameter names in error messages** (#377 / follow-up) — ANSI escape sequences / control chars in a user-supplied param name can no longer escape into terminal-rendered log output. Names are passed through `sanitize_param_name` (ASCII alphanumeric + `_` + `-`).
 - **Shutdown token constant-time compare** (#377) — `tools/server/src/state.rs::validate_shutdown_token` swapped `==` for `subtle::ConstantTimeEq::ct_eq`. Timing oracle on UUID prefix closed.
@@ -2931,7 +2931,7 @@ Major release. Three headline groups land in one pass:
 - **Double string allocation on `Contract` clone** (#324) -- `Contract` now wraps its symbol in `Arc<str>` so cloning into per-subscription bookkeeping does not copy the byte buffer twice.
 - **JSON serialization moved off the FPSS I/O thread** (#324) -- `next_event` now returns typed structs and the serialization step is only paid at the FFI boundary when the caller asks for JSON, keeping the streaming hot path allocation-free.
 - **`parse_right` no longer panics on unrecognized input** (#324) -- the canonical right parser returns a structured error for unknown vocabulary instead of panicking, so a single malformed row can no longer take down the decoder.
-- **Unset `DataValue` oneof fails loud in every strict decoder** (#326) -- `parse_option_contracts_v3` (expiration, right), `parse_calendar_days_v3` (date, type, open, close), and the generator-emitted EOD helpers plus contract-id injected `expiration` / `right` used to treat a `DataValue` whose `data_type` oneof was unset as a legitimate null and coalesce to `0`. They now return `DecodeError::TypeMismatch { observed: "Unset" }`, matching `row_number` / `row_date` / `row_float` / `row_text` / `row_number_i64` / `row_price_f64` and the Java terminal's default arm. `NullValue` is still coalesced (legitimate null); only the wire-anomaly path changes.
+- **Unset `DataValue` oneof fails loud in every strict decoder** (#326) -- `parse_option_contracts_v3` (expiration, right), `parse_calendar_days_v3` (date, type, open, close), and the generator-emitted EOD helpers plus contract-id injected `expiration` / `right` used to treat a `DataValue` whose `data_type` oneof was unset as a legitimate null and coalesce to `0`. They now return `DecodeError::TypeMismatch { observed: "Unset" }`, matching `row_number` / `row_date` / `row_float` / `row_text` / `row_number_i64` / `row_price_f64` and the JVM terminal's default arm. `NullValue` is still coalesced (legitimate null); only the wire-anomaly path changes.
 - **Option contract wildcard rejection** (#284) -- before this release the SDK had no working path to the server's bulk-chain mode: `*` was rejected client-side by `validate_expiration`, and `0` was rejected server-side. The SDK vocabulary now covers the full cross-product the server accepts.
 - **Validator tier detection drift** (#289) -- dropped the static tier gate that classified legitimate server responses as SKIP. The runtime permission fallback still catches drift between docs and the wire (for example, `interest_rate_history_eod` being labelled `free` on docs but gated higher by the server).
 - **CI unbroken on `main`** (#299) -- fixed a `timeout_ms` TOML field mismatch and made the Go pin-test CRLF-robust.
@@ -3071,7 +3071,7 @@ Major release. Three headline groups land in one pass:
 
 - **`DirectConfig::derive_ohlcvc(bool)`** -- config-driven OHLCVC opt-out, replaces duplicate method. (#129)
 - **REST server drop-in replacement** -- `--email`/`--password`, `--config`, `--fpss-region` CLI args. `/v3/system/status` endpoint. Startup banner. (#128)
-- **Error suppression 5s after STOP** -- matches Java terminal behavior. (#124)
+- **Error suppression 5s after STOP** -- matches the JVM terminal's behavior. (#124)
 - **Auth retry on transient errors** -- 3 attempts, 2s delay, network errors only. (#125)
 - **Config validation** -- clamps queue_depth (16-1M), window_size (64-1024) with warnings. (#126)
 - **Password character warning** -- on INVALID_CREDENTIALS disconnect. (#127)
@@ -3089,7 +3089,7 @@ Major release. Three headline groups land in one pass:
 
 ### Added
 
-- **FPSS auto-reconnect** with configurable policy: `Auto` (default, matches Java terminal), `Manual`, `Custom(fn)`. New control events: `Reconnecting`, `Reconnected`. (#119)
+- **FPSS auto-reconnect** with configurable policy: `Auto` (default, matches the JVM terminal), `Manual`, `Custom(fn)`. New control events: `Reconnecting`, `Reconnected`. (#119)
 - **Trade/quote condition descriptions** with special-case annotations (e.g., `*update last if only trade`).
 
 ### Fixed
@@ -3226,7 +3226,7 @@ Major release. Three headline groups land in one pass:
 - **Builder pattern** -- all endpoints return chainable builders. Zero noise for simple calls, all optional proto params discoverable via autocomplete.
 - **`received_at_ns`** -- nanosecond receive timestamp on every FPSS event for latency measurement
 - **`tdbe::latency::latency_ns()`** -- DST-aware wire-to-application latency computation
-- **`FpssFlushMode`** -- `Batched` (default, matches Java) or `Immediate` (lowest latency)
+- **`FpssFlushMode`** -- `Batched` (default, matches the JVM terminal) or `Immediate` (lowest latency)
 - **Metrics** -- `metrics` crate integration. Counters/histograms on all gRPC, FPSS, and auth operations. Zero overhead when no backend installed.
 - **Config file** -- `DirectConfig::from_file()` behind `config-file` feature flag. TOML format matching v3 terminal.
 - **`DirectConfig::stage()`** -- staging FPSS servers (port 20100)
@@ -3267,7 +3267,7 @@ Major release. Three headline groups land in one pass:
 
 - **Timezone hardcoded UTC-4** -- was producing ms_of_day shifted +1 hour for all Nov-Mar historical data. Now DST-aware with 5 unit tests. (#32)
 - **EOD parser divergent alias system** -- unified to shared `find_header()`. (#34)
-- **reconnect_wait_ms** -- changed from 1000 to 2000 to match Java terminal. (#35)
+- **reconnect_wait_ms** -- changed from 1000 to 2000 to match the JVM terminal. (#35)
 - **C++ OptionContract use-after-free** -- root string was dangling after array free. Now deep-copies to `std::string`. (#39)
 - **Active subscriptions not cleared on explicit shutdown** -- `shutdown()` clears, involuntary disconnect preserves for reconnect. (#38)
 - Mermaid diagram syntax in architecture.md (#30)
@@ -3297,9 +3297,9 @@ v3 MDDS DataTable parsing (Timestamp cells), DST-aware timezone, gRPC flow contr
 ### Fixed
 
 - **Interval conversion**: MDDS server accepts preset shorthand (`1m`, `5m`, `1h`), not raw milliseconds. `normalize_interval()` now converts `"60000"` -> `"1m"`, `"300000"` -> `"5m"`, etc. Sub-second presets supported: `"100"` -> `"100ms"`, `"500"` -> `"500ms"`. Users can pass either milliseconds or shorthand directly.
-- **Default start_time/end_time**: the Java terminal defaults these to `"09:30:00"` and `"16:00:00"`. Our SDK left them as None, causing `"Invalid time format: Expected hh:mm:ss.SSS"` on trade/quote/greeks endpoints. Now defaults to RTH.
+- **Default start_time/end_time**: the JVM terminal defaults these to `"09:30:00"` and `"16:00:00"`. Our SDK left them as None, causing `"Invalid time format: Expected hh:mm:ss.SSS"` on trade/quote/greeks endpoints. Now defaults to RTH.
 - **extract_text_column**: now handles Number and Price DataTable values. `option_list_strikes` was returning 0 results because strikes come as Number values, not Text.
-- **FPSS TLS certificate**: ThetaData's FPSS servers have certificates expired since Jan 2024. Skip certificate verification for FPSS connections (matching Java terminal behavior).
+- **FPSS TLS certificate**: ThetaData's FPSS servers have certificates expired since Jan 2024. Skip certificate verification for FPSS connections (matching the JVM terminal's behavior).
 
 ### Added
 
@@ -3319,7 +3319,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 
 ### Added
 
-- `subscribe_full_open_interest(sec_type)` -- full-stream open interest subscription (was missing, Java terminal has it)
+- `subscribe_full_open_interest(sec_type)` -- full-stream open interest subscription (was missing, the JVM terminal has it)
 - `unsubscribe_full_trades(sec_type)` -- full-stream trade unsubscribe (was missing)
 - `unsubscribe_full_open_interest(sec_type)` -- full-stream OI unsubscribe (was missing)
 - `reconnect_streaming(handler)` on `Client` -- saves active subscriptions, stops streaming, restarts with new handler, re-subscribes all per-contract and full-type subscriptions automatically
@@ -3487,7 +3487,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 
 - FPSS frame read: zero-alloc (reusable buffer)
 - FPSS decode: zero-alloc (tuple return, pre-allocated tick buffer)
-- Delta: wrapping_add (matches Java, no branch)
+- Delta: wrapping_add (matches the JVM terminal, no branch)
 - Required column validation (skip rows on missing headers, no garbage parse)
 - 43 criterion benchmarks across all modules
 
@@ -3520,13 +3520,13 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 
 - **OHLCVC-from-trade derivation** — `OhlcvcAccumulator` derives OHLCVC bars from trade
   ticks in real time. Only emits `StreamEvent::Data(StreamData::Ohlcvc { .. })` after a
-  server-seeded initial bar, matching the Java terminal's behavior. Subsequent trades
+  server-seeded initial bar, matching the JVM terminal's behavior. Subsequent trades
   update open/high/low/close/volume/count incrementally.
 - **StreamEvent split: `StreamData` + `StreamControl`** — the monolithic `StreamEvent` enum is now
   a 3-variant wrapper: `Data(StreamData)` for market data (Quote, Trade, OpenInterest, Ohlcvc),
   `Control(StreamControl)` for lifecycle events (LoginSuccess, Disconnected, MarketOpen, etc.),
   and `RawData` for unparsed frames. This enables `match` arms that handle all data without
-  touching control flow, and vice versa — an intentional improvement not present in Java.
+  touching control flow, and vice versa — an intentional improvement beyond the JVM terminal.
 - **Streaming `_stream` endpoint variants** — `stock_history_trade_stream`,
   `stock_history_quote_stream`, `option_history_trade_stream`, `option_history_quote_stream`
   process gRPC response chunks via callback without materializing the full response in memory.
@@ -3539,29 +3539,29 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 
 ### Fixed
 
-18 correctness and protocol-conformance fixes from a full audit against the Java terminal:
+18 correctness and protocol-conformance fixes from a full audit against the JVM terminal:
 
 **FPSS Protocol**
 
 1. **FPSS contract ID is FIT-decoded** — CONTRACT message contract IDs are now FIT-decoded
-   (matching the Java terminal), not read as raw big-endian i32. Previously produced wrong
+   (matching the JVM terminal), not read as raw big-endian i32. Previously produced wrong
    contract-to-symbol mappings.
 2. **Delta off-by-one fixed** — `apply_deltas` field indexing corrected; previous
    implementation could shift all fields by one position, corrupting tick data.
 3. **Delta state cleared on START/STOP** — per-contract delta accumulators are now reset
-   when the server sends START (market open) or STOP (market close), matching Java behavior.
+   when the server sends START (market open) or STOP (market close), matching the JVM terminal's behavior.
    Previously, stale deltas from the previous session leaked into the next session's ticks.
 4. **ROW_SEP unconditional reset** — ROW_SEP (0xC) now unconditionally resets the field
-   index to SPACING (5), matching the Java FIT reader. Previously this was conditional,
+   index to SPACING (5), matching the JVM terminal's FIT reader. Previously this was conditional,
    which could produce misaligned fields.
-5. **Credential sign-extension** — credential length fields are now read as unsigned,
-   matching Java's `readUnsignedShort()`. Previously, passwords longer than 127 bytes
+5. **Credential sign-extension** — credential length fields are now read as an unsigned
+   16-bit integer, matching the JVM terminal. Previously, passwords longer than 127 bytes
    could produce a negative length.
 6. **Flush only on PING** — the FPSS write buffer is now flushed only when sending PING
-   messages, matching Java's batching behavior. Previously, every write triggered a flush,
+   messages, matching the JVM terminal's batching behavior. Previously, every write triggered a flush,
    increasing syscall overhead and wire chattiness.
 7. **Ping 2000ms initial delay** — the first PING is now delayed by 2000ms after
-   authentication, matching the Java terminal's `Thread.sleep(2000)` before entering the
+   authentication, matching the JVM terminal's 2000 ms pause before entering the
    ping loop. Previously, pings started immediately.
 
 **MDDS / gRPC Protocol**
@@ -3570,11 +3570,11 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
    `null_value` variant (bool), matching the server's proto definition. Previously,
    null cells were silently dropped during deserialization.
 9. **`"client": "terminal"` in query_parameters** — all gRPC requests now include
-   `"client": "terminal"` in the `query_parameters` map, matching the Java terminal.
+   `"client": "terminal"` in the `query_parameters` map, matching the JVM terminal.
    Previously this field was omitted.
 10. **Dynamic concurrency from subscription tier** — `mdds_concurrent_requests` is now
     derived from the `AuthUser` response's subscription tier (`2^tier`), matching the
-    Java terminal's concurrency model. The config field still allows manual override.
+    JVM terminal's concurrency model. The config field still allows manual override.
 11. **Unknown compression returns error** — `decompress_response` now returns
     `Error::Decompress` for unrecognized compression algorithms instead of silently
     treating the data as uncompressed.
@@ -3582,8 +3582,8 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
     `DataTable` (with headers, zero rows) when the gRPC stream contains no data chunks,
     instead of returning `Error::NoData`. Callers can check `.data_table.is_empty()`.
 13. **gRPC flow control window** — the gRPC channel now configures
-    `initial_connection_window_size` and `initial_stream_window_size` to match the Java
-    terminal's Netty settings, preventing throughput bottlenecks on large responses.
+    `initial_connection_window_size` and `initial_stream_window_size` to match the JVM
+    terminal's flow-control settings, preventing throughput bottlenecks on large responses.
 
 **Auth / User Model**
 
@@ -3591,7 +3591,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
     `option_tier`, `index_tier`, and `futures_tier` fields from the Nexus auth response,
     enabling per-asset-class concurrency and permission checks.
 15. **Auth 401/404 handling** — Nexus HTTP responses with status 401 (Unauthorized) or
-    404 (Not Found) are now treated as invalid credentials, matching the Java terminal's
+    404 (Not Found) are now treated as invalid credentials, matching the JVM terminal's
     behavior. Previously these could surface as generic HTTP errors.
 
 **Observability**
@@ -3604,14 +3604,14 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 **Greeks**
 
 17. **6 Greeks formula fixes** — operator precedence corrections across 6 Greek functions
-    to match Java's evaluation order. All formulas now produce bit-identical results to
-    the Java terminal for the same inputs.
+    to match the JVM terminal's evaluation order. All formulas now produce bit-identical results to
+    the JVM terminal for the same inputs.
 18. **`Vera` DataType code (166)** — second-order Greek `Vera` added to the `DataType` enum,
     completing the full set of second-order Greeks (vanna, charm, vomma, veta, vera, sopdk).
 
 ### Security
 
-- **Contract wire format fix** — contract binary serialization now matches the Java terminal
+- **Contract wire format fix** — contract binary serialization now matches the JVM terminal
   exactly. Previous versions could produce incorrect wire bytes for option contracts, causing
   subscription failures or wrong contract assignments. This was a **protocol-level bug**;
   upgrading to 1.2.x is strongly recommended.
@@ -3706,7 +3706,7 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - **StreamingClient** for FPSS streaming — real-time quotes, trades, open interest, OHLC
   via TLS/TCP with heartbeat and manual reconnection
 - **Auth module** — Nexus API authentication (email/password → session UUID)
-- **FIT/FIE codec** — nibble-based tick compression/decompression (ported from Java)
+- **FIT/FIE codec** — nibble-based tick compression/decompression at JVM terminal parity
 - **Greeks calculator** — full Black-Scholes: 22 Greeks + IV bisection solver with
   precomputed shared intermediates and edge-case guards (t=0, v=0)
 - **All tick types** — TradeTick, QuoteTick, OhlcTick, EodTick, OpenInterestTick,
@@ -3724,7 +3724,7 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - **Go SDK** — CGo FFI bindings over the C ABI layer
 - **C++ SDK** — RAII C++ wrapper over the C header
 - **C FFI crate** (`thetadatadx-ffi`) — stable `extern "C"` ABI for all SDKs
-- **Documentation** — architecture (Mermaid), API reference, Java parity checklist
+- **Documentation** — architecture (Mermaid), API reference, JVM terminal parity checklist
 - **CI/CD** — GitHub Actions (fmt, clippy, test, FFI build, crates.io publish, PyPI publish, GitHub Release)
 - **Project infrastructure** — CHANGELOG, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT,
   clippy.toml, cliff.toml, rust-toolchain.toml, LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3713,8 +3713,8 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
   SnapshotTradeTick, TradeQuoteTick with fixed-point Price encoding
 - **80+ DataType enum codes** — quotes, trades, OHLC, all Greek orders, dividends,
   splits, fundamentals
-- **Proto definitions** — extracted via runtime FileDescriptor reflection from
-  ThetaData Terminal v202603181 (endpoints.proto + v3_endpoints.proto)
+- **Proto definitions** — the v3 protocol surface (endpoints.proto +
+  v3_endpoints.proto)
 - **Runtime configuration** — `DirectConfig` with all JVM-equivalent tuning knobs
 - `contract_lookup(id)` on `StreamingClient` for single-entry hot-path lookup
 - `StreamEvent::Error` variant for surfacing protocol parse failures

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Security fixes land on the current major line only. Older majors are not patched
 
 The ThetaData terminal ships with a hardcoded API key that is identical across all
 installations. **This is not a secret** — it is a protocol constant embedded in every
-copy of the Java terminal. thetadatadx includes this key for protocol compatibility. It
+copy of the JVM terminal. thetadatadx includes this key for protocol compatibility. It
 provides no privileged access.
 
 ### Credential Handling
@@ -53,7 +53,7 @@ All network operations enforce timeouts to prevent indefinite hangs:
 - **Nexus auth HTTP**: 10s request timeout, 5s connect timeout
 - **MDDS**: connect timeout + keepalive from `DirectConfig`
 - **FPSS TLS**: connect timeout wraps both TCP and TLS handshake
-- **FPSS read loop**: read timeout matching Java's `SO_TIMEOUT=10s`
+- **FPSS read loop**: a 10s read timeout matching the JVM terminal
 
 ### TLS
 
@@ -66,12 +66,12 @@ All network connections use a **unified TLS stack** (`rustls` with ring backend)
 Root certificates come from `webpki-roots` (Mozilla's CA bundle). Certificate
 validation is enforced on MDDS (gRPC) and Nexus (HTTP) connections. FPSS (streaming)
 skips certificate verification because ThetaData's FPSS servers have certificates
-expired since January 2024 -- this matches the Java terminal's behavior.
+expired since January 2024 -- this matches the JVM terminal's behavior.
 
 ### Credential Handling (FPSS)
 
-FPSS credential length fields are read as unsigned integers (matching Java's
-`readUnsignedShort()`), so passwords longer than 127 bytes authenticate correctly
+FPSS credential length fields are read as an unsigned 16-bit integer (matching the
+JVM terminal), so passwords longer than 127 bytes authenticate correctly
 (a signed read would sign-extend the length and break the handshake).
 
 ### Concurrent Request Limiting
@@ -90,9 +90,9 @@ silently passed to callers.
 
 ### FPSS Event Dispatch
 
-FPSS streaming uses a fully synchronous I/O thread with a lock-free event ring buffer
-for event dispatch. The bounded ring buffer prevents unbounded memory
-growth from unconsumed events.
+FPSS streaming uses a dedicated read path with bounded buffering for event
+dispatch. The bounded buffer prevents unbounded memory growth from unconsumed
+events.
 
 ### Frame Size Limits
 

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -1460,7 +1460,7 @@ code does not change.
 ### Added
 
 - **Seven Architecture Decision Records** under `docs/architecture/`:
-  ADR-001 (Java terminal parity sourcing), ADR-002 (FPSS ring power-of-two
+  ADR-001 (JVM terminal parity sourcing), ADR-002 (FPSS ring power-of-two
   capacity), ADR-003 (MDDS `2^tier` concurrent-request mapping), ADR-004
   (Eastern-time DST cutover), ADR-005 (OCC-21 century scope, expires
   2099-12-31), ADR-006 (FPSS reconnect policy with rate-limit-aware backoff),
@@ -1681,7 +1681,7 @@ PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
   vendor surface documented in the [v2 → v3 migration guide][v3-mig].
   The wire codec is unchanged — `Contract::to_bytes` /
   `Contract::from_bytes` still serialize the field as `root` per
-  `Contract.java` parity, and the FLATFILES decoder still resolves both
+  the contract codec parity, and the FLATFILES decoder still resolves both
   v2 (`root`) and v3 (`symbol`) response columns through the existing
   `decode::HEADER_ALIASES`. Per-language renames:
 
@@ -2014,13 +2014,13 @@ PR #489 (dispatcher core), #490 (C ABI), #492 (Python), #493
 ### Fixed
 
 - **`fpss::accumulator::change_price_type` now matches the JVM terminal's
-  `PriceCalcUtils.changePriceType` byte-for-byte.** v8.0.21 widened the
+  price-type rescale byte-for-byte.** v8.0.21 widened the
   multiplication through `i64` and returned the unscaled input on
-  overflow, which broke parity with the Java reference (Java `int * int`
-  silently wraps under two's-complement). The rescale now uses
-  `i32::wrapping_mul`, reproducing the JVM's exact wire bits in both
+  overflow, which broke parity with the JVM terminal (its `i32 * i32`
+  rescale silently wraps under two's-complement). The rescale now uses
+  `i32::wrapping_mul`, reproducing the JVM terminal's exact wire bits in both
   debug and release. Tests pin the wrapping result to manually-computed
-  Java-equivalent values (e.g. `2_148 * 10^6 → -2_146_967_296`).
+  reference values (e.g. `2_148 * 10^6 → -2_146_967_296`).
 - **`decode::row_number_i64` clamps `price_type` to `0..=19`** so the
   same wire cell decodes identically through `row_number_i64` and
   `row_price_f64` (the latter routes through `tdbe::Price::new`, which
@@ -2732,7 +2732,7 @@ Major release. Three headline groups land in one pass:
 ### Changed
 
 - **License switched to Apache-2.0** across every `Cargo.toml`, `package.json`, `pyproject.toml`, and the top-level `LICENSE`. `deny.toml` allowlist cleaned up accordingly.
-- **Top-level `README.md` rewritten** as a professional SDK landing page: tagline, highlights, per-SDK quickstart (Rust / Python / TypeScript / Go / C++), architecture diagram, Java parity note. Neutral technical framing throughout.
+- **Top-level `README.md` rewritten** as a professional SDK landing page: tagline, highlights, per-SDK quickstart (Rust / Python / TypeScript / Go / C++), architecture diagram, JVM terminal parity note. Neutral technical framing throughout.
 - **A consolidated parity-tracking checklist added** as the single source of truth for terminal parity — feature-by-feature table (parity / deviation / partial) covering wire protocol, authentication, control events, reconnection, FPSS streaming, tick decoding, Greeks, validation, and intentional improvements over the JVM terminal. Three earlier stand-alone parity notes folded in.
 - **Internal `docs/dev/` design notes removed** (no longer load-bearing).
 - **`DirectClient` renamed to `HistoricalClient`** (#383) — the historical-data gRPC client now carries the name of the service it actually speaks to (MDDS = Market Data Delivery Service). `use thetadatadx::DirectClient` call sites break; update to `use thetadatadx::HistoricalClient`. The `DirectConfig` associated config type keeps its name. High-level consumers of `Client` (Python / TypeScript / Go / C++ / Rust facade) are unaffected.
@@ -2817,7 +2817,7 @@ Major release. Three headline groups land in one pass:
 - **FPSS TLS: SPKI pinning replaces `NoVerifier`** (#377) — `PinnedVerifier` parses the leaf cert via `x509-parser`, computes SHA-256 over the SubjectPublicKeyInfo DER bytes, and constant-time compares (`subtle::ConstantTimeEq`) against the captured `FPSS_SPKI_SHA256` (verified identical across prod `nj-a:20000` / `nj-b:20000`, dev `:20200`, stage `:20100` — single keypair across every FPSS environment). Rejects with `CertificateError::NotValidForName` on hostname mismatch (allowlist) or `RustlsError::General("FPSS SPKI pin mismatch: ...")` on pin mismatch. `verify_tls12_signature` / `verify_tls13_signature` delegate to rustls' proper signature verification. Previously any on-path attacker terminating TLS to `nj-a.thetadata.us:20000` could present any cert and harvest the plaintext `StreamMsgType::Credentials` frame.
 - **Password `Zeroizing<String>`** (#377) — `Credentials.password` wrapped in `zeroize::Zeroizing<String>`. Every clone (`Client`, `io_loop`, reconnect re-serialise) now wipes the backing buffer on drop. Core dump / `/proc/<pid>/mem` no longer recovers the password after `Credentials` drops. `Deref<Target = str>` means call-sites are unchanged.
 - **CSV formula injection defused on `thetadatadx-server` exports** (#377) — `escape_csv_field` now prefixes cells whose first byte is `=`, `+`, `-`, `@`, or `\t` with a single-quote `'` and encloses in CSV quotes. Defuses `=cmd|'/C calc'!A1`, `@SUM(A1:A10)`, `+1+cmd|...` etc from executing in Excel downloads. Regression test covers all five payload shapes.
-- **FPSS `io_loop`: Java-parity mid-frame read retry with per-read deadline reset** (#370) — previously a mid-frame read timeout desynced the decoder. The client now retries transparently with the per-read deadline reset, matching the Java terminal's reconnect behaviour.
+- **FPSS `io_loop`: JVM-terminal-parity mid-frame read retry with per-read deadline reset** (#370) — previously a mid-frame read timeout desynced the decoder. The client now retries transparently with the per-read deadline reset, matching the JVM terminal's reconnect behaviour.
 - **WS subscribe strike / expiration use `i32::try_from`** (#377) — client-supplied expiration / strike no longer silently narrow via `as i32`. Returns `REQ_RESPONSE { response: "ERROR", ... }` with a descriptive message on overflow. Validates `exp` against `[19000101, 21000101]` YYYYMMDD bounds and `strike > 0` before building the FPSS frame (#378).
 - **`validate_generic_named` sanitises parameter names in error messages** (#377 / follow-up) — ANSI escape sequences / control chars in a user-supplied param name can no longer escape into terminal-rendered log output. Names are passed through `sanitize_param_name` (ASCII alphanumeric + `_` + `-`).
 - **Shutdown token constant-time compare** (#377) — `tools/server/src/state.rs::validate_shutdown_token` swapped `==` for `subtle::ConstantTimeEq::ct_eq`. Timing oracle on UUID prefix closed.
@@ -2931,7 +2931,7 @@ Major release. Three headline groups land in one pass:
 - **Double string allocation on `Contract` clone** (#324) -- `Contract` now wraps its symbol in `Arc<str>` so cloning into per-subscription bookkeeping does not copy the byte buffer twice.
 - **JSON serialization moved off the FPSS I/O thread** (#324) -- `next_event` now returns typed structs and the serialization step is only paid at the FFI boundary when the caller asks for JSON, keeping the streaming hot path allocation-free.
 - **`parse_right` no longer panics on unrecognized input** (#324) -- the canonical right parser returns a structured error for unknown vocabulary instead of panicking, so a single malformed row can no longer take down the decoder.
-- **Unset `DataValue` oneof fails loud in every strict decoder** (#326) -- `parse_option_contracts_v3` (expiration, right), `parse_calendar_days_v3` (date, type, open, close), and the generator-emitted EOD helpers plus contract-id injected `expiration` / `right` used to treat a `DataValue` whose `data_type` oneof was unset as a legitimate null and coalesce to `0`. They now return `DecodeError::TypeMismatch { observed: "Unset" }`, matching `row_number` / `row_date` / `row_float` / `row_text` / `row_number_i64` / `row_price_f64` and the Java terminal's default arm. `NullValue` is still coalesced (legitimate null); only the wire-anomaly path changes.
+- **Unset `DataValue` oneof fails loud in every strict decoder** (#326) -- `parse_option_contracts_v3` (expiration, right), `parse_calendar_days_v3` (date, type, open, close), and the generator-emitted EOD helpers plus contract-id injected `expiration` / `right` used to treat a `DataValue` whose `data_type` oneof was unset as a legitimate null and coalesce to `0`. They now return `DecodeError::TypeMismatch { observed: "Unset" }`, matching `row_number` / `row_date` / `row_float` / `row_text` / `row_number_i64` / `row_price_f64` and the JVM terminal's default arm. `NullValue` is still coalesced (legitimate null); only the wire-anomaly path changes.
 - **Option contract wildcard rejection** (#284) -- before this release the SDK had no working path to the server's bulk-chain mode: `*` was rejected client-side by `validate_expiration`, and `0` was rejected server-side. The SDK vocabulary now covers the full cross-product the server accepts.
 - **Validator tier detection drift** (#289) -- dropped the static tier gate that classified legitimate server responses as SKIP. The runtime permission fallback still catches drift between docs and the wire (for example, `interest_rate_history_eod` being labelled `free` on docs but gated higher by the server).
 - **CI unbroken on `main`** (#299) -- fixed a `timeout_ms` TOML field mismatch and made the Go pin-test CRLF-robust.
@@ -3071,7 +3071,7 @@ Major release. Three headline groups land in one pass:
 
 - **`DirectConfig::derive_ohlcvc(bool)`** -- config-driven OHLCVC opt-out, replaces duplicate method. (#129)
 - **REST server drop-in replacement** -- `--email`/`--password`, `--config`, `--fpss-region` CLI args. `/v3/system/status` endpoint. Startup banner. (#128)
-- **Error suppression 5s after STOP** -- matches Java terminal behavior. (#124)
+- **Error suppression 5s after STOP** -- matches the JVM terminal's behavior. (#124)
 - **Auth retry on transient errors** -- 3 attempts, 2s delay, network errors only. (#125)
 - **Config validation** -- clamps queue_depth (16-1M), window_size (64-1024) with warnings. (#126)
 - **Password character warning** -- on INVALID_CREDENTIALS disconnect. (#127)
@@ -3089,7 +3089,7 @@ Major release. Three headline groups land in one pass:
 
 ### Added
 
-- **FPSS auto-reconnect** with configurable policy: `Auto` (default, matches Java terminal), `Manual`, `Custom(fn)`. New control events: `Reconnecting`, `Reconnected`. (#119)
+- **FPSS auto-reconnect** with configurable policy: `Auto` (default, matches the JVM terminal), `Manual`, `Custom(fn)`. New control events: `Reconnecting`, `Reconnected`. (#119)
 - **Trade/quote condition descriptions** with special-case annotations (e.g., `*update last if only trade`).
 
 ### Fixed
@@ -3226,7 +3226,7 @@ Major release. Three headline groups land in one pass:
 - **Builder pattern** -- all endpoints return chainable builders. Zero noise for simple calls, all optional proto params discoverable via autocomplete.
 - **`received_at_ns`** -- nanosecond receive timestamp on every FPSS event for latency measurement
 - **`tdbe::latency::latency_ns()`** -- DST-aware wire-to-application latency computation
-- **`FpssFlushMode`** -- `Batched` (default, matches Java) or `Immediate` (lowest latency)
+- **`FpssFlushMode`** -- `Batched` (default, matches the JVM terminal) or `Immediate` (lowest latency)
 - **Metrics** -- `metrics` crate integration. Counters/histograms on all gRPC, FPSS, and auth operations. Zero overhead when no backend installed.
 - **Config file** -- `DirectConfig::from_file()` behind `config-file` feature flag. TOML format matching v3 terminal.
 - **`DirectConfig::stage()`** -- staging FPSS servers (port 20100)
@@ -3267,7 +3267,7 @@ Major release. Three headline groups land in one pass:
 
 - **Timezone hardcoded UTC-4** -- was producing ms_of_day shifted +1 hour for all Nov-Mar historical data. Now DST-aware with 5 unit tests. (#32)
 - **EOD parser divergent alias system** -- unified to shared `find_header()`. (#34)
-- **reconnect_wait_ms** -- changed from 1000 to 2000 to match Java terminal. (#35)
+- **reconnect_wait_ms** -- changed from 1000 to 2000 to match the JVM terminal. (#35)
 - **C++ OptionContract use-after-free** -- root string was dangling after array free. Now deep-copies to `std::string`. (#39)
 - **Active subscriptions not cleared on explicit shutdown** -- `shutdown()` clears, involuntary disconnect preserves for reconnect. (#38)
 - Mermaid diagram syntax in architecture.md (#30)
@@ -3297,9 +3297,9 @@ v3 MDDS DataTable parsing (Timestamp cells), DST-aware timezone, gRPC flow contr
 ### Fixed
 
 - **Interval conversion**: MDDS server accepts preset shorthand (`1m`, `5m`, `1h`), not raw milliseconds. `normalize_interval()` now converts `"60000"` -> `"1m"`, `"300000"` -> `"5m"`, etc. Sub-second presets supported: `"100"` -> `"100ms"`, `"500"` -> `"500ms"`. Users can pass either milliseconds or shorthand directly.
-- **Default start_time/end_time**: the Java terminal defaults these to `"09:30:00"` and `"16:00:00"`. Our SDK left them as None, causing `"Invalid time format: Expected hh:mm:ss.SSS"` on trade/quote/greeks endpoints. Now defaults to RTH.
+- **Default start_time/end_time**: the JVM terminal defaults these to `"09:30:00"` and `"16:00:00"`. Our SDK left them as None, causing `"Invalid time format: Expected hh:mm:ss.SSS"` on trade/quote/greeks endpoints. Now defaults to RTH.
 - **extract_text_column**: now handles Number and Price DataTable values. `option_list_strikes` was returning 0 results because strikes come as Number values, not Text.
-- **FPSS TLS certificate**: ThetaData's FPSS servers have certificates expired since Jan 2024. Skip certificate verification for FPSS connections (matching Java terminal behavior).
+- **FPSS TLS certificate**: ThetaData's FPSS servers have certificates expired since Jan 2024. Skip certificate verification for FPSS connections (matching the JVM terminal's behavior).
 
 ### Added
 
@@ -3319,7 +3319,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 
 ### Added
 
-- `subscribe_full_open_interest(sec_type)` -- full-stream open interest subscription (was missing, Java terminal has it)
+- `subscribe_full_open_interest(sec_type)` -- full-stream open interest subscription (was missing, the JVM terminal has it)
 - `unsubscribe_full_trades(sec_type)` -- full-stream trade unsubscribe (was missing)
 - `unsubscribe_full_open_interest(sec_type)` -- full-stream OI unsubscribe (was missing)
 - `reconnect_streaming(handler)` on `Client` -- saves active subscriptions, stops streaming, restarts with new handler, re-subscribes all per-contract and full-type subscriptions automatically
@@ -3487,7 +3487,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 
 - FPSS frame read: zero-alloc (reusable buffer)
 - FPSS decode: zero-alloc (tuple return, pre-allocated tick buffer)
-- Delta: wrapping_add (matches Java, no branch)
+- Delta: wrapping_add (matches the JVM terminal, no branch)
 - Required column validation (skip rows on missing headers, no garbage parse)
 - 43 criterion benchmarks across all modules
 
@@ -3520,13 +3520,13 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 
 - **OHLCVC-from-trade derivation** — `OhlcvcAccumulator` derives OHLCVC bars from trade
   ticks in real time. Only emits `StreamEvent::Data(StreamData::Ohlcvc { .. })` after a
-  server-seeded initial bar, matching the Java terminal's behavior. Subsequent trades
+  server-seeded initial bar, matching the JVM terminal's behavior. Subsequent trades
   update open/high/low/close/volume/count incrementally.
 - **StreamEvent split: `StreamData` + `StreamControl`** — the monolithic `StreamEvent` enum is now
   a 3-variant wrapper: `Data(StreamData)` for market data (Quote, Trade, OpenInterest, Ohlcvc),
   `Control(StreamControl)` for lifecycle events (LoginSuccess, Disconnected, MarketOpen, etc.),
   and `RawData` for unparsed frames. This enables `match` arms that handle all data without
-  touching control flow, and vice versa — an intentional improvement not present in Java.
+  touching control flow, and vice versa — an intentional improvement beyond the JVM terminal.
 - **Streaming `_stream` endpoint variants** — `stock_history_trade_stream`,
   `stock_history_quote_stream`, `option_history_trade_stream`, `option_history_quote_stream`
   process gRPC response chunks via callback without materializing the full response in memory.
@@ -3539,29 +3539,29 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 
 ### Fixed
 
-18 correctness and protocol-conformance fixes from a full audit against the Java terminal:
+18 correctness and protocol-conformance fixes from a full audit against the JVM terminal:
 
 **FPSS Protocol**
 
 1. **FPSS contract ID is FIT-decoded** — CONTRACT message contract IDs are now FIT-decoded
-   (matching the Java terminal), not read as raw big-endian i32. Previously produced wrong
+   (matching the JVM terminal), not read as raw big-endian i32. Previously produced wrong
    contract-to-symbol mappings.
 2. **Delta off-by-one fixed** — `apply_deltas` field indexing corrected; previous
    implementation could shift all fields by one position, corrupting tick data.
 3. **Delta state cleared on START/STOP** — per-contract delta accumulators are now reset
-   when the server sends START (market open) or STOP (market close), matching Java behavior.
+   when the server sends START (market open) or STOP (market close), matching the JVM terminal's behavior.
    Previously, stale deltas from the previous session leaked into the next session's ticks.
 4. **ROW_SEP unconditional reset** — ROW_SEP (0xC) now unconditionally resets the field
-   index to SPACING (5), matching the Java FIT reader. Previously this was conditional,
+   index to SPACING (5), matching the JVM terminal's FIT reader. Previously this was conditional,
    which could produce misaligned fields.
-5. **Credential sign-extension** — credential length fields are now read as unsigned,
-   matching Java's `readUnsignedShort()`. Previously, passwords longer than 127 bytes
+5. **Credential sign-extension** — credential length fields are now read as an unsigned
+   16-bit integer, matching the JVM terminal. Previously, passwords longer than 127 bytes
    could produce a negative length.
 6. **Flush only on PING** — the FPSS write buffer is now flushed only when sending PING
-   messages, matching Java's batching behavior. Previously, every write triggered a flush,
+   messages, matching the JVM terminal's batching behavior. Previously, every write triggered a flush,
    increasing syscall overhead and wire chattiness.
 7. **Ping 2000ms initial delay** — the first PING is now delayed by 2000ms after
-   authentication, matching the Java terminal's `Thread.sleep(2000)` before entering the
+   authentication, matching the JVM terminal's 2000 ms pause before entering the
    ping loop. Previously, pings started immediately.
 
 **MDDS / gRPC Protocol**
@@ -3570,11 +3570,11 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
    `null_value` variant (bool), matching the server's proto definition. Previously,
    null cells were silently dropped during deserialization.
 9. **`"client": "terminal"` in query_parameters** — all gRPC requests now include
-   `"client": "terminal"` in the `query_parameters` map, matching the Java terminal.
+   `"client": "terminal"` in the `query_parameters` map, matching the JVM terminal.
    Previously this field was omitted.
 10. **Dynamic concurrency from subscription tier** — `mdds_concurrent_requests` is now
     derived from the `AuthUser` response's subscription tier (`2^tier`), matching the
-    Java terminal's concurrency model. The config field still allows manual override.
+    JVM terminal's concurrency model. The config field still allows manual override.
 11. **Unknown compression returns error** — `decompress_response` now returns
     `Error::Decompress` for unrecognized compression algorithms instead of silently
     treating the data as uncompressed.
@@ -3582,8 +3582,8 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
     `DataTable` (with headers, zero rows) when the gRPC stream contains no data chunks,
     instead of returning `Error::NoData`. Callers can check `.data_table.is_empty()`.
 13. **gRPC flow control window** — the gRPC channel now configures
-    `initial_connection_window_size` and `initial_stream_window_size` to match the Java
-    terminal's Netty settings, preventing throughput bottlenecks on large responses.
+    `initial_connection_window_size` and `initial_stream_window_size` to match the JVM
+    terminal's flow-control settings, preventing throughput bottlenecks on large responses.
 
 **Auth / User Model**
 
@@ -3591,7 +3591,7 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
     `option_tier`, `index_tier`, and `futures_tier` fields from the Nexus auth response,
     enabling per-asset-class concurrency and permission checks.
 15. **Auth 401/404 handling** — Nexus HTTP responses with status 401 (Unauthorized) or
-    404 (Not Found) are now treated as invalid credentials, matching the Java terminal's
+    404 (Not Found) are now treated as invalid credentials, matching the JVM terminal's
     behavior. Previously these could surface as generic HTTP errors.
 
 **Observability**
@@ -3604,14 +3604,14 @@ Interval format conversion (later superseded by shorthand normalization in v4.2.
 **Greeks**
 
 17. **6 Greeks formula fixes** — operator precedence corrections across 6 Greek functions
-    to match Java's evaluation order. All formulas now produce bit-identical results to
-    the Java terminal for the same inputs.
+    to match the JVM terminal's evaluation order. All formulas now produce bit-identical results to
+    the JVM terminal for the same inputs.
 18. **`Vera` DataType code (166)** — second-order Greek `Vera` added to the `DataType` enum,
     completing the full set of second-order Greeks (vanna, charm, vomma, veta, vera, sopdk).
 
 ### Security
 
-- **Contract wire format fix** — contract binary serialization now matches the Java terminal
+- **Contract wire format fix** — contract binary serialization now matches the JVM terminal
   exactly. Previous versions could produce incorrect wire bytes for option contracts, causing
   subscription failures or wrong contract assignments. This was a **protocol-level bug**;
   upgrading to 1.2.x is strongly recommended.
@@ -3706,7 +3706,7 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - **StreamingClient** for FPSS streaming — real-time quotes, trades, open interest, OHLC
   via TLS/TCP with heartbeat and manual reconnection
 - **Auth module** — Nexus API authentication (email/password → session UUID)
-- **FIT/FIE codec** — nibble-based tick compression/decompression (ported from Java)
+- **FIT/FIE codec** — nibble-based tick compression/decompression at JVM terminal parity
 - **Greeks calculator** — full Black-Scholes: 22 Greeks + IV bisection solver with
   precomputed shared intermediates and edge-case guards (t=0, v=0)
 - **All tick types** — TradeTick, QuoteTick, OhlcTick, EodTick, OpenInterestTick,
@@ -3724,7 +3724,7 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - **Go SDK** — CGo FFI bindings over the C ABI layer
 - **C++ SDK** — RAII C++ wrapper over the C header
 - **C FFI crate** (`thetadatadx-ffi`) — stable `extern "C"` ABI for all SDKs
-- **Documentation** — architecture (Mermaid), API reference, Java parity checklist
+- **Documentation** — architecture (Mermaid), API reference, JVM terminal parity checklist
 - **CI/CD** — GitHub Actions (fmt, clippy, test, FFI build, crates.io publish, PyPI publish, GitHub Release)
 - **Project infrastructure** — CHANGELOG, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT,
   clippy.toml, cliff.toml, rust-toolchain.toml, LICENSE

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -3713,8 +3713,8 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
   SnapshotTradeTick, TradeQuoteTick with fixed-point Price encoding
 - **80+ DataType enum codes** — quotes, trades, OHLC, all Greek orders, dividends,
   splits, fundamentals
-- **Proto definitions** — extracted via runtime FileDescriptor reflection from
-  ThetaData Terminal v202603181 (endpoints.proto + v3_endpoints.proto)
+- **Proto definitions** — the v3 protocol surface (endpoints.proto +
+  v3_endpoints.proto)
 - **Runtime configuration** — `DirectConfig` with all JVM-equivalent tuning knobs
 - `contract_lookup(id)` on `StreamingClient` for single-entry hot-path lookup
 - `StreamEvent::Error` variant for surfacing protocol parse failures

--- a/docs-site/docs/migration/v9-to-v10.md
+++ b/docs-site/docs/migration/v9-to-v10.md
@@ -156,8 +156,8 @@ The session wakes the asyncio event loop only when events arrive:
 zero polling cost during quiet periods, one wake per coalesced
 batch. The matching surface on
 the standalone `StreamingClient` (`fpss_client.streaming_async()`) opens
-no historical-channel / Nexus surface — useful for asyncio apps coexisting with a
-parallel Java historical-channel process.
+no historical-channel / Nexus surface — useful for asyncio apps coexisting with the
+JVM terminal's historical-channel process.
 
 ## Standalone `StreamingClient` / `HistoricalClient` Python pyclasses
 

--- a/scripts/check_no_re_framing.py
+++ b/scripts/check_no_re_framing.py
@@ -79,6 +79,16 @@ SCAN_GLOBS = (
     "crates/thetadatadx/examples/**/*.rs",
     "crates/thetadatadx/tests/**/*.rs",
     "crates/thetadatadx/tests/**/*.toml",
+    # Publicly-rendered prose. The docs site re-publishes these straight
+    # from `main`, and the top-level Markdown is the first thing a reader
+    # sees on the repo. The same provenance bar applies: these render to
+    # every reader exactly like the crate doc comments, so a leak here
+    # ships just as widely. This is the surface the `.rs`-only scan missed.
+    "docs-site/docs/**/*.md",
+    "SECURITY.md",
+    "CHANGELOG.md",
+    "README.md",
+    "tools/server/README.md",
 )
 
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,6 +6,6 @@ Standalone applications built on the `thetadatadx` SDK. Each tool has its own RE
 |------|------|-------------|
 | CLI | [`tools/cli/`](cli/README.md) | `thetadatadx` command-line client. Exposes every generated historical endpoint plus two offline calculator commands (`greeks`, `iv`). Output as `table`, `json`, or `csv`. |
 | MCP server | [`tools/mcp/`](mcp/README.md) | Model Context Protocol server (`thetadatadx-mcp`). Exposes every generated historical endpoint plus three offline tools (`ping`, `all_greeks`, `implied_volatility`) as JSON-RPC 2.0 tool calls over stdio. |
-| REST / WebSocket server | [`tools/server/`](server/README.md) | Drop-in `thetadatadx-server` for the ThetaData Java terminal. Listens on port 25503, serves the same `/v3/*` REST routes and WebSocket streaming surface. |
+| REST / WebSocket server | [`tools/server/`](server/README.md) | Drop-in `thetadatadx-server` for the ThetaData JVM terminal. Listens on port 25503, serves the same `/v3/*` REST routes and WebSocket streaming surface. |
 
 All three tools read credentials from the same places (`--creds <path>`, `creds.txt`, or `THETA_EMAIL` / `THETA_PASSWORD` environment variables). MCP and server additionally accept an offline mode when credentials are absent.

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -143,7 +143,7 @@ For option tools, MCP uses `"0"` as the wildcard value for `strike` and `expirat
 - Use `"strike":"0"` when you want a bulk chain-style response with contract identification fields on each row.
 - `strike_range` filters a wildcard bulk selection around spot / ATM. It does **not** fan out a pinned strike into neighboring strikes.
 
-This matches the current Java terminal behavior. The v3 REST surface uses `*` for the same wildcard concept; the MCP server uses `"0"` because it follows the underlying SDK contract.
+This matches the current JVM terminal behavior. The v3 REST surface uses `*` for the same wildcard concept; the MCP server uses `"0"` because it follows the underlying SDK contract.
 
 ### Index Data (9 tools)
 - `index_list_symbols`, `index_list_dates`


### PR DESCRIPTION
An adversarial hygiene pass found reverse-engineering provenance leaking into the docs that actually render publicly. The changelog, SECURITY.md, the v9-to-v10 migration guide, and a couple of tools READMEs carried named JVM-internal identifiers, decompilation-only constants, and the "Java terminal" spelling our own no-re-framing gate forbids. The approved parity reference is the JVM terminal.

What this does:

- Rewords every "Java terminal" / "matches Java" / "Java behavior" hit to cite the JVM terminal as the parity target, and strips named Java identifiers (the contract codec filename, the price-type rescale method, the unsigned-short read, the sleep-before-ping constant) into plain behavioral descriptions. The technical facts are untouched; only the framing changes. Root CHANGELOG.md and the docs-site changelog stay byte-identical.

- SECURITY.md loses the named socket constant and the unsigned-short method name, and the FPSS dispatch section is reworded so it no longer exposes internal architecture.

- Fixes the root cause: scripts/check_no_re_framing.py only ever scanned the crate, FFI, and SDK source plus the schema descriptors. It never looked at the Markdown that the docs site re-publishes from main, which is exactly how this leak shipped. The scan globs now cover docs-site/docs, SECURITY.md, CHANGELOG.md, README.md, and tools/server/README.md.

Checks:

- python3 scripts/check_no_re_framing.py: clean
- python3 scripts/check_no_re_framing.py --selftest: ok
- python3 scripts/check_docs_consistency.py: ok (byte-identical changelog invariant holds)
- Verified the extended gate fires on a planted "Java terminal" line and is clean once reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)