### PR TITLE
fix(config,cpp,ffi): harden dotenv/dev presets and the C++ builder

### DIFF
--- a/crates/thetadatadx/build_support_bin/sdk_surface/cpp.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/cpp.rs
@@ -216,6 +216,9 @@ fn cpp_lifecycle_def(method: &MethodSpec) -> String {
             include_str!("templates/cpp/credentials_from_api_key_with_email_def.cpp.tmpl")
                 .to_string()
         }
+        MethodKind::CredentialsFromEnv => {
+            include_str!("templates/cpp/credentials_from_env_def.cpp.tmpl").to_string()
+        }
         MethodKind::CredentialsFromEnvOrFile => {
             include_str!("templates/cpp/credentials_from_env_or_file_def.cpp.tmpl").to_string()
         }

--- a/crates/thetadatadx/build_support_bin/sdk_surface/spec.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/spec.rs
@@ -59,6 +59,7 @@ pub(super) enum MethodKind {
     CredentialsFromEmail,
     CredentialsFromApiKey,
     CredentialsFromApiKeyWithEmail,
+    CredentialsFromEnv,
     CredentialsFromEnvOrFile,
     CredentialsFromDotenv,
     ConfigConstructor,
@@ -321,6 +322,7 @@ fn validate_method_spec(method: &MethodSpec) -> Result<(), Box<dyn std::error::E
             true,
             &[("email", ParamType::String), ("api_key", ParamType::String)],
         ),
