### PR TITLE
test(python): assert the IV residual magnitude, not its sign

### DIFF
--- a/sdks/python/tests/test_fresh_install_smoke.py
+++ b/sdks/python/tests/test_fresh_install_smoke.py
@@ -125,7 +125,9 @@ def test_documented_implied_volatility_runs(mod) -> None:
     """Smoke test the analytical helper documented in lib.rs."""
     iv, err = mod.implied_volatility(450.0, 455.0, 0.05, 0.015, 30.0 / 365.0, 8.50, "C")
     assert iv > 0
-    assert err >= 0
+    # iv_error is the signed relative residual (value - price) / price, so a
+    # converged solve sits near zero on either side; assert the magnitude is small.
+    assert abs(err) < 1e-3
 
 
 def test_version_attribute_exposed(mod) -> None:


### PR DESCRIPTION
The fresh-install smoke test asserted `err >= 0` on the second element of `implied_volatility`, but that value is the signed relative residual `(value - price) / price`. A converged solve can sit just below zero (the solver reaches the price from above), so the assertion fails non-deterministically depending on which side convergence lands. The free-threaded wheel job hit it on main.

This asserts the residual magnitude is small for a converged solve, which is what the smoke test means to check, and matches the documented `iv_error` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)