### PR TITLE
chore(release): prepare 13.0.0-rc.5

### DIFF
--- a/.github/release-notes/v13.0.0-rc.5.md
+++ b/.github/release-notes/v13.0.0-rc.5.md
@@ -1,0 +1,21 @@
+## ThetaDataDx 13.0.0-rc.5
+
+This release candidate adds staging-environment selection and first-class inline client construction. The only feature since rc.4; everything else is unchanged. See the [CHANGELOG](https://github.com/userFRM/ThetaDataDx/blob/v13.0.0-rc.5/CHANGELOG.md) for the full, itemized list.
+
+### Highlights
+
+- One-line connect with the API key passed straight to the client. Python `Client(api_key="...")`, TypeScript `Client.connectWith({ apiKey: "..." })`, Rust `Client::builder().api_key("...").connect()`, and the matching C++ builder. The typed `Client::connect(&Credentials, Config)` is still there when you want full control.
+- Staging-environment selection across authentication, historical, and streaming. Pick production or staging in code (`mdds_type="STAGE"` / `Config.stage()`), through the `THETADATA_MDDS_TYPE` environment variable (`PROD` or `STAGE`), or from a `.env` file so one file can hold both `THETADATA_API_KEY` and `THETADATA_MDDS_TYPE`.
+- Works with both credential types. API key or email and password, the environment selection and the inline construction behave the same either way.
+
+### Installing
+
+This is a pre-release, so the package managers will not pick it up unless you ask for it explicitly.
+
+- npm: `npm install thetadatadx@next`
+- PyPI: `pip install --pre thetadatadx`
+- crates.io: pin `thetadatadx = "=13.0.0-rc.5"`
+
+### Thanks
+
+Thanks to everyone running the release candidates and reporting back. If you sent feedback or a patch and you do not see your name, that is on us, not you. Open an issue and we will fix the credit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.5] - 2026-06-19
+
+### Added
+
+- Staging-environment selection (production or staging) across authentication, historical, and streaming, working with both API-key and email/password credentials. Choose it three ways: in code via `DirectConfig::stage()` / `with_environment(Environment::Stage)` in Rust (`Config.stage()` on every binding), through the `THETADATA_MDDS_TYPE` environment variable (`PROD` or `STAGE`), or from a `.env` file via `Config::from_dotenv(path)` so a single file can hold both `THETADATA_API_KEY` and `THETADATA_MDDS_TYPE`.
+- First-class inline client construction that takes the API key as a directly-passed argument. Rust and C++ gain a fluent `Client::builder()` (`.api_key`, `.api_key_from_env`, `.api_key_from_dotenv`, `.email_password`, `.credentials_file`, `.stage` / `.production` / `.environment`, `.connect`). Python gains `Client(api_key=..., mdds_type=...)` plus `Client.from_env(...)` and `Client.from_dotenv(...)`. TypeScript gains `Client.connectWith({ apiKey, apiKeyFromEnv, apiKeyFromDotenv, email, password, credentialsFile, mddsType })`. The typed `Client::connect(&Credentials, Config)` remains for full control.
+
+### Changed
+
+- `api_key_from_env` is strict in every binding: an unset or empty `THETADATA_API_KEY` is an error with no silent fallback to a credentials file. The lenient environment-or-file behaviour stays available under `from_env_or_file`.
+- The documentation now leads with passing the API key directly to the client.
+
 ## [13.0.0-rc.4] - 2026-06-19
 
 ### Added
@@ -3775,7 +3787,8 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.4...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.5...HEAD
+[13.0.0-rc.5]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.4...v13.0.0-rc.5
 [13.0.0-rc.4]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.3...v13.0.0-rc.4
 [13.0.0-rc.3]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.2...v13.0.0-rc.3
 [13.0.0-rc.2]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.1...v13.0.0-rc.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-cli"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "clap",
  "comfy-table",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "arrow-ipc",
  "disruptor",

