### PR TITLE
docs: repair changelog compare-link footer so version headings render as links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3744,7 +3744,40 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.11...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.1...HEAD
+[13.0.0-rc.1]: https://github.com/userFRM/ThetaDataDx/compare/v12.0.0...v13.0.0-rc.1
+[12.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v11.0.1...v12.0.0
+[11.0.1]: https://github.com/userFRM/ThetaDataDx/compare/v11.0.0...v11.0.1
+[11.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v10.0.0...v11.0.0
+[10.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v9.1.0...v10.0.0
+[9.1.0]: https://github.com/userFRM/ThetaDataDx/compare/v9.0.1...v9.1.0
+[9.0.1]: https://github.com/userFRM/ThetaDataDx/compare/v9.0.0...v9.0.1
+[9.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.37...v9.0.0
+[8.0.37]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.36...v8.0.37
+[8.0.36]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.35...v8.0.36
+[8.0.35]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.33...v8.0.35
+[8.0.33]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.32...v8.0.33
+[8.0.32]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.31...v8.0.32
+[8.0.31]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.30...v8.0.31
+[8.0.30]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.29...v8.0.30
+[8.0.29]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.28...v8.0.29
+[8.0.28]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.27...v8.0.28
+[8.0.27]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.26...v8.0.27
+[8.0.26]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.25...v8.0.26
+[8.0.25]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.24...v8.0.25
+[8.0.24]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.23...v8.0.24
+[8.0.23]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.22...v8.0.23
+[8.0.22]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.21...v8.0.22
+[8.0.21]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.20...v8.0.21
+[8.0.20]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.19...v8.0.20
+[8.0.19]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.18...v8.0.19
+[8.0.18]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.17...v8.0.18
+[8.0.17]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.16...v8.0.17
+[8.0.16]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.15...v8.0.16
+[8.0.15]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.14...v8.0.15
+[8.0.14]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.13...v8.0.14
+[8.0.13]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.12...v8.0.13
+[8.0.12]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.11...v8.0.12
 [8.0.11]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.10...v8.0.11
 [8.0.10]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.9...v8.0.10
 [8.0.9]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.8...v8.0.9

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -3744,7 +3744,40 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.11...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.1...HEAD
+[13.0.0-rc.1]: https://github.com/userFRM/ThetaDataDx/compare/v12.0.0...v13.0.0-rc.1
+[12.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v11.0.1...v12.0.0
+[11.0.1]: https://github.com/userFRM/ThetaDataDx/compare/v11.0.0...v11.0.1
+[11.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v10.0.0...v11.0.0
+[10.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v9.1.0...v10.0.0
+[9.1.0]: https://github.com/userFRM/ThetaDataDx/compare/v9.0.1...v9.1.0
+[9.0.1]: https://github.com/userFRM/ThetaDataDx/compare/v9.0.0...v9.0.1
+[9.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.37...v9.0.0
+[8.0.37]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.36...v8.0.37
+[8.0.36]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.35...v8.0.36
+[8.0.35]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.33...v8.0.35
+[8.0.33]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.32...v8.0.33
+[8.0.32]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.31...v8.0.32
+[8.0.31]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.30...v8.0.31
+[8.0.30]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.29...v8.0.30
+[8.0.29]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.28...v8.0.29
+[8.0.28]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.27...v8.0.28
+[8.0.27]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.26...v8.0.27
+[8.0.26]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.25...v8.0.26
+[8.0.25]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.24...v8.0.25
+[8.0.24]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.23...v8.0.24
+[8.0.23]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.22...v8.0.23
+[8.0.22]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.21...v8.0.22
+[8.0.21]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.20...v8.0.21
+[8.0.20]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.19...v8.0.20
+[8.0.19]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.18...v8.0.19
+[8.0.18]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.17...v8.0.18
+[8.0.17]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.16...v8.0.17
+[8.0.16]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.15...v8.0.16
+[8.0.15]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.14...v8.0.15
+[8.0.14]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.13...v8.0.14
+[8.0.13]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.12...v8.0.13
+[8.0.12]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.11...v8.0.12
 [8.0.11]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.10...v8.0.11
 [8.0.10]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.9...v8.0.10
 [8.0.9]: https://github.com/userFRM/ThetaDataDx/compare/v8.0.8...v8.0.9


### PR DESCRIPTION
Many version headings in the changelog rendered as literal bracketed text on GitHub and the docs-site because their reference-style footer links were never defined. The footer definitions stopped at 8.0.11, so every heading from 8.0.12 through 13.0.0-rc.1 had nothing to resolve against.

This is a pure footer repair. No changelog prose changed.

What this does:

- Backfills 33 missing compare-link footer definitions (13.0.0-rc.1 down through 8.0.12), each using the immediately preceding released version as the compare base, matching the existing footer convention exactly.
- Only generates links between tags that actually exist on the remote, so they resolve on GitHub. The 9.1.0 link skips the never-released 9.0.2 and compares against v9.0.1, and 8.0.35 compares against v8.0.33 since there is no v8.0.34.
- Defines 13.0.0-rc.1 as compare/v12.0.0...v13.0.0-rc.1 so it resolves the moment the tag is cut.
- Repoints Unreleased from the stale compare/v8.0.11...HEAD to compare/v13.0.0-rc.1...HEAD.

One heading is intentionally left without a link: 9.0.2 has no tag on the remote (the entry exists but the version was never released), so linking it would point at a nonexistent ref. It stays unlinked rather than fabricating a broken compare URL.

The docs-site copy stays byte-identical to the root changelog, verified by scripts/check_docs_consistency.py (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)