### PR TITLE
fix: correctness and CI-guard completeness across config, auth, streaming, and docs

### DIFF
--- a/crates/thetadatadx/build_support/endpoints/render/mdds.rs
+++ b/crates/thetadatadx/build_support/endpoints/render/mdds.rs
@@ -42,29 +42,27 @@ pub(super) fn generate_mdds_list_endpoint(out: &mut String, endpoint: &Generated
         .map(|param| format!("{}: &str", direct_method_arg_name(endpoint, param)))
         .collect::<Vec<_>>()
         .join(", ");
+    let list_column = endpoint
+        .list_column
+        .as_deref()
+        .expect("list endpoint must declare list_column");
+    // Emit the base method name plus the `<name>_with_deadline` overload
+    // name. `macro_rules!` cannot concatenate identifiers, so the explicit
+    // overload identifier is passed as a token here, keeping the macro a
+    // pure template. This mirrors the builder endpoints, which expose the
+    // same per-call deadline contract.
+    let with_deadline_fn = format!("{}_with_deadline", endpoint.name);
     if signature.is_empty() {
-        writeln!(
-            out,
-            "    fn {}() -> {:?};",
-            endpoint.name,
-            endpoint
-                .list_column
-                .as_deref()
-                .expect("list endpoint must declare list_column")
-        )
-        .unwrap();
+        writeln!(out, "    fn {}() -> {list_column:?};", endpoint.name).unwrap();
     } else {
         writeln!(
             out,
-            "    fn {}({signature}) -> {:?};",
-            endpoint.name,
-            endpoint
-                .list_column
-                .as_deref()
-                .expect("list endpoint must declare list_column")
+            "    fn {}({signature}) -> {list_column:?};",
+            endpoint.name
         )
         .unwrap();
     }
+    writeln!(out, "    with_deadline_fn: {with_deadline_fn};").unwrap();
 
     writeln!(out, "    grpc: {};", endpoint.grpc_name).unwrap();
     writeln!(out, "    request: {};", endpoint.request_type).unwrap();

--- a/crates/thetadatadx/src/auth/nexus.rs
+++ b/crates/thetadatadx/src/auth/nexus.rs
@@ -374,11 +374,6 @@ fn auth_tls_config() -> Result<rustls::ClientConfig, Error> {
     Ok(config)
 }
 
-/// Maximum number of characters from an upstream response body carried into
-/// a surfaced error. Bounds the untrusted excerpt so it cannot flood logs
-/// or smuggle a large payload through the error chain.
-const MAX_BODY_EXCERPT_CHARS: usize = 256;
-
 /// Render a non-reversible marker for a session id.
 ///
 /// The session id is a bearer token and must never appear verbatim in a
@@ -388,16 +383,18 @@ fn redacted_session_marker() -> &'static str {
     "redacted"
 }
 
-/// Produce a bounded excerpt of an untrusted upstream body.
+/// Build the surfaced message for a non-401/404 auth failure.
 ///
-/// Keeps at most [`MAX_BODY_EXCERPT_CHARS`] characters and appends an
-/// ellipsis marker when truncated. Operates on a `char` boundary so the
-/// result is always valid UTF-8.
-fn bound_body_excerpt(body: &str) -> String {
-    match body.char_indices().nth(MAX_BODY_EXCERPT_CHARS) {
-        Some((cut, _)) => format!("{}...", &body[..cut]),
-        None => body.to_string(),
-    }
+/// The message is a pure function of the HTTP status — it never takes the
+/// upstream response body as input, so it cannot mirror a credential that a
+/// proxy or Nexus error reflected back from the submitted auth request. This
+/// is the boundary that keeps the secret out of the error chain by
+/// construction.
+fn server_error_message(status: reqwest::StatusCode) -> String {
+    format!(
+        "authentication failed (server returned HTTP {})",
+        status.as_u16()
+    )
 }
 
 /// Authenticate against the Nexus API and return the session info.
@@ -527,20 +524,15 @@ pub async fn authenticate_at(
         });
     }
     if !status.is_success() {
-        let body_text = resp
-            .text()
-            .await
-            .unwrap_or_else(|_| "<unreadable>".to_string());
-        // The upstream body is untrusted and unbounded — it may carry
-        // arbitrary (or hostile) text. Carry only a bounded excerpt into
-        // the surfaced error so it cannot flood logs or smuggle a large
-        // payload through the error chain.
+        // The auth REQUEST body carries the credential (password / apiKey).
+        // A proxy or Nexus error that reflects the submitted JSON would
+        // otherwise mirror that secret into the surfaced error and any
+        // caller log. Carry only the HTTP status — never the upstream
+        // response body — so the error can never interpolate untrusted text
+        // that might echo a credential. (`resp` is dropped unread.)
         return Err(Error::Auth {
             kind: crate::error::AuthErrorKind::ServerError,
-            message: format!(
-                "Nexus API returned HTTP {status}: {}",
-                bound_body_excerpt(&body_text)
-            ),
+            message: server_error_message(status),
         });
     }
 
@@ -698,30 +690,24 @@ mod tests {
     }
 
     #[test]
-    fn bound_body_excerpt_truncates_oversized_body() {
-        let body = "x".repeat(MAX_BODY_EXCERPT_CHARS * 4);
-        let excerpt = bound_body_excerpt(&body);
-        assert!(excerpt.ends_with("..."), "missing truncation marker");
+    fn server_error_message_carries_status_not_body() {
+        // A non-401/404 auth failure must surface only the HTTP status. The
+        // upstream body can mirror the submitted auth request (which carries
+        // the password / apiKey); the message is a pure function of the
+        // status and never accepts that body, so a secret can never reach
+        // the error chain on this path.
+        let msg = server_error_message(reqwest::StatusCode::INTERNAL_SERVER_ERROR);
         assert!(
-            excerpt.chars().count() <= MAX_BODY_EXCERPT_CHARS + 3,
-            "excerpt exceeds bound: {} chars",
-            excerpt.chars().count()
+            msg.contains("500"),
+            "status code missing from message: {msg}"
         );
-    }
-
-    #[test]
-    fn bound_body_excerpt_passes_through_short_body() {
-        let body = "upstream is down";
-        assert_eq!(bound_body_excerpt(body), body);
-    }
-
-    #[test]
-    fn bound_body_excerpt_respects_char_boundaries() {
-        // Multi-byte characters must not be split mid-codepoint.
-        let body = "é".repeat(MAX_BODY_EXCERPT_CHARS * 2);
-        let excerpt = bound_body_excerpt(&body);
-        assert!(excerpt.ends_with("..."), "missing truncation marker");
-        // If a byte boundary had been used this would have panicked above.
+        // Stand-ins for a reflected credential or any upstream body text.
+        for leaked in ["hunter2", "td_secret_apikey", "password", "apiKey", "email"] {
+            assert!(
+                !msg.contains(leaked),
+                "message must not carry body-derived text {leaked:?}: {msg}"
+            );
+        }
     }
 
     #[test]

--- a/crates/thetadatadx/src/client_builder.rs
+++ b/crates/thetadatadx/src/client_builder.rs
@@ -323,8 +323,26 @@ impl ClientBuilder {
         // Surface a deferred conflict (two different auth sources) as a
         // clear error before resolving anything.
         let auth = auth.into_resolved_source()?;
-        let creds = auth.resolve()?;
-        let config = self.env.resolve()?;
+        let env = self.env;
+        // The file-backed sources (`credentials_file`, `api_key_from_dotenv`,
+        // `from_dotenv`) read from disk with synchronous `std::fs`. Running
+        // that on the async worker would block the runtime thread, so resolve
+        // both the credential and the config on a blocking-pool thread. The
+        // inline sources (`api_key`, `email_password`, an explicit env)
+        // perform no I/O and resolve there for free. Behavior and errors are
+        // identical to resolving inline — only the thread differs.
+        let (creds, config) = tokio::task::spawn_blocking(move || {
+            let creds = auth.resolve()?;
+            let config = env.resolve()?;
+            Ok::<(Credentials, DirectConfig), Error>((creds, config))
+        })
+        .await
+        .map_err(|e| {
+            // The closure never panics on the resolution paths; a join error
+            // here means the blocking task was cancelled or the worker
+            // panicked, which is an internal invariant violation.
+            Error::config_internal(format!("credential resolution task failed to join: {e}"))
+        })??;
         Client::connect(&creds, config).await
     }
 }
