### PR TITLE
fix(cli,fpss): use the real bin env var in tests and guard non-finite and overflow edges

### DIFF
--- a/crates/thetadatadx/src/fpss/accumulator.rs
+++ b/crates/thetadatadx/src/fpss/accumulator.rs
@@ -151,9 +151,23 @@ pub(super) fn change_price_type(price: i32, price_type: i32, new_price_type: i32
     if price == 0 || price_type == new_price_type {
         return price;
     }
-    let exp = new_price_type - price_type;
+    // Both `price_type`s are FPSS wire price types, validated into
+    // `0..=tdbe::types::price::MAX_PRICE_TYPE` (== 19) at the typed boundary by
+    // `strict_fpss_price` before any caller reaches here, so the difference is
+    // small and well-defined. Guard the helper at its boundary anyway: it is
+    // `pub(super)` with no compiler-enforced precondition, and a future caller
+    // must not be able to reintroduce a peer-triggerable subtract/negate
+    // debug-overflow. `saturating_sub` keeps `exp` finite; the `idx` lookups
+    // below are then bounded by `POW10.len()`, identical behavior for the valid
+    // range.
+    debug_assert!(
+        (0..=crate::tdbe::types::price::MAX_PRICE_TYPE).contains(&price_type)
+            && (0..=crate::tdbe::types::price::MAX_PRICE_TYPE).contains(&new_price_type),
+        "change_price_type expects price types in 0..=MAX_PRICE_TYPE"
+    );
+    let exp = new_price_type.saturating_sub(price_type);
     if exp <= 0 {
-        let idx = usize::try_from(-exp).unwrap_or(0);
+        let idx = usize::try_from(exp.unsigned_abs()).unwrap_or(usize::MAX);
         if idx < POW10.len() {
             // Match the JVM terminal's `int * int` wrap; differs from Rust's
             // default `*` which panics in debug. wrapping_mul makes the

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -226,6 +226,13 @@ fn format_ms(ms: i32) -> String {
 
 /// Format a decoded f64 price for display.
 fn format_price_f64(value: f64) -> String {
+    // Non-finite prices never carry a decimal point, so the `.find('.')` below
+    // would panic. Collapse them the way the REST / MCP surfaces do via
+    // `json_canon::finite_or_null` (non-finite -> null): here the display
+    // equivalent of null is an empty cell. Keeps all frontends consistent.
+    if !value.is_finite() {
+        return String::new();
+    }
     if value == 0.0 {
         return "0.00".into();
     }

--- a/tools/cli/tests/flatfile_subcommand.rs
+++ b/tools/cli/tests/flatfile_subcommand.rs
@@ -7,18 +7,12 @@
 use std::process::Command;
 
 fn binary() -> std::path::PathBuf {
-    // CARGO_BIN_EXE_<name> points at the compiled `thetadatadx` binary at the
-    // location cargo built it for the test runner. Falls back to the
-    // typical workspace path when the env var is missing (e.g. when
-    // someone runs the test via `cargo test -p thetadatadx-cli` from
-    // a CI matrix that bypassed CARGO_BIN_EXE_*).
-    std::env::var_os("CARGO_BIN_EXE_tdx")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| {
-            let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-            p.push("../../target/debug/thetadatadx");
-            p
-        })
+    // Cargo always sets `CARGO_BIN_EXE_<bin-name>` for same-crate integration
+    // tests, pointing at the binary it just built for the test runner. The bin
+    // is named `thetadatadx`, so the var is `CARGO_BIN_EXE_thetadatadx`; cargo
+    // honors `CARGO_TARGET_DIR` when computing the path, so this stays correct
+    // under a relocated target directory (CI matrices).
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_thetadatadx"))
 }
 
 #[test]


### PR DESCRIPTION
Three robustness fixes confined to the CLI tool and the FPSS OHLCVC accumulator.

The flatfile integration tests read CARGO_BIN_EXE_tdx, but the binary is named thetadatadx, so cargo exports CARGO_BIN_EXE_thetadatadx and the lookup always fell through to a hardcoded target/debug path. That path is wrong whenever CARGO_TARGET_DIR is relocated (CI matrices), so all four flatfile tests failed with NotFound. They now read CARGO_BIN_EXE_thetadatadx, which cargo always sets for same-crate integration tests and which honors CARGO_TARGET_DIR.

format_price_f64 rendered a non-finite price with no decimal point, so the subsequent decimal-point scan panicked. Non-finite values are now collapsed to an empty cell before the scan, mirroring how the REST and MCP surfaces null them through json_canon, so the table and CSV renderers stay consistent and panic-free.

change_price_type is pub(super) with no compiler-enforced precondition. Callers pre-validate price types into 0..=19, but the helper now self-defends with a boundary debug_assert plus saturating exponent arithmetic so a future caller cannot reintroduce a subtract or negate debug-overflow. Behavior is identical for the valid range.

Verification: cargo fmt --all -- --check; clippy clean with -D warnings on thetadatadx-cli (--all-targets) and on the thetadatadx lib; the four flatfile CLI tests pass under a relocated CARGO_TARGET_DIR; the fpss lib tests (including change_price_type) pass; lockfile drift check green with no lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)