--- a/crates/thetadatadx/Cargo.toml
+++ b/crates/thetadatadx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0-rc.5] - 2026-06-19
+
+### Added
+
+- Staging-environment selection (production or staging) across authentication, historical, and streaming, working with both API-key and email/password credentials. Choose it three ways: in code via `DirectConfig::stage()` / `with_environment(Environment::Stage)` in Rust (`Config.stage()` on every binding), through the `THETADATA_MDDS_TYPE` environment variable (`PROD` or `STAGE`), or from a `.env` file via `Config::from_dotenv(path)` so a single file can hold both `THETADATA_API_KEY` and `THETADATA_MDDS_TYPE`.
+- First-class inline client construction that takes the API key as a directly-passed argument. Rust and C++ gain a fluent `Client::builder()` (`.api_key`, `.api_key_from_env`, `.api_key_from_dotenv`, `.email_password`, `.credentials_file`, `.stage` / `.production` / `.environment`, `.connect`). Python gains `Client(api_key=..., mdds_type=...)` plus `Client.from_env(...)` and `Client.from_dotenv(...)`. TypeScript gains `Client.connectWith({ apiKey, apiKeyFromEnv, apiKeyFromDotenv, email, password, credentialsFile, mddsType })`. The typed `Client::connect(&Credentials, Config)` remains for full control.
+
+### Changed
+
+- `api_key_from_env` is strict in every binding: an unset or empty `THETADATA_API_KEY` is an error with no silent fallback to a credentials file. The lenient environment-or-file behaviour stays available under `from_env_or_file`.
+- The documentation now leads with passing the API key directly to the client.
+
 ## [13.0.0-rc.4] - 2026-06-19
 
 ### Added
@@ -3775,7 +3787,8 @@ See `TODO.md` (as of the 1.2.0 release) for the production readiness checklist a
 - FIT decoder uses i64 accumulator with i32 saturation (no silent overflow)
 - Price type range enforced with `assert!` in release builds
 
