### PR TITLE
test(fpss): assert the wait-strategy preset instead of wall-clock timing

### DIFF
--- a/crates/thetadatadx/src/config/fpss.rs
+++ b/crates/thetadatadx/src/config/fpss.rs
@@ -514,19 +514,13 @@ mod tests {
     #[test]
     fn build_wait_strategy_default_is_low_latency() {
         let cfg = StreamingConfig::production_defaults();
-        // The default config must reproduce the historical fixed strategy.
+        // The default config must reproduce the historical fixed strategy:
+        // the low-latency preset, which never parks. Assert the resolved
+        // wait mode equals the low-latency preset's mode rather than timing
+        // a poll, so the guard holds regardless of host scheduling load.
         let built = cfg.build_wait_strategy();
         let expected = crate::fpss::ring::AdaptiveWaitStrategy::low_latency();
-        // Both are LowLatency with the 100/10 tuning; compare the public
-        // preset constructor against the config-built strategy via their
-        // observable `wait_for` (LowLatency never sleeps).
-        use disruptor::wait_strategies::WaitStrategy;
-        let t0 = std::time::Instant::now();
-        built.wait_for(0);
-        expected.wait_for(0);
-        // LowLatency never parks, so two calls stay well under a
-        // millisecond — guards against the default silently parking.
-        assert!(t0.elapsed() < std::time::Duration::from_millis(5));
+        assert_eq!(built.mode(), expected.mode());
     }
 
     #[test]

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -3192,40 +3192,29 @@ mod builder_tests {
     #[test]
     fn builder_threads_wait_strategy_preset() {
         use crate::config::StreamingWaitStrategy;
-        use disruptor::wait_strategies::WaitStrategy;
+        use crate::fpss::ring::AdaptiveWaitStrategy;
         let creds = Credentials::new("user", "pw");
         let hosts: Vec<(String, u16)> = vec![("nj-a.thetadata.us".to_owned(), 20000)];
 
-        // Default preset is the low-latency strategy that never sleeps; a
-        // selected Balanced preset with a measurable park actually parks.
-        // Compare the two RELATIVELY: an absolute upper bound on the
-        // never-sleeping path flakes when a loaded host stretches the
-        // yield phase, whereas a real `thread::sleep` has a reliable lower
-        // bound and is always slower than the spin-only path.
+        // The default builder resolves to the low-latency preset that
+        // preserves the historical fixed behaviour, and a selected preset
+        // reaches the connect args unchanged. Assert the resolved wait mode
+        // against the expected preset's mode rather than timing a poll, so
+        // the guard cannot flake under contended host scheduling.
         let default_args = StreamingClientBuilder::new(&creds, &hosts).into_args();
-        let t0 = std::time::Instant::now();
-        default_args.wait_strategy.wait_for(0);
-        let low_latency_elapsed = t0.elapsed();
+        assert_eq!(
+            default_args.wait_strategy.mode(),
+            AdaptiveWaitStrategy::low_latency().mode(),
+            "default builder must resolve to the low-latency preset"
+        );
 
         let balanced_args = StreamingClientBuilder::new(&creds, &hosts)
             .wait_strategy(StreamingWaitStrategy::Balanced)
-            .wait_strategy_tuning(0, 0, 2_000)
             .into_args();
-        let t1 = std::time::Instant::now();
-        balanced_args.wait_strategy.wait_for(0);
-        let balanced_elapsed = t1.elapsed();
-
-        // Balanced parks ~its configured 2 ms (a sleep never returns much
-        // early — reliable lower bound).
-        assert!(
-            balanced_elapsed >= std::time::Duration::from_micros(1_800),
-            "Balanced should park ~2ms, took {balanced_elapsed:?}"
-        );
-        // The never-sleeping low-latency path is faster than the 2 ms park —
-        // a relative bound that holds even on a contended CI host.
-        assert!(
-            low_latency_elapsed < balanced_elapsed,
-            "LowLatency ({low_latency_elapsed:?}) should be faster than Balanced ({balanced_elapsed:?})"
+        assert_eq!(
+            balanced_args.wait_strategy.mode(),
+            AdaptiveWaitStrategy::balanced().mode(),
+            "selected Balanced preset must reach the connect args"
         );
     }
 

--- a/crates/thetadatadx/src/fpss/ring.rs
+++ b/crates/thetadatadx/src/fpss/ring.rs
@@ -203,6 +203,17 @@ impl AdaptiveWaitStrategy {
             park_us: park_us.min(Self::MAX_PARK_US),
         }
     }
+
+    /// The [`WaitMode`] that selects this strategy's phase shape.
+    ///
+    /// The mode is the deterministic identity of the resolved strategy:
+    /// it decides whether the consumer ever parks, so a caller can assert
+    /// which preset a config or builder resolved to without observing
+    /// wall-clock timing.
+    #[cfg(test)]
+    pub(crate) fn mode(&self) -> WaitMode {
+        self.mode
+    }
 }
 
 impl disruptor::wait_strategies::WaitStrategy for AdaptiveWaitStrategy {


### PR DESCRIPTION
Two streaming unit tests verified the resolved wait strategy by timing a single ring poll. The config default test asserted that a poll returned within ~5ms, and the builder preset test timed a never-sleeping poll against a parking one. A wall-clock assertion in a unit test is an inherent flake: under heavy parallel load the never-sleeping path can be descheduled long enough to blow the upper bound even though the resolved strategy is correct, so both tests passed in isolation but failed intermittently under contended CI.

What each test actually means is that the default and the selected preset resolve to the expected wait mode, not that a poll finishes inside a given window. The wait mode is the deterministic identity of the strategy: it is what decides whether the consumer ever parks. The fix asserts that identity directly through a test-only mode accessor on the adaptive wait strategy and drops the timing comparisons entirely. The guards still fail if a default or selected preset resolves to the wrong strategy, with no dependence on host scheduling.

Production behaviour is unchanged. The only non-test addition is a `#[cfg(test)]` accessor that returns the wait mode.

Verified deterministic: the affected tests pass with `--test-threads=1` and with `--test-threads=16`, across repeated runs. `cargo fmt --all` is clean and `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)