### PR TITLE
fix(ffi): guard the tick-chunk callback against panics and pin event-struct layout on the Rust side

### DIFF
--- a/crates/thetadatadx/build_support_bin/fpss_events/ffi_rust.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/ffi_rust.rs
@@ -15,6 +15,9 @@ use super::common::{
     is_byte_buffer, is_contract, rust_ffi_scalar, rust_ffi_zero_literal, snake_case,
     zero_const_name,
 };
+use super::layout::{
+    c_struct_size, contract_align, contract_size, fpss_event_align, fpss_event_size, struct_align,
+};
 use super::schema::{
     sorted_control_events, sorted_data_events, sorted_event_names, ColumnDef, EventDef, Schema,
 };
@@ -221,6 +224,69 @@ fn render_event_struct_rust(out: &mut String, event_name: &str, def: &EventDef) 
     out.push_str("}\n\n");
 }
 
+/// Emit one `const _: () = { ... };` block pinning a struct's `size_of`
+/// and `align_of`. The compiler evaluates both intrinsics against the
+/// real `#[repr(C)]` layout, so an accidental schema / field-width change
+/// that shifts the Rust layout fails the build at the definition site,
+/// before the generated C header and its C++ `static_assert` mirror can
+/// drift apart. Numbers come from the same layout walk that feeds the C++
+/// asserts, never hand-typed.
+fn render_layout_assert(out: &mut String, type_name: &str, size: usize, align: usize) {
+    writeln!(out, "const _: () = {{").unwrap();
+    writeln!(
+        out,
+        "    assert!(core::mem::size_of::<{type_name}>() == {size});"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "    assert!(core::mem::align_of::<{type_name}>() == {align});"
+    )
+    .unwrap();
+    out.push_str("};\n");
+}
+
+/// Render the size + align asserts for every emitted `#[repr(C)]` struct:
+/// the shared `ThetaDataDxContract`, each data and control variant, and
+/// the tagged `ThetaDataDxStreamEvent` wrapper. Mirrors the C++
+/// `static_assert` coverage so the layout is pinned on the Rust side that
+/// defines the ABI, not only on the C++ consumer.
+fn render_rust_layout_asserts(out: &mut String, schema: &Schema) {
+    out.push_str("// Layout drift-guard: pin the `#[repr(C)]` size + alignment of every\n");
+    out.push_str("// emitted struct on the Rust side that defines the ABI. A schema or\n");
+    out.push_str("// field-width change that shifts a layout fails the build here, before\n");
+    out.push_str("// the generated C header and its C++ asserts can drift out of sync.\n");
+    render_layout_assert(
+        out,
+        "ThetaDataDxContract",
+        contract_size(),
+        contract_align(),
+    );
+    for (event_name, def) in sorted_data_events(schema) {
+        render_layout_assert(
+            out,
+            &format!("ThetaDataDxStream{event_name}"),
+            c_struct_size(&def.columns),
+            struct_align(&def.columns),
+        );
+    }
+    for (event_name, def) in sorted_control_events(schema) {
+        render_layout_assert(
+            out,
+            &format!("ThetaDataDxStream{event_name}"),
+            c_struct_size(&def.columns),
+            struct_align(&def.columns),
+        );
+    }
+    render_layout_assert(
+        out,
+        "ThetaDataDxStreamEvent",
+        fpss_event_size(schema),
+        fpss_event_align(schema),
+    );
+    out.push('\n');
+}
+
 /// Render the matching `ZERO_*` const for one variant. All scalars zero,
 /// pointers null, lengths zero, contracts `ZERO_CONTRACT_STRUCT`, byte
 /// buffers `(null, 0)`, padding bytes 0.
@@ -315,6 +381,9 @@ pub(super) fn render_ffi_fpss_event_structs(schema: &Schema) -> String {
         writeln!(out, "    pub {field}: ThetaDataDxStream{event_name},").unwrap();
     }
     out.push_str("}\n\n");
+
+    // Size + align drift-guard for every emitted `#[repr(C)]` struct.
+    render_rust_layout_asserts(&mut out, schema);
 
     // Zero-initialised defaults for inactive fields.
     out.push_str("// Zero-initialized defaults for inactive union-style fields.\n");

--- a/crates/thetadatadx/build_support_bin/fpss_events/layout.rs
+++ b/crates/thetadatadx/build_support_bin/fpss_events/layout.rs
@@ -122,10 +122,12 @@ pub(super) fn c_struct_offsets(columns: &[ColumnDef]) -> Vec<(String, usize)> {
     offsets
 }
 
