### PR TITLE
fix(typescript): reset the streaming callback slot when the connect task panics

### DIFF
--- a/crates/thetadatadx/build_support_bin/sdk_surface/templates/typescript/start_streaming_body.rs.tmpl
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/templates/typescript/start_streaming_body.rs.tmpl
@@ -37,7 +37,7 @@
         // both `Send + 'static`, so the closure satisfies the
         // `spawn_blocking` bound.
         let client = Arc::clone(&self.client);
-        let result = tokio::task::spawn_blocking(move || {
+        let join_result = tokio::task::spawn_blocking(move || {
             client
                 .stream()
                 .start_streaming(move |event: &fpss::StreamEvent| {
@@ -71,11 +71,26 @@
                     dispatch_cb.call(typed, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
                 })
         })
-        .await
-        .map_err(|e| napi::Error::from_reason(format!("start_streaming task panicked: {e}")))?;
+        .await;
+
+        let result = match join_result {
+            Ok(result) => result,
+            Err(e) => {
+                // The connect task itself panicked. Release the slot we
+                // reserved above, mirroring the handshake-failure path, so
+                // the handle returns to a usable state and a later
+                // `startStreaming` retry sees a clean registration instead
+                // of a stuck "streaming already started".
+                let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
+                *cb_guard = None;
+                return Err(napi::Error::from_reason(format!(
+                    "start_streaming task panicked: {e}"
+                )));
+            }
+        };
 
         if let Err(e) = result {
-            // The handshake failed — release the slot we reserved above so
+            // The handshake failed -- release the slot we reserved above so
             // a later `startStreaming` retry sees a clean registration.
             let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
             *cb_guard = None;

--- a/sdks/typescript/src/_generated/streaming_methods.rs
+++ b/sdks/typescript/src/_generated/streaming_methods.rs
@@ -57,7 +57,7 @@ impl StreamView {
         // both `Send + 'static`, so the closure satisfies the
         // `spawn_blocking` bound.
         let client = Arc::clone(&self.client);
-        let result = tokio::task::spawn_blocking(move || {
+        let join_result = tokio::task::spawn_blocking(move || {
             client
                 .stream()
                 .start_streaming(move |event: &fpss::StreamEvent| {
@@ -91,11 +91,26 @@ impl StreamView {
                     dispatch_cb.call(typed, napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking);
                 })
         })
-        .await
-        .map_err(|e| napi::Error::from_reason(format!("start_streaming task panicked: {e}")))?;
+        .await;
+
+        let result = match join_result {
+            Ok(result) => result,
+            Err(e) => {
+                // The connect task itself panicked. Release the slot we
+                // reserved above, mirroring the handshake-failure path, so
+                // the handle returns to a usable state and a later
+                // `startStreaming` retry sees a clean registration instead
+                // of a stuck "streaming already started".
+                let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
+                *cb_guard = None;
+                return Err(napi::Error::from_reason(format!(
+                    "start_streaming task panicked: {e}"
+                )));
+            }
+        };
 
         if let Err(e) = result {
-            // The handshake failed — release the slot we reserved above so
+            // The handshake failed -- release the slot we reserved above so
             // a later `startStreaming` retry sees a clean registration.
             let mut cb_guard = self.callback.lock().unwrap_or_else(|e| e.into_inner());
             *cb_guard = None;

--- a/sdks/typescript/src/fpss_client.rs
+++ b/sdks/typescript/src/fpss_client.rs
@@ -260,10 +260,23 @@ impl StreamingClient {
         let dispatch_cb = Arc::clone(&callback);
 
         let params = self.params.clone();
-        let build_result = runtime()
+        let join_result = runtime()
             .spawn_blocking(move || params.builder().build())
-            .await
-            .map_err(|e| napi::Error::from_reason(format!("start_streaming task panicked: {e}")))?;
+            .await;
+        let build_result = match join_result {
+            Ok(build_result) => build_result,
+            Err(e) => {
+                // The connect task itself panicked. Release the slot
+                // reserved above, mirroring the handshake-failure path
+                // below, so the handle returns to a usable state and a
+                // later startStreaming retry sees a clean registration
+                // instead of a stuck "streaming already started".
+                *self.lock_callback() = None;
+                return Err(napi::Error::from_reason(format!(
+                    "start_streaming task panicked: {e}"
+                )));
+            }
+        };
         let client = match build_result {
             Ok(client) => client,
             Err(e) => {


### PR DESCRIPTION
The napi `startStreaming` reserves the registration slot before the blocking FPSS connect handshake so a concurrent call is rejected while the first is still connecting. The handshake-error path released that slot again, but the arm that fires when the spawned connect task itself panics returned the join error straight through without clearing it. After such a panic the handle stayed wedged on "streaming already started" until it was dropped, which is a recoverable state lock-up rather than undefined behaviour, and low likelihood in practice.

This clears the reserved slot in the panic arm exactly as the handshake-error path already does, so the handle returns to a usable state and a later `startStreaming` can proceed. The error surfaced to JS is unchanged: the call still rejects with the same panic message.

Two call sites carry this pattern. `StreamView.startStreaming` is generated, so the fix lives in its template (`start_streaming_body.rs.tmpl`) and the checked-in `_generated/streaming_methods.rs` is regenerated from it; the generator drift check passes. `StreamingClient.startStreaming` is hand-written and is fixed in place.

No runtime behaviour changes beyond the panic recovery. `index.d.ts` is unchanged. Clippy, the native build, the Rust unit test, and the full `npm test` suite (170 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)