### PR TITLE
chore(release): prepare 13.0.0-rc.4

### DIFF
--- a/.github/release-notes/v13.0.0-rc.4.md
+++ b/.github/release-notes/v13.0.0-rc.4.md
@@ -1,0 +1,21 @@
+## ThetaDataDx 13.0.0-rc.4
+
+This release candidate adds API-key authentication as an alternative to email and password. The only feature since rc.3; everything else is unchanged. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.4/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- API-key authentication. Generate a key from the ThetaData user portal and use it in place of your email and password. It authenticates both historical and streaming access, and it works across the Rust, Python, TypeScript, and C++ SDKs and the bundled server.
+- Three ways to supply the key. Pass it inline, read it from the `THETADATA_API_KEY` environment variable, or load it from a `.env` file. The server takes it through the `--api-key` flag or the same `THETADATA_API_KEY` environment variable.
+- Email and password still works. Nothing changes for existing setups: keep using the creds file, an inline pair, or a custom file path.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.4"`
+
+### Thanks
+
+Thanks to everyone running the release candidates and reporting back. If you sent feedback or a patch and you do not see your name, that is on us, not you. Open an issue and we will fix the credit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.4] - 2026-06-19
+
+### Added
+
+- API-key authentication as an alternative to email and password. A key can be supplied inline, read from the `THETADATA_API_KEY` environment variable, or loaded from a `.env` file, and it authenticates both historical and streaming access. It is available across the Rust, Python, TypeScript, and C++ SDKs and the bundled server (`--api-key` flag or the `THETADATA_API_KEY` environment variable). New `Credentials` factories cover the sourcing options (per-binding casing): `api_key` / `from_api_key` for an inline key, `api_key_with_email` / `from_api_key_with_email` to pair a key with an email, `from_env_or_file` to take the key from the environment or fall back to a file, and `from_dotenv` to read it from a `.env` file. Email and password authentication is unchanged (creds file, inline, or a custom file path).
+
 ## [13.0.0-rc.3] - 2026-06-18
 
 ### Removed
@@ -3769,7 +3775,8 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.3...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.4...HEAD
+[13.0.0-rc.4]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.3...v13.0.0-rc.4
 [13.0.0-rc.3]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.2...v13.0.0-rc.3
 [13.0.0-rc.2]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.1...v13.0.0-rc.2
 [13.0.0-rc.1]: https://github.com/userFRM/ThetaDataDx/compare/v12.0.0...v13.0.0-rc.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "arrow-ipc",
  "disruptor",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.4] - 2026-06-19
+
+### Added
+
+- API-key authentication as an alternative to email and password. A key can be supplied inline, read from the `THETADATA_API_KEY` environment variable, or loaded from a `.env` file, and it authenticates both historical and streaming access. It is available across the Rust, Python, TypeScript, and C++ SDKs and the bundled server (`--api-key` flag or the `THETADATA_API_KEY` environment variable). New `Credentials` factories cover the sourcing options (per-binding casing): `api_key` / `from_api_key` for an inline key, `api_key_with_email` / `from_api_key_with_email` to pair a key with an email, `from_env_or_file` to take the key from the environment or fall back to a file, and `from_dotenv` to read it from a `.env` file. Email and password authentication is unchanged (creds file, inline, or a custom file path).
+
 ## [13.0.0-rc.3] - 2026-06-18
 
 ### Removed
@@ -3769,7 +3775,8 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.3...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.4...HEAD
+[13.0.0-rc.4]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.3...v13.0.0-rc.4
 [13.0.0-rc.3]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.2...v13.0.0-rc.3
 [13.0.0-rc.2]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.1...v13.0.0-rc.2
 [13.0.0-rc.1]: https://github.com/userFRM/ThetaDataDx/compare/v12.0.0...v13.0.0-rc.1

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "arrow",
  "libc",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "arrow-ipc",
  "chrono",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.3",
+  "version": "13.0.0-rc.4",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.3",
+  "version": "13.0.0-rc.4",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.3",
+  "version": "13.0.0-rc.4",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.3",
+  "version": "13.0.0-rc.4",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -31,9 +31,9 @@
     "@types/node": "20.19.42"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.3",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.3",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.3"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.4",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.4",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.4"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.3"
+version = "13.0.0-rc.4"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Bumps the project from 13.0.0-rc.3 to 13.0.0-rc.4 and records the one feature added since rc.3: API-key authentication.

The version bump touches every manifest the version-sync gate enforces (the Rust crates, the FFI crate, the Python and TypeScript SDK crates, the CLI, server, and MCP tools, the TypeScript package.json plus its three optionalDependencies pins, and the three platform packages), and the Cargo.lock files are re-synced across all workspaces.

API-key authentication lets you use a key in place of email and password. The key can be supplied inline, read from the THETADATA_API_KEY environment variable, or loaded from a .env file, and it authenticates both historical and streaming access. It works across the Rust, Python, TypeScript, and C++ SDKs and the bundled server (--api-key flag or THETADATA_API_KEY). Email and password authentication is unchanged. The changelog (in both CHANGELOG.md and the docs-site copy) and a new release-notes file capture this.

No git tag is created here; the maintainer cuts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)