-[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.4...HEAD
+[Unreleased]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.5...HEAD
+[13.0.0-rc.5]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.4...v13.0.0-rc.5
 [13.0.0-rc.4]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.3...v13.0.0-rc.4
 [13.0.0-rc.3]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.2...v13.0.0-rc.3
 [13.0.0-rc.2]: https://github.com/userFRM/ThetaDataDx/compare/v13.0.0-rc.1...v13.0.0-rc.2

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-ffi"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/sdks/python/Cargo.lock
+++ b/sdks/python/Cargo.lock
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-py"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "arrow",
  "libc",

--- a/sdks/python/Cargo.toml
+++ b/sdks/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-py"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 edition = "2021"
 rust-version = "1.88"
 description = "Python bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "arrow-ipc",
  "chrono",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-napi"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 edition = "2021"
 rust-version = "1.88"
 description = "TypeScript/Node.js bindings for thetadatadx — native ThetaData SDK powered by Rust"

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm64')
         const bindingPackageVersion = require('thetadatadx-android-arm64/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-android-arm-eabi')
         const bindingPackageVersion = require('thetadatadx-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-gnu')
         const bindingPackageVersion = require('thetadatadx-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-x64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-ia32-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-win32-arm64-msvc')
         const bindingPackageVersion = require('thetadatadx-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('thetadatadx-darwin-universal')
       const bindingPackageVersion = require('thetadatadx-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-x64')
         const bindingPackageVersion = require('thetadatadx-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-darwin-arm64')
         const bindingPackageVersion = require('thetadatadx-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-x64')
         const bindingPackageVersion = require('thetadatadx-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-freebsd-arm64')
         const bindingPackageVersion = require('thetadatadx-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-x64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-musleabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-arm-gnueabihf')
           const bindingPackageVersion = require('thetadatadx-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-loong64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-musl')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('thetadatadx-linux-riscv64-gnu')
           const bindingPackageVersion = require('thetadatadx-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-ppc64-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-linux-s390x-gnu')
         const bindingPackageVersion = require('thetadatadx-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm64')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-x64')
         const bindingPackageVersion = require('thetadatadx-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('thetadatadx-openharmony-arm')
         const bindingPackageVersion = require('thetadatadx-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '13.0.0-rc.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '13.0.0-rc.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 13.0.0-rc.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/sdks/typescript/npm/darwin-arm64/package.json
+++ b/sdks/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-darwin-arm64",
-  "version": "13.0.0-rc.4",
+  "version": "13.0.0-rc.5",
   "os": [
     "darwin"
   ],

--- a/sdks/typescript/npm/linux-x64-gnu/package.json
+++ b/sdks/typescript/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-linux-x64-gnu",
-  "version": "13.0.0-rc.4",
+  "version": "13.0.0-rc.5",
   "os": [
     "linux"
   ],

--- a/sdks/typescript/npm/win32-x64-msvc/package.json
+++ b/sdks/typescript/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx-win32-x64-msvc",
-  "version": "13.0.0-rc.4",
+  "version": "13.0.0-rc.5",
   "os": [
     "win32"
   ],

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thetadatadx",
-  "version": "13.0.0-rc.4",
+  "version": "13.0.0-rc.5",
   "description": "Native ThetaData market-data SDK for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -31,9 +31,9 @@
     "@types/node": "20.19.42"
   },
   "optionalDependencies": {
-    "thetadatadx-darwin-arm64": "13.0.0-rc.4",
-    "thetadatadx-linux-x64-gnu": "13.0.0-rc.4",
-    "thetadatadx-win32-x64-msvc": "13.0.0-rc.4"
+    "thetadatadx-darwin-arm64": "13.0.0-rc.5",
+    "thetadatadx-linux-x64-gnu": "13.0.0-rc.5",
+    "thetadatadx-win32-x64-msvc": "13.0.0-rc.5"
   },
   "engines": {
     "node": ">= 20"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-cli"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tools/mcp/Cargo.lock
+++ b/tools/mcp/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "serde",
  "sonic-rs",

--- a/tools/mcp/Cargo.toml
+++ b/tools/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-mcp"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 edition = "2021"
 rust-version = "1.88"
 description = "MCP server for ThetaDataDx — gives LLMs instant access to ThetaData market data"

--- a/tools/server/Cargo.lock
+++ b/tools/server/Cargo.lock
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "thetadatadx-server"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 dependencies = [
  "axum",
  "clap",

--- a/tools/server/Cargo.toml
+++ b/tools/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thetadatadx-server"
-version = "13.0.0-rc.4"
+version = "13.0.0-rc.5"
 edition = "2021"
 rust-version = "1.88"
 authors = ["userFRM"]


### PR DESCRIPTION
Bumps every workspace manifest and lockfile from 13.0.0-rc.4 to 13.0.0-rc.5 and regenerates the napi binding version guard in the TypeScript index.js so it reads rc.5. rc.4 (API-key authentication) is already out, and this records the one feature since then.

What shipped since rc.4:

Staging-environment selection (production or staging) across authentication, historical, and streaming, working with both API-key and email/password credentials. You can pick it in code via Config.stage() / with_environment(Environment::Stage), through the THETADATA_MDDS_TYPE environment variable (PROD or STAGE), or from a .env file via Config::from_dotenv(path) so one file can hold both THETADATA_API_KEY and THETADATA_MDDS_TYPE.

First-class inline client construction that takes the API key as a directly-passed argument: a fluent Client::builder() in Rust and C++, Python Client(api_key=..., mdds_type=...) plus Client.from_env(...) / Client.from_dotenv(...), and TypeScript Client.connectWith({ apiKey, ... }). The typed Client::connect(&Credentials, Config) remains for full control. api_key_from_env is strict in every binding, and the docs now lead with passing the API key directly.

This PR is release prep only: version bump, the new [13.0.0-rc.5] CHANGELOG section (kept byte-identical with the docs-site copy), and the v13.0.0-rc.5 release notes. No tag is cut here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)