### PR TITLE
chore(release): prepare 13.0.0-rc.3

### DIFF
--- a/.github/release-notes/v13.0.0-rc.3.md
+++ b/.github/release-notes/v13.0.0-rc.3.md
@@ -1,0 +1,20 @@
+## ThetaDataDx 13.0.0-rc.3
+
+A small maintenance follow-up to rc.2. There are no SDK API changes since rc.2; this release tidies the public docs and the repository's own tooling. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.3/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- The discontinued Go SDK's lingering references are removed from the public surface. The OpenAPI reference document no longer lists or renders Go code samples, and the crate metadata and comments no longer mention Go.
+- The repository's automation scripts are reorganized into `ci`, `release`, and `dev` groups behind a single gate dispatcher, and the dormant Go codegen scaffolding is removed. This is repository tooling only and does not affect any published package.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.3"`
+
+### Thanks
+
+This cycle was internal maintenance. Thanks to everyone who tried the earlier release candidates and reported back. If you reported something or sent a patch and you do not see your name, that is on us, not you. Open an issue and we will fix the credit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.3] - 2026-06-18
+
+### Removed
+
+- The discontinued Go SDK's lingering references are removed from the public surface. The OpenAPI reference document no longer lists or renders Go code samples, and the crate metadata and comments no longer mention Go. No other binding is affected and there are no API changes since rc.2.
+
+### Internal
+
+- The repository's automation scripts are reorganized into `ci`, `release`, and `dev` groups behind a single gate dispatcher, with the dormant Go codegen scaffolding removed. This is repository tooling only and does not change any published package.
+
 ## [13.0.0-rc.2] - 2026-06-18
 
 ### Added
@@ -3759,7 +3769,8 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.3...HEAD
+[13.0.0-rc.3]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.2...v13.0.0-rc.3
 [13.0.0-rc.2]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.1...v13.0.0-rc.2
 [13.0.0-rc.1]: https://github.com/userFRM/ThetaDataDx/compare/v12.0.0...v13.0.0-rc.1
 [12.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v11.0.1...v12.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "arrow-ipc",
  "disruptor",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.3] - 2026-06-18
+
+### Removed
+
+- The discontinued Go SDK's lingering references are removed from the public surface. The OpenAPI reference document no longer lists or renders Go code samples, and the crate metadata and comments no longer mention Go. No other binding is affected and there are no API changes since rc.2.
+
+### Internal
+
+- The repository's automation scripts are reorganized into `ci`, `release`, and `dev` groups behind a single gate dispatcher, with the dormant Go codegen scaffolding removed. This is repository tooling only and does not change any published package.
+
 ## [13.0.0-rc.2] - 2026-06-18
 
 ### Added
@@ -3759,7 +3769,8 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.3...HEAD
+[13.0.0-rc.3]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.2...v13.0.0-rc.3
 [13.0.0-rc.2]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.1...v13.0.0-rc.2
 [13.0.0-rc.1]: https://github.com/userFRM/ThetaDataDx/compare/v12.0.0...v13.0.0-rc.1
 [12.0.0]: https://github.com/userFRM/ThetaDataDx/compare/v11.0.1...v12.0.0

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "arrow",
  "libc",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "arrow-ipc",
  "chrono",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.2",
+  "version": "13.0.0-rc.3",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.2",
+  "version": "13.0.0-rc.3",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.2",
+  "version": "13.0.0-rc.3",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.2",
+  "version": "13.0.0-rc.3",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -31,9 +31,9 @@
     "@types/node": "20.19.42"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.2",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.2",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.2"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.3",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.3",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.3"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.2"
+version = "13.0.0-rc.3"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Prepares the 13.0.0-rc.3 pre-release.

This bumps every published manifest from 13.0.0-rc.2 to 13.0.0-rc.3 (the Rust crates, the FFI crate, the Python and TypeScript SDK crates, the CLI / server / MCP tool crates, the TypeScript `package.json` plus its `optionalDependencies` pins, and the three per-platform npm packages) and re-syncs all the Cargo lockfiles. The version-sync gate reports canonical 13.0.0-rc.3, clean.

rc.3 records the two changes that landed since rc.2:

- The discontinued Go SDK's lingering references are removed from the public surface. The OpenAPI reference document no longer lists or renders Go code samples, and the crate metadata and comments no longer mention Go.
- The repository's automation scripts are reorganized into `ci`, `release`, and `dev` groups behind a single gate dispatcher, and the dormant Go codegen scaffolding is removed. This is repository tooling only and does not change any published package.

There are no SDK API changes since rc.2. The new `## [13.0.0-rc.3]` changelog section is added to both `CHANGELOG.md` and `docs-site/docs/changelog.md` (kept byte-identical), with the footer compare links updated, and a matching `.github/release-notes/v13.0.0-rc.3.md` is added in the house style.

No tag is cut here; the maintainer cuts the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