-/// Alignment requirement of a control-variant struct, computed from its
-/// columns. Empty-column control variants fall back to align=1 (one
-/// `_padding` byte).
-pub(super) fn control_struct_align(columns: &[ColumnDef]) -> usize {
+/// Alignment requirement of any emitted event struct, computed from the
+/// widest field in its expanded column list. An empty column list is a
+/// `_padding: u8` placeholder, hence align 1. Shared by the Rust-side
+/// `align_of!` asserts and the control-variant placement walk so the
+/// asserted alignment is never hand-typed.
+pub(super) fn struct_align(columns: &[ColumnDef]) -> usize {
     if columns.is_empty() {
         1
     } else {
@@ -135,6 +137,24 @@ pub(super) fn control_struct_align(columns: &[ColumnDef]) -> usize {
             .max()
             .unwrap_or(1)
     }
+}
+
+/// Alignment requirement of the shared `ThetaDataDxContract` struct,
+/// computed from its widest field so the Rust-side `align_of!` assert
+/// tracks the same layout walk that places every embedding event.
+pub(super) fn contract_align() -> usize {
+    contract_fields()
+        .iter()
+        .map(|(_, l)| l.align)
+        .max()
+        .unwrap_or(1)
+}
+
+/// Alignment requirement of a control-variant struct, computed from its
+/// columns. Empty-column control variants fall back to align=1 (one
+/// `_padding` byte).
+pub(super) fn control_struct_align(columns: &[ColumnDef]) -> usize {
+    struct_align(columns)
 }
 
 /// Returns the total C struct size, in bytes, of the tagged `ThetaDataDxStreamEvent` wrapper.
@@ -156,6 +176,17 @@ pub(super) fn fpss_event_offsets(schema: &Schema) -> Vec<(String, usize)> {
         size += layout.size;
     }
     offsets
+}
+
+/// Alignment requirement of the tagged `ThetaDataDxStreamEvent` wrapper,
+/// taken as the widest embedded field so the Rust-side `align_of!` assert
+/// tracks the same walk that sizes the wrapper.
+pub(super) fn fpss_event_align(schema: &Schema) -> usize {
+    fpss_event_fields(schema)
+        .into_iter()
+        .map(|(_, layout)| layout.align)
+        .max()
+        .unwrap_or(1)
 }
 
 fn fpss_event_fields(schema: &Schema) -> Vec<(String, CFieldLayout)> {

--- a/ffi/src/endpoints.rs
+++ b/ffi/src/endpoints.rs
@@ -69,8 +69,24 @@ impl TickChunkSink {
     /// Forward one chunk to the registered C callback. `rows` / `len` come
     /// straight from the decoder-owned slice (`chunk.as_ptr()` /
     /// `chunk.len()`), so there is no copy or re-marshaling on this path.
+    ///
+    /// The core wraps this handler in a `Mutex` and may drive it from a
+    /// runtime worker thread (see the type doc), not on the
+    /// `ffi_boundary!`-guarded entry point, so a panic raised inside the
+    /// user callback would unwind across the C ABI on a foreign thread.
+    /// Catch it per invocation, the same defence the reconnect callback and
+    /// the stream dispatcher apply, so a panicking callback is contained at
+    /// the boundary instead of aborting the process.
     fn emit(&self, rows: *const c_void, len: usize) {
-        (self.callback)(rows, len, self.ctx);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (self.callback)(rows, len, self.ctx);
+        }));
+        if outcome.is_err() {
+            tracing::error!(
+                target: "thetadatadx::ffi",
+                "tick-chunk callback panicked; chunk dropped and the panic contained at the C boundary",
+            );
+        }
     }
 }
 

--- a/ffi/src/fpss_event_structs.rs
+++ b/ffi/src/fpss_event_structs.rs
@@ -437,6 +437,107 @@ pub struct ThetaDataDxStreamEvent {
     pub unknown_frame: ThetaDataDxStreamUnknownFrame,
 }
 
