### PR TITLE
docs: add curated v13.0.0-rc.1 release notes with contributor credits

### DIFF
--- a/.github/release-notes/v13.0.0-rc.1.md
+++ b/.github/release-notes/v13.0.0-rc.1.md
@@ -1,0 +1,37 @@
+## ThetaDataDx 13.0.0-rc.1
+
+First release candidate of the 13.x line. This is a naming-and-surface cleanup across every binding, a tighter and better-documented streaming API, and a round of correctness and security hardening. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.1/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- Clients are named by role on every binding: `Client` (unified, with `AsyncClient` as the async companion in Python), `HistoricalClient`, and `StreamingClient`. The streaming callback payloads are `StreamEvent` / `StreamData` / `StreamControl`. The old long client name and the protocol-keyed `MddsClient` / `FpssClient` / `FpssEvent` names are gone.
+- The C++ surface is renamed from `thetadx` to `thetadatadx` so the header (`thetadatadx.hpp`), the C ABI header (`thetadatadx.h`), the namespace, the symbol prefix, and the package name all line up across languages.
+- The flat-file surface is restricted to the datasets the distribution actually serves: option `trade_quote` / `open_interest` / `eod` and stock `trade_quote` / `eod`. An unsupported request now fails fast with a typed invalid-parameter error instead of a server rejection.
+- Option contracts carry the strike both ways: a dollar `strike` and a raw `strike_thousandths` integer, on every binding, so you can pick whichever unit fits your code.
+- Streaming gives you derived OHLCVC bars off any trade subscription (opt-out), index market-value streaming, and per-contract market value.
+- Python's `AsyncClient` gained a non-blocking `connect` and awaitable flat-file terminals, so async code never stalls the event loop on the auth handshake or a bulk download.
+
+### Server
+
+- Rate limiting is opt-in and off by default. Set `THETADATADX_RATE_LIMIT_PER_SECOND` / `THETADATADX_RATE_LIMIT_BURST_SIZE` to turn it on, and `THETADATADX_WS_CLIENT_CAPACITY` to size the per-client WebSocket queue. The bundled server behaves like a local drop-in unless you ask it to do more.
+
+### Security
+
+- The streaming login no longer leaves the account password in a freed memory buffer after connect or reconnect. The credentials are wiped from memory the moment the login frame is sent.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.1"`
+
+### Thanks
+
+A big thank you to the people who pushed this release to be better.
+
+- [@trepidity](https://github.com/trepidity) filed a sharp run of streaming issues (#801-#805) that shaped most of the streaming work here: matching the WebSocket REQ_RESPONSE success values to the streaming API, keeping the standalone Python and TypeScript FPSS clients from dropping streaming config, de-duplicating active subscriptions and bounding control-plane bursts, clarifying the burst defaults and drop behavior, and returning a typed error instead of panicking on an oversized credential. Several of those landed directly in this release.
+- [@0xdefnoterr](https://github.com/0xdefnoterr) sent the PRs (#868, #869) that made the server's rate limits and WebSocket client capacity env-configurable. That feedback is exactly why rate limiting is opt-in and off by default now, instead of a hardcoded ceiling the terminal never imposed.
+
+If you reported something or sent a patch and you do not see your name, that is on us, not you. Open an issue and we will fix the credit.


### PR DESCRIPTION
Adds `.github/release-notes/v13.0.0-rc.1.md`, which the release workflow uses as the GitHub Release body. It summarizes the first 13.x release candidate and credits the contributors whose issues and PRs shaped it (@trepidity on the streaming hardening, @0xdefnoterr on the env-configurable rate limits and WebSocket capacity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)