### PR TITLE
fix(python): give Contract a hash consistent with its equality

### DIFF
--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -303,8 +303,16 @@ class Contract:
         """Return a representation of the contract."""
         ...
 
+    def __str__(self) -> str:
+        """Return the contract's wire-format string."""
+        ...
+
     def __eq__(self, other: object) -> bool:
         """Return whether ``other`` is a contract with the same identity."""
+        ...
+
+    def __hash__(self) -> int:
+        """Return a hash consistent with ``__eq__``, so equal contracts can share a dict key or set slot."""
         ...
 
 

--- a/sdks/python/src/fluent.rs
+++ b/sdks/python/src/fluent.rs
@@ -19,6 +19,9 @@
 //! `client.subscribe(sub)` path on the Rust core dispatches on the
 //! enum without any string parsing.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -223,6 +226,17 @@ impl PyContract {
 
     fn __eq__(&self, other: &Self) -> bool {
         self.inner == other.inner
+    }
+
+    fn __hash__(&self) -> isize {
+        // Hash the same value `__eq__` compares so equal contracts hash
+        // equal, keeping `Contract` usable as a dict key / set member.
+        // `protocol::Contract` derives `Hash` over exactly the fields
+        // its derived equality compares, so delegating here keeps the
+        // hash/eq invariant consistent by construction.
+        let mut hasher = DefaultHasher::new();
+        self.inner.hash(&mut hasher);
+        hasher.finish() as isize
     }
 }
 

--- a/sdks/python/tests/test_fluent_contract_example.py
+++ b/sdks/python/tests/test_fluent_contract_example.py
@@ -131,3 +131,71 @@ def test_contract_str_renders_strike_in_dollars(thetadatadx_mod) -> None:
 
     stock = thetadatadx_mod.Contract.stock("AAPL")
     assert str(stock) == "AAPL STOCK"
+
+
+def _spy_option(mod):
+    return mod.Contract.option(
+        "SPY",
+        expiration="20260620",
+        strike="550",
+        right="C",
+    )
+
+
+def test_equal_contracts_hash_equal(thetadatadx_mod) -> None:
+    """Two contracts that compare equal must hash equal, so `Contract`
+    obeys the hash/eq invariant Python requires of any dict key or set
+    member."""
+    a = _spy_option(thetadatadx_mod)
+    b = _spy_option(thetadatadx_mod)
+    assert a == b
+    assert hash(a) == hash(b)
+
+    s1 = thetadatadx_mod.Contract.stock("AAPL")
+    s2 = thetadatadx_mod.Contract.stock("AAPL")
+    assert s1 == s2
+    assert hash(s1) == hash(s2)
+
+
+def test_unequal_contracts_compare_unequal(thetadatadx_mod) -> None:
+    """Distinct contracts compare unequal; equality must distinguish a
+    different symbol and a different right."""
+    stock = thetadatadx_mod.Contract.stock("AAPL")
+    other = thetadatadx_mod.Contract.stock("MSFT")
+    assert stock != other
+
+    call = _spy_option(thetadatadx_mod)
+    put = thetadatadx_mod.Contract.option(
+        "SPY",
+        expiration="20260620",
+        strike="550",
+        right="P",
+    )
+    assert call != put
+
+
+def test_contract_works_as_dict_key(thetadatadx_mod) -> None:
+    """A `Contract` is a usable dict key: a freshly built equal contract
+    looks up the same entry and overwrites in place."""
+    key = _spy_option(thetadatadx_mod)
+    book = {key: 42}
+    assert book[_spy_option(thetadatadx_mod)] == 42
+
+    book[_spy_option(thetadatadx_mod)] = 7
+    assert len(book) == 1
+    assert book[key] == 7
+
+
+def test_contract_works_as_set_member(thetadatadx_mod) -> None:
+    """Equal contracts collapse to one set member; distinct ones do
+    not."""
+    members = {
+        _spy_option(thetadatadx_mod),
+        _spy_option(thetadatadx_mod),
+        thetadatadx_mod.Contract.stock("AAPL"),
+        thetadatadx_mod.Contract.stock("AAPL"),
+    }
+    assert len(members) == 2
+    assert _spy_option(thetadatadx_mod) in members
+    assert thetadatadx_mod.Contract.stock("AAPL") in members
+    assert thetadatadx_mod.Contract.stock("MSFT") not in members


### PR DESCRIPTION
The fluent `Contract` defined `__eq__` but no `__hash__`. A pyclass with a hand-written `__eq__` does not get its hash slot cleared the way a pure-Python class does, so it kept identity hashing: two contracts that compare equal hashed differently and silently broke as dict keys or set members. The sibling `SecType` already defines both.

This adds a `__hash__` that hashes the same value `__eq__` compares, delegating to the derived hash on the underlying contract so the hash/eq invariant holds by construction rather than by a hand-maintained field list. The `Contract` stub now declares `__hash__` and the already-implemented `__str__`, so the type stub matches the runtime, and the change is covered by tests that equal contracts hash equal and that a `Contract` works as a dict key and a set member.

Verification: stubtest passes with the CI flags (no stub-vs-runtime drift), the binding parity gate stays clean, `cargo fmt --all` and `cargo clippy -p thetadatadx-py --locked -- -D warnings` are clean, and the fluent-contract test module passes including the four new cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)