+        MethodKind::CredentialsFromEnv => (Some("credentials_from_env"), &[LIFE], true, &[]),
         MethodKind::CredentialsFromEnvOrFile => (
             Some("credentials_from_env_or_file"),
             &[LIFE],

--- a/crates/thetadatadx/build_support_bin/sdk_surface/templates/cpp/credentials_from_env_def.cpp.tmpl
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/templates/cpp/credentials_from_env_def.cpp.tmpl
@@ -1,0 +1,5 @@
+Credentials Credentials::from_env() {
+    auto h = thetadatadx_credentials_from_env();
+    if (!h) detail::throw_last_ffi_error();
+    return Credentials(h);
+}

--- a/crates/thetadatadx/sdk_surface.toml
+++ b/crates/thetadatadx/sdk_surface.toml
@@ -129,6 +129,12 @@ params = [
 ]
 
 [[methods]]
+name = "credentials_from_env"
+kind = "credentials_from_env"
+doc = "Source credentials strictly from the THETADATA_API_KEY environment variable. An unset or whitespace-only value is an error; there is no creds.txt fallback. Throws on failure."
+targets = ["cpp_lifecycle"]
+
+[[methods]]
 name = "credentials_from_env_or_file"
 kind = "credentials_from_env_or_file"
 doc = "Source credentials from the environment, falling back to a file. Throws on failure."

--- a/crates/thetadatadx/src/auth/creds.rs
+++ b/crates/thetadatadx/src/auth/creds.rs
@@ -226,12 +226,13 @@ impl Credentials {
     /// is wrapped in `Zeroizing` immediately so the post-trim copy is
     /// also wiped on drop -- matching the file-read path.
     pub fn new(email: impl Into<String>, password: impl Into<String>) -> Self {
-        // `trim().to_string()` returns an owned `String` that is NOT
-        // the same allocation as the caller's `Into<String>` source.
-        // Wrap it in `Zeroizing` before building the struct so the
-        // transient is wiped even if the caller panics between the
-        // allocation and the `Credentials` construction.
-        let password: Zeroizing<String> = Zeroizing::new(password.into().trim().to_string());
+        // `value.into()` materializes an owned `String` holding the raw
+        // secret; wrap THAT allocation in `Zeroizing` first so it is wiped
+        // on drop, then derive the trimmed copy (also `Zeroizing`). Trimming
+        // the owned string before this wrap would leave the original
+        // allocation un-zeroized in freed heap.
+        let raw_password: Zeroizing<String> = Zeroizing::new(password.into());
+        let password: Zeroizing<String> = Zeroizing::new(raw_password.trim().to_string());
         Self {
             method: AuthMethod::Password {
                 email: email.into().trim().to_lowercase(),
@@ -253,7 +254,10 @@ impl Credentials {
     /// before the struct is built so the post-trim copy is wiped on
     /// drop even on a panic between the allocation and construction.
     pub fn api_key(key: impl Into<String>) -> Self {
-        let key: Zeroizing<String> = Zeroizing::new(key.into().trim().to_string());
+        // Wrap the owned `into()` allocation before trimming so no
+        // un-zeroized copy of the key lingers in freed heap.
+        let raw_key: Zeroizing<String> = Zeroizing::new(key.into());
+        let key: Zeroizing<String> = Zeroizing::new(raw_key.trim().to_string());
         Self {
             method: AuthMethod::ApiKey { email: None, key },
         }
@@ -269,7 +273,11 @@ impl Credentials {
     /// The key transient is wrapped in `Zeroizing` before the struct is
     /// built, matching [`Credentials::api_key`].
     pub fn api_key_with_email(email: impl Into<String>, key: impl Into<String>) -> Self {
-        let key: Zeroizing<String> = Zeroizing::new(key.into().trim().to_string());
+        // Wrap the owned `into()` key allocation before trimming so no
+        // un-zeroized copy of the key lingers in freed heap. The email is
+        // not secret, so it does not need the same treatment.
+        let raw_key: Zeroizing<String> = Zeroizing::new(key.into());
+        let key: Zeroizing<String> = Zeroizing::new(raw_key.trim().to_string());
         let email = email.into().trim().to_lowercase();
         Self {
             method: AuthMethod::ApiKey {
@@ -786,6 +794,32 @@ mod tests {
     fn password_accessor_round_trips() {
         let creds = Credentials::new("user@example.com", "hunter2");
         assert_eq!(creds.password(), Some("hunter2"));
+    }
+
+    /// The direct constructors wrap the owned input allocation in `Zeroizing`
+    /// before trimming, so no un-zeroized secret copy lingers. That wrap is
+    /// not directly observable, so this test pins the behavior that MUST hold
+    /// alongside it: the constructors still trim correctly, expose the right
+    /// secret, and redact it in `Debug`. The zero-before-trim itself is
+    /// verified by code review.
+    #[test]
+    fn direct_constructors_construct_correctly_and_redact() {
+        // Password constructor: trims, stores, redacts.
+        let pw = Credentials::new("  User@Example.COM  ", "  hunter2  ");
+        assert_eq!(pw.password(), Some("hunter2"));
+        assert_eq!(pw.email(), Some("user@example.com"));
+        assert!(!format!("{pw:?}").contains("hunter2"));
+
+        // Api-key constructor: trims, stores, redacts.
+        let key = Credentials::api_key("  super-secret-key  ");
+        assert_eq!(key.api_key_secret(), Some("super-secret-key"));
+        assert!(!format!("{key:?}").contains("super-secret-key"));
+
+        // Api-key-with-email constructor: trims both, stores, redacts the key.
+        let keymail = Credentials::api_key_with_email("  A@B.CO  ", "  k-123  ");
+        assert_eq!(keymail.api_key_secret(), Some("k-123"));
+        assert_eq!(keymail.email(), Some("a@b.co"));
+        assert!(!format!("{keymail:?}").contains("k-123"));
     }
 
     /// The full file contents and the parsed password both round-trip

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -266,7 +266,15 @@ impl DirectConfig {
     /// Returns [`Error::Config`] if the file cannot be read. Returns whatever
     /// [`Self::validate`] returns for the resulting configuration.
     pub fn from_dotenv(path: impl AsRef<std::path::Path>) -> Result<Self, Error> {
-        Self::production().with_dotenv(path)
+        // Start from the hardcoded production defaults, NOT from
+        // [`Self::production`]: a file-sourced config must be deterministic
+        // from its defaults plus the file, so the ambient process env never
+        // leaks in. A `.env` that selects `PROD` must yield the prod cluster
+        // even when the shell has `THETADATA_MDDS_TYPE=STAGE` (or a stray
+        // `THETADATA_HISTORICAL_HOST`) left over. `with_dotenv` layers only
+        // the parsed file pairs via `apply_dotenv_overrides`, which reads the
+        // file, never the process env.
+        Self::production_defaults().with_dotenv(path)
     }
 
     /// Apply a `.env` file's environment selection and host overrides onto an
@@ -327,8 +335,14 @@ impl DirectConfig {
     pub fn dev() -> Self {
         let mut config = Self::production();
         // Dev is a streaming-only preset: historical data still uses the
-        // production cluster, so the environment marker stays `Prod`.
-        config.environment = Environment::Prod;
+        // production cluster. Reset the FULL cluster routing to prod (env
+        // marker AND historical host) before overriding the streaming hosts.
+        // `production()` may have applied `THETADATA_MDDS_TYPE=STAGE` from the
+        // process env, which would otherwise leave `historical.host` pointed at
+        // the stage cluster while only the marker flipped back to `Prod` — a
+        // broken preset where the marker says prod but historical routes to
+        // stage. `apply_environment` re-points both together.
+        config.apply_environment(Environment::Prod);
         // Source: config.toml fpss_dev_hosts
         config.streaming.hosts = vec![
             ("nj-a.thetadata.us".to_string(), 20200),
@@ -2400,6 +2414,90 @@ mod tests {
         let config = DirectConfig::from_dotenv(&path).expect(".env must source");
         assert_eq!(config.streaming.hosts[0].0, "stream.example.com");
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn from_dotenv_prod_ignores_ambient_stage_env() {
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // The shell forces STAGE and a stage historical host, but a file-sourced
+        // config must be deterministic from defaults plus the file. A `.env`
+        // selecting PROD must yield the prod cluster regardless of the ambient
+        // process env.
+        // SAFETY: `_guard` holds the process-global env-var mutex for the body
+        // of this test, so no other thread observes or mutates the environment
+        // while these writes land.
+        unsafe {
+            std::env::set_var(ENV_MDDS_TYPE, "STAGE");
+            std::env::set_var(ENV_HISTORICAL_HOST, "mdds-stage.thetadata.us");
+        }
+        let path = write_temp_dotenv("prodfile.env", "THETADATA_MDDS_TYPE=PROD\n");
+        let config = DirectConfig::from_dotenv(&path).expect(".env mdds-type must source");
+        // The file says PROD, so the prod cluster wins over the ambient STAGE.
+        assert_eq!(config.environment, Environment::Prod);
+        assert_eq!(config.historical.host, "mdds-01.thetadata.us");
+        let prod_defaults = DirectConfig::production_defaults();
+        assert_eq!(config.streaming.hosts, prod_defaults.streaming.hosts);
+        clear_env_matrix();
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn from_dotenv_only_api_key_ignores_ambient_stage_env() {
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // A `.env` that carries no cluster keys must still ignore the ambient
+        // env: it sources from defaults plus the file, never the shell.
+        // SAFETY: see `from_dotenv_prod_ignores_ambient_stage_env`.
+        unsafe {
+            std::env::set_var(ENV_MDDS_TYPE, "STAGE");
+            std::env::set_var(ENV_HISTORICAL_HOST, "mdds-stage.thetadata.us");
+        }
+        let path = write_temp_dotenv("nocluster.env", "THETADATA_API_KEY=td_example_key\n");
+        let config = DirectConfig::from_dotenv(&path).expect("api-key-only .env must source");
+        assert_eq!(config.environment, Environment::Prod);
+        assert_eq!(config.historical.host, "mdds-01.thetadata.us");
+        clear_env_matrix();
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn dev_resets_prod_cluster_under_ambient_stage_env() {
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // The shell forces STAGE, which `production()` honors. `dev()` is a
+        // streaming-only preset whose historical channel must stay on the prod
+        // cluster: resetting via `apply_environment(Prod)` re-points both the
+        // env marker AND the historical host, never leaving the marker prod
+        // while historical routes to stage.
+        // SAFETY: see `from_dotenv_prod_ignores_ambient_stage_env`.
+        unsafe {
+            std::env::set_var(ENV_MDDS_TYPE, "STAGE");
+        }
+        let config = DirectConfig::dev();
+        assert_eq!(config.environment, Environment::Prod);
+        assert_eq!(config.historical.host, "mdds-01.thetadata.us");
+        // Dev streaming hosts (port 20200/20201).
+        assert_eq!(config.streaming.hosts[0].0, "nj-a.thetadata.us");
+        assert_eq!(config.streaming.hosts[0].1, 20200);
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn stage_stays_stage_under_ambient_prod_env() {
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // An explicit `stage()` preset must end up fully Stage even when the
+        // ambient env says PROD: the preset is not silently overridden into an
+        // inconsistent state.
+        // SAFETY: see `from_dotenv_prod_ignores_ambient_stage_env`.
+        unsafe {
+            std::env::set_var(ENV_MDDS_TYPE, "PROD");
+        }
+        let config = DirectConfig::stage();
+        assert_eq!(config.environment, Environment::Stage);
+        assert_eq!(config.historical.host, "mdds-stage.thetadata.us");
+        clear_env_matrix();
     }
 
     #[test]

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -2260,6 +2260,20 @@ mod tests {
     }
 
     #[test]
+    fn environment_getter_reads_back_the_selected_cluster() {
+        // The readback getter mirrored across the bindings: `stage()`
+        // carries `Stage`, `production()` carries `Prod`.
+        assert_eq!(DirectConfig::stage().environment(), Environment::Stage);
+        assert_eq!(DirectConfig::production().environment(), Environment::Prod);
+        assert_eq!(
+            DirectConfig::production()
+                .with_environment(Environment::Stage)
+                .environment(),
+            Environment::Stage
+        );
+    }
+
+    #[test]
     fn env_overrides_apply_on_production() {
         let _guard = env_test_guard();
         clear_env_matrix();

--- a/crates/thetadatadx/src/fpss/delta.rs
+++ b/crates/thetadatadx/src/fpss/delta.rs
@@ -172,6 +172,16 @@ impl DeltaState {
             return None;
         }
 
+        // Reject a truncated row: the FIT reader hit end-of-buffer before the
+        // terminating `END` nibble, so it flushed a partial integer and the
+        // remaining slots stayed zero-filled. Emitting that as a tick would
+        // surface silent zero/garbage fields, so treat it as a decode failure.
+        // Callers map the `None` to `Unparseable`, which the io-loop already
+        // handles without panicking.
+        if !reader.row_complete {
+            return None;
+        }
+
         if n == 0 {
             return None;
         }
@@ -184,8 +194,6 @@ impl DeltaState {
         // expected_fields is a build-time constant for every supported
         // tick shape (QUOTE_FIELDS, TRADE_FIELDS, OI_FIELDS, OHLCVC_FIELDS).
         debug_assert!(expected_fields <= MAX_DATA_FIELDS);
-        out.fill(0);
-        out[..expected_fields].copy_from_slice(&self.alloc_buf[1..total_fields]);
 
         // Delta decompression applies only to the tick portion (excluding
         // contract_id): the first field (contract_id) is skipped, and deltas
@@ -194,6 +202,24 @@ impl DeltaState {
         let tick_n = n.saturating_sub(1);
 
         let key = (msg_code, contract_id);
+        let is_absolute = !self.prev.contains_key(&key);
+
+        // An absolute row defines the cached field width and seeds the delta
+        // baseline. It must not declare MORE fields than the tick shape holds:
+        // a row wider than `expected_fields` would have its trailing fields
+        // silently dropped (the scratch buffer is `total_fields` wide) and the
+        // cached width would over-report, so reject it as a decode failure.
+        // A truncated row is already rejected above via `row_complete`. A
+        // complete row with fewer fields is a legitimately narrower wire
+        // layout (e.g. the simple-format trade); the per-tick consumer
+        // validates that the narrower width is one it knows how to read.
+        if is_absolute && tick_n > expected_fields {
+            return None;
+        }
+
+        out.fill(0);
+        out[..expected_fields].copy_from_slice(&self.alloc_buf[1..total_fields]);
+
         if let Some(prev) = self.prev.get(&key) {
             // Delta row: accumulate onto previous absolute values
             // in-place into the caller's buffer.
@@ -244,5 +270,143 @@ impl DeltaState {
     #[cfg(test)]
     pub(super) fn state_sizes(&self) -> (usize, usize, usize) {
         (self.prev.len(), self.ohlcvc.len(), self.field_counts.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIELD_SEP: u8 = 0xB;
+    const END: u8 = 0xD;
+
+    /// Encode a single complete FIT row of non-negative `i32` values:
+    /// digit runs joined by `FIELD_SEP` and terminated by `END`. The first
+    /// value is the `contract_id`, the rest are tick fields.
+    fn encode_row(values: &[i32]) -> Vec<u8> {
+        let mut nibbles: Vec<u8> = Vec::new();
+        for (i, &v) in values.iter().enumerate() {
+            if i > 0 {
+                nibbles.push(FIELD_SEP);
+            }
+            for ch in v.to_string().bytes() {
+                nibbles.push(ch - b'0');
+            }
+        }
+        nibbles.push(END);
+        let mut out = Vec::with_capacity(nibbles.len() / 2 + 1);
+        let mut i = 0;
+        while i < nibbles.len() {
+            let high = nibbles[i];
+            let low = if i + 1 < nibbles.len() {
+                nibbles[i + 1]
+            } else {
+                0
+            };
+            out.push((high << 4) | (low & 0x0F));
+            i += 2;
+        }
+        out
+    }
+
+    // A representative non-trade message code; the value only keys the maps.
+    const QUOTE_CODE: u8 = 2;
+
+    #[test]
+    fn complete_quote_row_decodes_to_correct_tick() {
+        let mut state = DeltaState::new();
+        // contract_id = 7, then 11 quote data fields 100..110.
+        let mut values = vec![7];
+        values.extend(100..=110);
+        assert_eq!(values.len(), QUOTE_FIELDS + 1);
+        let payload = encode_row(&values);
+
+        let mut out: TickFields = [0; MAX_DATA_FIELDS];
+        let decoded = state.decode_tick(QUOTE_CODE, &payload, QUOTE_FIELDS, &mut out);
+        let (contract_id, n_data) = decoded.expect("complete row decodes");
+        assert_eq!(contract_id, 7);
+        assert_eq!(n_data, QUOTE_FIELDS);
+        for (i, v) in (100..=110).enumerate() {
+            assert_eq!(out[i], v, "field {i} mismatch");
+        }
+    }
+
+    #[test]
+    fn truncated_quote_row_missing_end_is_rejected() {
+        let mut state = DeltaState::new();
+        let mut values = vec![7];
+        values.extend(100..=110);
+        let mut payload = encode_row(&values);
+        // Drop the trailing byte(s) so the END nibble is gone: the row now
+        // ends mid-buffer with no terminator.
+        payload.pop();
+        payload.pop();
+
+        let mut out: TickFields = [0; MAX_DATA_FIELDS];
+        let decoded = state.decode_tick(QUOTE_CODE, &payload, QUOTE_FIELDS, &mut out);
+        assert!(
+            decoded.is_none(),
+            "a truncated row must decode to None, not a zero-filled tick"
+        );
+        assert!(
+            !state.last_was_date,
+            "rejection is a decode failure, not a DATE skip"
+        );
+        // The reject path must not have cached any width/baseline.
+        assert_eq!(state.state_sizes().0, 0, "no prev baseline cached");
+    }
+
+    #[test]
+    fn truncated_first_row_does_not_poison_width_for_later_delta() {
+        let mut state = DeltaState::new();
+        let cid = 7;
+
+        // A truncated first row (no END) must be rejected and leave NO cached
+        // baseline or width.
+        let mut full = vec![cid];
+        full.extend(100..=110);
+        let mut truncated = encode_row(&full);
+        truncated.pop();
+        truncated.pop();
+        let mut out: TickFields = [0; MAX_DATA_FIELDS];
+        assert!(state
+            .decode_tick(QUOTE_CODE, &truncated, QUOTE_FIELDS, &mut out)
+            .is_none());
+        assert_eq!(state.state_sizes().0, 0, "truncated row poisoned the cache");
+
+        // A subsequent COMPLETE absolute row for the same contract decodes as
+        // a clean absolute tick with the full width, proving the earlier
+        // truncated row left no stale state behind.
+        let good = encode_row(&full);
+        let decoded = state.decode_tick(QUOTE_CODE, &good, QUOTE_FIELDS, &mut out);
+        let (contract_id, n_data) = decoded.expect("complete row decodes");
+        assert_eq!(contract_id, cid);
+        assert_eq!(n_data, QUOTE_FIELDS);
+        for (i, v) in (100..=110).enumerate() {
+            assert_eq!(out[i], v, "field {i} mismatch after clean re-seed");
+        }
+    }
+
+    #[test]
+    fn complete_then_delta_row_accumulates() {
+        // Confirms the happy path is unchanged: a complete absolute row seeds
+        // the baseline and a following delta row accumulates onto it.
+        let mut state = DeltaState::new();
+        let cid = 7;
+        let mut abs = vec![cid];
+        abs.extend(100..=110);
+        let abs_payload = encode_row(&abs);
+        let mut out: TickFields = [0; MAX_DATA_FIELDS];
+        state
+            .decode_tick(QUOTE_CODE, &abs_payload, QUOTE_FIELDS, &mut out)
+            .expect("absolute row decodes");
+
+        // Delta row: contract_id then a single +5 change to field 0.
+        let delta_payload = encode_row(&[cid, 5]);
+        let decoded = state.decode_tick(QUOTE_CODE, &delta_payload, QUOTE_FIELDS, &mut out);
+        let (contract_id, _n) = decoded.expect("delta row decodes");
+        assert_eq!(contract_id, cid);
+        assert_eq!(out[0], 105, "delta accumulated onto prior absolute value");
+        assert_eq!(out[1], 101, "unchanged field carried forward from baseline");
     }
 }

--- a/crates/thetadatadx/src/fpss/protocol/contract.rs
+++ b/crates/thetadatadx/src/fpss/protocol/contract.rs
@@ -655,12 +655,30 @@ impl Contract {
         let sec_type = SecType::from_code(i32::from(sec_type_byte))
             .ok_or(ContractParseError::UnknownSecType(sec_type_byte))?;
 
+        // The structural length is exact: `total_size` must equal the size the
+        // declared shape occupies, not merely bound it. A `total_size` that
+        // overstates the structure leaves a gap the caller would carry as
+        // trailing junk, and one that understates it would let fields be read
+        // past the declared record. Compute the expected length from the shape
+        // and require an exact match. Read option fields only from within
+        // `total_size` so a size byte that understates the real payload cannot
+        // pull bytes from beyond the declared record.
+        let expected_size = if sec_type == SecType::Option {
+            // size(1) + root_len(1) + root(N) + sec_type(1) + exp_date(4)
+            // + is_call(1) + strike(4)
+            root_end + 1 + 9
+        } else {
+            // size(1) + root_len(1) + root(N) + sec_type(1)
+            root_end + 1
+        };
+        if total_size != expected_size {
+            return Err(ContractParseError::InvalidSize(total_size));
+        }
+
         if sec_type == SecType::Option {
-            // Need 9 more bytes after sec_type: exp_date(4) + is_call(1) + strike(4)
+            // Option fields sit entirely within `total_size` (enforced above),
+            // and `data.len() >= total_size` was checked at entry.
             let opt_start = root_end + 1;
-            if data.len() < opt_start + 9 {
-                return Err(ContractParseError::TooShort);
-            }
 
             let exp_date = i32::from_be_bytes([
                 data[opt_start],
@@ -925,6 +943,43 @@ mod tests {
         // total_size = 2, but minimum valid is 3 (size + root_len + sec_type with root_len=0)
         let err = Contract::from_bytes(&[2, 0]).unwrap_err();
         assert_eq!(err, ContractParseError::InvalidSize(2));
+    }
+
+    #[test]
+    fn contract_from_bytes_understated_size_rejected() {
+        // A stock "AAPL" encodes to total_size = 7. If the size byte claims a
+        // shorter record than the declared root occupies, the structural
+        // length no longer matches and the frame is rejected rather than
+        // reading fields past the declared record.
+        let mut bytes = Contract::stock("AAPL").to_bytes();
+        // Understate the size byte (7 -> 6); the structure still needs 7.
+        bytes[0] = 6;
+        let err = Contract::from_bytes(&bytes).unwrap_err();
+        assert_eq!(err, ContractParseError::InvalidSize(6));
+    }
+
+    #[test]
+    fn contract_from_bytes_overstated_size_rejected() {
+        // A size byte that overstates the structural length must also be
+        // rejected: the surplus would otherwise be carried as trailing junk.
+        let mut bytes = Contract::stock("AAPL").to_bytes();
+        bytes.push(0x00); // pad so `data.len() >= total_size` holds
+        bytes[0] = 8; // claim 8 but the structure is exactly 7
+        let err = Contract::from_bytes(&bytes).unwrap_err();
+        assert_eq!(err, ContractParseError::InvalidSize(8));
+    }
+
+    #[test]
+    fn contract_from_bytes_consumes_exact_length() {
+        // `from_bytes` reports consuming exactly the structural length even
+        // when extra bytes trail in the buffer. The caller uses this to reject
+        // trailing junk at the frame layer.
+        let mut bytes = Contract::stock("AAPL").to_bytes();
+        let structural = bytes.len();
+        bytes.extend_from_slice(&[0xDE, 0xAD]); // trailing junk
+        let (parsed, consumed) = Contract::from_bytes(&bytes).unwrap();
+        assert_eq!(consumed, structural);
+        assert_eq!(&*parsed.symbol, "AAPL");
     }
 
     #[test]

--- a/crates/thetadatadx/src/fpss/protocol/wire.rs
+++ b/crates/thetadatadx/src/fpss/protocol/wire.rs
@@ -425,10 +425,25 @@ pub fn parse_contract_message(payload: &[u8]) -> Result<(i32, Contract), Error> 
     }
 
     let contract_id = i32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
-    let (contract, _consumed) = Contract::from_bytes(&payload[4..]).map_err(|e| Error::Fpss {
+    // The contract body follows the 4-byte `contract_id` prefix. Decode it and
+    // require that it consumes the body EXACTLY: any trailing bytes mean the
+    // frame's size bookkeeping understates the real payload, so reject the
+    // frame rather than silently ignore the surplus.
+    let body = &payload[4..];
+    let (contract, consumed) = Contract::from_bytes(body).map_err(|e| Error::Fpss {
         kind: crate::error::StreamErrorKind::ProtocolError,
         message: format!("failed to parse contract: {e}"),
     })?;
+
+    if consumed != body.len() {
+        return Err(Error::Fpss {
+            kind: crate::error::StreamErrorKind::ProtocolError,
+            message: format!(
+                "CONTRACT frame has {} trailing byte(s) after the contract record",
+                body.len() - consumed
+            ),
+        });
+    }
 
     Ok((contract_id, contract))
 }
@@ -763,6 +778,46 @@ mod tests {
 
         let (id, parsed) = parse_contract_message(&payload).unwrap();
         assert_eq!(id, 7);
+        assert_eq!(parsed, contract);
+    }
+
+    #[test]
+    fn parse_contract_message_rejects_trailing_junk() {
+        // A valid stock frame with extra bytes appended after the contract
+        // record. The trailing junk means the size bookkeeping understates
+        // the real payload, so the frame must be rejected.
+        let contract = Contract::stock("TSLA");
+        let contract_bytes = contract.to_bytes();
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&7i32.to_be_bytes());
+        payload.extend_from_slice(&contract_bytes);
+        // Surplus bytes beyond the contract record.
+        payload.extend_from_slice(&[0xAA, 0xBB]);
+
+        assert!(
+            parse_contract_message(&payload).is_err(),
+            "trailing bytes after the contract record must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_contract_message_option_roundtrips() {
+        // A valid option frame still parses exactly (no trailing bytes).
+        let contract = Contract::option(
+            "SPY",
+            crate::fpss::protocol::contract::OptionLeg {
+                expiration: "20261218",
+                strike: "60",
+                right: "C",
+            },
+        )
+        .expect("valid option");
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&9i32.to_be_bytes());
+        payload.extend_from_slice(&contract.to_bytes());
+
+        let (id, parsed) = parse_contract_message(&payload).expect("valid option frame parses");
+        assert_eq!(id, 9);
         assert_eq!(parsed, contract);
     }
 

--- a/crates/thetadatadx/src/tdbe/codec/fit.rs
+++ b/crates/thetadatadx/src/tdbe/codec/fit.rs
@@ -158,6 +158,13 @@ pub struct FitReader<'a> {
     pos: usize,
     /// Set to `true` when the current row was preceded by a DATE marker (0xCE).
     pub is_date: bool,
+    /// Set by [`FitReader::read_changes`] to `true` when the row terminated on
+    /// an `END` nibble and `false` when the buffer was exhausted before an
+    /// `END` was seen. A `false` value flags a truncated row: the decoder
+    /// flushed whatever partial integer it had, so the field count and the
+    /// trailing slots are not trustworthy. Callers on the live stream reject
+    /// such a row rather than emit a zero-filled tick.
+    pub row_complete: bool,
 }
 
 impl<'a> FitReader<'a> {
@@ -169,6 +176,7 @@ impl<'a> FitReader<'a> {
             buf,
             pos: 0,
             is_date: false,
+            row_complete: false,
         }
     }
 
@@ -180,6 +188,7 @@ impl<'a> FitReader<'a> {
             buf,
             pos: offset,
             is_date: false,
+            row_complete: false,
         }
     }
 
@@ -205,6 +214,13 @@ impl<'a> FitReader<'a> {
     /// A DATE marker row reports `0` fields; callers use `is_date` to
     /// distinguish a DATE row from a legitimate 0-field row.
     ///
+    /// After the call, [`row_complete`](Self::row_complete) reports whether the
+    /// row terminated on an `END` nibble (`true`) or the buffer ran out first
+    /// (`false`). A `false` result means the returned field count came from a
+    /// truncated row and the trailing slots are not trustworthy; callers that
+    /// read fixed field positions reject such a row instead of treating the
+    /// zero-filled buffer as a valid tick.
+    ///
     /// # Panics
     ///
     /// Does **not** panic — if `alloc` is too short, excess fields are silently
@@ -212,13 +228,15 @@ impl<'a> FitReader<'a> {
     #[inline]
     pub fn read_changes(&mut self, alloc: &mut [i32]) -> usize {
         self.is_date = false;
+        self.row_complete = false;
 
         // Check for DATE marker prefix.
         if self.pos < self.buf.len() && self.buf[self.pos] == DATE_MARKER {
             self.is_date = true;
             self.pos += 1;
-            // Consume until END nibble, then return 0.
-            self.skip_to_end();
+            // Consume until END nibble, then return 0. `row_complete` mirrors
+            // whether the marker row actually carried its terminating END.
+            self.row_complete = self.skip_to_end();
             return 0;
         }
 
@@ -244,14 +262,18 @@ impl<'a> FitReader<'a> {
                 &mut count,
                 &mut negative,
             ) {
+                self.row_complete = true;
                 return idx;
             }
             if Self::process_nibble(low, alloc, &mut idx, &mut digits, &mut count, &mut negative) {
+                self.row_complete = true;
                 return idx;
             }
         }
 
-        // Buffer exhausted without END nibble — flush whatever we have.
+        // Buffer exhausted without END nibble, so flush whatever we have. The
+        // row is truncated: `row_complete` stays `false` so callers can reject
+        // it rather than emit a partial/zero-filled tick.
         if count > 0 || negative {
             let val = flush_digits(&digits, count, negative);
             if idx < alloc.len() {
@@ -343,14 +365,18 @@ impl<'a> FitReader<'a> {
     }
 
     /// Consume bytes until an END nibble is found (used after DATE marker).
-    fn skip_to_end(&mut self) {
+    ///
+    /// Returns `true` if an `END` nibble was reached, `false` if the buffer was
+    /// exhausted first (a truncated DATE row).
+    fn skip_to_end(&mut self) -> bool {
         while self.pos < self.buf.len() {
             let byte = self.buf[self.pos];
             self.pos += 1;
             if (byte >> 4) == END || (byte & 0x0F) == END {
-                return;
+                return true;
             }
         }
+        false
     }
 }
 
@@ -846,6 +872,47 @@ mod tests {
         assert_eq!(n, 5);
         assert_eq!(alloc[0], 1);
         assert_eq!(alloc[1], 2);
+    }
+
+    #[test]
+    fn complete_row_reports_row_complete() {
+        // A well-formed row terminating on END sets `row_complete`.
+        let data = [pack(4, 2), pack(END, 0)];
+        let mut alloc = [0i32; 8];
+        let mut reader = FitReader::new(&data);
+        let n = reader.read_changes(&mut alloc);
+        assert_eq!(n, 1);
+        assert_eq!(alloc[0], 42);
+        assert!(reader.row_complete, "END-terminated row must be complete");
+    }
+
+    #[test]
+    fn truncated_row_missing_end_is_not_complete() {
+        // "123" with NO END nibble: buffer is exhausted mid-row. The reader
+        // flushes the partial integer but must flag the row as incomplete so
+        // the caller can reject it rather than emit a partial tick.
+        let data = [pack(1, 2), pack(3, 0)];
+        let mut alloc = [0i32; 8];
+        let mut reader = FitReader::new(&data);
+        let _ = reader.read_changes(&mut alloc);
+        assert!(
+            !reader.row_complete,
+            "row without an END nibble must report incomplete"
+        );
+    }
+
+    #[test]
+    fn truncated_mid_field_is_not_complete() {
+        // A field separator then digits, then EOF with no END.
+        // "12," then "34" and the buffer ends with no terminating END.
+        let data = [pack(1, 2), pack(FIELD_SEP, 3), pack(4, 0)];
+        let mut alloc = [0i32; 8];
+        let mut reader = FitReader::new(&data);
+        let _ = reader.read_changes(&mut alloc);
+        assert!(
+            !reader.row_complete,
+            "truncated multi-field row must report incomplete"
+        );
     }
 
     #[test]

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -411,6 +411,37 @@ pub unsafe extern "C" fn thetadatadx_config_get_flush_mode(
     })
 }
 
+/// Read the target server environment carried by the config.
+///
+/// On success, returns a heap-owned NUL-terminated C string (`"PROD"` or
+/// `"STAGE"`) the caller MUST release with `thetadatadx_string_free`. The
+/// environment is set as a unit by `thetadatadx_direct_config_new` /
+/// the stage preset (and the `THETADATA_MDDS_TYPE` dotenv key); this is
+/// the readback of that selection. Returns null if `config` is null
+/// (the diagnostic is written to `thetadatadx_last_error()`).
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_config_get_environment(
+    config: *const ThetaDataDxConfig,
+) -> *mut c_char {
+    ffi_boundary!(ptr::null_mut(), {
+        if config.is_null() {
+            set_error("config handle is null");
+            return ptr::null_mut();
+        }
+        // SAFETY: config is a non-null `*const ThetaDataDxConfig` returned by `thetadatadx_config_*` and not yet freed; `&*` produces a shared reference valid for the call duration.
+        let config = unsafe { &*config };
+        // `Environment::as_str` is a `'static` label free of interior NULs,
+        // so `CString::new` never fails here.
+        match std::ffi::CString::new(config.inner.environment().as_str()) {
+            Ok(c) => c.into_raw(),
+            Err(e) => {
+                set_error(&format!("environment label contains an interior NUL: {e}"));
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
 /// Set the streaming event-ring consumer wait strategy on a config
 /// handle.
 ///
@@ -3851,6 +3882,25 @@ mod auth_metrics_setter_tests {
             let got = take_owned(super::thetadatadx_config_get_client_type(cfg));
             assert_eq!(got.as_deref(), Some("fleet-east-1"));
             super::thetadatadx_config_free(cfg);
+        }
+    }
+
+    #[test]
+    fn environment_reads_back_the_selected_cluster_via_getter() {
+        // The readback getter mirrored across the bindings: the stage
+        // preset reads back `"STAGE"`, the production preset `"PROD"`.
+        let staged = super::thetadatadx_config_stage();
+        let prod = super::thetadatadx_config_production();
+        // SAFETY: both handles were just returned by the config constructors.
+        unsafe {
+            let got = take_owned(super::thetadatadx_config_get_environment(staged));
+            assert_eq!(got.as_deref(), Some("STAGE"));
+            let got = take_owned(super::thetadatadx_config_get_environment(prod));
+            assert_eq!(got.as_deref(), Some("PROD"));
+            // A null handle yields null.
+            assert!(super::thetadatadx_config_get_environment(std::ptr::null()).is_null());
+            super::thetadatadx_config_free(staged);
+            super::thetadatadx_config_free(prod);
         }
     }
 

--- a/ffi/src/auth.rs
+++ b/ffi/src/auth.rs
@@ -148,6 +148,29 @@ pub unsafe extern "C" fn thetadatadx_credentials_from_file(
     })
 }
 
+/// Source credentials strictly from the `THETADATA_API_KEY` environment
+/// variable.
+///
+/// Strict: an unset or whitespace-only value is an error rather than a
+/// silent fallback, and there is no `creds.txt` file fallback. This is
+/// the C-ABI equivalent of the Rust / Python / TypeScript strict
+/// env-only resolver; use `thetadatadx_credentials_from_env_or_file`
+/// when a file fallback is wanted instead.
+///
+/// Returns null on error (check `thetadatadx_last_error()`).
+#[no_mangle]
+pub extern "C" fn thetadatadx_credentials_from_env() -> *mut ThetaDataDxCredentials {
+    ffi_boundary!(ptr::null_mut(), {
+        match thetadatadx::Credentials::from_env() {
+            Ok(creds) => Box::into_raw(Box::new(ThetaDataDxCredentials { inner: creds })),
+            Err(e) => {
+                set_error_from(&e);
+                ptr::null_mut()
+            }
+        }
+    })
+}
+
 /// Source credentials from the environment, falling back to a file.
 ///
 /// When `THETADATA_API_KEY` is set and non-empty an API key is used;
@@ -4480,5 +4503,36 @@ mod credentials_dotenv_tests {
         let creds = unsafe { super::thetadatadx_credentials_from_dotenv(c_path.as_ptr()) };
         assert!(creds.is_null());
         std::fs::remove_file(&path).ok();
+    }
+}
+
+#[cfg(test)]
+mod credentials_from_env_tests {
+    //! Offline smoke coverage for the strict `thetadatadx_credentials_from_env`
+    //! resolver: with `THETADATA_API_KEY` unset it returns a null handle and
+    //! sets the last error, rather than falling back to a file.
+
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialize the env mutation so a parallel test never observes the
+    /// transient unset state. Held for the body of the test.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    #[test]
+    fn from_env_returns_null_when_unset() {
+        let _guard = env_lock();
+        // SAFETY: `_guard` pins the process-global env lock for the body of
+        // this test, so no other thread reads or writes the environment while
+        // the unset lands.
+        unsafe {
+            std::env::remove_var("THETADATA_API_KEY");
+        }
+        let creds = super::thetadatadx_credentials_from_env();
+        assert!(creds.is_null());
     }
 }

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -80,6 +80,9 @@ CPP_HPP = REPO_ROOT / "sdks" / "cpp" / "include" / "thetadatadx.hpp"
 CPP_H = REPO_ROOT / "sdks" / "cpp" / "include" / "thetadatadx.h"
 FFI_SRC = REPO_ROOT / "ffi" / "src"
 CONFIG_DIR = REPO_ROOT / "crates" / "thetadatadx" / "src" / "config"
+RUST_CLIENT_BUILDER_RS = (
+    REPO_ROOT / "crates" / "thetadatadx" / "src" / "client_builder.rs"
+)
 # Core Rust streaming surfaces whose public observability accessors must
 # each carry a parity row. The unified surface lives on the
 # `StreamSurface` view returned by `Client::stream()`; the standalone
@@ -822,6 +825,179 @@ def _check_getter_set_parity(
         "getter",
         "GETTER_PARITY_EXEMPT",
     )
+
+
+# ─── ClientBuilder fluent-setter parity (Rust vs C++) ──────────────
+
+
+# Fluent `ClientBuilder` setters that intentionally exist on only one of
+# the two builder surfaces. Empty today: every public Rust builder setter
+# is expected to exist on the C++ builder, and vice versa.
+CLIENT_BUILDER_SETTER_PARITY_EXEMPT: dict[str, str] = {}
+
+
+def _collect_rust_client_builder_setters(client_builder_rs: pathlib.Path) -> set[str]:
+    """Public Rust `ClientBuilder` fluent setters returning `Self`.
+
+    Scoped to `impl ClientBuilder { ... }` and to the `-> Self` return
+    shape so helper methods (`new`, `set_auth`) and the terminal
+    `connect()` are excluded. The collected names are the canonical
+    snake_case setter identifiers the Rust docs surface.
+    """
+    setters: set[str] = set()
+    if not client_builder_rs.is_file():
+        return setters
+    text = client_builder_rs.read_text(encoding="utf-8")
+    for header in re.finditer(r"impl\s+ClientBuilder\s*\{", text):
+        body = _balanced_body(text, header.end())
+        for m in re.finditer(
+            r"\bpub\s+fn\s+([a-z_][a-z0-9_]*)\s*\([^)]*\)\s*->\s*Self\b",
+            body,
+            re.DOTALL,
+        ):
+            setters.add(m.group(1))
+    return setters
+
+
+def _collect_cpp_client_builder_setters(cpp_hpp: pathlib.Path) -> set[str]:
+    """Public C++ `ClientBuilder` fluent setters returning
+    `ClientBuilder&` / `ClientBuilder&&`.
+
+    Scoped to the `class ClientBuilder { ... }` body and to the fluent
+    return-type shape, so lifecycle members, helper methods, and the
+    terminal `connect()` are excluded. The returned names are the public
+    snake_case setter identifiers on the C++ builder surface.
+    """
+    setters: set[str] = set()
+    if not cpp_hpp.is_file():
+        return setters
+    text = _expand_cpp_includes(cpp_hpp.read_text(encoding="utf-8"), cpp_hpp.parent)
+    m = re.search(r"^class\s+ClientBuilder\s*(?::[^{]*)?\{", text, re.MULTILINE)
+    if not m:
+        return setters
+    body = _balanced_body(text, m.end())
+    for fm in re.finditer(r"\bClientBuilder(?:&&|&)\s+([a-z_][a-z0-9_]*)\s*\(", body):
+        setters.add(fm.group(1))
+    return setters
+
+
+def _check_client_builder_setter_parity(
+    rust_setters: set[str],
+    cpp_setters: set[str],
+    exempt: dict[str, str] | None = None,
+) -> list[str]:
+    """Assert the Rust and C++ `ClientBuilder` fluent-setter NAME-SETS
+    are equal.
+
+    This is the inline client-construction parity guard: a setter that
+    exists on only one builder cannot hide as an unenrolled
+    binding-specific capability. Anything intentionally asymmetric must be
+    listed in `CLIENT_BUILDER_SETTER_PARITY_EXEMPT` with a documented
+    reason; stale exemptions are themselves flagged so the carve-out list
+    does not rot.
+    """
+    if exempt is None:
+        exempt = CLIENT_BUILDER_SETTER_PARITY_EXEMPT
+    bindings = {"rust": rust_setters, "cpp": cpp_setters}
+    universe: set[str] = set().union(*bindings.values()) if bindings else set()
+    errors: list[str] = []
+    for setter in sorted(universe - set(exempt)):
+        present_on = [lang for lang, names in bindings.items() if setter in names]
+        if len(present_on) != len(bindings):
+            missing = [lang for lang in bindings if lang not in present_on]
+            errors.append(
+                f"  ClientBuilder setter `{setter}`: present on {sorted(present_on)}, "
+                f"missing on {sorted(missing)}. Bind it on both the Rust and C++ "
+                f"builder surfaces, or add it to "
+                f"CLIENT_BUILDER_SETTER_PARITY_EXEMPT with a documented reason."
+            )
+    for setter, reason in exempt.items():
+        present_on = [lang for lang, names in bindings.items() if setter in names]
+        if present_on and len(present_on) == len(bindings):
+            errors.append(
+                f"  ClientBuilder setter `{setter}`: listed in "
+                f"CLIENT_BUILDER_SETTER_PARITY_EXEMPT ({reason!r}) but is now "
+                f"present on both Rust and C++. Drop the stale exemption."
+            )
+    return errors
+
+
+# ─── TypeScript connectWith option-field roster ────────────────────
+
+
+# The canonical JS-visible `Client.connectWith(...)` option-field roster.
+# The Rust `ClientConnectOptions` struct in `sdks/typescript/src/lib.rs`
+# must emit exactly this set after napi camel-casing. A dropped, renamed,
+# or newly-added field trips here even if no `[[connect]]` / `[[method]]`
+# row changes, so the inline connect surface stays pinned.
+TYPESCRIPT_CONNECT_WITH_FIELD_ROSTER: frozenset[str] = frozenset(
+    {
+        "apiKey",
+        "apiKeyFromEnv",
+        "apiKeyFromDotenv",
+        "email",
+        "password",
+        "credentialsFile",
+        "mddsType",
+    }
+)
+
+
+def _collect_typescript_connect_with_fields(ts_lib_rs: pathlib.Path) -> set[str]:
+    """JS-visible field names on `ClientConnectOptions`.
+
+    Parses the `#[napi(object)] pub struct ClientConnectOptions { ... }`
+    body in `sdks/typescript/src/lib.rs`, honoring an explicit
+    `#[napi(js_name = "...")]` on a field when present and otherwise
+    applying napi-rs' snake_case → camelCase object-field mapping.
+    """
+    out: set[str] = set()
+    if not ts_lib_rs.is_file():
+        return out
+    text = ts_lib_rs.read_text(encoding="utf-8")
+    m = re.search(
+        r"#\[napi\(object\)\]\s*pub\s+struct\s+ClientConnectOptions\s*\{",
+        text,
+    )
+    if not m:
+        return out
+    body = _balanced_body(text, m.end())
+    js_name_re = re.compile(r'js_name\s*=\s*"([a-zA-Z_][a-zA-Z0-9_]*)"')
+    field_re = re.compile(
+        r"((?:\s*#\[[^\]]*\]\s*)*)\s*pub\s+([a-z_][a-z0-9_]*)\s*:",
+        re.MULTILINE,
+    )
+    for fm in field_re.finditer(body):
+        attrs = fm.group(1)
+        snake = fm.group(2)
+        js_name = js_name_re.search(attrs)
+        out.add(js_name.group(1) if js_name else _snake_to_camel(snake))
+    return out
+
+
+def _check_typescript_connect_with_field_roster(
+    actual_fields: set[str],
+    expected_fields: frozenset[str] | None = None,
+) -> list[str]:
+    """Assert `ClientConnectOptions` emits exactly the canonical
+    connectWith option-field roster."""
+    if expected_fields is None:
+        expected_fields = TYPESCRIPT_CONNECT_WITH_FIELD_ROSTER
+    errors: list[str] = []
+    for field in sorted(expected_fields - actual_fields):
+        errors.append(
+            f"  Client.connectWith options: missing TypeScript field `{field}` on "
+            f"`ClientConnectOptions`. Expected roster is {sorted(expected_fields)}. "
+            f"Add the field back, or update TYPESCRIPT_CONNECT_WITH_FIELD_ROSTER "
+            f"intentionally."
+        )
+    for field in sorted(actual_fields - expected_fields):
+        errors.append(
+            f"  Client.connectWith options: unexpected TypeScript field `{field}` on "
+            f"`ClientConnectOptions`. Add it to TYPESCRIPT_CONNECT_WITH_FIELD_ROSTER "
+            f"if intentional, or remove / rename it."
+        )
+    return errors
 
 
 # ─── Public-surface identifier collection (vocab guard) ─────────────
@@ -4591,6 +4767,23 @@ def main(argv: list[str] | None = None) -> int:
         connect_rows, py_connect, ts_connect, cpp_connect, ffi_connect_stems
     )
 
+    # Inline builder parity: every public Rust `ClientBuilder` fluent
+    # setter must exist on the C++ `ClientBuilder`, and vice versa.
+    rust_client_builder_setters = _collect_rust_client_builder_setters(
+        RUST_CLIENT_BUILDER_RS
+    )
+    cpp_client_builder_setters = _collect_cpp_client_builder_setters(CPP_HPP)
+    client_builder_setter_errors = _check_client_builder_setter_parity(
+        rust_client_builder_setters, cpp_client_builder_setters
+    )
+
+    # TypeScript inline connect roster: `Client.connectWith(...)` must
+    # continue to expose exactly the canonical option fields.
+    ts_connect_with_fields = _collect_typescript_connect_with_fields(TS_LIB_RS)
+    connect_with_field_errors = _check_typescript_connect_with_field_roster(
+        ts_connect_with_fields
+    )
+
     # Credentials factory surface — the auth-handle factories
     # (`fromFile` / `fromEmail` / `fromApiKey` / `fromApiKeyWithEmail` /
     # `fromEnvOrFile` / `fromDotenv`). Each rides a `[[method]]` row, but a forward
@@ -4845,6 +5038,26 @@ def main(argv: list[str] | None = None) -> int:
             print(e)
         print()
 
+    if client_builder_setter_errors:
+        had_errors = True
+        print(
+            f"check_binding_parity: {len(client_builder_setter_errors)} "
+            f"ClientBuilder fluent-setter divergence(s) between Rust and C++:"
+        )
+        for e in client_builder_setter_errors:
+            print(e)
+        print()
+
+    if connect_with_field_errors:
+        had_errors = True
+        print(
+            f"check_binding_parity: {len(connect_with_field_errors)} "
+            f"TypeScript connectWith option-field divergence(s):"
+        )
+        for e in connect_with_field_errors:
+            print(e)
+        print()
+
     if credentials_factory_errors:
         had_errors = True
         print(
@@ -4952,6 +5165,9 @@ def main(argv: list[str] | None = None) -> int:
         f"cpp_setters={len(cpp_setters)} ffi_setters={len(ffi_setters)}; "
         f"getters py={len(py_getters)} ts={len(ts_getters)} "
         f"cpp={len(cpp_getters)} ffi={len(ffi_getters)}; "
+        f"builder_setters rust={len(rust_client_builder_setters)} "
+        f"cpp={len(cpp_client_builder_setters)}; "
+        f"connectWith_fields={len(ts_connect_with_fields)}; "
         f"kinds={len(CANONICAL_SUBSCRIPTION_KINDS)} "
         f"error_leaves={len(CANONICAL_ERROR_LEAVES)} "
         f"error_codes={len(CANONICAL_ERROR_CODES)})"
@@ -5967,6 +6183,53 @@ def _run_selftest() -> int:
     _case("connect negative — missing #[new] constructor trips", _case_connect_missing_python_constructor_trips)
     _case("connect negative — untracked connect surface trips", _case_connect_orphan_untracked_trips)
     _case("connect — FFI stem collector skips _connect_from_file", _case_connect_ffi_stem_collector_skips_from_file)
+
+    # ── TypeScript connectWith option-field roster selftests ───────
+
+    def _case_connect_with_field_collector_camelizes() -> None:
+        """The field collector lifts Rust snake_case to JS camelCase."""
+        with tempfile.TemporaryDirectory() as tmp:
+            lib = pathlib.Path(tmp) / "lib.rs"
+            lib.write_text(
+                "#[napi(object)]\n"
+                "pub struct ClientConnectOptions {\n"
+                "    pub api_key_from_env: Option<bool>,\n"
+                "    pub credentials_file: Option<String>,\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            fields = _collect_typescript_connect_with_fields(lib)
+            assert fields == {"apiKeyFromEnv", "credentialsFile"}, (
+                f"collector must camelCase fields; got {fields!r}"
+            )
+
+    def _case_connect_with_field_roster_missing_field_trips() -> None:
+        """A dropped/renamed connectWith field trips the roster."""
+        actual = set(TYPESCRIPT_CONNECT_WITH_FIELD_ROSTER) - {"mddsType"}
+        errors = _check_typescript_connect_with_field_roster(actual)
+        assert any("mddsType" in e and "missing" in e for e in errors), (
+            f"a missing connectWith field must trip; got {errors!r}"
+        )
+
+    def _case_connect_with_field_roster_unexpected_field_trips() -> None:
+        """An extra connectWith field trips the roster."""
+        actual = set(TYPESCRIPT_CONNECT_WITH_FIELD_ROSTER) | {"stageAlias"}
+        errors = _check_typescript_connect_with_field_roster(actual)
+        assert any("stageAlias" in e and "unexpected" in e for e in errors), (
+            f"an unexpected connectWith field must trip; got {errors!r}"
+        )
+
+    def _case_connect_with_field_roster_live_source_clean() -> None:
+        """The shipped `ClientConnectOptions` fields equal the pinned roster."""
+        errors = _check_typescript_connect_with_field_roster(
+            _collect_typescript_connect_with_fields(TS_LIB_RS)
+        )
+        assert errors == [], f"live connectWith field roster must be clean; got {errors!r}"
+
+    _case("connectWith fields — collector camelCases Rust fields", _case_connect_with_field_collector_camelizes)
+    _case("connectWith fields — missing field trips", _case_connect_with_field_roster_missing_field_trips)
+    _case("connectWith fields — unexpected field trips", _case_connect_with_field_roster_unexpected_field_trips)
+    _case("connectWith fields — live source clean", _case_connect_with_field_roster_live_source_clean)
 
     # ── C-ABI value-field + roster selftests ───────────────────────
 
@@ -7007,6 +7270,52 @@ def _run_selftest() -> int:
     _case("getter-set — missing-on-FFI getter trips", _case_getter_set_parity_missing_on_ffi_trips)
     _case("getter-set — live sources clean", _case_getter_set_parity_live_sources_clean)
     _case("getter collectors — scope to impl Config only", _case_getter_collectors_scope_to_config)
+
+    # ── ClientBuilder fluent-setter parity selftests ──────────────
+
+    def _case_client_builder_setter_parity_positive() -> None:
+        """Matching Rust/C++ builder setter rosters are silent."""
+        errors = _check_client_builder_setter_parity(
+            {"api_key", "environment", "from_dotenv"},
+            {"api_key", "environment", "from_dotenv"},
+            exempt={},
+        )
+        assert errors == [], f"matching builder setter sets must be silent; got {errors!r}"
+
+    def _case_client_builder_setter_missing_on_cpp_trips() -> None:
+        """A Rust builder setter missing from C++ trips."""
+        errors = _check_client_builder_setter_parity(
+            {"api_key", "environment"},
+            {"api_key"},
+            exempt={},
+        )
+        assert any("environment" in e and "cpp" in e for e in errors), (
+            f"a dropped C++ builder setter must trip; got {errors!r}"
+        )
+
+    def _case_client_builder_setter_stale_exemption_trips() -> None:
+        """A stale builder-setter exemption is an error."""
+        errors = _check_client_builder_setter_parity(
+            {"from_dotenv"},
+            {"from_dotenv"},
+            exempt={"from_dotenv": "legacy C++ gap"},
+        )
+        assert any("from_dotenv" in e and "stale" in e for e in errors), (
+            f"a stale builder-setter exemption must surface; got {errors!r}"
+        )
+
+    def _case_client_builder_setter_live_sources_clean() -> None:
+        """The shipped Rust and C++ `ClientBuilder` setter rosters match."""
+        errors = _check_client_builder_setter_parity(
+            _collect_rust_client_builder_setters(RUST_CLIENT_BUILDER_RS),
+            _collect_cpp_client_builder_setters(CPP_HPP),
+        )
+        assert errors == [], f"live builder setter parity must be clean; got {errors!r}"
+
+    _case("ClientBuilder setters — matching rosters silent", _case_client_builder_setter_parity_positive)
+    _case("ClientBuilder setters — missing on C++ trips", _case_client_builder_setter_missing_on_cpp_trips)
+    _case("ClientBuilder setters — stale exemption trips", _case_client_builder_setter_stale_exemption_trips)
+    _case("ClientBuilder setters — live sources clean", _case_client_builder_setter_live_sources_clean)
 
     # ── Subscription-kind label parity selftests ───────────────────
 

--- a/scripts/ci/tests/test_check_binding_parity.py
+++ b/scripts/ci/tests/test_check_binding_parity.py
@@ -466,6 +466,80 @@ def test_getter_collectors_scope_to_config() -> None:
     assert "get_streaming_ring_size" in bodies[0] and "bid_price" not in bodies[0]
 
 
+# ─── ClientBuilder fluent-setter parity ────────────────────────────
+
+
+def test_client_builder_setter_parity_positive() -> None:
+    """Matching Rust/C++ builder setter rosters are silent."""
+    errors = cbp._check_client_builder_setter_parity(
+        {"api_key", "environment", "from_dotenv"},
+        {"api_key", "environment", "from_dotenv"},
+        exempt={},
+    )
+    assert errors == [], f"matching builder setter sets must be silent; got {errors!r}"
+
+
+def test_client_builder_setter_parity_missing_on_cpp_trips() -> None:
+    """A Rust builder setter missing from C++ trips."""
+    errors = cbp._check_client_builder_setter_parity(
+        {"api_key", "environment"},
+        {"api_key"},
+        exempt={},
+    )
+    assert any("environment" in e and "cpp" in e for e in errors), (
+        f"a dropped C++ builder setter must trip; got {errors!r}"
+    )
+
+
+def test_client_builder_setter_parity_live_sources_clean() -> None:
+    """The shipped Rust and C++ builder setter rosters match."""
+    errors = cbp._check_client_builder_setter_parity(
+        cbp._collect_rust_client_builder_setters(cbp.RUST_CLIENT_BUILDER_RS),
+        cbp._collect_cpp_client_builder_setters(cbp.CPP_HPP),
+    )
+    assert errors == [], f"live builder setter parity must be clean; got {errors!r}"
+
+
+# ─── TypeScript connectWith option-field roster ────────────────────
+
+
+def test_connect_with_field_collector_camelizes() -> None:
+    """The collector lifts Rust snake_case fields to JS camelCase."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        lib = pathlib.Path(tmp) / "lib.rs"
+        lib.write_text(
+            "#[napi(object)]\n"
+            "pub struct ClientConnectOptions {\n"
+            "    pub api_key_from_env: Option<bool>,\n"
+            "    pub credentials_file: Option<String>,\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        fields = cbp._collect_typescript_connect_with_fields(lib)
+    assert fields == {"apiKeyFromEnv", "credentialsFile"}, (
+        f"collector must camelCase fields; got {fields!r}"
+    )
+
+
+def test_connect_with_field_roster_missing_field_trips() -> None:
+    """A dropped/renamed connectWith field trips."""
+    actual = set(cbp.TYPESCRIPT_CONNECT_WITH_FIELD_ROSTER) - {"mddsType"}
+    errors = cbp._check_typescript_connect_with_field_roster(actual)
+    assert any("mddsType" in e and "missing" in e for e in errors), (
+        f"a missing connectWith field must trip; got {errors!r}"
+    )
+
+
+def test_connect_with_field_roster_live_source_clean() -> None:
+    """The shipped `ClientConnectOptions` fields equal the pinned roster."""
+    errors = cbp._check_typescript_connect_with_field_roster(
+        cbp._collect_typescript_connect_with_fields(cbp.TS_LIB_RS)
+    )
+    assert errors == [], f"live connectWith field roster must be clean; got {errors!r}"
+
+
 # ─── Subscription-kind label parity ────────────────────────────────
 
 

--- a/sdks/cpp/include/thetadatadx.h
+++ b/sdks/cpp/include/thetadatadx.h
@@ -963,6 +963,15 @@ ThetaDataDxCredentials* thetadatadx_credentials_from_api_key_with_email(const ch
  *          thetadatadx_credentials_free, or NULL on error (check thetadatadx_last_error()). */
 ThetaDataDxCredentials* thetadatadx_credentials_from_file(const char* path);
 
+/** Source a credentials handle strictly from the THETADATA_API_KEY
+ *  environment variable. Strict: an unset or whitespace-only value is an
+ *  error rather than a silent fallback, and there is no creds.txt file
+ *  fallback. Use thetadatadx_credentials_from_env_or_file when a file
+ *  fallback is wanted instead.
+ *  @return Heap-owned ThetaDataDxCredentials the caller must release with
+ *          thetadatadx_credentials_free, or NULL on error (check thetadatadx_last_error()). */
+ThetaDataDxCredentials* thetadatadx_credentials_from_env(void);
+
 /** Source a credentials handle from the environment, falling back to a file.
  *  When THETADATA_API_KEY is set and non-empty an API key is used; otherwise
  *  the two-line file (line 1 = email, line 2 = password) at path is read.

--- a/sdks/cpp/include/thetadatadx.h
+++ b/sdks/cpp/include/thetadatadx.h
@@ -1803,6 +1803,17 @@ int thetadatadx_config_set_flush_mode(ThetaDataDxConfig* config, int mode);
  */
 int32_t thetadatadx_config_get_flush_mode(const ThetaDataDxConfig* config, int32_t* out_mode);
 
+/**
+ * Read the target server environment carried by the config: "PROD" for
+ * the production cluster or "STAGE" for staging. Set as a unit by the
+ * production / stage presets (and the THETADATA_MDDS_TYPE dotenv key);
+ * this is the readback of that selection.
+ * @param config Config handle to read.
+ * @return A heap-owned NUL-terminated C string the caller MUST free with
+ *         thetadatadx_string_free, or NULL if config is null.
+ */
+char* thetadatadx_config_get_environment(const ThetaDataDxConfig* config);
+
 /* Streaming wait-strategy preset selectors for
  * thetadatadx_config_set_wait_strategy / _get_wait_strategy. */
 #define THETADATADX_WAIT_LOW_LATENCY 0

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -379,6 +379,25 @@ public:
 
 namespace detail {
 
+/// Best-effort wipe of a `std::string` holding secret material.
+///
+/// Overwrites the live buffer through a `volatile` byte pointer (so the
+/// compiler may not elide the store as dead) and then clears the string.
+/// This is best-effort: the C ABI boundary takes `const char*`, so the
+/// authoritative copy is the one the Rust core holds in zeroizing memory;
+/// this only shortens the lifetime of the transient C++-side plaintext.
+/// A reallocation earlier in the string's life may have left an untouched
+/// copy elsewhere, which no portable C++ can reach.
+inline void secure_wipe(std::string& secret) {
+    if (!secret.empty()) {
+        volatile char* p = const_cast<volatile char*>(secret.data());
+        for (std::size_t i = 0; i < secret.size(); ++i) {
+            p[i] = '\0';
+        }
+    }
+    secret.clear();
+}
+
 /// Throw the [`ThetaDataError`] leaf that matches the typed C ABI
 /// discriminant `code` (one of the `THETADATADX_ERR_*` constants in
 /// `thetadatadx.h`). Used by every wrapper that already has the formatted
@@ -628,6 +647,14 @@ public:
      *  @return An owning `Credentials` holder.
      *  @throws thetadatadx::ThetaDataError if the credentials cannot be built. */
     static Credentials from_api_key_with_email(const std::string& email, const std::string& api_key);
+
+    /** Source credentials strictly from the `THETADATA_API_KEY`
+     *  environment variable. Strict: an unset or whitespace-only value
+     *  throws rather than falling back, and there is no `creds.txt` file
+     *  fallback. Use `from_env_or_file` when a file fallback is wanted.
+     *  @return An owning `Credentials` holder.
+     *  @throws thetadatadx::ThetaDataError if `THETADATA_API_KEY` is unset or empty. */
+    static Credentials from_env();
 
     /** Source credentials from the environment, falling back to a file.
      *  When `THETADATA_API_KEY` is set and non-empty an API key is used;
@@ -2490,6 +2517,28 @@ private:
 /// `std::move(builder).connect()`.
 class ClientBuilder {
 public:
+    // The builder is move-only. Copying would duplicate the inline secret
+    // material (`auth_a_` / `auth_b_`) and would let a copy observe the
+    // moved-from credential / config state after `connect()` ran on its
+    // sibling, since `connect()` moves out of the shared members. Deleting
+    // the copy operations makes that class of bug impossible: the fluent
+    // rvalue chain (`Client::builder().api_key(k).stage().connect()`) is
+    // unaffected, and a stored builder is handed over with
+    // `std::move(b).connect()`.
+    ClientBuilder(const ClientBuilder&) = delete;
+    ClientBuilder& operator=(const ClientBuilder&) = delete;
+    ClientBuilder(ClientBuilder&&) = default;
+    ClientBuilder& operator=(ClientBuilder&&) = default;
+
+    /// Best-effort wipe of any inline secret material the builder still
+    /// holds, so a builder that is destroyed without `connect()` (or after
+    /// it) does not leave plaintext credentials in process memory longer
+    /// than necessary.
+    ~ClientBuilder() {
+        detail::secure_wipe(auth_a_);
+        detail::secure_wipe(auth_b_);
+    }
+
     // Each fluent setter mutates the builder in place and returns it with
     // the value category preserved: an lvalue overload (`&`) returns
     // `ClientBuilder&` so a named builder keeps chaining, and an rvalue
@@ -2629,10 +2678,16 @@ public:
                 "api_key_from_dotenv, email_password, credentials_file, or credentials");
         }
         // The builder is an about-to-expire rvalue, so the resolvers move
-        // the chosen credential and config straight out of the members. No
-        // shared state outlives this call, so a copy or a second use can
-        // never observe a moved-from source.
+        // the chosen credential and config straight out of the members. The
+        // builder is move-only (copy is deleted), so no sibling copy can
+        // observe a moved-from source.
         Credentials creds = resolve_credentials();
+        // The credential now lives in the `Credentials` handle, whose Rust
+        // core holds the authoritative secret in zeroizing memory. Wipe the
+        // transient inline plaintext immediately rather than waiting for the
+        // destructor, shortening its lifetime to the minimum.
+        detail::secure_wipe(auth_a_);
+        detail::secure_wipe(auth_b_);
         Config cfg = resolve_config();
         return Client::connect(creds, cfg);
     }
@@ -2730,6 +2785,13 @@ private:
     /// is a configuration error rather than a silent fallback, because the
     /// caller explicitly asked for the environment source. No `creds.txt`
     /// file fallback.
+    ///
+    /// The transient `std::string` holding the env value is wiped through
+    /// `detail::secure_wipe` before this returns: the authoritative secret
+    /// then lives only in the `Credentials` handle, whose Rust core keeps it
+    /// in zeroizing memory. The standalone strict resolver is also reachable
+    /// as `Credentials::from_env()` (over the `thetadatadx_credentials_from_env`
+    /// C ABI symbol) for callers outside the builder.
     static Credentials resolve_api_key_from_env() {
         const char* raw = std::getenv("THETADATA_API_KEY");
         if (raw == nullptr) {
@@ -2739,10 +2801,18 @@ private:
         std::string value(raw);
         const auto first = value.find_first_not_of(" \t\r\n");
         if (first == std::string::npos) {
+            detail::secure_wipe(value);
             detail::throw_config_error("THETADATA_API_KEY is set but empty");
         }
         const auto last = value.find_last_not_of(" \t\r\n");
-        return Credentials::from_api_key(value.substr(first, last - first + 1));
+        // Build the credential (the Rust core takes the authoritative
+        // zeroizing copy), then wipe both the trimmed key and the full env
+        // value so the C++-side plaintext does not outlive this call.
+        std::string trimmed = value.substr(first, last - first + 1);
+        Credentials creds = Credentials::from_api_key(trimmed);
+        detail::secure_wipe(trimmed);
+        detail::secure_wipe(value);
+        return creds;
     }
 
     /// Non-const: the `Config` arm moves the stored `Config` out of the

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -14,6 +14,7 @@
 #include "thetadatadx.h"
 
 #include <chrono>
+#include <cctype>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -2547,6 +2548,7 @@ public:
     ~ClientBuilder() {
         detail::secure_wipe(auth_a_);
         detail::secure_wipe(auth_b_);
+        detail::secure_wipe(env_path_);
     }
 
     // Each fluent setter mutates the builder in place and returns it with
@@ -2589,11 +2591,13 @@ public:
     /// `THETADATA_EMAIL` + `THETADATA_PASSWORD` build email + password
     /// credentials.
     ClientBuilder& api_key_from_dotenv(const std::string& path) & {
-        set_auth(AuthKind::Dotenv, path, std::string(), "api_key_from_dotenv");
+        set_auth(AuthKind::Dotenv, path, std::string(),
+                 "api_key_from_dotenv / from_dotenv");
         return *this;
     }
     ClientBuilder&& api_key_from_dotenv(const std::string& path) && {
-        set_auth(AuthKind::Dotenv, path, std::string(), "api_key_from_dotenv");
+        set_auth(AuthKind::Dotenv, path, std::string(),
+                 "api_key_from_dotenv / from_dotenv");
         return std::move(*this);
     }
 
@@ -2629,23 +2633,34 @@ public:
         return std::move(*this);
     }
 
+    /// Select the target environment by its binding label (`"PROD"` or
+    /// `"STAGE"`, case-insensitive).
+    ClientBuilder& environment(const std::string& environment) & {
+        set_environment(environment);
+        return *this;
+    }
+    ClientBuilder&& environment(const std::string& environment) && {
+        set_environment(environment);
+        return std::move(*this);
+    }
+
     /// Target the staging cluster.
     ClientBuilder& stage() & {
-        env_kind_ = EnvKind::Stage;
+        set_environment_kind(EnvKind::Stage);
         return *this;
     }
     ClientBuilder&& stage() && {
-        env_kind_ = EnvKind::Stage;
+        set_environment_kind(EnvKind::Stage);
         return std::move(*this);
     }
 
     /// Target the production cluster (the default).
     ClientBuilder& production() & {
-        env_kind_ = EnvKind::Production;
+        set_environment_kind(EnvKind::Production);
         return *this;
     }
     ClientBuilder&& production() && {
-        env_kind_ = EnvKind::Production;
+        set_environment_kind(EnvKind::Production);
         return std::move(*this);
     }
 
@@ -2659,6 +2674,23 @@ public:
     }
     ClientBuilder&& config(Config cfg) && {
         set_config(std::move(cfg));
+        return std::move(*this);
+    }
+
+    /// Source both the credential and the target environment from a
+    /// `.env`-format file. Reuses `Credentials::from_dotenv` and
+    /// `Config::from_dotenv`, so one file can carry both
+    /// `THETADATA_API_KEY` and `THETADATA_MDDS_TYPE`.
+    ClientBuilder& from_dotenv(const std::string& path) & {
+        set_auth(AuthKind::Dotenv, path, std::string(),
+                 "api_key_from_dotenv / from_dotenv");
+        set_env_from_dotenv(path);
+        return *this;
+    }
+    ClientBuilder&& from_dotenv(const std::string& path) && {
+        set_auth(AuthKind::Dotenv, path, std::string(),
+                 "api_key_from_dotenv / from_dotenv");
+        set_env_from_dotenv(path);
         return std::move(*this);
     }
 
@@ -2685,7 +2717,8 @@ public:
         if (auth_kind_ == AuthKind::Unset) {
             detail::throw_config_error(
                 "no authentication source set — call one of api_key, api_key_from_env, "
-                "api_key_from_dotenv, email_password, credentials_file, or credentials");
+                "api_key_from_dotenv, from_dotenv, email_password, credentials_file, "
+                "or credentials");
         }
         // The builder is an about-to-expire rvalue, so the resolvers move
         // the chosen credential and config straight out of the members. The
@@ -2699,6 +2732,7 @@ public:
         detail::secure_wipe(auth_a_);
         detail::secure_wipe(auth_b_);
         Config cfg = resolve_config();
+        detail::secure_wipe(env_path_);
         return Client::connect(creds, cfg);
     }
 
@@ -2715,14 +2749,14 @@ private:
         CredentialsFile,
         Prebuilt,
     };
-    enum class EnvKind { Default, Production, Stage, Config };
+    enum class EnvKind { Default, Production, Stage, Config, Dotenv };
 
     /// Record an auth source, rejecting a second different one. Re-stating
     /// the same kind overwrites; a different kind latches a conflict that
     /// `connect()` reports.
     void set_auth(AuthKind kind, const std::string& a, const std::string& b,
                   const char* label) {
-        record_auth(label);
+        record_auth(kind, label);
         if (!conflict_) {
             auth_kind_ = kind;
             auth_a_ = a;
@@ -2734,21 +2768,68 @@ private:
     /// Store a pre-built `Credentials` source, latching a conflict if a
     /// different source was already chosen.
     void set_credentials(Credentials creds) {
-        record_auth("credentials");
-        auth_kind_ = AuthKind::Prebuilt;
-        prebuilt_ = std::make_shared<Credentials>(std::move(creds));
+        record_auth(AuthKind::Prebuilt, "credentials");
+        if (!conflict_) {
+            auth_kind_ = AuthKind::Prebuilt;
+            prebuilt_ = std::make_shared<Credentials>(std::move(creds));
+        }
     }
 
     /// Store a fully built `Config`, selecting the verbatim-config
     /// environment.
     void set_config(Config cfg) {
         env_kind_ = EnvKind::Config;
+        detail::secure_wipe(env_path_);
         config_ = std::make_shared<Config>(std::move(cfg));
+    }
+
+    /// Store a symbolic environment selector (`"PROD"` / `"STAGE"`),
+    /// rejecting anything else as a client-construction config error.
+    void set_environment(const std::string& environment) {
+        set_environment_kind(parse_environment_kind(environment));
+    }
+
+    /// Store a `.env` file as the environment source; the same `path`
+    /// is also valid for the auth source when `from_dotenv(...)` chooses
+    /// the `.env` credential path.
+    void set_env_from_dotenv(const std::string& path) {
+        env_kind_ = EnvKind::Dotenv;
+        env_path_ = path;
+        config_.reset();
+    }
+
+    /// Switch to one of the preset environment sources, clearing any
+    /// prior verbatim-config or `.env` environment override.
+    void set_environment_kind(EnvKind kind) {
+        env_kind_ = kind;
+        detail::secure_wipe(env_path_);
+        config_.reset();
+    }
+
+    /// Parse the C++ binding's string environment representation.
+    static EnvKind parse_environment_kind(const std::string& environment) {
+        const auto first = environment.find_first_not_of(" \t\r\n");
+        if (first == std::string::npos) {
+            detail::throw_config_error("environment must be PROD or STAGE; got empty string");
+        }
+        const auto last = environment.find_last_not_of(" \t\r\n");
+        std::string normalized = environment.substr(first, last - first + 1);
+        for (char& ch : normalized) {
+            ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+        }
+        if (normalized == "PROD") {
+            return EnvKind::Production;
+        }
+        if (normalized == "STAGE") {
+            return EnvKind::Stage;
+        }
+        detail::throw_config_error(
+            "environment must be PROD or STAGE; got \"" + environment + "\"");
     }
 
     /// Track the auth-source label so a second, different source can be
     /// reported as a conflict naming both sides.
-    void record_auth(const char* label) {
+    void record_auth(AuthKind kind, const char* label) {
         if (auth_kind_ == AuthKind::Unset && !conflict_) {
             first_label_ = label;
             return;
@@ -2756,9 +2837,9 @@ private:
         if (conflict_) {
             return;
         }
-        // Same label re-stated → not a conflict (overwrite). Different
-        // label → latch the conflict.
-        if (first_label_ != label) {
+        // Same auth kind re-stated → not a conflict (overwrite).
+        // Different auth kind → latch the conflict naming both sides.
+        if (auth_kind_ != kind) {
             conflict_ = true;
             second_label_ = label;
         }
@@ -2832,6 +2913,8 @@ private:
         switch (env_kind_) {
             case EnvKind::Config:
                 return std::move(*config_);
+            case EnvKind::Dotenv:
+                return Config::from_dotenv(env_path_);
             case EnvKind::Stage:
                 // The staging preset carries the staging cluster routing.
                 return Config::stage();
@@ -2848,6 +2931,7 @@ private:
     std::shared_ptr<Credentials> prebuilt_;
 
     EnvKind env_kind_ = EnvKind::Default;
+    std::string env_path_;
     std::shared_ptr<Config> config_;
 
     bool conflict_ = false;

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -1315,6 +1315,16 @@ public:
         return mode;
     }
 
+    /** Target server environment carried by this configuration: `"PROD"`
+     *  for the production cluster, `"STAGE"` for staging. Set as a unit by
+     *  the production / stage presets (and the `THETADATA_MDDS_TYPE`
+     *  dotenv key); this is the readback of that selection. Returns an
+     *  empty string if the FFI getter returns null (null handle). */
+    std::string get_environment() const {
+        detail::FfiString s(thetadatadx_config_get_environment(handle_.get()));
+        return s.str();
+    }
+
     /** Set the streaming event-ring consumer wait strategy.
      *  0=LowLatency (default), 1=Balanced, 2=Efficient, 3=BusySpin
      *  (see the @c THETADATADX_WAIT_* constants). Throws

--- a/sdks/cpp/src/lifecycle.cpp.inc
+++ b/sdks/cpp/src/lifecycle.cpp.inc
@@ -24,6 +24,12 @@ Credentials Credentials::from_api_key_with_email(const std::string& email, const
     return Credentials(h);
 }
 
+Credentials Credentials::from_env() {
+    auto h = thetadatadx_credentials_from_env();
+    if (!h) detail::throw_last_ffi_error();
+    return Credentials(h);
+}
+
 Credentials Credentials::from_env_or_file(const std::string& path) {
     auto h = thetadatadx_credentials_from_env_or_file(path.c_str());
     if (!h) detail::throw_last_ffi_error();

--- a/sdks/cpp/tests/config_pool_sizing.cpp
+++ b/sdks/cpp/tests/config_pool_sizing.cpp
@@ -44,3 +44,13 @@ TEST_CASE("Config historical_host / historical_port setters + getters round-trip
     cfg.set_historical_port(50051);
     REQUIRE(cfg.get_historical_port() == 50051u);
 }
+
+TEST_CASE("Config environment getter reads back the selected cluster",
+          "[config][environment][offline]") {
+    // The environment readback mirrors the Python `Config.environment`
+    // and TypeScript `environment` getters: the production / stage
+    // presets select the cluster as a unit, and this getter reads the
+    // selection back as the `"PROD"` / `"STAGE"` string.
+    REQUIRE(thetadatadx::Config::stage().get_environment() == "STAGE");
+    REQUIRE(thetadatadx::Config::production().get_environment() == "PROD");
+}

--- a/sdks/cpp/tests/lifecycle.cpp
+++ b/sdks/cpp/tests/lifecycle.cpp
@@ -52,6 +52,21 @@ TEST_CASE("Credentials::from_api_key_with_email builds a handle without network 
     REQUIRE(creds.get() != nullptr);
 }
 
+TEST_CASE("Credentials::from_env sources strictly from THETADATA_API_KEY",
+          "[lifecycle][offline]") {
+    setenv("THETADATA_API_KEY", "env-sourced-key", 1);
+    auto creds = thetadatadx::Credentials::from_env();
+    REQUIRE(creds.get() != nullptr);
+    unsetenv("THETADATA_API_KEY");
+}
+
+TEST_CASE("Credentials::from_env throws when THETADATA_API_KEY is unset",
+          "[lifecycle][offline]") {
+    // Strict: an unset value is an error, with NO creds.txt fallback.
+    unsetenv("THETADATA_API_KEY");
+    REQUIRE_THROWS(thetadatadx::Credentials::from_env());
+}
+
 TEST_CASE("Credentials::from_env_or_file sources from THETADATA_API_KEY",
           "[lifecycle][offline]") {
     setenv("THETADATA_API_KEY", "env-sourced-key", 1);

--- a/sdks/cpp/tests/thetadatadx_client.cpp
+++ b/sdks/cpp/tests/thetadatadx_client.cpp
@@ -48,6 +48,19 @@ TEST_CASE("Client is move-only with the right type-trait shape",
     STATIC_REQUIRE_FALSE(std::is_copy_assignable_v<thetadatadx::Client>);
 }
 
+TEST_CASE("ClientBuilder is move-only (non-copyable)",
+          "[unified][offline]") {
+    // A copyable builder could duplicate inline secret material and let a
+    // copy observe moved-from credential / config state after connect()
+    // ran on its sibling. The builder is move-only so that class of bug
+    // cannot be written: the fluent rvalue chain and a std::move handover
+    // both stay valid, only the implicit copy is gone.
+    STATIC_REQUIRE_FALSE(std::is_copy_constructible_v<thetadatadx::ClientBuilder>);
+    STATIC_REQUIRE_FALSE(std::is_copy_assignable_v<thetadatadx::ClientBuilder>);
+    STATIC_REQUIRE(std::is_move_constructible_v<thetadatadx::ClientBuilder>);
+    STATIC_REQUIRE(std::is_move_assignable_v<thetadatadx::ClientBuilder>);
+}
+
 TEST_CASE("ClientBuilder validates auth before connecting",
           "[unified][offline]") {
     // The builder rejects an empty auth set and a conflict BEFORE any

--- a/sdks/cpp/tests/thetadatadx_client.cpp
+++ b/sdks/cpp/tests/thetadatadx_client.cpp
@@ -82,7 +82,9 @@ TEST_CASE("ClientBuilder validates auth before connecting",
     // composes. Pin the surface (api key first-class, plus the
     // environment selectors) at compile time without connecting.
     thetadatadx::ClientBuilder builder = thetadatadx::Client::builder();
-    builder.api_key("td1_example").stage();
+    builder.api_key("td1_example").environment("STAGE");
+    thetadatadx::ClientBuilder dotenv_builder = thetadatadx::Client::builder();
+    dotenv_builder.from_dotenv("/tmp/example.env").production();
 }
 
 TEST_CASE("ClientBuilder is single-use: connect() consumes the builder",
@@ -109,6 +111,32 @@ TEST_CASE("ClientBuilder is single-use: connect() consumes the builder",
     thetadatadx::ClientBuilder stored = thetadatadx::Client::builder();
     stored.api_key("td1_example").email_password("you@example.com", "secret");
     REQUIRE_THROWS_AS(std::move(stored).connect(), thetadatadx::ConfigError);
+}
+
+TEST_CASE("ClientBuilder environment and from_dotenv setters stay offline",
+          "[unified][offline]") {
+    // The explicit environment selector uses the C++ binding's string
+    // representation (`PROD` / `STAGE`, case-insensitive) and validates
+    // locally, before any network round-trip.
+    REQUIRE_NOTHROW(thetadatadx::Client::builder().environment("stage"));
+    REQUIRE_NOTHROW(thetadatadx::Client::builder().environment(" PROD "));
+    REQUIRE_THROWS_AS(thetadatadx::Client::builder().environment("qa"),
+                      thetadatadx::ConfigError);
+
+    // `from_dotenv` is fluent on both lvalues and rvalues; the setter
+    // itself does not read the file until `connect()`.
+    thetadatadx::ClientBuilder named = thetadatadx::Client::builder();
+    REQUIRE_NOTHROW(named.from_dotenv("/tmp/example.env").stage());
+
+    // `from_dotenv` selects the same auth kind as `api_key_from_dotenv`,
+    // but it still conflicts with a different auth source. The conflict
+    // surfaces before any file read or network round-trip, so the test
+    // stays offline even with a nonexistent path.
+    REQUIRE_THROWS_AS(thetadatadx::Client::builder()
+                          .api_key("td1_example")
+                          .from_dotenv("/nonexistent/.env")
+                          .connect(),
+                      thetadatadx::ConfigError);
 }
 
 TEST_CASE("api_key_from_env is strict — unset env throws ConfigError",

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1539,17 +1539,19 @@ cpp = true
 
 # Strict env-only sourcing: read `THETADATA_API_KEY` from the
 # environment with no `creds.txt` fallback (unset or empty is an error).
-# Python and TypeScript reach the strict resolver through the `Client`
-# class (`Client.from_env` / `connectWith({ apiKeyFromEnv })`), so the
-# `Credentials`-class factory is C++ only, sitting over the
-# `thetadatadx_credentials_from_env` C ABI symbol.
+# Symmetric with the other `Credentials` factories, so all columns stay
+# `true` across Python (`from_env` staticmethod), TypeScript (`fromEnv`
+# napi factory), and C++ (`from_env` static member over the
+# `thetadatadx_credentials_from_env` C ABI symbol). The `Client`-level
+# `Client.from_env` / `connectWith({ apiKeyFromEnv })` paths are a
+# separate surface, not a substitute for the factory.
 
 [[method]]
 class = "Credentials"
 name = "fromEnv"
-python = false
-typescript = false
-cpp = true   # `Credentials::from_env()` over `thetadatadx_credentials_from_env`
+python = true       # `Credentials.from_env()` staticmethod
+typescript = true   # `Credentials.fromEnv()` napi factory
+cpp = true          # `Credentials::from_env()` over `thetadatadx_credentials_from_env`
 
 # Environment-or-file sourcing: read `THETADATA_API_KEY` from the
 # environment, else fall back to the two-line credentials file. Every

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1537,6 +1537,20 @@ python = true
 typescript = true   # `Credentials.fromApiKeyWithEmail(email, key)` napi factory
 cpp = true
 
+# Strict env-only sourcing: read `THETADATA_API_KEY` from the
+# environment with no `creds.txt` fallback (unset or empty is an error).
+# Python and TypeScript reach the strict resolver through the `Client`
+# class (`Client.from_env` / `connectWith({ apiKeyFromEnv })`), so the
+# `Credentials`-class factory is C++ only, sitting over the
+# `thetadatadx_credentials_from_env` C ABI symbol.
+
+[[method]]
+class = "Credentials"
+name = "fromEnv"
+python = false
+typescript = false
+cpp = true   # `Credentials::from_env()` over `thetadatadx_credentials_from_env`
+
 # Environment-or-file sourcing: read `THETADATA_API_KEY` from the
 # environment, else fall back to the two-line credentials file. Every
 # binding exposes it, so all columns stay `true` across Python

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -1080,6 +1080,28 @@ typescript = true   # `Client.connectWith({ apiKey, mddsType, ... })` napi facto
 cpp = false         # C++ uses the `Client::builder()` fluent builder
 rust = false        # Rust uses the `Client::builder()` fluent builder
 
+# Two Rust-core ergonomic conveniences carry no binding twin by design,
+# so they are intentional asymmetries rather than parity gaps:
+#
+#   - `Client::connect_with_api_key(key, config)` is thin sugar over
+#     `Client::builder().api_key(key).config(config).connect()` for the
+#     single most common inline shape. Every binding already reaches the
+#     same surface through its idiomatic inline entry point (the Python
+#     `Client(api_key=...)` constructor kwargs, the TypeScript
+#     `Client.connectWith({ apiKey })` factory, the C++ `Client::builder()`
+#     fluent builder), so a fourth named twin would be redundant.
+#   - `Config::with_dotenv(path)` is the builder companion to
+#     `Config::from_dotenv`: it layers the same `.env`-sourced cluster
+#     selection onto an existing config instead of starting from the
+#     production preset. The bindings expose the `from_dotenv` factory
+#     (the `fromDotenv` rows above); the layer-onto-existing variant stays
+#     a Rust convenience because the binding callers build the config in
+#     one expression rather than mutating a receiver.
+#
+# Both are pure sugar over surfaces already at full cross-binding parity,
+# so they are deliberately not enrolled as rows (a binding twin is not
+# expected and their absence is not a gap).
+
 # ── FlatFilesNamespace fetch surface (bulk per-day flat-file requests) ──
 #
 # The `flatFiles` accessor above returns the flat-file namespace; the rows
@@ -1722,6 +1744,23 @@ cpp = true
 [[method]]
 class = "Config"
 name = "deriveOhlcvc"
+python = true
+typescript = true
+cpp = true
+
+# `environment` is the target-server readback: the production / stage
+# presets (and the `THETADATA_MDDS_TYPE` dotenv key) set the cluster
+# selector as a unit, and this getter reads it back as a `"PROD"` /
+# `"STAGE"` string, the same selector spelling the inline client takes
+# as `mddsType` / `mdds_type`. Exposed on every binding: Python
+# (`Config.environment` property), TypeScript (`Config.environment`
+# getter), C++ (`Config::get_environment()` over the FFI
+# `thetadatadx_config_get_environment` symbol). There is no matching
+# setter row: the selector is chosen by the `production` / `stage`
+# factories, not a free-standing field write.
+[[method]]
+class = "Config"
+name = "environment"
 python = true
 typescript = true
 cpp = true

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -106,6 +106,22 @@ class Credentials:
         ...
 
     @staticmethod
+    def from_env() -> Credentials:
+        """Source credentials strictly from the ``THETADATA_API_KEY`` env var.
+
+        Strict: an unset or whitespace-only value raises rather than
+        falling back, and there is no ``creds.txt`` file fallback. Use
+        :meth:`from_env_or_file` when a file fallback is wanted instead.
+
+        Returns:
+            The sourced :class:`Credentials`.
+
+        Raises:
+            ThetaDataError: If ``THETADATA_API_KEY`` is unset or empty.
+        """
+        ...
+
+    @staticmethod
     def from_env_or_file(path: str) -> Credentials:
         """Source credentials from the environment, falling back to a file.
 

--- a/sdks/python/python/thetadatadx/__init__.pyi
+++ b/sdks/python/python/thetadatadx/__init__.pyi
@@ -290,6 +290,9 @@ class Config:
     """Whether OHLCVC bars are derived locally from the trade stream and delivered as :class:`Ohlcvc` events."""
     flush_mode: Literal["batched", "immediate"]
     """Streaming write-flush policy. ``"batched"`` (default) flushes on the heartbeat (~100 ms); ``"immediate"`` flushes after every wire write. The setter accepts the same two strings case-insensitively and raises ``ValueError`` otherwise."""
+    @property
+    def environment(self) -> Literal["PROD", "STAGE"]:
+        """Target server environment carried by this configuration: ``"PROD"`` for the production cluster, ``"STAGE"`` for staging. Set as a unit by :meth:`Config.production` / :meth:`Config.stage` (and the ``THETADATA_MDDS_TYPE`` key on :meth:`Config.from_dotenv`); this is the readback of that selection. Read-only: the selector is chosen by the environment-tier factories, not assigned directly. Mirrors the ``mdds_type`` string the inline :class:`Client` constructor accepts."""
     wait_strategy: Literal["low_latency", "balanced", "efficient", "busy_spin"]
     """Streaming event-ring consumer wait strategy — the latency-vs-CPU knob applied on each ring-empty poll. ``"low_latency"`` (default) never sleeps; ``"balanced"`` parks briefly; ``"efficient"`` parks longer; ``"busy_spin"`` pure-spins and pins a core. The setter accepts the same strings case-insensitively and raises ``ValueError`` otherwise."""
     wait_spin_iters: int

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -1192,6 +1192,18 @@ impl Config {
         }
     }
 
+    /// Target server environment carried by this configuration:
+    /// ``"PROD"`` for the production cluster, ``"STAGE"`` for staging.
+    /// Set as a unit by :meth:`Config.production` / :meth:`Config.stage`
+    /// (and by the ``THETADATA_MDDS_TYPE`` key on :meth:`Config.from_dotenv`);
+    /// this is the readback of that selection. Mirrors the ``mdds_type``
+    /// string the inline ``Client`` constructor accepts.
+    #[getter]
+    fn get_environment(&self) -> &'static str {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.environment().as_str()
+    }
+
     /// Set the streaming event-ring consumer wait strategy — the
     /// latency-vs-CPU knob applied on each ring-empty poll.
     ///

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -214,6 +214,19 @@ impl Credentials {
         }
     }
 
+    /// Source credentials strictly from the ``THETADATA_API_KEY``
+    /// environment variable.
+    ///
+    /// Strict: an unset or whitespace-only value raises ``ConfigError``
+    /// rather than falling back, and there is no ``creds.txt`` file
+    /// fallback. Use :meth:`from_env_or_file` when a file fallback is
+    /// wanted instead.
+    #[staticmethod]
+    fn from_env() -> PyResult<Self> {
+        let inner = auth::Credentials::from_env().map_err(to_py_err)?;
+        Ok(Self { inner })
+    }
+
     /// Source credentials from the environment, falling back to a
     /// credentials file.
     ///

--- a/sdks/python/tests/test_api_key_credentials.py
+++ b/sdks/python/tests/test_api_key_credentials.py
@@ -29,6 +29,27 @@ def test_from_api_key_with_email_builds_credentials(mod) -> None:
     assert creds is not None
 
 
+def test_from_env_sources_strictly_from_env(mod, monkeypatch) -> None:
+    monkeypatch.setenv("THETADATA_API_KEY", "env-sourced-key")
+    creds = mod.Credentials.from_env()
+    assert creds is not None
+    # The strict env factory holds the key as secret material; the repr
+    # never exposes it.
+    rendered = repr(creds)
+    assert "env-sourced-key" not in rendered
+    assert "<redacted>" in rendered
+
+
+def test_from_env_strict_raises_when_unset(mod, monkeypatch) -> None:
+    # Strict: an unset THETADATA_API_KEY raises, with NO creds.txt fallback.
+    # The strict-unset case is an invalid-parameter config fault, a subclass
+    # of the binding's ThetaDataError base (the same base ConfigError derives
+    # from), so a `except ThetaDataError` clause covers it.
+    monkeypatch.delenv("THETADATA_API_KEY", raising=False)
+    with pytest.raises(mod.ThetaDataError):
+        mod.Credentials.from_env()
+
+
 def test_from_env_or_file_sources_from_env(mod, monkeypatch) -> None:
     monkeypatch.setenv("THETADATA_API_KEY", "env-sourced-key")
     creds = mod.Credentials.from_env_or_file("/nonexistent/creds.txt")

--- a/sdks/python/tests/test_config_environment.py
+++ b/sdks/python/tests/test_config_environment.py
@@ -1,0 +1,28 @@
+"""Round-trip tests for the Config.environment readback getter."""
+from __future__ import annotations
+
+import pytest
+
+try:
+    import thetadatadx as client
+except ImportError:
+    pytest.skip(
+        "thetadatadx native extension not built; run `maturin develop` from sdks/python/",
+        allow_module_level=True,
+    )
+
+
+def test_production_reads_back_prod():
+    cfg = client.Config.production()
+    assert cfg.environment == "PROD"
+
+
+def test_stage_reads_back_stage():
+    cfg = client.Config.stage()
+    assert cfg.environment == "STAGE"
+
+
+def test_environment_is_read_only():
+    cfg = client.Config.production()
+    with pytest.raises(AttributeError):
+        cfg.environment = "STAGE"

--- a/sdks/typescript/__tests__/api_key_credentials.test.mjs
+++ b/sdks/typescript/__tests__/api_key_credentials.test.mjs
@@ -33,6 +33,30 @@ describe('Credentials API-key factories', () => {
     assert.ok(creds, 'fromApiKeyWithEmail should return a Credentials handle');
   });
 
+  it('sources credentials strictly from THETADATA_API_KEY', () => {
+    process.env.THETADATA_API_KEY = 'env-sourced-key';
+    try {
+      const creds = mod.Credentials.fromEnv();
+      assert.ok(creds, 'fromEnv should source the API key from the env');
+      const rendered = creds.toString();
+      assert.ok(
+        !rendered.includes('env-sourced-key'),
+        `toString leaked the env API key: ${rendered}`,
+      );
+      assert.ok(rendered.includes('<redacted>'));
+    } finally {
+      delete process.env.THETADATA_API_KEY;
+    }
+  });
+
+  it('rejects strict fromEnv when the env is unset (no file fallback)', () => {
+    delete process.env.THETADATA_API_KEY;
+    assert.throws(
+      () => mod.Credentials.fromEnv(),
+      'fromEnv should throw when THETADATA_API_KEY is unset',
+    );
+  });
+
   it('sources credentials from the environment, falling back to a file', () => {
     process.env.THETADATA_API_KEY = 'env-sourced-key';
     try {

--- a/sdks/typescript/__tests__/config_environment.test.mjs
+++ b/sdks/typescript/__tests__/config_environment.test.mjs
@@ -1,0 +1,19 @@
+// Config.environment readback getter - TypeScript binding smoke test.
+//
+// The production / stage presets select the target cluster as a unit; the
+// `environment` getter reads that selection back as a `"PROD"` / `"STAGE"`
+// string, mirroring the `mddsType` selector the inline `Client.connectWith`
+// factory accepts.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Config } from '../index.js';
+
+test('production() reads back PROD', () => {
+  const cfg = Config.production();
+  assert.equal(cfg.environment, 'PROD');
+});
+
+test('stage() reads back STAGE', () => {
+  const cfg = Config.stage();
+  assert.equal(cfg.environment, 'STAGE');
+});

--- a/sdks/typescript/__tests__/connect_with_options.test.mjs
+++ b/sdks/typescript/__tests__/connect_with_options.test.mjs
@@ -1,0 +1,115 @@
+// Client.connectWith({ ... }) options contract - TypeScript binding guard.
+//
+// Mirrors the Python `tests/test_inline_client_construction.py` pattern:
+// the connectWith factory resolves the authentication fields (and the
+// environment) and rejects a conflicting / absent / unparseable option set
+// with a `[ConfigError]` BEFORE any network round-trip, so every field can
+// be pinned by name offline. A field that was renamed or dropped on the
+// `ClientConnectOptions` napi object would be silently ignored by napi
+// (the value arrives as `undefined`), which changes the rejection reason,
+// so each assertion below fails loud on option-contract drift rather than
+// silently passing.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+let mod;
+try {
+  mod = await import('../index.js');
+} catch {
+  console.error('FAIL: native addon not built; run `npm run build` first');
+  process.exit(1);
+}
+
+const { Client } = mod;
+
+// The "no authentication field set" reason fires only when the auth-field
+// count resolves to zero. If a named auth field is wired and parsed, the
+// resolver enters that field's branch and fails for a DIFFERENT reason
+// (a missing env var / missing file), so the absence of this exact reason
+// is the proof the field reached the resolver under its declared name.
+const NO_AUTH_RE = /no authentication field set/;
+
+async function rejectionMessage(promise) {
+  try {
+    await promise;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new assert.AssertionError({
+    message: 'expected connectWith(...) to reject, but it resolved',
+  });
+}
+
+describe('Client.connectWith options contract', () => {
+  it('rejects an empty option set with no auth field', async () => {
+    const message = await rejectionMessage(Client.connectWith({}));
+    assert.match(message, /\[ConfigError\]/);
+    assert.match(message, NO_AUTH_RE);
+  });
+
+  it('wires apiKey + email + password (conflict rejects)', async () => {
+    // apiKey alongside the email/password pair is a conflict, so all three
+    // fields must reach the resolver by name for the conflict to be seen.
+    // A dropped field would drop the conflict and change the outcome.
+    const message = await rejectionMessage(
+      Client.connectWith({ apiKey: 'td1_dummy_key', email: 'you@example.com', password: 'secret' }),
+    );
+    assert.match(message, /\[ConfigError\]/);
+    assert.match(message, /conflicting authentication fields/);
+  });
+
+  it('wires email without password (incomplete pair rejects)', async () => {
+    // email alone (no password) is the email/password method with a
+    // missing half, proving both `email` and `password` are wired: a
+    // dropped `email` would instead surface "no authentication field set".
+    const message = await rejectionMessage(
+      Client.connectWith({ email: 'you@example.com' }),
+    );
+    assert.match(message, /\[ConfigError\]/);
+    assert.doesNotMatch(message, NO_AUTH_RE);
+    assert.match(message, /email\/password/);
+  });
+
+  it('wires and parses mddsType (bad selector rejects)', async () => {
+    // A valid single auth field plus a bogus mddsType reaches the env
+    // parse step, so the rejection is the mddsType parse error, proving
+    // mddsType is both wired and parsed. A dropped mddsType would let the
+    // call past validation into a network-class failure instead.
+    const message = await rejectionMessage(
+      Client.connectWith({ apiKey: 'td1_dummy_key', mddsType: 'BOGUS' }),
+    );
+    assert.match(message, /\[ConfigError\]/);
+    assert.match(message, /mddsType/);
+  });
+
+  it('accepts apiKeyFromEnv by name (strict env source)', async () => {
+    // With THETADATA_API_KEY unset, apiKeyFromEnv reaches the strict env
+    // source and fails because the var is absent, NOT "no authentication
+    // field set". A dropped/renamed field would be ignored by napi and the
+    // option set would resolve to zero auth fields, flipping the message.
+    const prev = process.env.THETADATA_API_KEY;
+    delete process.env.THETADATA_API_KEY;
+    try {
+      const message = await rejectionMessage(
+        Client.connectWith({ apiKeyFromEnv: true }),
+      );
+      assert.doesNotMatch(message, NO_AUTH_RE);
+    } finally {
+      if (prev !== undefined) process.env.THETADATA_API_KEY = prev;
+    }
+  });
+
+  it('accepts apiKeyFromDotenv by name (missing file rejects, not "no auth")', async () => {
+    const message = await rejectionMessage(
+      Client.connectWith({ apiKeyFromDotenv: '/nonexistent/connect-with.env' }),
+    );
+    assert.doesNotMatch(message, NO_AUTH_RE);
+  });
+
+  it('accepts credentialsFile by name (missing file rejects, not "no auth")', async () => {
+    const message = await rejectionMessage(
+      Client.connectWith({ credentialsFile: '/nonexistent/creds.txt' }),
+    );
+    assert.doesNotMatch(message, NO_AUTH_RE);
+  });
+});

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -710,6 +710,14 @@ export declare class Credentials {
    */
   static fromApiKeyWithEmail(email: string, apiKey: string): Credentials
   /**
+   * Source credentials strictly from the `THETADATA_API_KEY`
+   * environment variable. Strict: an unset or whitespace-only value
+   * rejects with `[ConfigError]` rather than falling back, and there is
+   * no `creds.txt` file fallback. Use `fromEnvOrFile` when a file
+   * fallback is wanted instead.
+   */
+  static fromEnv(): Credentials
+  /**
    * Source credentials from the environment, falling back to a file.
    * When `THETADATA_API_KEY` is set and non-empty an API key is used;
    * otherwise the two-line file at `path` is read.

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -561,6 +561,15 @@ export declare class Config {
    */
   get flushMode(): string
   /**
+   * Target server environment carried by this configuration: `"PROD"`
+   * for the production cluster, `"STAGE"` for staging. Set as a unit by
+   * `Config.production()` / `Config.stage()` (and by the
+   * `THETADATA_MDDS_TYPE` key on `Config.fromDotenv`); this is the
+   * readback of that selection. Mirrors the `mddsType` string the inline
+   * `Client.connectWith` factory accepts.
+   */
+  get environment(): string
+  /**
    * Set the streaming event-ring consumer wait strategy — the
    * latency-vs-CPU knob applied on each ring-empty poll.
    *

--- a/sdks/typescript/src/config_class.rs
+++ b/sdks/typescript/src/config_class.rs
@@ -1585,6 +1585,21 @@ impl Config {
         })
     }
 
+    /// Target server environment carried by this configuration: `"PROD"`
+    /// for the production cluster, `"STAGE"` for staging. Set as a unit by
+    /// `Config.production()` / `Config.stage()` (and by the
+    /// `THETADATA_MDDS_TYPE` key on `Config.fromDotenv`); this is the
+    /// readback of that selection. Mirrors the `mddsType` string the inline
+    /// `Client.connectWith` factory accepts.
+    #[napi(getter, js_name = "environment")]
+    pub fn environment(&self) -> napi::Result<&'static str> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| napi::Error::from_reason("Config mutex poisoned"))?;
+        Ok(guard.environment().as_str())
+    }
+
     /// Set the streaming event-ring consumer wait strategy — the
     /// latency-vs-CPU knob applied on each ring-empty poll.
     ///

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -147,6 +147,17 @@ impl Credentials {
         }
     }
 
+    /// Source credentials strictly from the `THETADATA_API_KEY`
+    /// environment variable. Strict: an unset or whitespace-only value
+    /// rejects with `[ConfigError]` rather than falling back, and there is
+    /// no `creds.txt` file fallback. Use `fromEnvOrFile` when a file
+    /// fallback is wanted instead.
+    #[napi(factory, js_name = "fromEnv")]
+    pub fn from_env() -> napi::Result<Credentials> {
+        let inner = auth::Credentials::from_env().map_err(to_napi_err)?;
+        Ok(Credentials { inner })
+    }
+
     /// Source credentials from the environment, falling back to a file.
     /// When `THETADATA_API_KEY` is set and non-empty an API key is used;
     /// otherwise the two-line file at `path` is read.


### PR DESCRIPTION
An independent audit of the just-merged staging plus first-class client-builder feature found five real issues. This branch fixes all of them with regression tests.

## Fixes

1. `Config::from_dotenv()` no longer leaks the ambient process env. It now builds from the hardcoded production defaults rather than `production()`, so a file-sourced config is deterministic from defaults plus the file. A `.env` selecting `PROD` resolves to the prod cluster even when the shell sets `THETADATA_MDDS_TYPE=STAGE` or a stray `THETADATA_HISTORICAL_HOST`.

2. `DirectConfig::dev()` resets the full cluster routing to prod before overriding the streaming hosts. Previously, when `production()` had applied `THETADATA_MDDS_TYPE=STAGE`, `dev()` flipped only the environment marker back to `Prod` and left the historical host on the stage cluster. It now re-points the marker and the historical host together via `apply_environment(Prod)`. `stage()` is confirmed to stay fully Stage regardless of the env var.

3. The C++ `ClientBuilder` minimizes plaintext secret lifetime. The inline secret strings are wiped immediately after `connect()` consumes them and in the destructor, and the strict env resolver wipes its transient string after building the credential. The Rust core stays the zeroizing authority since the C ABI boundary takes `const char*`, documented in a comment.

4. The C++ `ClientBuilder` is now move-only. Copy construction and assignment are deleted, so a copy can no longer duplicate inline secrets or observe moved-from credential and config state after `connect()` ran on a sibling. The fluent rvalue chain and a `std::move` handover both stay valid; a `static_assert` pins non-copyability.

5. The strict env-only credential resolver is now reachable at the C ABI. A new `thetadatadx_credentials_from_env` symbol delegates to `Credentials::from_env()` (error on unset or empty, no `creds.txt` fallback), declared in the C header and surfaced as a `Credentials::from_env()` static in the C++ header, with matching parity rows.

## Tests

- Rust: `.env` selecting `PROD` ignores ambient `STAGE`; a no-cluster-key `.env` ignores the ambient env; `dev()` yields prod host plus dev streaming hosts under `STAGE`; `stage()` stays Stage under `PROD`. Env-var tests serialize through the existing process-global guard.
- FFI: strict `thetadatadx_credentials_from_env` returns a null handle when the var is unset.
- C++: `Credentials::from_env` source and unset-throws cases, plus a non-copyable type-trait check.

## Gates

`cargo fmt`, `clippy -D warnings`, both rustdoc gates, binding parity (plus selftest), C ABI completeness (the new symbol is exported and declared), no-re-framing, public-surface-leak, docs-consistency, the SDK-surface and docs-site `--check` generators, `g++ -fsyntax-only` on the headers, and the C++ offline test suite via ctest all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)