### PR TITLE
fix(config): enforce a floor on the reconnect wait interval

### DIFF
--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -367,6 +367,27 @@ impl DirectConfig {
                 "replay_burst_size must be at least 1".to_string(),
             ));
         }
+        // Generic-transient ladder: both the base delay and its exponential
+        // ceiling must be positive and in band. A `0` base (or a `0` cap that
+        // drags the base down through the ordering check below) would yield a
+        // 0 ms reconnect busy-loop on every generic transient, so both ends are
+        // band-checked the same way the sibling cadences are.
+        if !reconnect_bounds::WAIT_MS.contains(&self.reconnect.wait_ms) {
+            return Err(Error::config_out_of_range(
+                "reconnect.wait_ms",
+                to_i64(self.reconnect.wait_ms),
+                to_i64(*reconnect_bounds::WAIT_MS.start()),
+                to_i64(*reconnect_bounds::WAIT_MS.end()),
+            ));
+        }
+        if !reconnect_bounds::WAIT_MS.contains(&self.reconnect.wait_max_ms) {
+            return Err(Error::config_out_of_range(
+                "reconnect.wait_max_ms",
+                to_i64(self.reconnect.wait_max_ms),
+                to_i64(*reconnect_bounds::WAIT_MS.start()),
+                to_i64(*reconnect_bounds::WAIT_MS.end()),
+            ));
+        }
         if self.reconnect.wait_max_ms < self.reconnect.wait_ms {
             return Err(Error::config_invalid(
                 "reconnect.wait_max_ms",
@@ -1730,6 +1751,50 @@ mod tests {
         config.streaming.ring_size = 100; // not a power of two
         let err = config.validate().expect_err("must reject non-power-of-two");
         assert!(err.to_string().contains("ring_size"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_reconnect_wait_ms() {
+        let mut config = DirectConfig::production_defaults();
+        config.reconnect.wait_ms = 0;
+        let err = config
+            .validate()
+            .expect_err("must reject zero base reconnect cadence");
+        assert!(err.to_string().contains("wait_ms"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_reconnect_wait_max_ms() {
+        let mut config = DirectConfig::production_defaults();
+        // Drive both ends to 0 so the ordering check cannot mask the floor:
+        // the band-check must reject the degenerate ceiling on its own.
+        config.reconnect.wait_ms = 0;
+        config.reconnect.wait_max_ms = 0;
+        let err = config
+            .validate()
+            .expect_err("must reject zero reconnect ceiling");
+        assert!(err.to_string().contains("wait_ms"));
+    }
+
+    #[test]
+    fn validate_rejects_above_band_reconnect_wait_ms() {
+        let mut config = DirectConfig::production_defaults();
+        config.reconnect.wait_ms = 600_001;
+        config.reconnect.wait_max_ms = 600_001;
+        let err = config
+            .validate()
+            .expect_err("must reject above-band reconnect cadence");
+        assert!(err.to_string().contains("wait_ms"));
+    }
+
+    #[test]
+    fn validate_accepts_in_band_reconnect_wait_ms() {
+        let mut config = DirectConfig::production_defaults();
+        config.reconnect.wait_ms = 500;
+        config.reconnect.wait_max_ms = 60_000;
+        config
+            .validate()
+            .expect("a legitimate base/ceiling pair must validate");
     }
 
     #[test]

--- a/crates/thetadatadx/src/config/reconnect.rs
+++ b/crates/thetadatadx/src/config/reconnect.rs
@@ -317,6 +317,13 @@ impl Default for ReconnectConfig {
 pub mod bounds {
     use std::ops::RangeInclusive;
 
+    /// Allowed range (ms) for [`super::ReconnectConfig::wait_ms`] and its
+    /// exponential ceiling [`super::ReconnectConfig::wait_max_ms`]. Both ends
+    /// of the generic-transient ladder must be a positive delay so a `0` base
+    /// or `0` cap cannot collapse the ladder into a 0 ms reconnect busy-loop;
+    /// capped at ten minutes to match the server-restart cadence band.
+    pub const WAIT_MS: RangeInclusive<u64> = 1..=600_000;
+
     /// Allowed range (ms) for [`super::ReconnectConfig::wait_rate_limited_ms`].
     /// The rate-limit cooldown is upstream-instructed; it must be a positive
     /// delay and is capped at one hour so a typo cannot strand a client.

--- a/crates/thetadatadx/src/tdbe/latency.rs
+++ b/crates/thetadatadx/src/tdbe/latency.rs
@@ -12,7 +12,7 @@
 
 #![allow(dead_code)]
 
-use crate::tdbe::time::{civil_to_epoch_days, eastern_offset_ms};
+use crate::tdbe::time::{civil_to_epoch_days, eastern_offset_ms, is_valid_yyyymmdd};
 
 /// Compute wire-to-application latency in nanoseconds.
 ///
@@ -24,21 +24,31 @@ use crate::tdbe::time::{civil_to_epoch_days, eastern_offset_ms};
 ///
 /// # Returns
 ///
-/// Latency in nanoseconds. May be negative if clocks are skewed (exchange
-/// timestamp ahead of local wall clock).
-// Reason: epoch timestamps may exceed i64::MAX in the far future; wrapping is acceptable
-// for the valid date range of market data (1970--2100).
-#[allow(clippy::cast_possible_wrap)]
+/// `Some(latency_ns)` for a real calendar `event_date`. The latency may be
+/// negative if clocks are skewed (exchange timestamp ahead of local wall
+/// clock). Returns `None` when `event_date` is not a valid YYYYMMDD calendar
+/// date, so a malformed or sentinel date can never feed unvalidated arithmetic.
 #[must_use]
-pub fn latency_ns(exchange_ms_of_day: i32, event_date: i32, received_at_ns: u64) -> i64 {
-    let exchange_epoch_ns = exchange_epoch_ns(exchange_ms_of_day, event_date);
-    received_at_ns as i64 - exchange_epoch_ns
+pub fn latency_ns(exchange_ms_of_day: i32, event_date: i32, received_at_ns: u64) -> Option<i64> {
+    let exchange_epoch_ns = exchange_epoch_ns(exchange_ms_of_day, event_date)?;
+    // Reason: epoch timestamps may exceed i64::MAX in the far future; wrapping is
+    // acceptable for the valid date range of market data (1970--2100).
+    #[allow(clippy::cast_possible_wrap)]
+    Some(received_at_ns as i64 - exchange_epoch_ns)
 }
 
-/// Convert `event_date` (YYYYMMDD) + `ms_of_day` (Eastern Time) to epoch nanoseconds.
-// Reason: date components are from valid YYYYMMDD integers; casts are safe for the valid range.
+/// Convert `event_date` (YYYYMMDD) + `ms_of_day` (Eastern Time) to epoch
+/// nanoseconds, or `None` when `date_yyyymmdd` is not a real calendar date.
+///
+/// The date is validated through [`is_valid_yyyymmdd`] before any arithmetic so
+/// an impossible date (`0`, `20260230`, …) cannot multiply through into a bogus
+/// epoch.
+// Reason: date components are from a validated YYYYMMDD integer; casts are safe for the valid range.
 #[allow(clippy::cast_sign_loss)]
-fn exchange_epoch_ns(ms_of_day: i32, date_yyyymmdd: i32) -> i64 {
+fn exchange_epoch_ns(ms_of_day: i32, date_yyyymmdd: i32) -> Option<i64> {
+    if !is_valid_yyyymmdd(date_yyyymmdd) {
+        return None;
+    }
     let year = date_yyyymmdd / 10_000;
     let month = ((date_yyyymmdd % 10_000) / 100) as u32;
     let day = (date_yyyymmdd % 100) as u32;
@@ -56,7 +66,7 @@ fn exchange_epoch_ns(ms_of_day: i32, date_yyyymmdd: i32) -> i64 {
     // exchange_epoch_ms = midnight_utc_ms + ms_of_day - offset_ms
     // (offset_ms is negative, e.g. -5h for EST, so subtracting it adds hours)
     let exchange_epoch_ms = midnight_utc_ms + i64::from(ms_of_day) - offset_ms;
-    exchange_epoch_ms * 1_000_000
+    Some(exchange_epoch_ms * 1_000_000)
 }
 
 #[cfg(test)]
@@ -76,7 +86,7 @@ mod tests {
         let received_at_ns = (midnight_utc_ns + utc_offset_ns) as u64;
 
         // If received_at_ns == exchange epoch time, latency should be ~0.
-        let lat = latency_ns(34_200_000, 20240115, received_at_ns);
+        let lat = latency_ns(34_200_000, 20240115, received_at_ns).expect("valid date");
         assert!(
             lat.abs() < 1_000_000, // less than 1ms rounding
             "expected ~0 latency, got {lat} ns"
@@ -93,7 +103,7 @@ mod tests {
         let utc_offset_ns = (13 * 3600 + 30 * 60) as i64 * 1_000_000_000;
         let received_at_ns = (midnight_utc_ns + utc_offset_ns) as u64;
 
-        let lat = latency_ns(34_200_000, 20240615, received_at_ns);
+        let lat = latency_ns(34_200_000, 20240615, received_at_ns).expect("valid date");
         assert!(lat.abs() < 1_000_000, "expected ~0 latency, got {lat} ns");
     }
 
@@ -105,7 +115,7 @@ mod tests {
         let utc_offset_ns = (14 * 3600 + 30 * 60) as i64 * 1_000_000_000;
         let received_at_ns = (midnight_utc_ns + utc_offset_ns) as u64 + 100_000_000; // +100ms
 
-        let lat = latency_ns(34_200_000, 20240115, received_at_ns);
+        let lat = latency_ns(34_200_000, 20240115, received_at_ns).expect("valid date");
         // Should be ~100ms = 100_000_000 ns
         assert!(
             (lat - 100_000_000).abs() < 1_000_000,
@@ -121,10 +131,26 @@ mod tests {
         let utc_offset_ns = (14 * 3600 + 30 * 60) as i64 * 1_000_000_000;
         let received_at_ns = (midnight_utc_ns + utc_offset_ns) as u64 - 50_000_000; // -50ms
 
-        let lat = latency_ns(34_200_000, 20240115, received_at_ns);
+        let lat = latency_ns(34_200_000, 20240115, received_at_ns).expect("valid date");
         assert!(
             (lat + 50_000_000).abs() < 1_000_000,
             "expected ~-50ms latency, got {lat} ns"
+        );
+    }
+
+    #[test]
+    fn latency_rejects_impossible_dates() {
+        // Sentinel and out-of-range dates must short-circuit to None rather
+        // than multiplying an unvalidated value into a bogus epoch.
+        for bad_date in [0, -1, 20260230, 19990431] {
+            assert!(
+                latency_ns(34_200_000, bad_date, 0).is_none(),
+                "expected None for invalid date {bad_date}"
+            );
+        }
+        assert!(
+            latency_ns(34_200_000, 20240115, 0).is_some(),
+            "a real calendar date must still compute"
         );
     }
 }


### PR DESCRIPTION
The generic-transient reconnect ladder only checked that wait_max_ms was at least wait_ms, with no absolute band on either end. The rate-limited and server-restart cadences were already band-checked, but the base generic cadence was not, so a wait_ms of 0 (or a 0 ceiling pulled down through the ordering check) validated clean and turned into a 0 ms reconnect busy-loop on every generic transient drop. Both the base delay and its exponential ceiling now validate against a positive 1..=600_000 ms band, the same band the server-restart cadence uses, and they raise the same out-of-range config error as the sibling cadences. Tests cover a zero base, a zero ceiling, an above-band value, and a legitimate in-band pair.

While here, the FPSS latency epoch helper now validates its date through the crate's is_valid_yyyymmdd before doing any arithmetic. The module has no in-crate caller today, but exchange_epoch_ns previously multiplied an unvalidated YYYYMMDD value straight into an epoch, so an impossible date (0, 20260230, ...) would have produced a bogus timestamp if the module were ever wired up. It now short-circuits to None on an invalid date and latency_ns returns Option<i64> to carry that through. No new public items are added.

Verification: config and tdbe::latency lib tests pass, cargo fmt clean, and both the crate clippy and the CI-exact `cargo clippy --workspace --all-targets --locked -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)