### PR TITLE
fix(fpss): zeroize the credentials payload and correct the IV-solver doc

### DIFF
--- a/crates/thetadatadx/src/fpss/io_loop/mod.rs
+++ b/crates/thetadatadx/src/fpss/io_loop/mod.rs
@@ -67,8 +67,8 @@ use super::decode::decode_frame;
 use super::delta::DeltaState;
 use super::events::{FpssEventInternal, IoCommand, StreamControl};
 use super::framing::{
-    self, is_drain_yield, read_frame_into_with_stall_timeout, write_frame, write_raw_frame,
-    write_raw_frame_no_flush, Frame, FrameReadState,
+    self, is_drain_yield, read_frame_into_with_stall_timeout, write_raw_frame,
+    write_raw_frame_no_flush, FrameReadState,
 };
 use super::protocol::{self, build_credentials_payload, Contract};
 use super::reconnect_delay;
@@ -1046,8 +1046,11 @@ where
                 break 'session;
             }
         };
-        let frame = Frame::new(StreamMsgType::Credentials, cred_payload);
-        if let Err(e) = write_frame(&mut new_stream, &frame) {
+        // Write the credentials from the `Zeroizing` buffer directly rather than
+        // moving the cleartext into a `Frame`, so the secret bytes are wiped on
+        // drop instead of lingering in a frame-owned `Vec`.
+        if let Err(e) = write_raw_frame(&mut new_stream, StreamMsgType::Credentials, &cred_payload)
+        {
             tracing::warn!(error = %e, "failed to send credentials on reconnect");
             continue 'session;
         }

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -1243,10 +1243,11 @@ impl StreamingClient {
             keepalive,
             ping_interval,
         } = args;
-        // Send CREDENTIALS (code 0).
+        // Send CREDENTIALS (code 0). Write straight from the `Zeroizing` buffer
+        // rather than moving the cleartext into a `Frame`, so the secret bytes
+        // are wiped on drop instead of lingering in a frame-owned `Vec`.
         let cred_payload = build_credentials_payload(&creds.email, &creds.password)?;
-        let frame = Frame::new(StreamMsgType::Credentials, cred_payload);
-        write_frame(&mut stream, &frame)?;
+        framing::write_raw_frame(&mut stream, StreamMsgType::Credentials, &cred_payload)?;
         tracing::debug!("sent CREDENTIALS to {server_addr}");
 
         // Wait for METADATA (success) or DISCONNECTED (failure). Blocks until

--- a/crates/thetadatadx/src/fpss/protocol/wire.rs
+++ b/crates/thetadatadx/src/fpss/protocol/wire.rs
@@ -11,6 +11,7 @@ use crate::tdbe::types::enums::{RemoveReason, SecType, StreamResponseType};
 use super::contract::Contract;
 use crate::error::Error;
 use crate::fpss::framing::MAX_PAYLOAD_LEN;
+use zeroize::Zeroizing;
 
 // ---------------------------------------------------------------------------
 // Credentials payload
@@ -36,7 +37,19 @@ use crate::fpss::framing::MAX_PAYLOAD_LEN;
 /// length is `3 + username.len() + password.len()`; oversized credentials are
 /// rejected here so the caller gets a typed configuration error instead of a
 /// frame-construction panic.
-pub fn build_credentials_payload(username: &str, password: &str) -> Result<Vec<u8>, Error> {
+///
+/// # Secret handling
+///
+/// The returned buffer holds the cleartext password and is wrapped in
+/// [`zeroize::Zeroizing`] so its backing allocation is wiped on drop. This
+/// keeps the credentials buffer on the same zeroize discipline as the rest of
+/// the auth path ([`crate::auth`] holds the password in `Zeroizing`), so no
+/// transient between the credentials struct and the socket leaves cleartext in
+/// freed heap memory.
+pub fn build_credentials_payload(
+    username: &str,
+    password: &str,
+) -> Result<Zeroizing<Vec<u8>>, Error> {
     let user_bytes = username.as_bytes();
     let pass_bytes = password.as_bytes();
 
@@ -73,7 +86,7 @@ pub fn build_credentials_payload(username: &str, password: &str) -> Result<Vec<u
     buf.extend_from_slice(&user_len.to_be_bytes());
     buf.extend_from_slice(user_bytes);
     buf.extend_from_slice(pass_bytes);
-    Ok(buf)
+    Ok(Zeroizing::new(buf))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -360,7 +360,7 @@ pub use crate::tdbe::types::price::{Price, PriceError, PriceType, MAX_PRICE_TYPE
 ///
 /// All calculations follow the standard Black-Scholes-Merton model.
 /// Use [`all_greeks`] to compute the full Greek surface from a quoted option
-/// price, or [`implied_volatility`] for the Newton-Raphson IV solve alone.
+/// price, or [`implied_volatility`] for the bisection IV solve alone.
 pub mod greeks {
     /// Error returned by the offline analytics surface ([`all_greeks`],
     /// [`implied_volatility`], [`parse_right`], [`parse_right_strict`]) for


### PR DESCRIPTION
The CREDENTIALS payload holds the cleartext password. It was returned as a plain `Vec<u8>` and, on the two streaming login paths, moved into a `Frame` whose payload `Vec` dropped without wiping. That left the password in freed heap memory on every login and reconnect, breaking the zeroize discipline the auth path otherwise keeps (the password is held in `Zeroizing` throughout, and the credential file read and transient copies are `Zeroizing`).

## Zeroize consistency

`build_credentials_payload` now returns `Zeroizing<Vec<u8>>`, so the buffer is wiped on drop. The two streaming sites (FPSS connect and reconnect) write straight from that buffer via `write_raw_frame` instead of moving the secret into a `Frame`, so the cleartext never lands in a frame-owned `Vec`. The flat-files login already passed the buffer by reference, so it picks up the wiped-on-drop behaviour for free.

The wire bytes are unchanged. The existing credential-layout tests assert the exact payload (version byte, big-endian `u16` username length, username, password, total length) and still pass byte-for-byte.

## Doc accuracy

The public `greeks` module doc claimed the implied-volatility solve is Newton-Raphson, but the solver is bisection (`iv_bisection`, matching the FFI comment). This rendered on docs.rs. The docstring now says bisection. It was the only `Newton` reference on a public item.

## Verification

- `cargo test -p thetadatadx --lib fpss` and `--lib flatfiles` pass.
- `cargo fmt --all` clean.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)