### PR TITLE
test(fpss): serialize the affinity tests sharing global pin state

### DIFF
--- a/crates/thetadatadx/src/fpss/affinity.rs
+++ b/crates/thetadatadx/src/fpss/affinity.rs
@@ -74,8 +74,21 @@ pub(crate) fn pin_consumer_thread(core: Option<usize>) {
 mod tests {
     use super::*;
 
+    // `LAST_PINNED_CORE` is a process-global singleton; the tests that
+    // reset and read it must serialise so they never observe each other's
+    // writes under `cargo test -- --test-threads=N`. Each test holds the
+    // guard for its full reset + call + assert sequence.
+    fn pin_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
     #[test]
     fn none_does_not_record_a_pin() {
+        let _guard = pin_test_guard();
         LAST_PINNED_CORE.store(-1, Ordering::Relaxed);
         pin_consumer_thread(None);
         assert_eq!(LAST_PINNED_CORE.load(Ordering::Relaxed), -1);
@@ -86,6 +99,7 @@ mod tests {
         // Use a deliberately high core id: it is almost certainly absent
         // on CI, so this exercises the "record the attempt, then no-op
         // gracefully" path without depending on real affinity support.
+        let _guard = pin_test_guard();
         LAST_PINNED_CORE.store(-1, Ordering::Relaxed);
         pin_consumer_thread(Some(4096));
         assert_eq!(LAST_PINNED_CORE.load(Ordering::Relaxed), 4096);


### PR DESCRIPTION
The two affinity tests both reset and read the process-global LAST_PINNED_CORE atomic, but ran in parallel under default cargo test. The Some-records test could store its core id in the window between the None test's reset and its assert, so none_does_not_record_a_pin intermittently observed a foreign write and failed on some CI runs while passing on others.

The fix serializes the two tests through a process-global Mutex guard held across each test's reset, call, and assert sequence. It reuses the OnceLock<Mutex<()>> guard pattern the config env-var tests already use, including poison recovery via into_inner. Production code is untouched: pin_consumer_thread and LAST_PINNED_CORE keep their existing behavior, since the atomic is a real observability seam for the drain loop. Coverage is unchanged, both the None no-op path and the Some-records path are still asserted.

Verified deterministic: 20 consecutive runs of the two tests all pass, the full fpss lib suite passes (283 passed), fmt is clean, and clippy --workspace --all-targets --locked -- -D warnings is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)