@@ -479,6 +497,33 @@ mod tests {
         assert!(msg.contains("conflicting authentication"), "got: {msg}");
         assert!(msg.contains("api_key"), "got: {msg}");
         assert!(msg.contains("email_password"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn file_backed_source_resolution_error_surfaces_through_connect() {
+        // `connect()` resolves the file-backed credential on a blocking-pool
+        // thread (so the synchronous `std::fs` read never blocks the async
+        // worker). The resolution error must surface unchanged — identical to
+        // resolving the same source inline.
+        let missing = std::env::temp_dir().join(format!(
+            "thetadatadx-no-such-creds-{}.txt",
+            std::process::id()
+        ));
+        // Inline resolution (the test-only path) for the same source.
+        let inline_err = resolve(ClientBuilder::new().credentials_file(&missing))
+            .expect_err("missing credentials file must error inline");
+        // Resolution routed through connect()'s spawn_blocking offload.
+        let connect_err = match ClientBuilder::new()
+            .credentials_file(&missing)
+            .connect()
+            .await
+        {
+            Ok(_) => panic!("expected an error for a missing credentials file"),
+            Err(e) => e,
+        };
+        // Same surfaced message — the offload changes the thread, not the
+        // error.
+        assert_eq!(inline_err.to_string(), connect_err.to_string());
     }
 
     #[test]

--- a/crates/thetadatadx/src/config/env.rs
+++ b/crates/thetadatadx/src/config/env.rs
@@ -19,9 +19,12 @@ use super::{DirectConfig, Environment};
 /// Target server environment selector (`PROD` / `STAGE`, case-insensitive).
 /// Equivalent to ThetaData's `mdds_type` option. `STAGE` points every
 /// cluster-bound channel at the staging environment; `PROD` (or unset)
-/// keeps production. Applied before the explicit host overrides below, so
-/// an explicit `THETADATA_HISTORICAL_HOST` / `THETADATA_STREAMING_HOST`
-/// still wins over the environment default.
+/// keeps production. The explicit host/port overrides are recorded first
+/// and the environment is selected last, so an explicit
+/// `THETADATA_HISTORICAL_HOST` / `THETADATA_STREAMING_HOST` /
+/// `THETADATA_STREAMING_PORT` patches the selected environment's cluster
+/// (the failover hosts still track that environment) rather than being
+/// overwritten by it.
 pub const ENV_MDDS_TYPE: &str = "THETADATA_MDDS_TYPE";
 
 /// Historical host.
@@ -30,10 +33,12 @@ pub const ENV_HISTORICAL_HOST: &str = "THETADATA_HISTORICAL_HOST";
 pub const ENV_HISTORICAL_PORT: &str = "THETADATA_HISTORICAL_PORT";
 /// Nexus auth base URL override.
 pub const ENV_NEXUS_URL: &str = "THETADATA_NEXUS_URL";
-/// Streaming hostname override. Replaces the primary streaming host slot;
-/// fallback hosts are preserved.
+/// Streaming hostname override. Replaces the host of the primary streaming
+/// slot; the selected environment's failover hosts are preserved.
 pub const ENV_STREAMING_HOST: &str = "THETADATA_STREAMING_HOST";
-/// Streaming port override. Pairs with [`ENV_STREAMING_HOST`].
+/// Streaming port override. Replaces the port of the primary streaming slot
+/// independently of [`ENV_STREAMING_HOST`]: a port-only override keeps the
+/// selected environment's primary host and only re-points its port.
 pub const ENV_STREAMING_PORT: &str = "THETADATA_STREAMING_PORT";
 /// `QueryInfo.client_type` override — steer server-side quotas and
 /// dashboards to treat a deployment as a named fleet.
@@ -43,25 +48,13 @@ pub const ENV_CLIENT_TYPE: &str = "THETADATA_CLIENT_TYPE";
 /// receiver. Unknown / malformed values are logged and skipped so a
 /// typo never silently flips production to the wrong endpoint.
 pub(super) fn apply_env_overrides(cfg: &mut DirectConfig) {
-    // Environment selector first, so it sets the cluster default before
-    // the explicit host overrides below — an explicit host:port always
-    // wins over the environment default. An empty value is treated as
-    // unset; an unrecognized value is logged and skipped (lenient, matching
-    // the malformed-port handling) so a typo never silently flips the
-    // cluster to the wrong endpoint.
-    if let Ok(mdds_type) = std::env::var(ENV_MDDS_TYPE) {
-        let trimmed = mdds_type.trim();
-        if !trimmed.is_empty() {
-            match Environment::parse(trimmed) {
-                Some(env) => cfg.apply_environment(env),
-                None => tracing::warn!(
-                    env = ENV_MDDS_TYPE,
-                    value = %mdds_type,
-                    "ignoring unrecognized env var (expected PROD or STAGE); keeping current environment"
-                ),
-            }
-        }
-    }
+    // Record the explicit host/port overrides into the typed override fields
+    // FIRST, then select the environment LAST: `apply_environment` rebuilds
+    // the cluster routing from the selected environment and patches the
+    // recorded overrides on top, so an explicit host:port always wins over
+    // the environment default while the environment's failover hosts are
+    // preserved. Recording before selecting is what lets the override survive
+    // the environment rewrite (and a later `with_environment` switch).
     if let Ok(host) = std::env::var(ENV_HISTORICAL_HOST) {
         let trimmed = host.trim();
         if !trimmed.is_empty() {
@@ -90,45 +83,51 @@ pub(super) fn apply_env_overrides(cfg: &mut DirectConfig) {
             cfg.auth.client_type = trimmed.to_string();
         }
     }
-    // Streaming host/port are mirrored as a (host, port) tuple in the
-    // primary slot. If only one of the pair is set we keep the
-    // default for the other half rather than guessing.
-    let env_host = std::env::var(ENV_STREAMING_HOST).ok();
-    let env_port = std::env::var(ENV_STREAMING_PORT).ok();
-    if env_host.is_some() || env_port.is_some() {
-        if cfg.streaming.hosts.is_empty() {
-            // Empty defaults would mean "no primary to override".
-            // Skip silently — production_defaults seeds 4 hosts, so
-            // this only fires for hand-built configs.
-            tracing::warn!(
-                "ignoring THETADATA_STREAMING_HOST / THETADATA_STREAMING_PORT; \
-                 DirectConfig has no streaming hosts to override"
-            );
-        } else {
-            let (default_host, default_port) = cfg.streaming.hosts[0].clone();
-            let host = env_host
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map_or(default_host, str::to_string);
-            let port = env_port
-                .as_deref()
-                .and_then(|raw| match raw.trim().parse::<u16>() {
-                    Ok(p) if p > 0 => Some(p),
-                    _ => {
-                        tracing::warn!(
-                            env = ENV_STREAMING_PORT,
-                            value = %raw,
-                            "ignoring malformed env var; keeping hardcoded default"
-                        );
-                        None
-                    }
-                })
-                .unwrap_or(default_port);
-            cfg.streaming.hosts[0] = (host, port);
-            cfg.mark_streaming_hosts_overridden();
+    // Streaming host and port are independent overrides of the primary slot:
+    // a host-only override keeps the environment's primary port, a port-only
+    // override keeps the environment's primary host cluster, and the
+    // environment's failover hosts are always preserved. Recording the port
+    // alone must NOT suppress the host rebuild.
+    if let Ok(host) = std::env::var(ENV_STREAMING_HOST) {
+        let trimmed = host.trim();
+        if !trimmed.is_empty() {
+            cfg.set_streaming_primary_host_override(trimmed.to_string());
         }
     }
+    if let Ok(port_str) = std::env::var(ENV_STREAMING_PORT) {
+        match port_str.trim().parse::<u16>() {
+            Ok(port) if port > 0 => cfg.set_streaming_primary_port_override(port),
+            _ => tracing::warn!(
+                env = ENV_STREAMING_PORT,
+                value = %port_str,
+                "ignoring malformed env var; keeping hardcoded default"
+            ),
+        }
+    }
+
+    // Environment selector last: rebuild the cluster routing for the selected
+    // environment, applying the overrides recorded above. An empty value is
+    // treated as unset; an unrecognized value is logged and skipped (lenient,
+    // matching the malformed-port handling) so a typo never silently flips
+    // the cluster to the wrong endpoint. When no (or an unrecognized)
+    // selector is present we still re-apply the CURRENT environment so a host
+    // override recorded above patches the existing cluster.
+    let selected = match std::env::var(ENV_MDDS_TYPE) {
+        Ok(mdds_type) if !mdds_type.trim().is_empty() => match Environment::parse(mdds_type.trim())
+        {
+            Some(env) => env,
+            None => {
+                tracing::warn!(
+                    env = ENV_MDDS_TYPE,
+                    value = %mdds_type,
+                    "ignoring unrecognized env var (expected PROD or STAGE); keeping current environment"
+                );
+                cfg.environment
+            }
+        },
+        _ => cfg.environment,
+    };
+    cfg.apply_environment(selected);
 }
 
 /// Apply the environment-selector and host overrides carried by a parsed
@@ -149,33 +148,47 @@ pub(super) fn apply_env_overrides(cfg: &mut DirectConfig) {
 pub(super) fn apply_dotenv_overrides(cfg: &mut DirectConfig, pairs: &[(String, &str)]) {
     use crate::auth::dotenv::lookup;
 
-    // Environment selector first, so it sets the cluster default before the
-    // explicit host override below — an explicit host always wins over the
-    // environment default. An empty value reads as unset; an unrecognized
-    // value is logged and skipped (lenient, matching the process-env path).
-    if let Some(mdds_type) = lookup(pairs, ENV_MDDS_TYPE) {
-        match Environment::parse(mdds_type) {
-            Some(env) => cfg.apply_environment(env),
-            None => tracing::warn!(
-                env = ENV_MDDS_TYPE,
-                value = %mdds_type,
-                "ignoring unrecognized .env value (expected PROD or STAGE); keeping current environment"
-            ),
-        }
-    }
+    // Mirror the process-env path: record the explicit host/port overrides
+    // FIRST, then select the environment LAST so `apply_environment` rebuilds
+    // the cluster routing and patches the overrides on top. An explicit host
+    // wins over the environment default while the environment's failover hosts
+    // are preserved. `lookup` already returns trimmed, non-empty values.
     if let Some(host) = lookup(pairs, ENV_HISTORICAL_HOST) {
         cfg.set_historical_host_override(host.to_string());
     }
     if let Some(host) = lookup(pairs, ENV_STREAMING_HOST) {
-        if cfg.streaming.hosts.is_empty() {
-            tracing::warn!(
-                "ignoring THETADATA_STREAMING_HOST from .env; \
-                 DirectConfig has no streaming hosts to override"
-            );
-        } else {
-            let port = cfg.streaming.hosts[0].1;
-            cfg.streaming.hosts[0] = (host.to_string(), port);
-            cfg.mark_streaming_hosts_overridden();
+        cfg.set_streaming_primary_host_override(host.to_string());
+    }
+    if let Some(port_str) = lookup(pairs, ENV_STREAMING_PORT) {
+        match port_str.parse::<u16>() {
+            Ok(port) if port > 0 => cfg.set_streaming_primary_port_override(port),
+            _ => tracing::warn!(
+                env = ENV_STREAMING_PORT,
+                value = %port_str,
+                "ignoring malformed .env value; keeping hardcoded default"
+            ),
         }
     }
+
+    // Environment selector last: rebuild the cluster routing for the selected
+    // environment, applying the overrides recorded above. An empty value
+    // reads as unset; an unrecognized value is logged and skipped (lenient,
+    // matching the process-env path). When no (or an unrecognized) selector is
+    // present we re-apply the CURRENT environment so a host override recorded
+    // above patches the existing cluster.
+    let selected = match lookup(pairs, ENV_MDDS_TYPE) {
+        Some(mdds_type) => match Environment::parse(mdds_type) {
+            Some(env) => env,
+            None => {
+                tracing::warn!(
+                    env = ENV_MDDS_TYPE,
+                    value = %mdds_type,
+                    "ignoring unrecognized .env value (expected PROD or STAGE); keeping current environment"
+                );
+                cfg.environment
+            }
+        },
+        None => cfg.environment,
+    };
+    cfg.apply_environment(selected);
 }

--- a/crates/thetadatadx/src/config/env.rs
+++ b/crates/thetadatadx/src/config/env.rs
@@ -65,7 +65,7 @@ pub(super) fn apply_env_overrides(cfg: &mut DirectConfig) {
     if let Ok(host) = std::env::var(ENV_HISTORICAL_HOST) {
         let trimmed = host.trim();
         if !trimmed.is_empty() {
-            cfg.historical.host = trimmed.to_string();
+            cfg.set_historical_host_override(trimmed.to_string());
         }
     }
     if let Ok(port_str) = std::env::var(ENV_HISTORICAL_PORT) {
@@ -126,6 +126,7 @@ pub(super) fn apply_env_overrides(cfg: &mut DirectConfig) {
                 })
                 .unwrap_or(default_port);
             cfg.streaming.hosts[0] = (host, port);
+            cfg.mark_streaming_hosts_overridden();
         }
     }
 }
@@ -163,7 +164,7 @@ pub(super) fn apply_dotenv_overrides(cfg: &mut DirectConfig, pairs: &[(String, &
         }
     }
     if let Some(host) = lookup(pairs, ENV_HISTORICAL_HOST) {
-        cfg.historical.host = host.to_string();
+        cfg.set_historical_host_override(host.to_string());
     }
     if let Some(host) = lookup(pairs, ENV_STREAMING_HOST) {
         if cfg.streaming.hosts.is_empty() {
@@ -174,6 +175,7 @@ pub(super) fn apply_dotenv_overrides(cfg: &mut DirectConfig, pairs: &[(String, &
         } else {
             let port = cfg.streaming.hosts[0].1;
             cfg.streaming.hosts[0] = (host.to_string(), port);
+            cfg.mark_streaming_hosts_overridden();
         }
     }
 }

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -102,24 +102,29 @@ pub use crate::backoff::JitterMode;
 /// | `THETADATA_EMAIL`       | str | credential helper ([`crate::auth`]) |
 /// | `THETADATA_PASSWORD`    | str | credential helper ([`crate::auth`]) |
 ///
-/// `THETADATA_MDDS_TYPE` is applied first and sets the cluster default
-/// (historical host + streaming hosts) for the selected environment; the
-/// explicit `THETADATA_HISTORICAL_HOST` / `THETADATA_STREAMING_HOST`
-/// overrides are layered on top, so an explicit host still wins over the
-/// environment default. It is independent of the credential — it works the
-/// same with either an api-key or an email/password login. The typed
+/// The explicit host/port overrides are recorded first and the environment
+/// is selected last: selecting the environment rebuilds the cluster routing
+/// (historical host + streaming hosts) and then patches the recorded
+/// overrides on top, so an explicit `THETADATA_HISTORICAL_HOST` /
+/// `THETADATA_STREAMING_HOST` / `THETADATA_STREAMING_PORT` wins over the
+/// environment default while the selected environment's **failover** hosts
+/// are preserved. It is independent of the credential — it works the same
+/// with either an api-key or an email/password login. The typed
 /// [`DirectConfig::with_environment`] is the programmatic equivalent.
 ///
 /// The "explicit host wins over the environment default" precedence holds
 /// for **every** path that selects an environment, not only the env-var
-/// ordering above. An explicit `THETADATA_HISTORICAL_HOST` /
-/// `THETADATA_STREAMING_HOST` (set via the process env, a `.env`, or a
-/// config file) survives a later [`DirectConfig::with_environment`],
+/// ordering above. An explicit override (set via the process env, a `.env`,
+/// or a config file) survives a later [`DirectConfig::with_environment`],
 /// [`DirectConfig::stage`], or [`DirectConfig::dev`]: the override is
-/// tracked per channel and environment selection skips a channel whose host
-/// was set explicitly, while still flipping the [`Environment`] marker that
-/// routes the auth session. A plain `production()` / `stage()` / `dev()`
-/// with no override yields that environment's full cluster, unchanged.
+/// recorded as a typed value and re-applied on top of the selected
+/// environment's cluster on every switch, while the [`Environment`] marker
+/// that routes the auth session still flips. The streaming override has two
+/// tiers — a primary host/port patch (env-var / `.env`) that keeps the
+/// environment's failover hosts, and a full explicit host list (the
+/// config-file `[streaming] hosts` power-user list) that wins outright. A
+/// plain `production()` / `stage()` / `dev()` with no override yields that
+/// environment's full cluster, unchanged.
 ///
 /// Malformed values (e.g. a non-integer `THETADATA_HISTORICAL_PORT`, or a
 /// `THETADATA_MDDS_TYPE` that is neither `PROD` nor `STAGE`) are ignored
@@ -149,18 +154,28 @@ pub struct DirectConfig {
     /// [`Environment::Stage`]. Carried on the auth request so the server
     /// routes the session to the matching cluster.
     pub environment: Environment,
-    /// Whether [`Self::historical`]'s host was set explicitly (via an
-    /// env-var / `.env` / config-file override). When set, environment
-    /// selection ([`Self::apply_environment`]) leaves the host untouched
-    /// so an explicit host wins over the environment's default — the
-    /// precedence documented on this struct. Not part of the public field
-    /// set; reset implicitly by [`Default`] and the preset constructors.
-    historical_host_overridden: bool,
-    /// Whether [`Self::streaming`]'s hosts were set explicitly (via an
-    /// env-var / `.env` / config-file override). Gates the streaming-host
-    /// rewrite in [`Self::apply_environment`] the same way
-    /// [`Self::historical_host_overridden`] gates the historical host.
-    streaming_hosts_overridden: bool,
+    /// Explicit historical host override (env-var / `.env` / config-file).
+    /// When set, environment selection ([`Self::apply_environment`]) uses
+    /// this host instead of the environment's default so an explicit host
+    /// wins over the environment — the precedence documented on this
+    /// struct. Not part of the public field set; reset implicitly by
+    /// [`Default`] and the preset constructors.
+    historical_host_override: Option<String>,
+    /// Explicit primary streaming host override (`THETADATA_STREAMING_HOST`
+    /// / `.env`). Patches the primary slot of the selected environment's
+    /// streaming hosts in [`Self::apply_environment`], leaving that
+    /// environment's failover hosts in place.
+    streaming_primary_host_override: Option<String>,
+    /// Explicit primary streaming port override (`THETADATA_STREAMING_PORT`
+    /// / `.env`). Patches the primary slot's port independently of the
+    /// host, so a port-only override keeps the selected environment's host
+    /// cluster and only re-points the primary port.
+    streaming_primary_port_override: Option<u16>,
+    /// Explicit full streaming host list (the config-file `[streaming]
+    /// hosts` power-user list). When set, it wins outright in
+    /// [`Self::apply_environment`]: environment selection does not touch
+    /// the streaming hosts at all.
+    streaming_hosts_full_override: Option<Vec<(String, u16)>>,
 }
 
 impl DirectConfig {
@@ -210,10 +225,12 @@ impl DirectConfig {
             environment: Environment::Prod,
             // The canonical defaults are the environment's own cluster, not
             // a caller override, so environment selection is free to move
-            // them. The override layer flips these when an explicit host is
-            // supplied.
-            historical_host_overridden: false,
-            streaming_hosts_overridden: false,
+            // them. The override layer records these when an explicit host
+            // (or port, or full host list) is supplied.
+            historical_host_override: None,
+            streaming_primary_host_override: None,
+            streaming_primary_port_override: None,
+            streaming_hosts_full_override: None,
         }
     }
 
@@ -225,50 +242,122 @@ impl DirectConfig {
     /// [`Self::production`], [`Self::stage`], and [`Self::with_environment`]
     /// all stay in agreement without duplicating host literals.
     ///
-    /// A channel whose host was set explicitly (env-var / `.env` /
-    /// config-file override; tracked by [`Self::historical_host_overridden`]
-    /// / [`Self::streaming_hosts_overridden`]) is left untouched: an
-    /// explicit host wins over the environment's default for that channel,
-    /// the precedence documented on the struct. The environment marker
-    /// still flips regardless, since it routes the auth session.
+    /// Recorded host overrides (env-var / `.env` / config-file) are layered
+    /// on top of the environment's cluster so an explicit host wins over the
+    /// environment's default — the precedence documented on the struct. The
+    /// environment marker still flips regardless, since it routes the auth
+    /// session.
+    ///
+    /// The streaming override has two tiers, both rebuilt from the selected
+    /// environment on every call so a host override tracks the current
+    /// environment's failover hosts:
+    ///
+    /// * A full host list ([`Self::streaming_hosts_full_override`], the
+    ///   config-file `[streaming] hosts` power-user list) wins outright —
+    ///   the environment does not touch the streaming hosts at all.
+    /// * Otherwise the environment's streaming hosts are taken as the base
+    ///   and a recorded primary host
+    ///   ([`Self::streaming_primary_host_override`]) and/or primary port
+    ///   ([`Self::streaming_primary_port_override`]) patch the primary slot,
+    ///   keeping that environment's failover hosts.
     ///
     /// Only the cluster routing changes; every tuning knob (timeouts,
     /// ring size, retry policy, ...) is left as-is.
     fn apply_environment(&mut self, env: Environment) {
         self.environment = env;
         // Historical (gRPC) targets the cluster host on the same TLS port;
-        // only the host differs between environments. Skip the rewrite when
-        // an explicit host override is in force so it survives environment
+        // only the host differs between environments. An explicit override
+        // wins over the environment default so it survives environment
         // selection.
-        if !self.historical_host_overridden {
-            self.historical.host = env.historical_host().to_string();
-        }
-        if !self.streaming_hosts_overridden {
-            self.streaming.hosts = env.streaming_hosts();
-        }
+        self.historical.host = self
+            .historical_host_override
+            .clone()
+            .unwrap_or_else(|| env.historical_host().to_string());
+        // Streaming: rebuild from the selected environment's host set, then
+        // apply the recorded streaming overrides. Rebuilding from `env` every
+        // call is what makes an env-var primary override keep tracking the
+        // current environment's failover hosts across a later switch.
+        let base = env.streaming_hosts();
+        self.streaming.hosts = self.resolve_streaming_hosts(base);
     }
 
-    /// Set the historical host explicitly and record the override.
+    /// Apply the recorded streaming host overrides on top of a `base` host
+    /// set, returning the resolved host list.
     ///
-    /// The recorded flag makes the host survive a later
+    /// This is the single accounting path for the streaming override
+    /// precedence, shared by [`Self::apply_environment`] (where `base` is the
+    /// selected environment's hosts) and [`Self::dev`] (where `base` is the
+    /// dev replay hosts), so the two can never drift:
+    ///
+    /// * A full host list ([`Self::streaming_hosts_full_override`], the
+    ///   config-file `[streaming] hosts` power-user list) wins outright — the
+    ///   `base` is discarded entirely.
+    /// * Otherwise a recorded primary host
+    ///   ([`Self::streaming_primary_host_override`]) and/or primary port
+    ///   ([`Self::streaming_primary_port_override`]) patch the primary slot of
+    ///   `base`, keeping its failover hosts.
+    fn resolve_streaming_hosts(&self, base: Vec<(String, u16)>) -> Vec<(String, u16)> {
+        if let Some(full) = &self.streaming_hosts_full_override {
+            return full.clone();
+        }
+        let mut hosts = base;
+        if let Some(first) = hosts.first_mut() {
+            if let Some(host) = &self.streaming_primary_host_override {
+                first.0 = host.clone();
+            }
+            if let Some(port) = self.streaming_primary_port_override {
+                first.1 = port;
+            }
+        }
+        hosts
+    }
+
+    /// Record an explicit historical host override.
+    ///
+    /// The recorded override makes the host survive a later
     /// [`Self::apply_environment`] (and therefore [`Self::with_environment`]
     /// / [`Self::stage`] / [`Self::dev`]), so an explicit host wins over the
-    /// environment's default — the precedence documented on the struct.
-    /// This is the single internal entry point the env-var / `.env` override
-    /// layers use, so the override accounting can never drift from the write.
+    /// environment's default — the precedence documented on the struct. This
+    /// is the single internal entry point the env-var / `.env` / config-file
+    /// layers use, so the override accounting can never drift. The override
+    /// is only applied to [`Self::historical`] when [`Self::apply_environment`]
+    /// next runs, which every preset and the env-var path guarantee.
     pub(crate) fn set_historical_host_override(&mut self, host: String) {
-        self.historical.host = host;
-        self.historical_host_overridden = true;
+        self.historical_host_override = Some(host);
     }
 
-    /// Record that the streaming hosts were set explicitly, so they survive
-    /// a later [`Self::apply_environment`].
+    /// Record an explicit primary streaming host override
+    /// (`THETADATA_STREAMING_HOST` / `.env`).
     ///
-    /// The streaming override edits the primary slot in place (see the env
-    /// layer), so unlike [`Self::set_historical_host_override`] the value is
-    /// written by the caller and this method only records the override.
-    pub(crate) fn mark_streaming_hosts_overridden(&mut self) {
-        self.streaming_hosts_overridden = true;
+    /// Patches the primary slot of whatever environment is selected when
+    /// [`Self::apply_environment`] next runs, keeping that environment's
+    /// failover hosts. Independent of the port override.
+    pub(crate) fn set_streaming_primary_host_override(&mut self, host: String) {
+        self.streaming_primary_host_override = Some(host);
+    }
+
+    /// Record an explicit primary streaming port override
+    /// (`THETADATA_STREAMING_PORT` / `.env`).
+    ///
+    /// Patches the primary slot's port of whatever environment is selected
+    /// when [`Self::apply_environment`] next runs, independently of the host
+    /// — a port-only override keeps the environment's host cluster and only
+    /// re-points the primary port.
+    pub(crate) fn set_streaming_primary_port_override(&mut self, port: u16) {
+        self.streaming_primary_port_override = Some(port);
+    }
+
+    /// Record an explicit full streaming host list (the config-file
+    /// `[streaming] hosts` power-user list).
+    ///
+    /// When recorded, the list wins outright in [`Self::apply_environment`]:
+    /// environment selection does not touch the streaming hosts at all. Only
+    /// the config-file loader supplies a full host list, so this setter is
+    /// gated on that feature; the field stays `None` (and the override is
+    /// inert) without it.
+    #[cfg(feature = "config-file")]
+    pub(crate) fn set_streaming_hosts_full_override(&mut self, hosts: Vec<(String, u16)>) {
+        self.streaming_hosts_full_override = Some(hosts);
     }
 
     /// Select the target server environment, returning the updated config.
@@ -408,7 +497,12 @@ impl DirectConfig {
         // broken preset where the marker says prod but historical routes to
         // stage. `apply_environment` re-points both together.
         config.apply_environment(Environment::Prod);
-        config.streaming.hosts = Self::dev_streaming_hosts();
+        // Dev's distinct streaming host set is the base; the recorded
+        // streaming overrides (primary host/port, or a config-file full list)
+        // patch it through the same accounting path as `apply_environment`, so
+        // an explicit `THETADATA_STREAMING_HOST` survives `dev()` instead of
+        // being clobbered by this assignment.
+        config.streaming.hosts = config.resolve_streaming_hosts(Self::dev_streaming_hosts());
         config
             .validate()
             .expect("dev preset is within validated bounds")
@@ -1018,7 +1112,11 @@ mod config_file {
     #[derive(Debug, Deserialize)]
     #[serde(default, deny_unknown_fields)]
     struct MddsSection {
-        host: String,
+        /// Historical host. `None` (key absent) leaves the environment's
+        /// default host in force and records no override, so a later
+        /// environment switch still re-points it; an explicit value is
+        /// recorded as a host override that survives environment selection.
+        host: Option<String>,
         port: u16,
         tls: bool,
         keepalive_time_secs: u64,
@@ -1030,7 +1128,9 @@ mod config_file {
         fn default() -> Self {
             let prod = DirectConfig::production();
             Self {
-                host: prod.historical.host,
+                // Absent by default so the environment's host stays the
+                // single source of truth unless the operator sets it.
+                host: None,
                 port: prod.historical.port,
                 tls: prod.historical.tls,
                 keepalive_time_secs: prod.historical.keepalive_secs,
@@ -1043,8 +1143,11 @@ mod config_file {
     #[derive(Debug, Deserialize)]
     #[serde(default, deny_unknown_fields)]
     struct FpssSection {
-        /// Hosts as `["host:port", ...]` array or `"host:port,host:port"` string.
-        hosts: FpssHosts,
+        /// Hosts as `["host:port", ...]` array or `"host:port,host:port"`
+        /// string. `None` (key absent) leaves the environment's default host
+        /// set in force and records no override; an explicit list is recorded
+        /// as a full override that wins outright over environment selection.
+        hosts: Option<FpssHosts>,
         connect_timeout: u64,
         read_timeout: u64,
         ping_interval: u64,
@@ -1067,13 +1170,9 @@ mod config_file {
         fn default() -> Self {
             let prod = DirectConfig::production();
             Self {
-                hosts: FpssHosts::Array(
-                    prod.streaming
-                        .hosts
-                        .iter()
-                        .map(|(h, p)| format!("{h}:{p}"))
-                        .collect(),
-                ),
+                // Absent by default so the environment's host set stays the
+                // single source of truth unless the operator lists hosts.
+                hosts: None,
                 connect_timeout: prod.streaming.connect_timeout_ms,
                 read_timeout: prod.streaming.timeout_ms,
                 ping_interval: prod.streaming.ping_interval_ms,
@@ -1100,19 +1199,6 @@ mod config_file {
     enum FpssHosts {
         Array(Vec<String>),
         Csv(String),
-    }
-
-    impl Default for FpssHosts {
-        fn default() -> Self {
-            let prod = DirectConfig::production();
-            FpssHosts::Array(
-                prod.streaming
-                    .hosts
-                    .iter()
-                    .map(|(h, p)| format!("{h}:{p}"))
-                    .collect(),
-            )
-        }
     }
 
     #[derive(Debug, Deserialize)]
@@ -1305,7 +1391,19 @@ mod config_file {
             };
 
             let mut out = DirectConfig::production_defaults();
-            out.historical.host = cf.historical.host;
+            // An explicit `[historical] host` is the operator's choice, so
+            // record it as an override (not a bare field write): a later
+            // `with_environment()` / `stage()` / `dev()` must respect it
+            // rather than clobber it back to the environment default. The
+            // override is only applied to the live fields by
+            // `apply_environment`; this path does not switch environments, so
+            // mirror the value into `historical.host` here too. An absent key
+            // leaves the production default in force and records no override,
+            // so a later environment switch still re-points the host.
+            if let Some(host) = cf.historical.host {
+                out.historical.host = host.clone();
+                out.set_historical_host_override(host);
+            }
             out.historical.port = cf.historical.port;
             out.historical.tls = cf.historical.tls;
             out.historical.max_message_size = max_message_size;
@@ -1315,7 +1413,19 @@ mod config_file {
             out.historical.connection_window_size_kb = cf.grpc.connection_window_size_kb;
             // mdds.connect_timeout_secs is not yet TOML-surfaced; keep production default.
 
-            out.streaming.hosts = cf.streaming.hosts.parse()?;
+            // An explicit `[streaming] hosts` list is the operator's full host
+            // set (a power-user list), so record it as a full override: a
+            // later `with_environment()` / `stage()` / `dev()` respects it
+            // outright rather than rebuilding from the environment cluster. As
+            // with the historical host, mirror it into the live field here
+            // since this path does not switch environments. An absent key
+            // leaves the production default host set in force and records no
+            // override, so a later environment switch still re-points it.
+            if let Some(hosts) = cf.streaming.hosts {
+                let streaming_hosts = hosts.parse()?;
+                out.streaming.hosts = streaming_hosts.clone();
+                out.set_streaming_hosts_full_override(streaming_hosts);
+            }
             out.streaming.timeout_ms = cf.streaming.read_timeout;
             out.streaming.ring_size = cf.streaming.ring_size;
             out.streaming.ping_interval_ms = cf.streaming.ping_interval;
@@ -1866,6 +1976,70 @@ mod tests {
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("TOML"));
         }
+
+        #[test]
+        fn config_file_streaming_hosts_win_over_later_environment_switch() {
+            use crate::config::Environment;
+            // The config-file `[streaming] hosts` list is the power-user full
+            // override: a later `with_environment(Stage)` must respect it
+            // outright (environment selection does not touch the streaming
+            // hosts at all).
+            let toml = r#"
+                [streaming]
+                hosts = ["a.example.com:1", "b.example.com:2"]
+            "#;
+            let config = DirectConfig::from_toml_str(toml)
+                .unwrap()
+                .with_environment(Environment::Stage);
+            assert_eq!(config.environment, Environment::Stage);
+            assert_eq!(
+                config.streaming.hosts,
+                vec![
+                    ("a.example.com".to_string(), 1),
+                    ("b.example.com".to_string(), 2),
+                ],
+                "the config-file full host list must win over the stage cluster"
+            );
+        }
+
+        #[test]
+        fn config_file_historical_host_wins_over_later_environment_switch() {
+            // The config-file `[historical] host` is an explicit override that
+            // must survive a later `stage()` / `with_environment` switch while
+            // the (non-overridden) streaming hosts still move to the cluster.
+            let toml = r#"
+                [historical]
+                host = "h.example.com"
+            "#;
+            let config = DirectConfig::from_toml_str(toml).unwrap();
+            // Build the stage routing on top of the config-file override.
+            let staged = config.with_environment(super::Environment::Stage);
+            assert_eq!(staged.environment, super::Environment::Stage);
+            assert_eq!(
+                staged.historical.host, "h.example.com",
+                "the config-file historical host must survive the environment switch"
+            );
+        }
+
+        #[test]
+        fn config_file_omitting_hosts_lets_environment_switch_repoint() {
+            use crate::config::Environment;
+            // When the TOML omits `[streaming] hosts` and `[historical] host`,
+            // no override is recorded, so a later environment switch still
+            // re-points both channels to the selected cluster.
+            let toml = r#"
+                [streaming]
+                ring_size = 65536
+            "#;
+            let config = DirectConfig::from_toml_str(toml)
+                .unwrap()
+                .with_environment(Environment::Stage);
+            assert_eq!(config.environment, Environment::Stage);
+            assert_eq!(config.historical.host, "mdds-stage.thetadata.us");
+            assert_eq!(config.streaming.hosts, Environment::Stage.streaming_hosts());
+            // The non-host tuning knob from the file is still honoured.
+            assert_eq!(config.streaming.ring_size, 65536);
+        }
     }
 
     // -- Validation tests --
@@ -2393,26 +2567,184 @@ mod tests {
         let _guard = env_test_guard();
         clear_env_matrix();
 
+        // Pin the FULL host vectors as literals (not via the source-of-truth
+        // helpers) so this stays a hard regression guard: the override-model
+        // rework must leave every no-override preset byte-identical to today.
         let prod = DirectConfig::production();
         assert_eq!(prod.environment, Environment::Prod);
         assert_eq!(prod.historical.host, "mdds-01.thetadata.us");
         assert_eq!(
             prod.streaming.hosts,
-            StreamingConfig::production_defaults().hosts
+            vec![
+                ("nj-a.thetadata.us".to_string(), 20000),
+                ("nj-a.thetadata.us".to_string(), 20001),
+                ("nj-b.thetadata.us".to_string(), 20000),
+                ("nj-b.thetadata.us".to_string(), 20001),
+            ]
         );
 
         let stage = DirectConfig::stage();
         assert_eq!(stage.environment, Environment::Stage);
         assert_eq!(stage.historical.host, "mdds-stage.thetadata.us");
-        assert_eq!(stage.streaming.hosts, Environment::Stage.streaming_hosts());
+        assert_eq!(
+            stage.streaming.hosts,
+            vec![
+                ("nj-a.thetadata.us".to_string(), 20100),
+                ("test-server.thetadata.us".to_string(), 20100),
+                ("test-server.thetadata.us".to_string(), 20101),
+            ]
+        );
 
         let dev = DirectConfig::dev();
         // Dev keeps the prod environment + prod historical host; only the
         // streaming hosts switch to the dev replay cluster.
         assert_eq!(dev.environment, Environment::Prod);
         assert_eq!(dev.historical.host, "mdds-01.thetadata.us");
-        assert_eq!(dev.streaming.hosts, DirectConfig::dev_streaming_hosts());
+        assert_eq!(
+            dev.streaming.hosts,
+            vec![
+                ("nj-a.thetadata.us".to_string(), 20200),
+                ("test-server.thetadata.us".to_string(), 20200),
+                ("test-server.thetadata.us".to_string(), 20201),
+            ]
+        );
 
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn streaming_host_override_keeps_environment_failover() {
+        // `THETADATA_STREAMING_HOST` patches only the PRIMARY slot of the
+        // SELECTED environment; the environment's own failover hosts stay in
+        // place (not production's). This is the core streaming-override defect
+        // fix: the override must not suppress the whole host-vector rewrite.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // SAFETY: see `mdds_type_env_stage_selects_stage_cluster`.
+        unsafe {
+            std::env::set_var(ENV_STREAMING_HOST, "myhost");
+        }
+        let config = DirectConfig::stage();
+        // Primary patched; failover hosts are stage's, not prod's.
+        assert_eq!(
+            config.streaming.hosts,
+            vec![
+                ("myhost".to_string(), 20100),
+                ("test-server.thetadata.us".to_string(), 20100),
+                ("test-server.thetadata.us".to_string(), 20101),
+            ]
+        );
+        assert_eq!(config.streaming.hosts[0].0, "myhost");
+        assert_eq!(
+            &config.streaming.hosts[1..],
+            &Environment::Stage.streaming_hosts()[1..],
+            "failover must track the stage cluster, not production"
+        );
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn streaming_port_only_override_keeps_environment_host_cluster() {
+        // A port-only `THETADATA_STREAMING_PORT` (host NOT set) must patch
+        // ONLY the primary port of the selected environment; the host cluster
+        // stays the environment's. Previously a port-only override suppressed
+        // the host rebuild entirely.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // SAFETY: see `mdds_type_env_stage_selects_stage_cluster`.
+        unsafe {
+            std::env::set_var(ENV_STREAMING_PORT, "9999");
+        }
+        let config = DirectConfig::stage();
+        assert_eq!(
+            config.streaming.hosts,
+            vec![
+                ("nj-a.thetadata.us".to_string(), 9999),
+                ("test-server.thetadata.us".to_string(), 20100),
+                ("test-server.thetadata.us".to_string(), 20101),
+            ],
+            "only the primary port is patched; the host cluster stays stage"
+        );
+        // The host cluster is unchanged from stage; only the primary port moved.
+        let stage_hosts = Environment::Stage.streaming_hosts();
+        assert_eq!(config.streaming.hosts[0].0, stage_hosts[0].0);
+        assert_eq!(config.streaming.hosts[0].1, 9999);
+        assert_eq!(&config.streaming.hosts[1..], &stage_hosts[1..]);
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn streaming_host_override_persists_across_environment_switches() {
+        // A recorded `THETADATA_STREAMING_HOST` must survive repeated
+        // `with_environment` switches, and the failover must always track the
+        // CURRENT environment (stage failover under Stage, prod failover under
+        // Prod) while the overridden primary host persists.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // SAFETY: see `mdds_type_env_stage_selects_stage_cluster`.
+        unsafe {
+            std::env::set_var(ENV_STREAMING_HOST, "sticky.example.com");
+        }
+        let staged = DirectConfig::production().with_environment(Environment::Stage);
+        assert_eq!(staged.streaming.hosts[0].0, "sticky.example.com");
+        assert_eq!(
+            &staged.streaming.hosts[1..],
+            &Environment::Stage.streaming_hosts()[1..],
+            "failover tracks the stage cluster after the first switch"
+        );
+        let back = staged.with_environment(Environment::Prod);
+        assert_eq!(
+            back.streaming.hosts[0].0, "sticky.example.com",
+            "the primary override persists across the switch"
+        );
+        assert_eq!(
+            &back.streaming.hosts[1..],
+            &Environment::Prod.streaming_hosts()[1..],
+            "failover now tracks the production cluster"
+        );
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn historical_host_override_with_dev_keeps_dev_streaming() {
+        // `THETADATA_HISTORICAL_HOST` must survive `dev()` on the historical
+        // channel while the streaming channel stays on the dev replay hosts.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // SAFETY: see `mdds_type_env_stage_selects_stage_cluster`.
+        unsafe {
+            std::env::set_var(ENV_HISTORICAL_HOST, "hist.example.com");
+        }
+        let config = DirectConfig::dev();
+        assert_eq!(config.environment, Environment::Prod);
+        assert_eq!(
+            config.historical.host, "hist.example.com",
+            "explicit historical host must survive dev()"
+        );
+        assert_eq!(
+            config.streaming.hosts,
+            DirectConfig::dev_streaming_hosts(),
+            "streaming stays on the dev replay cluster"
+        );
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn streaming_host_override_survives_dev_primary_slot() {
+        // Companion: a streaming primary override must also survive `dev()`,
+        // patching the dev primary while keeping the dev failover hosts —
+        // `dev()` no longer clobbers the override.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // SAFETY: see `mdds_type_env_stage_selects_stage_cluster`.
+        unsafe {
+            std::env::set_var(ENV_STREAMING_HOST, "devstream.example.com");
+        }
+        let config = DirectConfig::dev();
+        let dev_hosts = DirectConfig::dev_streaming_hosts();
+        assert_eq!(config.streaming.hosts[0].0, "devstream.example.com");
+        assert_eq!(config.streaming.hosts[0].1, dev_hosts[0].1);
+        assert_eq!(&config.streaming.hosts[1..], &dev_hosts[1..]);
         clear_env_matrix();
     }
 
@@ -2609,6 +2941,30 @@ mod tests {
         );
         let config = DirectConfig::from_dotenv(&path).expect(".env must source");
         assert_eq!(config.streaming.hosts[0].0, "stream.example.com");
+        // The stage failover hosts are preserved around the overridden primary.
+        assert_eq!(
+            &config.streaming.hosts[1..],
+            &Environment::Stage.streaming_hosts()[1..]
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn from_dotenv_streaming_port_only_patches_primary_port() {
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // A `.env` carrying only the streaming PORT (no host) must patch the
+        // selected environment's primary port and keep its host cluster — the
+        // `.env` path mirrors the process-env override model.
+        let path = write_temp_dotenv(
+            "streamport.env",
+            "THETADATA_MDDS_TYPE=STAGE\nTHETADATA_STREAMING_PORT=9999\n",
+        );
+        let config = DirectConfig::from_dotenv(&path).expect(".env must source");
+        let stage_hosts = Environment::Stage.streaming_hosts();
+        assert_eq!(config.streaming.hosts[0].0, stage_hosts[0].0);
+        assert_eq!(config.streaming.hosts[0].1, 9999);
+        assert_eq!(&config.streaming.hosts[1..], &stage_hosts[1..]);
         std::fs::remove_file(&path).ok();
     }
 

--- a/crates/thetadatadx/src/config/mod.rs
+++ b/crates/thetadatadx/src/config/mod.rs
@@ -110,6 +110,17 @@ pub use crate::backoff::JitterMode;
 /// same with either an api-key or an email/password login. The typed
 /// [`DirectConfig::with_environment`] is the programmatic equivalent.
 ///
+/// The "explicit host wins over the environment default" precedence holds
+/// for **every** path that selects an environment, not only the env-var
+/// ordering above. An explicit `THETADATA_HISTORICAL_HOST` /
+/// `THETADATA_STREAMING_HOST` (set via the process env, a `.env`, or a
+/// config file) survives a later [`DirectConfig::with_environment`],
+/// [`DirectConfig::stage`], or [`DirectConfig::dev`]: the override is
+/// tracked per channel and environment selection skips a channel whose host
+/// was set explicitly, while still flipping the [`Environment`] marker that
+/// routes the auth session. A plain `production()` / `stage()` / `dev()`
+/// with no override yields that environment's full cluster, unchanged.
+///
 /// Malformed values (e.g. a non-integer `THETADATA_HISTORICAL_PORT`, or a
 /// `THETADATA_MDDS_TYPE` that is neither `PROD` nor `STAGE`) are ignored
 /// with a `tracing::warn!` — the current value is retained so a typo
@@ -138,6 +149,18 @@ pub struct DirectConfig {
     /// [`Environment::Stage`]. Carried on the auth request so the server
     /// routes the session to the matching cluster.
     pub environment: Environment,
+    /// Whether [`Self::historical`]'s host was set explicitly (via an
+    /// env-var / `.env` / config-file override). When set, environment
+    /// selection ([`Self::apply_environment`]) leaves the host untouched
+    /// so an explicit host wins over the environment's default — the
+    /// precedence documented on this struct. Not part of the public field
+    /// set; reset implicitly by [`Default`] and the preset constructors.
+    historical_host_overridden: bool,
+    /// Whether [`Self::streaming`]'s hosts were set explicitly (via an
+    /// env-var / `.env` / config-file override). Gates the streaming-host
+    /// rewrite in [`Self::apply_environment`] the same way
+    /// [`Self::historical_host_overridden`] gates the historical host.
+    streaming_hosts_overridden: bool,
 }
 
 impl DirectConfig {
@@ -185,25 +208,67 @@ impl DirectConfig {
             metrics: MetricsConfig::default(),
             runtime: RuntimeConfig::default(),
             environment: Environment::Prod,
+            // The canonical defaults are the environment's own cluster, not
+            // a caller override, so environment selection is free to move
+            // them. The override layer flips these when an explicit host is
+            // supplied.
+            historical_host_overridden: false,
+            streaming_hosts_overridden: false,
         }
     }
 
     /// Route every cluster-bound channel at `env`.
     ///
-    /// Sets [`Self::environment`] and overwrites the historical host and
-    /// streaming hosts with that environment's cluster. This is the
-    /// single place that maps an [`Environment`] to its hosts, so
+    /// Sets [`Self::environment`] and points the historical host and
+    /// streaming hosts at that environment's cluster. This is the single
+    /// place that maps an [`Environment`] to its hosts, so
     /// [`Self::production`], [`Self::stage`], and [`Self::with_environment`]
     /// all stay in agreement without duplicating host literals.
+    ///
+    /// A channel whose host was set explicitly (env-var / `.env` /
+    /// config-file override; tracked by [`Self::historical_host_overridden`]
+    /// / [`Self::streaming_hosts_overridden`]) is left untouched: an
+    /// explicit host wins over the environment's default for that channel,
+    /// the precedence documented on the struct. The environment marker
+    /// still flips regardless, since it routes the auth session.
     ///
     /// Only the cluster routing changes; every tuning knob (timeouts,
     /// ring size, retry policy, ...) is left as-is.
     fn apply_environment(&mut self, env: Environment) {
         self.environment = env;
         // Historical (gRPC) targets the cluster host on the same TLS port;
-        // only the host differs between environments.
-        self.historical.host = env.historical_host().to_string();
-        self.streaming.hosts = env.streaming_hosts();
+        // only the host differs between environments. Skip the rewrite when
+        // an explicit host override is in force so it survives environment
+        // selection.
+        if !self.historical_host_overridden {
+            self.historical.host = env.historical_host().to_string();
+        }
+        if !self.streaming_hosts_overridden {
+            self.streaming.hosts = env.streaming_hosts();
+        }
+    }
+
+    /// Set the historical host explicitly and record the override.
+    ///
+    /// The recorded flag makes the host survive a later
+    /// [`Self::apply_environment`] (and therefore [`Self::with_environment`]
+    /// / [`Self::stage`] / [`Self::dev`]), so an explicit host wins over the
+    /// environment's default — the precedence documented on the struct.
+    /// This is the single internal entry point the env-var / `.env` override
+    /// layers use, so the override accounting can never drift from the write.
+    pub(crate) fn set_historical_host_override(&mut self, host: String) {
+        self.historical.host = host;
+        self.historical_host_overridden = true;
+    }
+
+    /// Record that the streaming hosts were set explicitly, so they survive
+    /// a later [`Self::apply_environment`].
+    ///
+    /// The streaming override edits the primary slot in place (see the env
+    /// layer), so unlike [`Self::set_historical_host_override`] the value is
+    /// written by the caller and this method only records the override.
+    pub(crate) fn mark_streaming_hosts_overridden(&mut self) {
+        self.streaming_hosts_overridden = true;
     }
 
     /// Select the target server environment, returning the updated config.
@@ -343,15 +408,28 @@ impl DirectConfig {
         // broken preset where the marker says prod but historical routes to
         // stage. `apply_environment` re-points both together.
         config.apply_environment(Environment::Prod);
-        // Source: config.toml fpss_dev_hosts
-        config.streaming.hosts = vec![
-            ("nj-a.thetadata.us".to_string(), 20200),
-            ("test-server.thetadata.us".to_string(), 20200),
-            ("test-server.thetadata.us".to_string(), 20201),
-        ];
+        config.streaming.hosts = Self::dev_streaming_hosts();
         config
             .validate()
             .expect("dev preset is within validated bounds")
+    }
+
+    /// Streaming hosts for the dev preset.
+    ///
+    /// Dev is not an [`Environment`] (historical still uses the production
+    /// cluster), so its streaming host set lives here rather than on
+    /// [`Environment::streaming_hosts`]. This is the single source of truth
+    /// for the dev hosts, shared with the FPSS allowlist coverage test so a
+    /// new dev host can never drift out of the FPSS hostname allowlist.
+    ///
+    /// Source: `config.toml` `fpss_dev_hosts`.
+    #[must_use]
+    pub(crate) fn dev_streaming_hosts() -> Vec<(String, u16)> {
+        vec![
+            ("nj-a.thetadata.us".to_string(), 20200),
+            ("test-server.thetadata.us".to_string(), 20200),
+            ("test-server.thetadata.us".to_string(), 20201),
+        ]
     }
 
     /// Staging environment configuration.
@@ -2231,6 +2309,110 @@ mod tests {
         // override wins over the environment's default cluster host.
         assert_eq!(config.environment, Environment::Stage);
         assert_eq!(config.historical.host, "custom.example.com");
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn explicit_historical_host_survives_stage_preset() {
+        // Finding 2(a): an explicit `THETADATA_HISTORICAL_HOST` must survive
+        // the `stage()` preset. `stage()` selects the stage cluster, but the
+        // explicit host wins for the historical channel while the
+        // non-overridden streaming hosts still move to the stage set.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // SAFETY: see `mdds_type_env_stage_selects_stage_cluster`.
+        unsafe {
+            std::env::set_var(ENV_HISTORICAL_HOST, "myhost");
+        }
+        let config = DirectConfig::stage();
+        assert_eq!(config.environment, Environment::Stage);
+        assert_eq!(
+            config.historical.host, "myhost",
+            "explicit historical host must survive stage()"
+        );
+        assert_eq!(
+            config.streaming.hosts,
+            Environment::Stage.streaming_hosts(),
+            "non-overridden streaming hosts must move to the stage cluster"
+        );
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn with_environment_honors_previously_set_explicit_host() {
+        // Finding 2(b): the typed `with_environment(Stage)` setter, applied
+        // after an explicit historical host was recorded, must keep that
+        // host while still routing the (non-overridden) streaming hosts and
+        // the environment marker to stage.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // SAFETY: see `mdds_type_env_stage_selects_stage_cluster`.
+        unsafe {
+            std::env::set_var(ENV_HISTORICAL_HOST, "myhost");
+        }
+        let config = DirectConfig::production().with_environment(Environment::Stage);
+        assert_eq!(config.environment, Environment::Stage);
+        assert_eq!(
+            config.historical.host, "myhost",
+            "with_environment must not clobber an explicit historical host"
+        );
+        assert_eq!(config.streaming.hosts, Environment::Stage.streaming_hosts());
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn explicit_streaming_host_survives_stage_preset() {
+        // Companion to 2(a) for the streaming channel: an explicit
+        // `THETADATA_STREAMING_HOST` survives `stage()` in the primary slot
+        // while the non-overridden historical host moves to the stage host.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+        // SAFETY: see `mdds_type_env_stage_selects_stage_cluster`.
+        unsafe {
+            std::env::set_var(ENV_STREAMING_HOST, "stream.example.com");
+        }
+        let config = DirectConfig::stage();
+        assert_eq!(config.environment, Environment::Stage);
+        assert_eq!(
+            config.streaming.hosts[0].0, "stream.example.com",
+            "explicit streaming host must survive stage()"
+        );
+        assert_eq!(
+            config.historical.host,
+            Environment::Stage.historical_host(),
+            "non-overridden historical host must move to the stage cluster"
+        );
+        clear_env_matrix();
+    }
+
+    #[test]
+    fn presets_unchanged_without_any_override() {
+        // Finding 2(c): with no override in the environment, the plain
+        // presets must produce exactly today's hosts — the override-tracking
+        // change must be invisible on the common paths.
+        let _guard = env_test_guard();
+        clear_env_matrix();
+
+        let prod = DirectConfig::production();
+        assert_eq!(prod.environment, Environment::Prod);
+        assert_eq!(prod.historical.host, "mdds-01.thetadata.us");
+        assert_eq!(
+            prod.streaming.hosts,
+            StreamingConfig::production_defaults().hosts
+        );
+
+        let stage = DirectConfig::stage();
+        assert_eq!(stage.environment, Environment::Stage);
+        assert_eq!(stage.historical.host, "mdds-stage.thetadata.us");
+        assert_eq!(stage.streaming.hosts, Environment::Stage.streaming_hosts());
+
+        let dev = DirectConfig::dev();
+        // Dev keeps the prod environment + prod historical host; only the
+        // streaming hosts switch to the dev replay cluster.
+        assert_eq!(dev.environment, Environment::Prod);
+        assert_eq!(dev.historical.host, "mdds-01.thetadata.us");
+        assert_eq!(dev.streaming.hosts, DirectConfig::dev_streaming_hosts());
+
         clear_env_matrix();
     }
 

--- a/crates/thetadatadx/src/fpss/pinning.rs
+++ b/crates/thetadatadx/src/fpss/pinning.rs
@@ -43,8 +43,10 @@ pub(crate) fn ct_eq_bytes(a: &[u8], b: &[u8]) -> bool {
 }
 
 /// SHA-256 of the `SubjectPublicKeyInfo` presented by every `ThetaData`
-/// FPSS endpoint (prod `nj-a:20000`, `nj-a:20001`, `nj-b:20000`, `nj-b:20001`;
-/// dev `nj-a:20200`; stage `nj-a:20100`).
+/// FPSS endpoint. The same keypair fronts every preset host: prod
+/// (`nj-a:20000/20001`, `nj-b:20000/20001`), stage (`nj-a:20100`,
+/// `test-server:20100/20101`), and dev (`nj-a:20200`,
+/// `test-server:20200/20201`).
 ///
 /// Captured 2026-04-20 via the `openssl` pipeline documented in the module
 /// header. SPKI (not whole-cert) so the pin survives `ThetaData`'s cert
@@ -58,10 +60,26 @@ pub(crate) const FPSS_SPKI_SHA256: [u8; 32] = [
 
 /// Hostnames we are willing to connect to for FPSS.
 ///
-/// Even with SPKI pinning we keep an explicit hostname allowlist: if a
-/// config typo or DNS shenanigan points us at an unexpected host that
-/// happens to share the pinned keypair, we still fail closed.
-pub(crate) const ALLOWED_FPSS_HOSTS: &[&str] = &["nj-a.thetadata.us", "nj-b.thetadata.us"];
+/// Covers every host the shipped presets dial: production spans the two NJ
+/// machines (`nj-a` / `nj-b`), while the stage and dev presets dial
+/// `nj-a` plus `test-server.thetadata.us`. The hostname allowlist runs
+/// before the SPKI pin, so a host missing here fails TLS with
+/// `NotValidForName` and that environment loses failover — `test-server`
+/// must be present for stage/dev to connect at all.
+///
+/// Even with SPKI pinning we keep this explicit allowlist: if a config typo
+/// or DNS shenanigan points us at an unexpected host that happens to share
+/// the pinned keypair, we still fail closed. The [`FPSS_SPKI_SHA256`] pin is
+/// the independent verifier and continues to reject any host that presents
+/// an unpinned key, so widening the hostname set never weakens the pin.
+///
+/// A unit test enumerates the hosts across every preset and asserts each is
+/// listed here, so a future preset host that is missing trips CI.
+pub(crate) const ALLOWED_FPSS_HOSTS: &[&str] = &[
+    "nj-a.thetadata.us",
+    "nj-b.thetadata.us",
+    "test-server.thetadata.us",
+];
 
 /// `rustls` server-cert verifier that enforces the FPSS SPKI pin.
 ///
@@ -289,14 +307,29 @@ mod tests {
 
     #[test]
     fn allowed_hosts_cover_every_fpss_environment() {
-        // Prod, dev, and stage all use either nj-a or nj-b. Keep this
-        // test in sync with `DirectConfig::{production,dev,stage}` so we
-        // notice if a new environment is added that needs an allowlist
-        // entry.
-        for host in ["nj-a.thetadata.us", "nj-b.thetadata.us"] {
+        use crate::config::{DirectConfig, Environment};
+
+        // Enumerate every streaming host the shipped presets dial, pulled
+        // from the config layer itself rather than a hardcoded list, and
+        // assert each hostname is in the allowlist. The allowlist runs
+        // before the SPKI pin, so a preset host missing here fails TLS with
+        // `NotValidForName` and that environment silently loses failover.
+        // Sourcing from `Environment::streaming_hosts` + the dev preset
+        // means a future preset host that is not allowlisted trips this
+        // test instead of shipping a dead environment.
+        let mut preset_hosts: Vec<(String, u16)> = Vec::new();
+        for env in [Environment::Prod, Environment::Stage] {
+            preset_hosts.extend(env.streaming_hosts());
+        }
+        // Dev is not an `Environment` (historical stays on prod), so its
+        // streaming hosts come from the dedicated source of truth.
+        preset_hosts.extend(DirectConfig::dev_streaming_hosts());
+
+        for (host, _port) in preset_hosts {
             assert!(
-                ALLOWED_FPSS_HOSTS.contains(&host),
-                "{host} must be in ALLOWED_FPSS_HOSTS"
+                ALLOWED_FPSS_HOSTS.contains(&host.as_str()),
+                "preset streaming host {host} is missing from ALLOWED_FPSS_HOSTS \
+                 — that environment fails TLS hostname verification and loses failover"
             );
         }
     }

--- a/crates/thetadatadx/src/mdds/macros.rs
+++ b/crates/thetadatadx/src/mdds/macros.rs
@@ -525,13 +525,24 @@ fn classify_error(err: &crate::error::Error) -> StatusClass {
 /// column from the response `DataTable`.
 ///
 /// Pattern: build request -> gRPC call -> collect stream -> extract text column.
-/// Emits one method on `HistoricalClient`:
-/// - `pub async fn <name>(...)` — per-call deadline routed through
-///   [`EndpointArgs::with_timeout_ms`] + the builder-style APIs.
+/// Emits two methods on `HistoricalClient`, matching the deadline contract
+/// of the builder endpoints:
+/// - `pub async fn <name>(...)` — bounded by the configured
+///   [`crate::config::HistoricalConfig::request_timeout_secs`] default so a
+///   live-but-silent stream cannot hang the request forever.
+/// - `pub async fn <name>_with_deadline(..., deadline: Duration)` — same
+///   call with an explicit per-call deadline. `Duration::ZERO` opts out of
+///   any deadline (see [`effective_deadline`]).
+///
+/// Both route through [`run_with_optional_deadline`], so the in-flight gRPC
+/// call (`<grpc>` + `collect_stream`) is dropped on expiry — the `_permit`
+/// releases its semaphore slot and the `tonic::Streaming` is dropped
+/// (RST_STREAM), returning `Err(Error::Timeout)`.
 macro_rules! list_endpoint {
     (
         $(#[$meta:meta])*
         fn $name:ident( $($arg:ident : $arg_ty:ty),* ) -> $col:literal;
+        with_deadline_fn: $with_deadline:ident;
         grpc: $grpc:ident;
         request: $req:ident;
         query: $query:ident { $($field:ident : $val:expr),* $(,)? };
@@ -541,19 +552,81 @@ macro_rules! list_endpoint {
         /// # Errors
         ///
         /// Returns an error on network, authentication, or parsing failure.
+        /// Returns [`Error::Timeout`] when the configured request deadline
+        /// elapses before the response completes.
         pub async fn $name(&self, $($arg : $arg_ty),*) -> Result<Vec<String>, Error> {
+            // No explicit deadline: fall back to the configured default so
+            // the request is always bounded.
+            let deadline = $crate::mdds::macros::effective_deadline(
+                None,
+                self.config().historical.request_timeout_secs,
+            );
+            list_endpoint_impl_body!(
+                self, deadline, $name, $grpc, $req,
+                $query { $($field : $val),* }, $col
+            )
+        }
+
+        #[allow(clippy::too_many_arguments)] // Reason: ThetaData endpoints require many parameters (symbol, date, strike, exp, right, etc.).
+        $(#[$meta])*
+        /// Same as the deadline-free variant, but bounds the call with an
+        /// explicit per-call deadline. `Duration::ZERO` opts out of any
+        /// deadline.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error on network, authentication, or parsing failure.
+        /// Returns [`Error::Timeout`] when `deadline` elapses first.
+        pub async fn $with_deadline(
+            &self,
+            $($arg : $arg_ty,)*
+            deadline: std::time::Duration,
+        ) -> Result<Vec<String>, Error> {
+            let deadline = $crate::mdds::macros::effective_deadline(
+                Some(deadline),
+                self.config().historical.request_timeout_secs,
+            );
+            list_endpoint_impl_body!(
+                self, deadline, $name, $grpc, $req,
+                $query { $($field : $val),* }, $col
+            )
+        }
+    };
+}
+
+/// Shared request/collect body for the [`list_endpoint!`] pair (`<name>` /
+/// `<name>_with_deadline`). Defined once so the deadline-bounded
+/// request/collect path is written a single time; the two public methods
+/// differ only in how they resolve the `deadline` they pass in.
+///
+/// `macro_rules!` cannot synthesize a private impl-method name (no `paste`
+/// dependency), so rather than a shared method this is a shared macro: each
+/// public method expands it inline with the already-resolved `deadline` and
+/// the per-endpoint specifics (receiver, gRPC stub, request/query types,
+/// fields, column).
+macro_rules! list_endpoint_impl_body {
+    (
+        $client:expr, $deadline:ident, $name:ident, $grpc:ident, $req:ident,
+        $query:ident { $($field:ident : $val:expr),* $(,)? }, $col:literal
+    ) => {{
+        // `&HistoricalClient` is `Copy`, so bind the receiver once and reuse
+        // it across the (possibly retried) request closure. Passing `self`
+        // through a macro parameter is required: a `self` token synthesized
+        // by the macro body cannot reach the caller's `self`.
+        let client: &HistoricalClient = $client;
+        $crate::mdds::macros::run_with_optional_deadline($deadline, async move {
             tracing::debug!(endpoint = stringify!($name), "gRPC request");
             metrics::counter!("thetadatadx.grpc.requests", "endpoint" => stringify!($name)).increment(1);
             let _metrics_start = std::time::Instant::now();
-            let _permit = self.request_semaphore.acquire().await
+            let _permit = client.request_semaphore.acquire().await
                 .map_err(|_| Error::config_internal("request semaphore closed"))?;
-            let policy = self.config().retry;
+            let policy = client.config().retry;
             let table: proto::DataTable = $crate::mdds::macros::run_unary_retry_loop(
-                self.session(),
+                client.session(),
                 &policy,
                 stringify!($name),
                 |snap| async move {
-                    let qi = self.build_query_info(snap.uuid.clone());
+                    let qi = client.build_query_info(snap.uuid.clone());
                     let request = proto::$req {
                         query_info: Some(qi),
                         params: Some(proto::$query { $($field : $val),* }),
@@ -565,14 +638,14 @@ macro_rules! list_endpoint {
                     // contention. Deref coercion from `&ChannelLease`
                     // to `&Channel` satisfies the generated stub
                     // signature.
-                    let lease = self.channel();
+                    let lease = client.channel();
                     let stream = $crate::proto::beta_theta_terminal::$grpc(
                         &lease,
                         request,
                     )
                     .await
                     .map_err(|e| -> Error { e.into() })?;
-                    self.collect_stream(stream).await
+                    client.collect_stream(stream).await
                 },
             ).await?;
             metrics::histogram!("thetadatadx.grpc.latency_ms", "endpoint" => stringify!($name))
@@ -585,8 +658,8 @@ macro_rules! list_endpoint {
                     .flatten()
                     .collect(),
             ))
-        }
-    };
+        }).await
+    }};
 }
 
 /// Generate an endpoint that returns parsed tick data (`Vec<T>`) via a builder.

--- a/crates/thetadatadx/tests/grpc_mock_server.rs
+++ b/crates/thetadatadx/tests/grpc_mock_server.rs
@@ -44,7 +44,7 @@ fn frame<M: Message>(msg: &M) -> Bytes {
 /// in its `compressed_data` field. The real server zstd-compresses
 /// the inner payload; the bench/test bypasses that step and asserts on
 /// the framed protobuf alone.
-fn make_response_data(symbols: &[&str]) -> ResponseData {
+pub fn make_response_data(symbols: &[&str]) -> ResponseData {
     let list = DataValueList {
         values: symbols
             .iter()

--- a/crates/thetadatadx/tests/test_endpoint_routing.rs
+++ b/crates/thetadatadx/tests/test_endpoint_routing.rs
@@ -265,3 +265,121 @@ async fn option_history_trade_greeks_implied_volatility_routes_to_iv_parser() {
         "price column dropped — routing reverted to non-trade IV parser"
     );
 }
+
+// ────────────────────────────────────────────────────────────────────
+// List endpoints honor the per-request deadline
+//
+// List RPCs (`*_list_*`) must apply the same deadline contract as the
+// builder endpoints: the configured `request_timeout_secs` bounds the
+// plain method, and the generated `<name>_with_deadline` overload accepts
+// an explicit per-call deadline. Without it a live-but-silent stream hangs
+// the request forever (the gRPC keepalive PING only detects a fully dead
+// peer, not a stalled one).
+// ────────────────────────────────────────────────────────────────────
+
+use std::time::Duration;
+
+use thetadatadx::Error;
+
+/// Build a `HistoricalClient` wired to a mock that delays its response by
+/// `pre_response_delay`, with `request_timeout_secs` set on the config so
+/// the default-deadline path can be exercised deterministically.
+async fn client_for_delayed_mock(
+    response: proto::ResponseData,
+    pre_response_delay: Duration,
+    request_timeout_secs: u64,
+) -> (mock::MockServer, HistoricalClient) {
+    let server = mock::MockServer::spawn_with_behaviour(
+        vec![response],
+        0,
+        String::new(),
+        mock::MockBehaviour {
+            pre_response_delay: Some(pre_response_delay),
+            ..mock::MockBehaviour::default()
+        },
+    )
+    .await;
+    let channel = Channel::connect_h2c("127.0.0.1", server.addr.port())
+        .await
+        .expect("h2c connect to mock");
+    let pool = ChannelPool::from_channels(vec![channel]);
+    let mut cfg = DirectConfig::production();
+    cfg.historical.request_timeout_secs = request_timeout_secs;
+    let sem = Arc::new(Semaphore::new(4));
+    let client = HistoricalClient::for_endpoint_routing_test(cfg, pool, sem);
+    (server, client)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_endpoint_plain_call_is_bounded_by_configured_default() {
+    // The mock holds the response 5s; the configured default deadline is
+    // 1s. The plain `stock_list_symbols()` (no explicit deadline) must
+    // surface `Error::Timeout` from the configured default rather than
+    // hang on the silent stream.
+    let (_mock, client) = client_for_delayed_mock(
+        mock::make_response_data(&["AAPL"]),
+        Duration::from_secs(5),
+        1,
+    )
+    .await;
+
+    let result = client.stock_list_symbols().await;
+    match result {
+        Err(Error::Timeout { duration_ms }) => {
+            assert!(
+                duration_ms <= 1_000,
+                "default deadline carried the wrong bound; got {duration_ms}ms"
+            );
+        }
+        other => panic!("expected Error::Timeout from the configured default, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_endpoint_with_deadline_overload_bounds_the_call() {
+    // The generated `<name>_with_deadline` overload exists (compile-time)
+    // and an explicit short deadline wins: the mock delays 5s, the call
+    // bounds at 100ms. `request_timeout_secs` is left high to prove the
+    // explicit per-call deadline — not the default — drives the timeout.
+    let (_mock, client) = client_for_delayed_mock(
+        mock::make_response_data(&["AAPL"]),
+        Duration::from_secs(5),
+        300,
+    )
+    .await;
+
+    let result = client
+        .stock_list_symbols_with_deadline(Duration::from_millis(100))
+        .await;
+    match result {
+        Err(Error::Timeout { duration_ms }) => {
+            assert!(
+                duration_ms <= 100,
+                "explicit deadline carried the wrong bound; got {duration_ms}ms"
+            );
+        }
+        other => panic!("expected Error::Timeout from the explicit deadline, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_endpoint_completes_within_deadline() {
+    // A prompt response well inside the deadline returns `Ok`, proving the
+    // deadline wrapper is transparent on the success path (the in-flight
+    // call completes and is not cancelled). The mock responds immediately,
+    // far inside the 10s bound.
+    let (_mock, client) = client_for_delayed_mock(
+        mock::make_response_data(&["AAPL", "MSFT"]),
+        Duration::from_millis(0),
+        300,
+    )
+    .await;
+
+    let result = client
+        .stock_list_symbols_with_deadline(Duration::from_secs(10))
+        .await;
+    assert!(
+        result.is_ok(),
+        "prompt list call must complete within the deadline, got {result:?}"
+    );
+}

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -649,7 +649,7 @@ paths:
   # STOCK / LIST
   # =========================================================================
 
-  /stock/list/symbols:
+  /v3/stock/list/symbols:
     x-min-subscription: free
     get:
       operationId: stockListSymbols
@@ -675,7 +675,7 @@ paths:
           source: |
             auto symbols = client.historical().stock_list_symbols();
 
-  /stock/list/dates:
+  /v3/stock/list/dates:
     x-min-subscription: free
     get:
       operationId: stockListDates
@@ -708,7 +708,7 @@ paths:
   # STOCK / SNAPSHOT
   # =========================================================================
 
-  /stock/snapshot/ohlc:
+  /v3/stock/snapshot/ohlc:
     x-min-subscription: value
     get:
       operationId: stockSnapshotOhlc
@@ -739,7 +739,7 @@ paths:
           source: |
             auto ohlc = client.historical().stock_snapshot_ohlc({"AAPL"});
 
-  /stock/snapshot/trade:
+  /v3/stock/snapshot/trade:
     x-min-subscription: standard
     get:
       operationId: stockSnapshotTrade
@@ -770,7 +770,7 @@ paths:
           source: |
             auto trades = client.historical().stock_snapshot_trade({"AAPL"});
 
-  /stock/snapshot/quote:
+  /v3/stock/snapshot/quote:
     x-min-subscription: value
     get:
       operationId: stockSnapshotQuote
@@ -801,7 +801,7 @@ paths:
           source: |
             auto quotes = client.historical().stock_snapshot_quote({"AAPL"});
 
-  /stock/snapshot/market_value:
+  /v3/stock/snapshot/market_value:
     x-min-subscription: standard
     get:
       operationId: stockSnapshotMarketValue
@@ -834,7 +834,7 @@ paths:
   # STOCK / HISTORY
   # =========================================================================
 
-  /stock/history/eod:
+  /v3/stock/history/eod:
     x-min-subscription: free
     get:
       operationId: stockHistoryEod
@@ -863,7 +863,7 @@ paths:
           source: |
             auto eod = client.historical().stock_history_eod("AAPL", "20240101", "20240301");
 
-  /stock/history/ohlc:
+  /v3/stock/history/ohlc:
     x-min-subscription: value
     get:
       operationId: stockHistoryOhlc
@@ -896,7 +896,7 @@ paths:
           source: |
             auto bars = client.historical().stock_history_ohlc("AAPL", "20240315", "60000");
 
-  /stock/history/ohlc_range:
+  /v3/stock/history/ohlc_range:
     x-min-subscription: value
     get:
       operationId: stockHistoryOhlcRange
@@ -930,7 +930,7 @@ paths:
           source: |
             auto bars = client.historical().stock_history_ohlc_range("AAPL", "20240101", "20240301", "60000");
 
-  /stock/history/trade:
+  /v3/stock/history/trade:
     x-min-subscription: standard
     get:
       operationId: stockHistoryTrade
@@ -972,7 +972,7 @@ paths:
           label: C++
           source: |
             auto trades = client.historical().stock_history_trade("AAPL", "20240315");
-  /stock/history/quote:
+  /v3/stock/history/quote:
     x-min-subscription: value
     get:
       operationId: stockHistoryQuote
@@ -1015,7 +1015,7 @@ paths:
           label: C++
           source: |
             auto quotes = client.historical().stock_history_quote("AAPL", "20240315", "60000");
-  /stock/history/trade_quote:
+  /v3/stock/history/trade_quote:
     x-min-subscription: standard
     get:
       operationId: stockHistoryTradeQuote
@@ -1064,7 +1064,7 @@ paths:
   # STOCK / AT-TIME
   # =========================================================================
 
-  /stock/at_time/trade:
+  /v3/stock/at_time/trade:
     x-min-subscription: standard
     get:
       operationId: stockAtTimeTrade
@@ -1096,7 +1096,7 @@ paths:
           source: |
             auto trades = client.historical().stock_at_time_trade("AAPL", "20240101", "20240301", "09:30:00.000");
 
-  /stock/at_time/quote:
+  /v3/stock/at_time/quote:
     x-min-subscription: value
     get:
       operationId: stockAtTimeQuote
@@ -1131,7 +1131,7 @@ paths:
   # OPTION / LIST
   # =========================================================================
 
-  /option/list/symbols:
+  /v3/option/list/symbols:
     x-min-subscription: free
     get:
       operationId: optionListSymbols
@@ -1157,7 +1157,7 @@ paths:
           source: |
             auto symbols = client.historical().option_list_symbols();
 
-  /option/list/dates:
+  /v3/option/list/dates:
     x-min-subscription: free
     get:
       operationId: optionListDates
@@ -1188,7 +1188,7 @@ paths:
           source: |
             auto dates = client.historical().option_list_dates("TRADE", "SPY", "20240419", "500", "C");
 
-  /option/list/expirations:
+  /v3/option/list/expirations:
     x-min-subscription: free
     get:
       operationId: optionListExpirations
@@ -1215,7 +1215,7 @@ paths:
           source: |
             auto exps = client.historical().option_list_expirations("SPY");
 
-  /option/list/strikes:
+  /v3/option/list/strikes:
     x-min-subscription: free
     get:
       operationId: optionListStrikes
@@ -1250,7 +1250,7 @@ paths:
           source: |
             auto strikes = client.historical().option_list_strikes("SPY", "20240419");
 
-  /option/list/contracts:
+  /v3/option/list/contracts:
     x-min-subscription: free
     get:
       operationId: optionListContracts
@@ -1285,7 +1285,7 @@ paths:
   # OPTION / SNAPSHOT
   # =========================================================================
 
-  /option/snapshot/ohlc:
+  /v3/option/snapshot/ohlc:
     x-min-subscription: value
     get:
       operationId: optionSnapshotOhlc
@@ -1318,7 +1318,7 @@ paths:
           source: |
             auto ohlc = client.historical().option_snapshot_ohlc("SPY", "20240419", "500", "C");
 
-  /option/snapshot/trade:
+  /v3/option/snapshot/trade:
     x-min-subscription: standard
     get:
       operationId: optionSnapshotTrade
@@ -1350,7 +1350,7 @@ paths:
           source: |
             auto trades = client.historical().option_snapshot_trade("SPY", "20240419", "500", "C");
 
-  /option/snapshot/quote:
+  /v3/option/snapshot/quote:
     x-min-subscription: value
     get:
       operationId: optionSnapshotQuote
@@ -1383,7 +1383,7 @@ paths:
           source: |
             auto quotes = client.historical().option_snapshot_quote("SPY", "20240419", "500", "C");
 
-  /option/snapshot/open_interest:
+  /v3/option/snapshot/open_interest:
     x-min-subscription: value
     get:
       operationId: optionSnapshotOpenInterest
@@ -1416,7 +1416,7 @@ paths:
           source: |
             auto oi = client.historical().option_snapshot_open_interest("SPY", "20240419", "500", "C");
 
-  /option/snapshot/market_value:
+  /v3/option/snapshot/market_value:
     x-min-subscription: standard
     get:
       operationId: optionSnapshotMarketValue
@@ -1453,7 +1453,7 @@ paths:
   # OPTION / SNAPSHOT GREEKS
   # =========================================================================
 
-  /option/snapshot/greeks/implied_volatility:
+  /v3/option/snapshot/greeks/implied_volatility:
     x-min-subscription: standard
     get:
       operationId: optionSnapshotGreeksImpliedVolatility
@@ -1492,7 +1492,7 @@ paths:
           source: |
             auto iv = client.historical().option_snapshot_greeks_implied_volatility("SPY", "20240419", "500", "C");
 
-  /option/snapshot/greeks/all:
+  /v3/option/snapshot/greeks/all:
     x-min-subscription: professional
     get:
       operationId: optionSnapshotGreeksAll
@@ -1532,7 +1532,7 @@ paths:
           source: |
             auto greeks = client.historical().option_snapshot_greeks_all("SPY", "20240419", "500", "C");
 
-  /option/snapshot/greeks/first_order:
+  /v3/option/snapshot/greeks/first_order:
     x-min-subscription: standard
     get:
       operationId: optionSnapshotGreeksFirstOrder
@@ -1571,7 +1571,7 @@ paths:
           source: |
             auto g1 = client.historical().option_snapshot_greeks_first_order("SPY", "20240419", "500", "C");
 
-  /option/snapshot/greeks/second_order:
+  /v3/option/snapshot/greeks/second_order:
     x-min-subscription: professional
     get:
       operationId: optionSnapshotGreeksSecondOrder
@@ -1610,7 +1610,7 @@ paths:
           source: |
             auto g2 = client.historical().option_snapshot_greeks_second_order("SPY", "20240419", "500", "C");
 
-  /option/snapshot/greeks/third_order:
+  /v3/option/snapshot/greeks/third_order:
     x-min-subscription: professional
     get:
       operationId: optionSnapshotGreeksThirdOrder
@@ -1653,7 +1653,7 @@ paths:
   # OPTION / HISTORY
   # =========================================================================
 
-  /option/history/eod:
+  /v3/option/history/eod:
     x-min-subscription: free
     get:
       operationId: optionHistoryEod
@@ -1688,7 +1688,7 @@ paths:
           source: |
             auto eod = client.historical().option_history_eod("SPY", "20240419", "500", "C", "20240101", "20240301");
 
-  /option/history/ohlc:
+  /v3/option/history/ohlc:
     x-min-subscription: value
     get:
       operationId: optionHistoryOhlc
@@ -1735,7 +1735,7 @@ paths:
           source: |
             auto bars = client.historical().option_history_ohlc("SPY", "20240419", "500", "C", "20240315", "60000");
 
-  /option/history/trade:
+  /v3/option/history/trade:
     x-min-subscription: standard
     get:
       operationId: optionHistoryTrade
@@ -1781,7 +1781,7 @@ paths:
           label: C++
           source: |
             auto trades = client.historical().option_history_trade("SPY", "20240419", "500", "C", "20240315");
-  /option/history/quote:
+  /v3/option/history/quote:
     x-min-subscription: value
     get:
       operationId: optionHistoryQuote
@@ -1828,7 +1828,7 @@ paths:
           label: C++
           source: |
             auto quotes = client.historical().option_history_quote("SPY", "20240419", "500", "C", "20240315", "60000");
-  /option/history/trade_quote:
+  /v3/option/history/trade_quote:
     x-min-subscription: standard
     get:
       operationId: optionHistoryTradeQuote
@@ -1876,7 +1876,7 @@ paths:
           source: |
             auto tq = client.historical().option_history_trade_quote("SPY", "20240419", "500", "C", "20240315");
 
-  /option/history/open_interest:
+  /v3/option/history/open_interest:
     x-min-subscription: value
     get:
       operationId: optionHistoryOpenInterest
@@ -1925,7 +1925,7 @@ paths:
   # OPTION / HISTORY GREEKS
   # =========================================================================
 
-  /option/history/greeks/eod:
+  /v3/option/history/greeks/eod:
     x-min-subscription: standard
     get:
       operationId: optionHistoryGreeksEod
@@ -1964,7 +1964,7 @@ paths:
           source: |
             auto greeks = client.historical().option_history_greeks_eod("SPY", "20240419", "500", "C", "20240101", "20240301");
 
-  /option/history/greeks/all:
+  /v3/option/history/greeks/all:
     x-min-subscription: professional
     get:
       operationId: optionHistoryGreeksAll
@@ -2015,7 +2015,7 @@ paths:
           source: |
             auto greeks = client.historical().option_history_greeks_all("SPY", "20240419", "500", "C", "20240315", "60000");
 
-  /option/history/greeks/first_order:
+  /v3/option/history/greeks/first_order:
     x-min-subscription: standard
     get:
       operationId: optionHistoryGreeksFirstOrder
@@ -2066,7 +2066,7 @@ paths:
           source: |
             auto g1 = client.historical().option_history_greeks_first_order("SPY", "20240419", "500", "C", "20240315", "60000");
 
-  /option/history/greeks/second_order:
+  /v3/option/history/greeks/second_order:
     x-min-subscription: professional
     get:
       operationId: optionHistoryGreeksSecondOrder
@@ -2117,7 +2117,7 @@ paths:
           source: |
             auto g2 = client.historical().option_history_greeks_second_order("SPY", "20240419", "500", "C", "20240315", "60000");
 
-  /option/history/greeks/third_order:
+  /v3/option/history/greeks/third_order:
     x-min-subscription: professional
     get:
       operationId: optionHistoryGreeksThirdOrder
@@ -2168,7 +2168,7 @@ paths:
           source: |
             auto g3 = client.historical().option_history_greeks_third_order("SPY", "20240419", "500", "C", "20240315", "60000");
 
-  /option/history/greeks/implied_volatility:
+  /v3/option/history/greeks/implied_volatility:
     x-min-subscription: standard
     get:
       operationId: optionHistoryGreeksImpliedVolatility
@@ -2223,7 +2223,7 @@ paths:
   # OPTION / HISTORY TRADE GREEKS
   # =========================================================================
 
-  /option/history/trade_greeks/all:
+  /v3/option/history/trade_greeks/all:
     x-min-subscription: professional
     get:
       operationId: optionHistoryTradeGreeksAll
@@ -2274,7 +2274,7 @@ paths:
           source: |
             auto tg = client.historical().option_history_trade_greeks_all("SPY", "20240419", "500", "C", "20240315");
 
-  /option/history/trade_greeks/first_order:
+  /v3/option/history/trade_greeks/first_order:
     x-min-subscription: professional
     get:
       operationId: optionHistoryTradeGreeksFirstOrder
@@ -2325,7 +2325,7 @@ paths:
           source: |
             auto tg1 = client.historical().option_history_trade_greeks_first_order("SPY", "20240419", "500", "C", "20240315");
 
-  /option/history/trade_greeks/second_order:
+  /v3/option/history/trade_greeks/second_order:
     x-min-subscription: professional
     get:
       operationId: optionHistoryTradeGreeksSecondOrder
@@ -2376,7 +2376,7 @@ paths:
           source: |
             auto tg2 = client.historical().option_history_trade_greeks_second_order("SPY", "20240419", "500", "C", "20240315");
 
-  /option/history/trade_greeks/third_order:
+  /v3/option/history/trade_greeks/third_order:
     x-min-subscription: professional
     get:
       operationId: optionHistoryTradeGreeksThirdOrder
@@ -2427,7 +2427,7 @@ paths:
           source: |
             auto tg3 = client.historical().option_history_trade_greeks_third_order("SPY", "20240419", "500", "C", "20240315");
 
-  /option/history/trade_greeks/implied_volatility:
+  /v3/option/history/trade_greeks/implied_volatility:
     x-min-subscription: professional
     get:
       operationId: optionHistoryTradeGreeksImpliedVolatility
@@ -2482,7 +2482,7 @@ paths:
   # OPTION / AT-TIME
   # =========================================================================
 
-  /option/at_time/trade:
+  /v3/option/at_time/trade:
     x-min-subscription: standard
     get:
       operationId: optionAtTimeTrade
@@ -2517,7 +2517,7 @@ paths:
           source: |
             auto trades = client.historical().option_at_time_trade("SPY", "20240419", "500", "C", "20240101", "20240301", "09:30:00.000");
 
-  /option/at_time/quote:
+  /v3/option/at_time/quote:
     x-min-subscription: value
     get:
       operationId: optionAtTimeQuote
@@ -2556,7 +2556,7 @@ paths:
   # INDEX / LIST
   # =========================================================================
 
-  /index/list/symbols:
+  /v3/index/list/symbols:
     x-min-subscription: free
     get:
       operationId: indexListSymbols
@@ -2582,7 +2582,7 @@ paths:
           source: |
             auto symbols = client.historical().index_list_symbols();
 
-  /index/list/dates:
+  /v3/index/list/dates:
     x-min-subscription: free
     get:
       operationId: indexListDates
@@ -2613,7 +2613,7 @@ paths:
   # INDEX / SNAPSHOT
   # =========================================================================
 
-  /index/snapshot/ohlc:
+  /v3/index/snapshot/ohlc:
     x-min-subscription: standard
     get:
       operationId: indexSnapshotOhlc
@@ -2641,7 +2641,7 @@ paths:
           source: |
             auto ohlc = client.historical().index_snapshot_ohlc({"SPX"});
 
-  /index/snapshot/price:
+  /v3/index/snapshot/price:
     x-min-subscription: standard
     get:
       operationId: indexSnapshotPrice
@@ -2669,7 +2669,7 @@ paths:
           source: |
             auto price = client.historical().index_snapshot_price({"SPX"});
 
-  /index/snapshot/market_value:
+  /v3/index/snapshot/market_value:
     x-min-subscription: standard
     get:
       operationId: indexSnapshotMarketValue
@@ -2701,7 +2701,7 @@ paths:
   # INDEX / HISTORY
   # =========================================================================
 
-  /index/history/eod:
+  /v3/index/history/eod:
     x-min-subscription: free
     get:
       operationId: indexHistoryEod
@@ -2730,7 +2730,7 @@ paths:
           source: |
             auto eod = client.historical().index_history_eod("SPX", "20240101", "20240301");
 
-  /index/history/ohlc:
+  /v3/index/history/ohlc:
     x-min-subscription: standard
     get:
       operationId: indexHistoryOhlc
@@ -2762,7 +2762,7 @@ paths:
           source: |
             auto bars = client.historical().index_history_ohlc("SPX", "20240101", "20240301", "60000");
 
-  /index/history/price:
+  /v3/index/history/price:
     x-min-subscription: value
     get:
       operationId: indexHistoryPrice
@@ -2809,7 +2809,7 @@ paths:
   # INDEX / AT-TIME
   # =========================================================================
 
-  /index/at_time/price:
+  /v3/index/at_time/price:
     x-min-subscription: value
     get:
       operationId: indexAtTimePrice
@@ -2843,7 +2843,7 @@ paths:
   # CALENDAR
   # =========================================================================
 
-  /calendar/open_today:
+  /v3/calendar/open_today:
     x-min-subscription: free
     get:
       operationId: calendarOpenToday
@@ -2869,7 +2869,7 @@ paths:
           source: |
             auto open = client.historical().calendar_open_today();
 
-  /calendar/on_date:
+  /v3/calendar/on_date:
     x-min-subscription: free
     get:
       operationId: calendarOnDate
@@ -2896,7 +2896,7 @@ paths:
           source: |
             auto cal = client.historical().calendar_on_date("20240315");
 
-  /calendar/year:
+  /v3/calendar/year:
     x-min-subscription: free
     get:
       operationId: calendarYear
@@ -2933,7 +2933,7 @@ paths:
   # INTEREST RATE
   # =========================================================================
 
-  /rate/history/eod:
+  /v3/rate/history/eod:
     x-min-subscription: free
     get:
       operationId: interestRateHistoryEod

--- a/docs-site/docs/public/thetadatadx.yaml
+++ b/docs-site/docs/public/thetadatadx.yaml
@@ -22,8 +22,8 @@ info:
     url: https://github.com/userFRM/ThetaDataDx/blob/main/LICENSE
 
 servers:
-  - url: grpc://mdds.thetadata.us
-    description: ThetaData MDDS production gRPC server (TLS)
+  - url: http://localhost:25503
+    description: Local ThetaDataDx server (HTTP)
 
 tags:
   - name: Stock / List

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -9,8 +9,13 @@ Class-level rows (no dot in `name`):
 - Python: every `m.add_class::<T>()` registered in `lib.rs` + helper
   `register_*` calls, expanded statically by parsing the Rust source.
   Mirrors the regex powering `test_no_pyclass_name_collisions.py`.
-- TypeScript: `export declare class X` / `export class X` declarations
-  in `sdks/typescript/index.d.ts`.
+- TypeScript: the package entry resolved from `sdks/typescript/package.json`
+  `types` (declarations) and `main` (runtime). The gate scans that entry,
+  follows its `export * from './...'` re-exports, and harvests
+  `export class X` / `export declare class X` / `export declare const X`
+  declarations plus the runtime `module.exports` names. This sees the
+  actually-shipped surface (the napi `index.*` re-export PLUS the wrapper-side
+  classes such as the context-managed session and the typed-error leaves).
 - C++: `^class X` / `^struct X` declarations in
   `sdks/cpp/include/thetadatadx.hpp`. The `.h` header is C-only and not
   considered for parity.
@@ -63,6 +68,7 @@ audit-protocol convention for CI gates.
 
 from __future__ import annotations
 
+import json
 import pathlib
 import re
 import sys
@@ -74,7 +80,37 @@ from typing import Any
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 PARITY_TOML = REPO_ROOT / "sdks" / "parity.toml"
 PY_SRC = REPO_ROOT / "sdks" / "python" / "src"
-TS_DTS = REPO_ROOT / "sdks" / "typescript" / "index.d.ts"
+TS_PKG_DIR = REPO_ROOT / "sdks" / "typescript"
+
+
+def _resolve_ts_entry(pkg_dir: pathlib.Path, key: str, fallback: str) -> pathlib.Path:
+    """Resolve the package's declared entry file for a `package.json` key.
+
+    The published TypeScript package declares its root through `package.json`
+    `main` (the runtime `.js` entry) and `types` (the `.d.ts` entry). The
+    parity gate must scan THOSE files, not a hardcoded `index.*`, so it sees
+    the surface a consumer actually imports. The entry may re-export the napi
+    `index.*` and add its own wrapper-side exports (the context-managed
+    streaming session, the typed-error classes). Falls back to `fallback`
+    (e.g. `index.d.ts`) only when the key is absent so a package without an
+    explicit `main`/`types` still resolves.
+    """
+    pkg_json = pkg_dir / "package.json"
+    declared: str | None = None
+    if pkg_json.is_file():
+        try:
+            declared = json.loads(pkg_json.read_text(encoding="utf-8")).get(key)
+        except (json.JSONDecodeError, OSError):
+            declared = None
+    return pkg_dir / (declared or fallback)
+
+
+# The package entry the gate scans for the TypeScript surface. Resolved from
+# `package.json` `types` (declarations) / `main` (runtime) so the gate reads
+# the actually-shipped root, which re-exports the napi `index.*` and layers
+# the wrapper-side exports on top.
+TS_DTS = _resolve_ts_entry(TS_PKG_DIR, "types", "index.d.ts")
+TS_MAIN_JS = _resolve_ts_entry(TS_PKG_DIR, "main", "index.js")
 TS_SRC = REPO_ROOT / "sdks" / "typescript" / "src"
 CPP_HPP = REPO_ROOT / "sdks" / "cpp" / "include" / "thetadatadx.hpp"
 CPP_H = REPO_ROOT / "sdks" / "cpp" / "include" / "thetadatadx.h"
@@ -198,23 +234,121 @@ def collect_python_classes(py_src: pathlib.Path) -> set[str]:
     return out
 
 
-TS_CLASS_RE = re.compile(r"export\s+declare\s+class\s+(\w+)")
+# `export class X` / `export declare class X` (the `declare` keyword is
+# optional: the napi `index.d.ts` declares ambient classes, while the
+# wrapper entry ships concrete `export class` leaves such as the typed-error
+# hierarchy).
+TS_CLASS_RE = re.compile(r"export\s+(?:declare\s+)?(?:abstract\s+)?class\s+(\w+)")
 TS_INTERFACE_RE = re.compile(r"export\s+(?:declare\s+)?interface\s+(\w+)")
+# `export declare const X: { new (...): X; ... }`: the runtime-class shape
+# the wrapper uses for a hand-written class (e.g. `StreamingSession`) that has
+# a companion `interface` of the same name.
+TS_CONST_CLASS_RE = re.compile(r"export\s+declare\s+const\s+(\w+)\s*:")
+# `export * from './<module>'`: the wrapper entry re-exports the whole napi
+# surface this way, so the gate must follow the re-export to see those
+# declarations as part of the scanned entry.
+TS_REEXPORT_RE = re.compile(r"export\s+\*\s+from\s+['\"]([^'\"]+)['\"]")
+
+
+def _ts_resolve_module(from_file: pathlib.Path, spec: str) -> pathlib.Path | None:
+    """Resolve a relative module specifier (`./index`) to a `.d.ts` file
+    next to `from_file`, honoring an explicit or implied `.d.ts` extension."""
+    if not spec.startswith("."):
+        return None
+    base = (from_file.parent / spec).resolve()
+    for cand in (base, base.with_suffix(".d.ts"), base.parent / (base.name + ".d.ts")):
+        if cand.is_file():
+            return cand
+    return None
+
+
+def _collect_ts_dts_classes(
+    dts: pathlib.Path, _seen: set[pathlib.Path] | None = None
+) -> set[str]:
+    """Harvest every exported class / interface / runtime-class-const name
+    declared in `dts`, following `export * from './...'` re-exports so the
+    declared package entry's full surface is seen."""
+    out: set[str] = set()
+    if not dts.is_file():
+        return out
+    seen = _seen if _seen is not None else set()
+    resolved = dts.resolve()
+    if resolved in seen:
+        return out
+    seen.add(resolved)
+    text = dts.read_text(encoding="utf-8")
+    for rx in (TS_CLASS_RE, TS_INTERFACE_RE, TS_CONST_CLASS_RE):
+        for m in rx.finditer(text):
+            out.add(m.group(1))
+    for m in TS_REEXPORT_RE.finditer(text):
+        target = _ts_resolve_module(dts, m.group(1))
+        if target is not None:
+            out |= _collect_ts_dts_classes(target, seen)
+    return out
+
+
+# Runtime (`.js`) export shapes the wrapper entry uses:
+# `exports.X = Y` (napi-generated) and `module.exports = Object.assign(...,
+# { X, Y, ... })` (the wrapper's object-shorthand re-export of its
+# hand-written classes). The object-literal scan is bounded to identifier
+# shorthand / `Name: expr` entries so it cannot pick up arbitrary code.
+JS_EXPORTS_ASSIGN_RE = re.compile(r"exports\.(\w+)\s*=")
+JS_REQUIRE_RE = re.compile(r"require\(\s*['\"]([^'\"]+)['\"]\s*\)")
+
+
+def _collect_js_exports(js: pathlib.Path, _seen: set[pathlib.Path] | None = None) -> set[str]:
+    """Harvest the runtime export names from a `.js` entry: `exports.X = ...`,
+    the keys of a `module.exports = Object.assign(..., { ... })` object, and
+    (transitively) the exports of any `require('./...')` it re-exports."""
+    out: set[str] = set()
+    if not js.is_file():
+        return out
+    seen = _seen if _seen is not None else set()
+    resolved = js.resolve()
+    if resolved in seen:
+        return out
+    seen.add(resolved)
+    text = js.read_text(encoding="utf-8")
+    for m in JS_EXPORTS_ASSIGN_RE.finditer(text):
+        out.add(m.group(1))
+    # `module.exports = Object.assign(..., { StreamingSession, ThetaDataError, ... })`:
+    # capture each object-literal block passed to the export assignment and
+    # read its identifier-shorthand / `Name:` keys.
+    for obj in re.finditer(
+        r"module\.exports\s*=\s*Object\.assign\(([^;]*)\)", text, re.DOTALL
+    ):
+        for key in re.finditer(
+            r"(?:^|[{,])\s*([A-Za-z_$][\w$]*)\s*(?:[,:}]|$)", obj.group(1)
+        ):
+            name = key.group(1)
+            if name not in {"Object", "assign"}:
+                out.add(name)
+    # A `module.exports = require('./index')`-style re-export (or a
+    # `const native = require('./index')` spread into the export) means the
+    # napi runtime surface ships through this entry too; follow it.
+    for m in JS_REQUIRE_RE.finditer(text):
+        target = js.parent / m.group(1)
+        for cand in (target, target.with_suffix(".js"), target.parent / (target.name + ".js")):
+            if cand.is_file():
+                out |= _collect_js_exports(cand, seen)
+                break
+    return out
 
 
 def collect_typescript_classes(ts_dts: pathlib.Path) -> set[str]:
-    out: set[str] = set()
-    if not ts_dts.is_file():
-        return out
-    text = ts_dts.read_text(encoding="utf-8")
-    for m in TS_CLASS_RE.finditer(text):
-        out.add(m.group(1))
-    for m in TS_INTERFACE_RE.finditer(text):
-        out.add(m.group(1))
-    js_path = ts_dts.with_name("index.js")
-    if js_path.is_file():
-        for m in re.finditer(r"exports\.(\w+)\s*=\s*\w+", js_path.read_text(encoding="utf-8")):
-            out.add(m.group(1))
+    """Exported class / interface names on the published TypeScript surface.
+
+    Scans the declared package entry (`package.json` `types`), following its
+    `export * from './...'` re-exports, and unions the runtime entry
+    (`package.json` `main`) export names so a class shipped only through the
+    wrapper's runtime object-export (the typed-error leaves, the
+    context-managed session) is seen. `ts_dts` is the resolved `types` entry;
+    the matching runtime entry is resolved from the same package directory.
+    """
+    out = _collect_ts_dts_classes(ts_dts)
+    # Resolve the runtime entry from the package the types entry lives in, so
+    # a caller passing a synthetic `types` path picks up the sibling `.js`.
+    out |= _collect_js_exports(_resolve_ts_entry(ts_dts.parent, "main", "index.js"))
     return out
 
 
@@ -1254,7 +1388,9 @@ def _collect_python_class_methods(py_src: pathlib.Path) -> dict[str, set[str]]:
     return out
 
 
-def _collect_typescript_class_methods(ts_src: pathlib.Path) -> dict[str, set[str]]:
+def _collect_typescript_class_methods(
+    ts_src: pathlib.Path, ts_pkg_dir: pathlib.Path | None = None
+) -> dict[str, set[str]]:
     """Return `{ts_class_name: {method, ...}}` for every TypeScript
     napi class.
 
@@ -1263,6 +1399,14 @@ def _collect_typescript_class_methods(ts_src: pathlib.Path) -> dict[str, set[str
     live across multiple files (`lib.rs`, `_generated/*.rs`,
     `config_class.rs`, ...); the collector walks each one and bounds
     the method scan to the impl body with a brace counter.
+
+    A method may also be added on the WRAPPER side rather than the napi
+    `impl`. The package entry augments a napi class through a
+    `declare module './index' { interface Client { ... } }` block and a
+    matching `Client.prototype.<name> = ...` runtime assignment (the
+    context-managed `Client.streaming(...)` helper is the load-bearing
+    case). When `ts_pkg_dir` is supplied, those augmentations are merged
+    in so a wrapper-only method is seen exactly like a napi one.
 
     Covers both method-attribute shapes:
 
@@ -1318,6 +1462,52 @@ def _collect_typescript_class_methods(ts_src: pathlib.Path) -> dict[str, set[str
                 camel = head + "".join(p.capitalize() for p in rest)
                 out.setdefault(class_name, set()).add(camel)
                 out.setdefault(class_name, set()).add(snake)
+    if ts_pkg_dir is not None:
+        for cls, methods in _collect_ts_wrapper_class_methods(ts_pkg_dir).items():
+            out.setdefault(cls, set()).update(methods)
+    return out
+
+
+# A wrapper-side method augmentation on the `.d.ts` entry:
+# `declare module './index' { interface <Class> { <name>(...): ...; } }`.
+# Captures each augmented interface name and its method declarations so a
+# method the wrapper layers onto a napi class (e.g. `Client.streaming`) is
+# harvested under that class.
+TS_AUGMENT_MODULE_RE = re.compile(
+    r"declare\s+module\s+['\"][^'\"]+['\"]\s*\{(.*?)\n\}", re.DOTALL
+)
+TS_AUGMENT_IFACE_RE = re.compile(r"interface\s+(\w+)\s*\{(.*?)\n\s*\}", re.DOTALL)
+TS_AUGMENT_METHOD_RE = re.compile(r"^\s*(\w+)\s*[(<]", re.MULTILINE)
+# A wrapper-side runtime method on the `.js` entry:
+# `<Native>.Client.prototype.<name> = ...` or `Client.prototype.<name> = ...`.
+JS_PROTOTYPE_METHOD_RE = re.compile(
+    r"(?:\b\w+\.)?(\w+)\.prototype\.(\w+)\s*="
+)
+
+
+def _collect_ts_wrapper_class_methods(ts_pkg_dir: pathlib.Path) -> dict[str, set[str]]:
+    """Harvest wrapper-side method augmentations from the package entry.
+
+    Reads the declared `.d.ts` entry (`package.json` `types`) for
+    `declare module './index' { interface <Class> { ... } }` augmentations and
+    the declared `.js` entry (`main`) for `<Class>.prototype.<name> = ...`
+    runtime additions, returning `{class: {method, ...}}`. This is how a
+    method present on the public TS surface only because the wrapper adds it
+    (not the napi `impl`) becomes visible to the parity gate.
+    """
+    out: dict[str, set[str]] = {}
+    dts = _resolve_ts_entry(ts_pkg_dir, "types", "index.d.ts")
+    if dts.is_file():
+        text = dts.read_text(encoding="utf-8")
+        for mod in TS_AUGMENT_MODULE_RE.finditer(text):
+            for iface in TS_AUGMENT_IFACE_RE.finditer(mod.group(1)):
+                cls = iface.group(1)
+                for meth in TS_AUGMENT_METHOD_RE.finditer(iface.group(2)):
+                    out.setdefault(cls, set()).add(meth.group(1))
+    js = _resolve_ts_entry(ts_pkg_dir, "main", "index.js")
+    if js.is_file():
+        for m in JS_PROTOTYPE_METHOD_RE.finditer(js.read_text(encoding="utf-8")):
+            out.setdefault(m.group(1), set()).add(m.group(2))
     return out
 
 
@@ -1412,17 +1602,46 @@ def _collect_cpp_class_methods(cpp_hpp: pathlib.Path) -> dict[str, set[str]]:
     return out
 
 
-# The unified `Client`'s data surfaces are reached through view
-# accessors that return a cheap handle clone (`historical`, `stream`,
-# `flatFiles`). They are hand-written per binding rather than generated
-# from `endpoint_surface.toml`, so a drop or rename in one binding would
-# otherwise pass silently. The forward `[[method]]` check catches a drop
-# of a declared accessor; this roster anchors the reverse-direction scan
-# that catches a NEW symmetric view accessor added on a binding without
-# an enrolling row. Names are the canonical camelCase row spelling; the
-# scan derives the per-binding form exactly as the forward check does.
+# The unified `Client`'s data surfaces are reached through view accessors
+# that return a cheap handle clone (`historical`, `stream`, `flatFiles`).
+# They are hand-written per binding rather than generated from
+# `endpoint_surface.toml`. Kept as the canonical-name reference for the view
+# accessors; the reverse-orphan scan below is no longer limited to this set.
+# It discovers every Client-level helper from the bindings so a NEW helper
+# (any shape, not just a view accessor) cannot ship on a binding untracked.
 CLIENT_VIEW_ACCESSORS: frozenset[str] = frozenset(
     {"historical", "stream", "flatFiles"}
+)
+
+
+# Client-level members the reverse-orphan scan must NOT treat as
+# cross-binding helper methods needing a `[[method]]` row. The scan
+# discovers candidate helpers from the precise Python (`#[pymethods]`) and
+# TypeScript (napi `#[napi]` + wrapper augmentation) collectors; this roster
+# names the members those collectors harvest that carry no Client
+# `[[method]]` contract, with the reason each is exempt:
+#
+#   * constructors / connection factories, gated by the `[[connect]]` and
+#     `[[from_file]]` families, not Client `[[method]]` rows;
+#   * Python-only convenience readbacks (`sessionUuid` / `subscriptionInfo`)
+#     that expose an auth-time value and have no symmetric cross-binding
+#     method contract.
+#
+# Names are the canonical camelCase spelling the scan derives. The blob-to-
+# disk helper (`flatFileToPath` / `flatfile_to_path`) is enrolled through
+# `METHOD_BINDING_OVERRIDES` against a `FlatFilesNamespace` row, so it is
+# resolved as enrolled by the scan (not listed here) and never double-counts.
+CLIENT_REVERSE_ORPHAN_EXEMPT_MEMBERS: frozenset[str] = frozenset(
+    {
+        "connect",
+        "connectBlocking",
+        "connectFromFile",
+        "fromFile",
+        "fromEnv",
+        "fromDotenv",
+        "sessionUuid",
+        "subscriptionInfo",
+    }
 )
 
 
@@ -1559,11 +1778,14 @@ def _check_method_rows(
     returns a list of human-readable mismatch strings (empty when
     every row matches).
 
-    Beyond the per-row forward check, the unified `Client` view accessors
-    (`CLIENT_VIEW_ACCESSORS`) get a reverse-direction orphan scan: a view
-    accessor that exists on the `Client` class in a binding but carries no
-    enrolling `Client` `[[method]]` row trips the gate, so a future
-    accessor cannot ship on one binding untracked.
+    Beyond the per-row forward check, Client-level helper methods get a
+    reverse-direction orphan scan. It is NOT limited to the view accessors:
+    candidate helpers are discovered from the precise Python and TypeScript
+    collectors (the latter including the wrapper-side `Client` augmentation),
+    so any helper a user calls as `client.<helper>(...)` that exists on a
+    binding but carries no enrolling `Client` `[[method]]` row trips the gate
+    unless it is named in `CLIENT_REVERSE_ORPHAN_EXEMPT_MEMBERS`. A future
+    helper cannot ship on one binding untracked.
     """
     errors: list[str] = []
     for row in method_rows:
@@ -1687,38 +1909,89 @@ def _check_method_rows(
                     f"crates/thetadatadx/src/client.rs)"
                 )
 
-    # Reverse-direction orphan scan for the unified-client view accessors.
-    # An accessor present on the `Client` class in a binding but carrying
-    # no enrolling `Client` `[[method]]` row is undocumented drift: the
-    # symmetric `historical` / `stream` / `flatFiles` surface stays in
-    # lockstep only if every accessor each binding exposes is enrolled.
+    # Reverse-direction orphan scan for Client-level helper methods. A helper
+    # present on the `Client` class in a binding but carrying no enrolling
+    # `Client` `[[method]]` row is undocumented drift. This is NOT limited to
+    # the view accessors: candidate helpers are discovered from the PRECISE
+    # Python (`#[pymethods]`) and TypeScript (napi `#[napi]` impls + the
+    # wrapper-side `Client` augmentation) collectors, so any new Client helper
+    # (a view accessor, a context-managed session opener, anything a user
+    # calls as `client.<helper>(...)`) trips unless it is enrolled or named
+    # in the exempt roster. The C++ collector is intentionally not a discovery
+    # source here: its heuristic class-body scan harvests FFI-extern calls,
+    # data members, and tokens inside method bodies that are not public
+    # methods; the C++ column of each helper is validated by the FORWARD row
+    # check instead. The error still reports every binding the flagged helper
+    # appears on (Python / TypeScript / C++) for context.
     enrolled_client_methods = {
         row["name"]
         for row in method_rows
         if row.get("class") == "Client" and row.get("name")
     }
+    # Members enrolled against a non-Client row but whose binding-specific
+    # home IS the `Client` class (the blob-to-disk helper routed through
+    # `METHOD_BINDING_OVERRIDES`). Keyed per binding so the scan resolves them
+    # as enrolled without double-counting under a Client row.
+    override_client_members: dict[str, set[str]] = {}
+    for binding_targets in METHOD_BINDING_OVERRIDES.values():
+        for binding, (target_class, target_member) in binding_targets.items():
+            if target_class == "Client":
+                override_client_members.setdefault(binding, set()).add(target_member)
     py_client = py_methods.get("Client", set())
     ts_client = ts_methods.get("Client", set())
     cpp_client = cpp_methods.get(_cpp_class_for("Client"), set())
-    for camel in sorted(CLIENT_VIEW_ACCESSORS):
-        if camel in enrolled_client_methods:
+
+    def _client_member_enrolled(camel: str, snake: str) -> bool:
+        return camel in enrolled_client_methods or snake in enrolled_client_methods
+
+    # Discover candidate helpers from the precise collectors. A Python
+    # `<name>_async` member is the awaitable twin of its sync helper, not a
+    # distinct contract, so its base is matched (mirroring the flat-file and
+    # historical `_async` handling). The camelCase row spelling is the lookup
+    # key; a Python override-home member (`flatfile_to_path`) and a TS one
+    # (`flatFileToPath`) are skipped as enrolled-elsewhere.
+    py_override_members = override_client_members.get("python", set())
+    ts_override_members = override_client_members.get("typescript", set())
+    candidates: set[str] = set()
+    for member in py_client:
+        base = member[: -len("_async")] if member.endswith("_async") else member
+        # An override-home member (and its `_async` twin) is enrolled against
+        # its own non-Client row; skip it here.
+        if member in py_override_members or base in py_override_members:
             continue
+        candidates.add(_snake_to_camel(base))
+    for member in ts_client:
+        if member in ts_override_members or _snake_to_camel(member) in {
+            _snake_to_camel(o) for o in ts_override_members
+        }:
+            continue
+        # napi members are recorded in both snake and camel form; normalise to
+        # the camelCase row spelling.
+        candidates.add(_snake_to_camel(member) if "_" in member else member)
+
+    for camel in sorted(candidates):
         snake = _camel_to_snake(camel)
+        if _client_member_enrolled(camel, snake):
+            continue
+        if camel in CLIENT_REVERSE_ORPHAN_EXEMPT_MEMBERS:
+            continue
         present_on = sorted(
             lang
             for lang, seen in (
-                ("python", snake in py_client or f"get_{snake}" in py_client),
-                ("typescript", camel in ts_client),
+                ("python", snake in py_client or f"{snake}_async" in py_client),
+                ("typescript", camel in ts_client or snake in ts_client),
                 ("cpp", snake in cpp_client or f"get_{snake}" in cpp_client),
             )
             if seen
         )
         if present_on:
             errors.append(
-                f"  Client.{camel}: view accessor present on {present_on} but "
-                f"has no Client [[method]] row. Add one enrolling its "
-                f"per-binding presence so the unified-client view surface "
-                f"stays tracked."
+                f"  Client.{camel}: helper method present on {present_on} but "
+                f"has no Client [[method]] row. Either enroll it (with its "
+                f"per-binding presence) so the unified-client helper surface "
+                f"stays tracked, or add it to "
+                f"CLIENT_REVERSE_ORPHAN_EXEMPT_MEMBERS with the documented "
+                f"reason it carries no cross-binding contract."
             )
 
     # Reverse-direction orphan scan for the flat-file fetch namespace. A fetch
@@ -4580,7 +4853,7 @@ def main(argv: list[str] | None = None) -> int:
     rust_fields = _collect_rust_pub_fields(CONFIG_DIR)
 
     py_class_methods = _collect_python_class_methods(PY_SRC)
-    ts_class_methods = _collect_typescript_class_methods(TS_SRC)
+    ts_class_methods = _collect_typescript_class_methods(TS_SRC, TS_PKG_DIR)
     cpp_class_methods = _collect_cpp_class_methods(CPP_HPP)
     rust_view_methods = _collect_rust_view_methods(CORE_CLIENT_RS)
 
@@ -5635,7 +5908,10 @@ def _run_selftest() -> int:
         every method is scoped to its owning class. This protects
         against false-positive 'unexpected' verdicts when two classes
         coincidentally share a method name (`subscribe` on both
-        `Client` and `Subscription` etc.).
+        `Subscription` and `StreamingClient` etc.). The decoy holder is
+        `Subscription` (a non-Client class) so the forward-isolation
+        behaviour is exercised without entangling the Client-scoped
+        reverse-orphan scan.
         """
         rows = [
             {
@@ -5646,10 +5922,10 @@ def _run_selftest() -> int:
                 "cpp": True,
             }
         ]
-        # `subscribe` exists on `Client` (TS) but NOT on
+        # `subscribe` exists on `Subscription` (TS) but NOT on
         # `StreamingClient` (TS). Class-scoped lookup must respect that.
         py_methods = {"StreamingClient": {"subscribe"}}
-        ts_methods = {"Client": {"subscribe"}}
+        ts_methods = {"Subscription": {"subscribe"}}
         cpp_methods = {"StreamingClient": {"subscribe"}}
         errors = _check_method_rows(rows, py_methods, ts_methods, cpp_methods)
         assert errors == [], (
@@ -5775,6 +6051,155 @@ def _run_selftest() -> int:
     _case("method negative — stale `false` row with method present", _case_method_unexpected_extra)
     _case("method negative — malformed row missing class or name", _case_method_row_missing_class_or_name)
     _case("method positive — class-scoped TS lookup isolates classes", _case_method_class_scoping_isolates_classes)
+
+    def _case_client_reverse_orphan_generalized_trips() -> None:
+        """A NEW Client helper (not one of the historical view accessors)
+        present on Python + TypeScript but carrying no `[[method]]` row trips
+        the generalized reverse-orphan scan."""
+        rows: list[dict[str, Any]] = []  # no Client rows at all
+        py_methods = {"Client": {"streaming"}}
+        ts_methods = {"Client": {"streaming"}}
+        cpp_methods: dict[str, set[str]] = {}
+        errors = _check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+        assert any(
+            "Client.streaming" in e and "no Client [[method]] row" in e
+            for e in errors
+        ), f"a new unenrolled Client helper must trip; got {errors!r}"
+
+    def _case_client_reverse_orphan_enrolled_silent() -> None:
+        """An enrolled Client helper does NOT trip the reverse-orphan scan."""
+        rows = [
+            {
+                "class": "Client",
+                "name": "streaming",
+                "python": True,
+                "typescript": True,
+                "cpp": False,
+                "rust": False,
+            }
+        ]
+        py_methods = {"Client": {"streaming"}}
+        ts_methods = {"Client": {"streaming"}}
+        cpp_methods: dict[str, set[str]] = {}
+        errors = _check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+        assert errors == [], f"enrolled Client helper must be silent; got {errors!r}"
+
+    def _case_client_reverse_orphan_exempt_silent() -> None:
+        """An exempt Client member (a connection factory, a Python-only
+        readback) does NOT trip the reverse-orphan scan."""
+        rows: list[dict[str, Any]] = []
+        py_methods = {
+            "Client": {"from_file", "from_env", "from_dotenv", "session_uuid", "subscription_info"}
+        }
+        ts_methods = {"Client": {"connect", "connectFromFile"}}
+        cpp_methods: dict[str, set[str]] = {}
+        errors = _check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+        assert errors == [], (
+            f"exempt Client members must not trip; got {errors!r}"
+        )
+
+    def _case_client_reverse_orphan_override_home_silent() -> None:
+        """The blob-to-disk helper lives on the Client class per binding but is
+        enrolled against a `FlatFilesNamespace` row through
+        `METHOD_BINDING_OVERRIDES`; neither it nor its Python `_async` twin
+        trips the Client reverse-orphan scan."""
+        rows = [
+            {
+                "class": "FlatFilesNamespace",
+                "name": "flatFileToPath",
+                "python": True,
+                "typescript": True,
+                "cpp": True,
+            }
+        ]
+        py_methods = {"Client": {"flatfile_to_path", "flatfile_to_path_async"}}
+        ts_methods = {"Client": {"flatFileToPath"}}
+        cpp_methods = {"FlatFiles": {"to_path"}}
+        errors = _check_method_rows(rows, py_methods, ts_methods, cpp_methods)
+        assert errors == [], (
+            f"override-home Client member must not trip; got {errors!r}"
+        )
+
+    _case("client reverse-orphan - new helper trips (beyond the triple)", _case_client_reverse_orphan_generalized_trips)
+    _case("client reverse-orphan - enrolled helper silent", _case_client_reverse_orphan_enrolled_silent)
+    _case("client reverse-orphan - exempt members silent", _case_client_reverse_orphan_exempt_silent)
+    _case("client reverse-orphan - override-home member silent", _case_client_reverse_orphan_override_home_silent)
+
+    def _case_ts_entry_resolves_from_package_json() -> None:
+        """The TS class collector resolves the entry from `package.json`
+        `types`, follows `export * from './index'`, and harvests `export class`
+        / `export declare const` leaves plus runtime `Object.assign` exports
+        from the `main` entry."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = pathlib.Path(tmp)
+            (pkg / "package.json").write_text(
+                '{"main": "entry.js", "types": "entry.d.ts"}\n', encoding="utf-8"
+            )
+            (pkg / "index.d.ts").write_text(
+                "export declare class NapiClient {}\n"
+                "export interface NapiThing {}\n",
+                encoding="utf-8",
+            )
+            (pkg / "entry.d.ts").write_text(
+                "export * from './index';\n"
+                "export class WrapperError extends Error {}\n"
+                "export declare const WrapperSession: { new (): WrapperSession };\n"
+                "export interface WrapperSession {}\n",
+                encoding="utf-8",
+            )
+            (pkg / "entry.js").write_text(
+                "const native = require('./index');\n"
+                "module.exports = Object.assign({}, native, "
+                "{ WrapperError, WrapperSession });\n",
+                encoding="utf-8",
+            )
+            (pkg / "index.js").write_text(
+                "exports.NapiClient = class {};\n", encoding="utf-8"
+            )
+            found = collect_typescript_classes(_resolve_ts_entry(pkg, "types", "index.d.ts"))
+            for want in ("NapiClient", "NapiThing", "WrapperError", "WrapperSession"):
+                assert want in found, f"{want} must be seen via the resolved entry; got {sorted(found)}"
+
+    def _case_ts_entry_falls_back_to_index() -> None:
+        """With no `types`/`main` keys, the resolver falls back to `index.*`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = pathlib.Path(tmp)
+            (pkg / "package.json").write_text("{}\n", encoding="utf-8")
+            (pkg / "index.d.ts").write_text(
+                "export declare class OnlyClient {}\n", encoding="utf-8"
+            )
+            found = collect_typescript_classes(_resolve_ts_entry(pkg, "types", "index.d.ts"))
+            assert "OnlyClient" in found, f"fallback to index.d.ts must work; got {sorted(found)}"
+
+    def _case_ts_wrapper_augmentation_method_seen() -> None:
+        """A wrapper-side `declare module './index' { interface Client { ... } }`
+        augmentation and its `Client.prototype.<name>` runtime addition are
+        harvested under `Client`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = pathlib.Path(tmp)
+            (pkg / "package.json").write_text(
+                '{"main": "entry.js", "types": "entry.d.ts"}\n', encoding="utf-8"
+            )
+            (pkg / "entry.d.ts").write_text(
+                "declare module './index' {\n"
+                "  interface Client {\n"
+                "    streaming(cb: unknown): Promise<void>;\n"
+                "  }\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            (pkg / "entry.js").write_text(
+                "native.Client.prototype.streaming = async function streaming(cb) {};\n",
+                encoding="utf-8",
+            )
+            wrapper = _collect_ts_wrapper_class_methods(pkg)
+            assert wrapper.get("Client") == {"streaming"}, (
+                f"wrapper augmentation must surface Client.streaming; got {wrapper!r}"
+            )
+
+    _case("ts entry - resolves from package.json + follows re-exports", _case_ts_entry_resolves_from_package_json)
+    _case("ts entry - falls back to index.* when keys absent", _case_ts_entry_falls_back_to_index)
+    _case("ts entry - wrapper Client augmentation harvested", _case_ts_wrapper_augmentation_method_seen)
 
     def _case_flatfiles_namespace_fetch_resolves() -> None:
         """A `FlatFilesNamespace` fetch row resolves through the C++ alias to the

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -268,38 +268,95 @@ def _collect_ts_dts_classes(
     """Harvest every exported class / interface / runtime-class-const name
     declared in `dts`, following `export * from './...'` re-exports so the
     declared package entry's full surface is seen."""
-    out: set[str] = set()
+    classes, interfaces = _collect_ts_dts_class_kinds(dts, _seen)
+    return classes | interfaces
+
+
+def _collect_ts_dts_class_kinds(
+    dts: pathlib.Path, _seen: set[pathlib.Path] | None = None
+) -> tuple[set[str], set[str]]:
+    """Harvest declaration-side names from `dts`, split by runtime kind.
+
+    Returns `(runtime_classes, interfaces)`:
+
+    - `runtime_classes` are `export class` / `export declare class` and the
+      `export declare const X: { new (...): X }` runtime-class shape. These
+      compile to a real constructor that MUST be reachable at runtime, so a
+      row declaring one is held to having a matching runtime export.
+    - `interfaces` are `export interface` declarations (the napi `#[napi(object)]`
+      plain-object shape and hand-written interfaces). These are erased at
+      compile time and carry no runtime constructor, so a row backed by one
+      is satisfied by the declaration alone.
+
+    Follows `export * from './...'` re-exports so the declared package entry's
+    full surface is seen.
+    """
+    classes: set[str] = set()
+    interfaces: set[str] = set()
     if not dts.is_file():
-        return out
+        return classes, interfaces
     seen = _seen if _seen is not None else set()
     resolved = dts.resolve()
     if resolved in seen:
-        return out
+        return classes, interfaces
     seen.add(resolved)
     text = dts.read_text(encoding="utf-8")
-    for rx in (TS_CLASS_RE, TS_INTERFACE_RE, TS_CONST_CLASS_RE):
+    for rx in (TS_CLASS_RE, TS_CONST_CLASS_RE):
         for m in rx.finditer(text):
-            out.add(m.group(1))
+            classes.add(m.group(1))
+    for m in TS_INTERFACE_RE.finditer(text):
+        interfaces.add(m.group(1))
     for m in TS_REEXPORT_RE.finditer(text):
         target = _ts_resolve_module(dts, m.group(1))
         if target is not None:
-            out |= _collect_ts_dts_classes(target, seen)
-    return out
+            sub_classes, sub_interfaces = _collect_ts_dts_class_kinds(target, seen)
+            classes |= sub_classes
+            interfaces |= sub_interfaces
+    return classes, interfaces
 
 
 # Runtime (`.js`) export shapes the wrapper entry uses:
-# `exports.X = Y` (napi-generated) and `module.exports = Object.assign(...,
-# { X, Y, ... })` (the wrapper's object-shorthand re-export of its
-# hand-written classes). The object-literal scan is bounded to identifier
-# shorthand / `Name: expr` entries so it cannot pick up arbitrary code.
+# `exports.X = Y` / `module.exports.X = Y` (napi-generated) and
+# `module.exports = Object.assign(..., { X, Y, ... })` (the wrapper's
+# object-shorthand re-export of its hand-written classes). The object-literal
+# scan is bounded to identifier shorthand / `Name: expr` entries so it cannot
+# pick up arbitrary code. `module.exports.X` contains the `exports.X` substring,
+# so the same pattern catches both forms.
 JS_EXPORTS_ASSIGN_RE = re.compile(r"exports\.(\w+)\s*=")
 JS_REQUIRE_RE = re.compile(r"require\(\s*['\"]([^'\"]+)['\"]\s*\)")
+# Identifier-shorthand (`Name,`) and `Name: expr` keys of an object literal.
+# The trailing delimiter is a lookahead, not a consumed group, so a key never
+# eats the comma that the next key needs to anchor on; otherwise alternating
+# keys drop out of the scan and a runtime export reads as absent.
+JS_OBJECT_KEY_RE = re.compile(r"(?:[{,])\s*([A-Za-z_$][\w$]*)\s*(?=[,:}])")
+# Strip `/* ... */` block comments and `// ...` line comments. The runtime
+# export blocks carry explanatory comments between the keys; without removing
+# them the whitespace-then-comment run breaks the object-key scan's anchor.
+JS_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+JS_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+
+
+def _strip_js_comments(text: str) -> str:
+    """Remove block and line comments from JS source.
+
+    Export blocks rely on identifier / delimiter adjacency to be scanned; an
+    interleaved comment otherwise hides the keys that follow it. The export
+    names this gate reads are bare identifiers, never string literals, so a
+    coarse comment strip is sufficient and cannot drop a tracked name.
+    """
+    return JS_LINE_COMMENT_RE.sub("", JS_BLOCK_COMMENT_RE.sub("", text))
 
 
 def _collect_js_exports(js: pathlib.Path, _seen: set[pathlib.Path] | None = None) -> set[str]:
     """Harvest the runtime export names from a `.js` entry: `exports.X = ...`,
     the keys of a `module.exports = Object.assign(..., { ... })` object, and
-    (transitively) the exports of any `require('./...')` it re-exports."""
+    (transitively) the exports of any `require('./...')` it re-exports.
+
+    This is the TRUE shipped surface: the names a consumer can reach at
+    runtime through the package `main` entry. A class declared only in the
+    `.d.ts` but dropped from this set is not actually exported, so the gate
+    must never substitute a declaration-side hit for a runtime export.
+    """
     out: set[str] = set()
     if not js.is_file():
         return out
@@ -308,7 +365,7 @@ def _collect_js_exports(js: pathlib.Path, _seen: set[pathlib.Path] | None = None
     if resolved in seen:
         return out
     seen.add(resolved)
-    text = js.read_text(encoding="utf-8")
+    text = _strip_js_comments(js.read_text(encoding="utf-8"))
     for m in JS_EXPORTS_ASSIGN_RE.finditer(text):
         out.add(m.group(1))
     # `module.exports = Object.assign(..., { StreamingSession, ThetaDataError, ... })`:
@@ -317,9 +374,7 @@ def _collect_js_exports(js: pathlib.Path, _seen: set[pathlib.Path] | None = None
     for obj in re.finditer(
         r"module\.exports\s*=\s*Object\.assign\(([^;]*)\)", text, re.DOTALL
     ):
-        for key in re.finditer(
-            r"(?:^|[{,])\s*([A-Za-z_$][\w$]*)\s*(?:[,:}]|$)", obj.group(1)
-        ):
+        for key in JS_OBJECT_KEY_RE.finditer(obj.group(1)):
             name = key.group(1)
             if name not in {"Object", "assign"}:
                 out.add(name)
@@ -335,21 +390,134 @@ def _collect_js_exports(js: pathlib.Path, _seen: set[pathlib.Path] | None = None
     return out
 
 
+def _collect_ts_runtime_classes(ts_dts: pathlib.Path) -> set[str]:
+    """Runtime export names reachable through the package `main` entry.
+
+    Resolves the runtime entry from the package directory the `types` entry
+    lives in (so a caller passing a synthetic `types` path picks up the sibling
+    `.js`), then harvests its export names. This is the shipped surface a
+    consumer can `require`; the class-presence check holds every declared
+    runtime class to a hit here.
+    """
+    return _collect_js_exports(_resolve_ts_entry(ts_dts.parent, "main", "index.js"))
+
+
 def collect_typescript_classes(ts_dts: pathlib.Path) -> set[str]:
-    """Exported class / interface names on the published TypeScript surface.
+    """Every TypeScript surface name: declarations unioned with runtime.
 
     Scans the declared package entry (`package.json` `types`), following its
     `export * from './...'` re-exports, and unions the runtime entry
-    (`package.json` `main`) export names so a class shipped only through the
-    wrapper's runtime object-export (the typed-error leaves, the
-    context-managed session) is seen. `ts_dts` is the resolved `types` entry;
-    the matching runtime entry is resolved from the same package directory.
+    (`package.json` `main`) export names. This union is the name UNIVERSE used
+    by the public-surface vocabulary scan (which only needs the full set of
+    identifiers to check for banned tokens). It deliberately does NOT decide
+    class presence: a name present in the `.d.ts` but absent from the runtime
+    is in this union yet is NOT a shipped class. Presence is decided by
+    `_collect_ts_dts_class_kinds` (declaration kind) plus
+    `_collect_ts_runtime_classes` (runtime export) so a declaration-side hit
+    can never stand in for a dropped runtime export.
     """
-    out = _collect_ts_dts_classes(ts_dts)
-    # Resolve the runtime entry from the package the types entry lives in, so
-    # a caller passing a synthetic `types` path picks up the sibling `.js`.
-    out |= _collect_js_exports(_resolve_ts_entry(ts_dts.parent, "main", "index.js"))
-    return out
+    classes, interfaces = _collect_ts_dts_class_kinds(ts_dts)
+    return classes | interfaces | _collect_ts_runtime_classes(ts_dts)
+
+
+def _ts_class_presence(
+    name: str,
+    ts_declared_classes: set[str],
+    ts_declared_interfaces: set[str],
+    ts_runtime_exports: set[str],
+) -> tuple[bool, str | None]:
+    """Decide whether `name` is shipped on the TypeScript surface.
+
+    Returns `(present, detail)`. `present` is the actual-state boolean the
+    class-row check compares against the row's `typescript` claim; `detail`
+    is a non-empty string only when the name is in a half-shipped state the
+    gate must call out even where it would otherwise read as present:
+
+    - declared as a runtime `class` / runtime-class `const` but missing from
+      the runtime export set: NOT present. A consumer importing it gets
+      `undefined`, so this is a dropped export, not a typing detail.
+    - exported at runtime but with no declaration of any kind: present, but
+      flagged as an untyped runtime export (a `.d.ts` gap) so it cannot pass
+      silently on a declaration the package never ships.
+    - declared only as an `interface` (the napi plain-object shape, erased at
+      compile time): present on the declaration alone, since the type carries
+      no runtime constructor to export.
+    """
+    declared_class = name in ts_declared_classes
+    declared_interface = name in ts_declared_interfaces
+    runtime = name in ts_runtime_exports
+    if declared_class:
+        if runtime:
+            return True, None
+        return (
+            False,
+            "declared on the TypeScript .d.ts as a runtime class but missing "
+            "from the package runtime export; a consumer importing it resolves "
+            "to undefined (restore the export on the package `main` entry)",
+        )
+    if declared_interface:
+        # Object-shape type: no runtime constructor, declaration is the surface.
+        return True, None
+    if runtime:
+        return (
+            True,
+            "exported at runtime with no matching .d.ts declaration (add the "
+            "declaration so the typed surface matches what ships)",
+        )
+    return False, None
+
+
+def _check_class_rows(
+    rows: list[dict[str, Any]],
+    py_classes: set[str],
+    cpp_classes: set[str],
+    ts_declared_classes: set[str],
+    ts_declared_interfaces: set[str],
+    ts_runtime_exports: set[str],
+) -> list[str]:
+    """Class-level presence parity for the non-dotted `[[class]]` rows.
+
+    Compares each row's `python` / `typescript` / `cpp` claim to the actual
+    binding state. The TypeScript verdict goes through `_ts_class_presence`, so
+    a row marked `typescript = true` requires the runtime export when the class
+    is a real runtime class; a `.d.ts` declaration never stands in for a dropped
+    runtime export, and an untyped runtime export is flagged as a typing gap.
+    """
+    errors: list[str] = []
+    for row in rows:
+        name = row["name"]
+        if "." in name:
+            continue
+        for lang, declared in (
+            ("python", row["python"]),
+            ("typescript", row["typescript"]),
+            ("cpp", row["cpp"]),
+        ):
+            detail: str | None = None
+            if lang == "python":
+                actual = name in py_classes
+            elif lang == "typescript":
+                actual, detail = _ts_class_presence(
+                    name,
+                    ts_declared_classes,
+                    ts_declared_interfaces,
+                    ts_runtime_exports,
+                )
+            else:
+                actual = cpp_has(name, cpp_classes)
+            if actual != declared:
+                verb = "missing" if declared and not actual else "unexpected"
+                suffix = f" -- {detail}" if detail else ""
+                errors.append(
+                    f"  {name}.{lang}: declared={declared}, actual={actual} "
+                    f"({verb}){suffix}"
+                )
+            elif detail and declared:
+                # actual == declared (both true) yet the surface is half-shipped
+                # (e.g. a runtime export with no declaration). Flag it so a
+                # typing/parity gap cannot pass silently behind a true claim.
+                errors.append(f"  {name}.{lang}: {detail}")
+    return errors
 
 
 CPP_CLASS_RE = re.compile(r"^(?:class|struct)\s+(\w+)", re.MULTILINE)
@@ -4842,6 +5010,12 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     py_classes = collect_python_classes(PY_SRC)
+    # The TypeScript surface is read in three parts so a row's class-presence
+    # verdict rests on what actually ships at runtime, not on a declaration the
+    # runtime entry may have dropped. `ts_classes` (the union) is retained only
+    # for the name-universe consumers (anchor rows, the vocab scan).
+    ts_declared_classes, ts_declared_interfaces = _collect_ts_dts_class_kinds(TS_DTS)
+    ts_runtime_exports = _collect_ts_runtime_classes(TS_DTS)
     ts_classes = collect_typescript_classes(TS_DTS)
     cpp_classes = collect_cpp_classes(CPP_HPP)
 
@@ -4859,25 +5033,17 @@ def main(argv: list[str] | None = None) -> int:
 
     declared_names: set[str] = {row["name"] for row in rows}
 
-    # Class-level mismatches (non-dotted rows).
-    class_mismatches: list[tuple[str, str, bool, bool]] = []
-    for row in rows:
-        name = row["name"]
-        if "." in name:
-            continue
-        for lang, declared in (
-            ("python", row["python"]),
-            ("typescript", row["typescript"]),
-            ("cpp", row["cpp"]),
-        ):
-            if lang == "python":
-                actual = name in py_classes
-            elif lang == "typescript":
-                actual = name in ts_classes
-            else:
-                actual = cpp_has(name, cpp_classes)
-            if actual != declared:
-                class_mismatches.append((name, lang, declared, actual))
+    # Class-level mismatches (non-dotted rows). The TypeScript column is held
+    # to the runtime export, not the declaration, so a class dropped from the
+    # shipped package surface trips even while the `.d.ts` still declares it.
+    class_mismatches = _check_class_rows(
+        rows,
+        py_classes,
+        cpp_classes,
+        ts_declared_classes,
+        ts_declared_interfaces,
+        ts_runtime_exports,
+    )
 
     # Field-level mismatches (dotted rows / #595). The class universe lets
     # the dotted-row check validate documentation-anchor rows (an anchor on
@@ -5171,9 +5337,8 @@ def main(argv: list[str] | None = None) -> int:
             f"check_binding_parity: {len(class_mismatches)} class-level "
             f"mismatch(es) vs sdks/parity.toml:"
         )
-        for name, lang, declared, actual in class_mismatches:
-            verb = "missing" if declared and not actual else "unexpected"
-            print(f"  {name}.{lang}: declared={declared}, actual={actual} ({verb})")
+        for e in class_mismatches:
+            print(e)
         print()
 
     if field_errors:
@@ -6200,6 +6365,128 @@ def _run_selftest() -> int:
     _case("ts entry - resolves from package.json + follows re-exports", _case_ts_entry_resolves_from_package_json)
     _case("ts entry - falls back to index.* when keys absent", _case_ts_entry_falls_back_to_index)
     _case("ts entry - wrapper Client augmentation harvested", _case_ts_wrapper_augmentation_method_seen)
+
+    def _materialize_ts_pkg(
+        tmp: str, *, dts_body: str, js_body: str
+    ) -> tuple[set[str], set[str], set[str]]:
+        """Write a synthetic TypeScript package and return the three TS sets the
+        class-row check consumes: declared classes, declared interfaces, runtime
+        exports. The package declares its entries through `package.json` so the
+        resolver path under test runs exactly as it does on the real tree."""
+        pkg = pathlib.Path(tmp)
+        (pkg / "package.json").write_text(
+            '{"main": "entry.js", "types": "entry.d.ts"}\n', encoding="utf-8"
+        )
+        (pkg / "entry.d.ts").write_text(dts_body, encoding="utf-8")
+        (pkg / "entry.js").write_text(js_body, encoding="utf-8")
+        dts_path = _resolve_ts_entry(pkg, "types", "index.d.ts")
+        declared_classes, declared_interfaces = _collect_ts_dts_class_kinds(dts_path)
+        runtime = _collect_ts_runtime_classes(dts_path)
+        return declared_classes, declared_interfaces, runtime
+
+    def _case_ts_class_row_runtime_present_silent() -> None:
+        """A class declared in `.d.ts` AND exported at runtime is silent."""
+        rows = [{"name": "Widget", "python": False, "typescript": True, "cpp": False}]
+        with tempfile.TemporaryDirectory() as tmp:
+            dc, di, rt = _materialize_ts_pkg(
+                tmp,
+                dts_body="export declare class Widget {}\n",
+                js_body="module.exports = Object.assign({}, { Widget });\n",
+            )
+            errors = _check_class_rows(rows, set(), set(), dc, di, rt)
+        assert errors == [], (
+            f"declared + runtime-exported class must be silent; got {errors!r}"
+        )
+
+    def _case_ts_class_row_runtime_drop_trips() -> None:
+        """Dropping ONLY the JS runtime export (the class still declared in the
+        `.d.ts`) must trip the gate. This is the audit-proven hole: a
+        declaration-side hit must never stand in for the shipped surface."""
+        rows = [{"name": "Widget", "python": False, "typescript": True, "cpp": False}]
+        with tempfile.TemporaryDirectory() as tmp:
+            dc, di, rt = _materialize_ts_pkg(
+                tmp,
+                # Still declared as a runtime class on the typed surface ...
+                dts_body="export declare class Widget {}\n",
+                # ... but absent from the runtime export object.
+                js_body="module.exports = Object.assign({}, {});\n",
+            )
+            errors = _check_class_rows(rows, set(), set(), dc, di, rt)
+        assert any(
+            "Widget.typescript" in e and "missing" in e and "runtime export" in e
+            for e in errors
+        ), f"dropped JS runtime export must trip the gate; got {errors!r}"
+
+    def _case_ts_class_row_dts_drop_caught_as_typing_gap() -> None:
+        """Dropping ONLY the `.d.ts` declaration (the class still exported at
+        runtime) is caught as a typing/parity gap, not passed silently."""
+        rows = [{"name": "Widget", "python": False, "typescript": True, "cpp": False}]
+        with tempfile.TemporaryDirectory() as tmp:
+            dc, di, rt = _materialize_ts_pkg(
+                tmp,
+                # No declaration of any kind on the typed surface ...
+                dts_body="export declare class Other {}\n",
+                # ... yet present at runtime.
+                js_body="module.exports = Object.assign({}, { Widget });\n",
+            )
+            errors = _check_class_rows(rows, set(), set(), dc, di, rt)
+        assert any(
+            "Widget.typescript" in e and "no matching .d.ts declaration" in e
+            for e in errors
+        ), f"runtime export with no declaration must be flagged; got {errors!r}"
+
+    def _case_ts_interface_row_no_runtime_required() -> None:
+        """An `interface`-declared object type (the napi `#[napi(object)]`
+        plain-object shape) is satisfied by the declaration alone; it has no
+        runtime constructor to export, so a true claim stays silent."""
+        rows = [
+            {"name": "PlainShape", "python": False, "typescript": True, "cpp": False}
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            dc, di, rt = _materialize_ts_pkg(
+                tmp,
+                dts_body="export interface PlainShape { x: number }\n",
+                # The runtime ships no `PlainShape` constructor, and that is
+                # correct for an erased interface.
+                js_body="module.exports = Object.assign({}, {});\n",
+            )
+            errors = _check_class_rows(rows, set(), set(), dc, di, rt)
+        assert errors == [], (
+            f"interface-only object type must not require a runtime export; "
+            f"got {errors!r}"
+        )
+
+    def _case_ts_runtime_export_via_object_literal_comments() -> None:
+        """`_collect_js_exports` reads every key of a `module.exports =
+        Object.assign(..., { ... })` literal even when comments interleave the
+        keys; this covers the alternating-drop and comment-anchor defects that
+        previously hid half the runtime names."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pkg = pathlib.Path(tmp)
+            js = pkg / "entry.js"
+            js.write_text(
+                "module.exports = Object.assign({}, native, {\n"
+                "  Alpha,\n"
+                "  // a comment between two keys must not hide the next key\n"
+                "  Beta,\n"
+                "  Gamma: native.GammaImpl,\n"
+                "  /* block comment */ Delta,\n"
+                "  Epsilon,\n"
+                "});\n",
+                encoding="utf-8",
+            )
+            found = _collect_js_exports(js)
+        for want in ("Alpha", "Beta", "Gamma", "Delta", "Epsilon"):
+            assert want in found, (
+                f"runtime export {want} must be harvested despite comments; "
+                f"got {sorted(found)}"
+            )
+
+    _case("ts class row - declared + runtime export silent", _case_ts_class_row_runtime_present_silent)
+    _case("ts class row - JS runtime export drop trips", _case_ts_class_row_runtime_drop_trips)
+    _case("ts class row - .d.ts drop caught as typing gap", _case_ts_class_row_dts_drop_caught_as_typing_gap)
+    _case("ts class row - interface-only needs no runtime export", _case_ts_interface_row_no_runtime_required)
+    _case("ts runtime - object-literal keys read past comments", _case_ts_runtime_export_via_object_literal_comments)
 
     def _case_flatfiles_namespace_fetch_resolves() -> None:
         """A `FlatFilesNamespace` fetch row resolves through the C++ alias to the

--- a/scripts/ci/check_docs_consistency.py
+++ b/scripts/ci/check_docs_consistency.py
@@ -43,6 +43,14 @@ ENDPOINT_NAMES = {ep["name"] for ep in ENDPOINTS}
 # generated client to resolve it. Compare the registry paths as-is.
 REST_PATHS = {ep["rest_path"] for ep in ENDPOINTS}
 
+# The single server a generated client targets: the local HTTP server root.
+# `tools/server` listens on this port by default (`tools/server/src/main.rs`),
+# and the documented paths are the `/v3/...` routes served there. The block
+# must name an `http(s)` URL on this host; a backend scheme/host (a `grpc://`
+# URL, or an `mdds`/private-backend host) is a request a generated client
+# cannot issue and must trip the gate.
+OPENAPI_SERVER_URL = "http://localhost:25503"
+
 DOCS_SITE = ROOT / "docs-site/docs"
 OPENAPI_YAML = DOCS_SITE / "public/thetadatadx.yaml"
 
@@ -386,8 +394,64 @@ def check_llms_txt() -> None:
         )
 
 
+def _openapi_server_urls(text: str) -> list[str]:
+    """Return the `url:` values under the top-level `servers:` block.
+
+    Reads from the `servers:` key to the next top-level key (a line starting in
+    column zero), collecting each `- url: <value>` entry in order. Keeps the
+    parse local to the block so a `url:` under `info`/`contact`/`license` never
+    leaks in.
+    """
+    lines = text.splitlines()
+    urls: list[str] = []
+    in_block = False
+    for line in lines:
+        if not in_block:
+            if re.match(r"^servers:\s*$", line):
+                in_block = True
+            continue
+        # A new top-level key (no indentation) ends the servers block.
+        if line and not line[0].isspace():
+            break
+        m = re.match(r"\s*-\s*url:\s*(\S+)", line)
+        if m:
+            urls.append(m.group(1).strip())
+    return urls
+
+
 def check_openapi() -> None:
     text = OPENAPI_YAML.read_text()
+
+    # The `servers` block is the base URL a generated client prepends to every
+    # documented path. It must name the local HTTP server root; a missing /
+    # empty block, or a backend scheme/host (a `grpc://` URL or an
+    # `mdds`/private-backend host), yields a contract a client cannot call.
+    server_urls = _openapi_server_urls(text)
+    if not server_urls:
+        fail(
+            f"{OPENAPI_YAML.relative_to(ROOT)} has no `servers:` entry. "
+            f"Declare the local HTTP server: {OPENAPI_SERVER_URL}"
+        )
+    for url in server_urls:
+        scheme = url.split("://", 1)[0].lower() if "://" in url else ""
+        if scheme not in {"http", "https"}:
+            fail(
+                f"{OPENAPI_YAML.relative_to(ROOT)} servers url {url!r} is not an "
+                f"http(s) endpoint a generated client can call. Use the local "
+                f"HTTP server: {OPENAPI_SERVER_URL}"
+            )
+        host = url.split("://", 1)[1].split("/", 1)[0].lower()
+        if "mdds" in host:
+            fail(
+                f"{OPENAPI_YAML.relative_to(ROOT)} servers url {url!r} points at a "
+                f"backend host. Use the local HTTP server: {OPENAPI_SERVER_URL}"
+            )
+    if OPENAPI_SERVER_URL not in server_urls:
+        fail(
+            f"{OPENAPI_YAML.relative_to(ROOT)} servers block is missing the local "
+            f"HTTP server url {OPENAPI_SERVER_URL!r}; found {server_urls}"
+        )
+
     actual_paths = {
         match.group(1)
         for match in re.finditer(r"^  (/[A-Za-z0-9_/-]+):\s*$", text, re.MULTILINE)

--- a/scripts/ci/check_docs_consistency.py
+++ b/scripts/ci/check_docs_consistency.py
@@ -37,7 +37,11 @@ SURFACE = tomllib.loads((ROOT / "crates/thetadatadx/endpoint_surface.toml").read
 ENDPOINTS = SURFACE["endpoints"]
 TEMPLATES = SURFACE["templates"]
 ENDPOINT_NAMES = {ep["name"] for ep in ENDPOINTS}
-REST_PATHS = {ep["rest_path"].removeprefix("/v3") for ep in ENDPOINTS}
+# The OpenAPI `servers` block points at the HTTP server root
+# (`http://localhost:25503`), so each documented path must carry the full
+# served route (the registry `rest_path` verbatim, `/v3/...`) for a
+# generated client to resolve it. Compare the registry paths as-is.
+REST_PATHS = {ep["rest_path"] for ep in ENDPOINTS}
 
 DOCS_SITE = ROOT / "docs-site/docs"
 OPENAPI_YAML = DOCS_SITE / "public/thetadatadx.yaml"

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -71,8 +71,8 @@ cpp = true          # returned by `client.stream()`; exposed as `thetadatadx::St
 [[class]]
 name = "StreamingSession"
 python = true
-typescript = false  # JS uses a Promise-based async iterator instead — equivalent ergonomics
-cpp = false         # C++ uses RAII guard pattern instead
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts}) as the `await using` session wrapper
+cpp = false         # C++ uses the RAII guard pattern instead
 
 [[class]]
 name = "Contract"
@@ -140,90 +140,89 @@ cpp = true
 # ports across bindings by class name.
 #
 # C++ exposes one class per leaf in `thetadatadx.hpp`, matching the Python
-# tree. TypeScript also exposes one runtime class per leaf, but they
-# live in the package entry point `streaming-session.{js,d.ts}` (the
-# napi shim re-casts every `[ClassName] ...`-prefixed rejection into the
-# matching subclass). The parity checker reads the napi-generated
-# `index.d.ts`, which does not declare these JS-side classes, so each
-# row records the TypeScript column as `false` — the classes exist on
-# the public TS surface, they are simply not in the file the gate scans.
+# tree. TypeScript also exposes one runtime class per leaf; they live in the
+# package entry point `streaming-session.{js,d.ts}` (the napi shim re-casts
+# every `[ClassName] ...`-prefixed rejection into the matching subclass). The
+# parity checker resolves the TypeScript entry from `package.json` `types` /
+# `main` and scans it, so it sees these wrapper-side leaves and each row
+# records the TypeScript column as `true`.
 
 [[class]]
 name = "ThetaDataError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "AuthenticationError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "InvalidCredentialsError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "SubscriptionError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "RateLimitError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "InvalidParameterError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "NetworkError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "UnavailableError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "DeadlineExceededError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "NotFoundError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "SchemaMismatchError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "StreamError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 [[class]]
 name = "ConfigError"
 python = true
-typescript = false  # exported via streaming-session.{js,d.ts}, not index.d.ts
+typescript = true   # exported from the package entry (streaming-session.{js,d.ts})
 cpp = true
 
 # ─── FlatFilesConfig cross-binding setters ─────────────────────────────
@@ -1039,6 +1038,24 @@ python = true
 typescript = true
 cpp = true
 rust = true         # `Client::flat_files()` view accessor
+
+# Context-managed streaming session opener. A managed-binding ergonomic that
+# pairs `start_streaming` with a scope-exit `stop_streaming` + drain barrier:
+# Python `with client.streaming(cb) as session:` and TypeScript
+# `await using session = await client.streaming(cb)`. C++ and Rust express the
+# same lifecycle through idiomatic scope-bound resource management (the C++
+# `Client` RAII destructor; Rust scoped streaming APIs) rather than a named
+# `streaming(...)` factory, so the helper is intentionally Python + TypeScript
+# only. The TypeScript side lives on the package-entry wrapper
+# (`streaming-session.{js,d.ts}`), which the method collector reads alongside
+# the napi `impl` blocks.
+[[method]]
+class = "Client"
+name = "streaming"
+python = true       # `with client.streaming(callback) as session:` context manager
+typescript = true   # `await using session = await client.streaming(callback)` wrapper
+cpp = false         # C++ uses the `Client` RAII destructor, no `streaming()` factory
+rust = false        # Rust uses scoped streaming APIs, no `streaming()` factory
 
 # ── Inline client construction (first-class API-key entry points) ──
 #


### PR DESCRIPTION
A sweep across the v13 surface that fixes correctness gaps and completes several CI guards so cross-binding and contract drift cannot pass unnoticed.

## Core correctness

Authentication errors on non-401/404 responses now carry only the HTTP status, never the upstream response body, so a gateway that reflects the submitted request can never surface a credential through the error chain.

Explicit host overrides now win over environment selection, as documented. `THETADATA_HISTORICAL_HOST`, `THETADATA_STREAMING_HOST`, `THETADATA_STREAMING_PORT`, a `.env` file, and a config-file host list are tracked as typed overrides and survive `stage()`, `dev()`, and `with_environment()`. The streaming primary host and port are tracked independently, and a config-file host list wins outright. Presets with no override are byte-identical to before.

List endpoints now honor `request_timeout_secs` and expose a `_with_deadline` variant, so a live-but-silent stream can no longer hang a list call indefinitely.

The streaming TLS host allowlist now includes the staging and dev host, and its coverage test enumerates every preset host so a future preset host cannot silently fall outside the allowlist.

The client builder resolves file-backed credentials and config off the async worker thread.

## CI guard completeness

The binding-parity gate resolves the TypeScript entry from the package manifest and requires the runtime export, not only the type declaration, so a class dropped from the shipped package can no longer pass on its `.d.ts` alone. This corrected fourteen mis-recorded TypeScript rows and a missing `Client.streaming` row, and the Client helper scan is now general rather than a fixed list.

The published OpenAPI contract points at the local HTTP server, and every path carries the `/v3` prefix that the served routes use. The docs gate now enforces both the server URL and the full paths.

## Verification

The full library test suite and every CI gate pass, and the changes were independently re-reviewed for regressions.

One pre-existing latent item remains for a follow-up: the parity gate's `export declare const` pattern treats any such const as a runtime class. It is correct for the only current case and is not exercised otherwise today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