+// Layout drift-guard: pin the `#[repr(C)]` size + alignment of every
+// emitted struct on the Rust side that defines the ABI. A schema or
+// field-width change that shifts a layout fails the build here, before
+// the generated C header and its C++ asserts can drift out of sync.
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxContract>() == 40);
+    assert!(core::mem::align_of::<ThetaDataDxContract>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamMarketValue>() == 88);
+    assert!(core::mem::align_of::<ThetaDataDxStreamMarketValue>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamOhlcvc>() == 112);
+    assert!(core::mem::align_of::<ThetaDataDxStreamOhlcvc>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamOpenInterest>() == 64);
+    assert!(core::mem::align_of::<ThetaDataDxStreamOpenInterest>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamQuote>() == 104);
+    assert!(core::mem::align_of::<ThetaDataDxStreamQuote>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamTrade>() == 120);
+    assert!(core::mem::align_of::<ThetaDataDxStreamTrade>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamConnected>() == 1);
+    assert!(core::mem::align_of::<ThetaDataDxStreamConnected>() == 1);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamContractAssigned>() == 48);
+    assert!(core::mem::align_of::<ThetaDataDxStreamContractAssigned>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamDisconnected>() == 4);
+    assert!(core::mem::align_of::<ThetaDataDxStreamDisconnected>() == 4);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamLoginSuccess>() == 8);
+    assert!(core::mem::align_of::<ThetaDataDxStreamLoginSuccess>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamMarketClose>() == 1);
+    assert!(core::mem::align_of::<ThetaDataDxStreamMarketClose>() == 1);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamMarketOpen>() == 1);
+    assert!(core::mem::align_of::<ThetaDataDxStreamMarketOpen>() == 1);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamParseError>() == 8);
+    assert!(core::mem::align_of::<ThetaDataDxStreamParseError>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamPing>() == 16);
+    assert!(core::mem::align_of::<ThetaDataDxStreamPing>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamReconnected>() == 1);
+    assert!(core::mem::align_of::<ThetaDataDxStreamReconnected>() == 1);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamReconnectedServer>() == 1);
+    assert!(core::mem::align_of::<ThetaDataDxStreamReconnectedServer>() == 1);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamReconnecting>() == 16);
+    assert!(core::mem::align_of::<ThetaDataDxStreamReconnecting>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamReconnectsExhausted>() == 8);
+    assert!(core::mem::align_of::<ThetaDataDxStreamReconnectsExhausted>() == 4);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamReqResponse>() == 8);
+    assert!(core::mem::align_of::<ThetaDataDxStreamReqResponse>() == 4);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamRestart>() == 1);
+    assert!(core::mem::align_of::<ThetaDataDxStreamRestart>() == 1);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamServerError>() == 8);
+    assert!(core::mem::align_of::<ThetaDataDxStreamServerError>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamUnknownControl>() == 1);
+    assert!(core::mem::align_of::<ThetaDataDxStreamUnknownControl>() == 1);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamUnknownFrame>() == 24);
+    assert!(core::mem::align_of::<ThetaDataDxStreamUnknownFrame>() == 8);
+};
+const _: () = {
+    assert!(core::mem::size_of::<ThetaDataDxStreamEvent>() == 688);
+    assert!(core::mem::align_of::<ThetaDataDxStreamEvent>() == 8);
+};
+
 // Zero-initialized defaults for inactive union-style fields.
 pub(crate) const ZERO_MARKET_VALUE: ThetaDataDxStreamMarketValue = ThetaDataDxStreamMarketValue {
     contract: ZERO_CONTRACT_STRUCT,


### PR DESCRIPTION
Two hardening fixes in the C-ABI crate.

The historical stream entry points forward each decoded chunk to the user callback through `TickChunkSink::emit`. The core wraps that handler in a `Mutex` and may drive it from a runtime worker thread, not on the `ffi_boundary!`-guarded entry point, so a panic raised inside the user callback would unwind across the C ABI on a foreign thread. The emit path now wraps the invocation in `catch_unwind`, matching the per-invocation defence the reconnect callback and the stream dispatcher already apply. A panicking callback is contained at the boundary, the chunk is dropped, and an error is traced instead of aborting the process. The success path and the callback ABI are unchanged.

The generated `#[repr(C)]` FPSS event structs had no Rust-side layout assertion. The C++ mirror already asserts size and offsets, but the Rust side that defines the ABI did not, so a schema or field-width change could shift the Rust layout out of sync with the generated C header before the C++ assert caught it. The generator now emits a `const _` `size_of` / `align_of` guard for `ThetaDataDxContract` and every event struct, computed by the same layout walk that feeds the C++ asserts so the numbers are never hand-typed. A layout shift now fails the build at the definition site. This was added in the emitter and the file regenerated, so the generated source is not hand-edited; the drift `--check` gate passes clean.

Verification: `cargo build`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --locked -- -D warnings`, and the full test suite all pass on the crate. The size assert was confirmed non-tautological by temporarily setting the contract size to a wrong value and observing the compile fail, then reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)