### PR TITLE
ci: close gameable gaps in the surface-leak, version-sync, c-abi, re-framing, and parity guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ int main() {
 
 ```toml
 [dependencies]
-thetadatadx = "13.0.0-rc.1"
+thetadatadx = "13.0.0-rc.5"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -59,11 +59,20 @@ for agreement so a stale regenerated header is caught. This is the core
 
 Exits non-zero on any mismatch. Run from the repo root.
 
+The `.rs` / `.hpp` / `.h` / `.inc` collectors read source with C-style
+comments stripped first (`_read_source` / `_read_cpp_expanded`), so a
+symbol left behind only in a comment (a deleted-but-not-removed
+declaration) is not counted as present and cannot mask cross-binding
+drift. The one collector that intentionally harvests the documented
+label vocabulary FROM a doc comment
+(`_collect_ffi_subscription_kinds`) reads raw, and says so at its call.
+
 A `--selftest` switch runs an in-process synthetic-source matrix
 covering positive (all-bound) and negative (missing-on-TS,
 missing-on-C++, missing-on-FFI, undocumented-orphan, rust_only-
-without-issue) cases. The selftest is registered with the
-audit-protocol convention for CI gates.
+without-issue) cases, plus comment-stripping cases proving a
+commented-out declaration is ignored. The selftest is registered with
+the audit-protocol convention for CI gates.
 """
 
 from __future__ import annotations
@@ -224,12 +233,12 @@ def collect_python_classes(py_src: pathlib.Path) -> set[str]:
     would surface them."""
     out: set[str] = set()
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in PYCLASS_RE.finditer(text):
             out.add(_python_name(m.group(1), m.group(2)))
     errors_rs = py_src / "errors.rs"
     if errors_rs.is_file():
-        for m in re.finditer(r'm\.add\(\s*"(\w+)"\s*,', errors_rs.read_text(encoding="utf-8")):
+        for m in re.finditer(r'm\.add\(\s*"(\w+)"\s*,', _read_source(errors_rs)):
             out.add(m.group(1))
     return out
 
@@ -389,6 +398,34 @@ def _strip_js_comments(text: str) -> str:
     coarse comment strip is sufficient and cannot drop a tracked name.
     """
     return JS_LINE_COMMENT_RE.sub("", JS_BLOCK_COMMENT_RE.sub("", text))
+
+
+# Rust, C, and C++ share JavaScript's `//` line / `/* */` block comment
+# syntax (Rust `///` and `//!` doc comments and `/** */` are subsumed),
+# so the same coarse strip applies. Every symbol this gate reads from
+# those sources is a bare identifier in declaration position, never a
+# string-literal payload, so stripping comments before the symbol regexes
+# cannot drop a tracked name — but it DOES stop a deleted symbol left
+# behind in a comment (`// removed: historical()`) from reading as still
+# present, which would otherwise let real cross-binding drift pass.
+def _read_source(path: pathlib.Path) -> str:
+    """Read a Rust / C / C++ source file with comments stripped."""
+    return _strip_js_comments(path.read_text(encoding="utf-8"))
+
+
+def _read_cpp_expanded(cpp_hpp: pathlib.Path) -> str:
+    """Read a C++ wrapper header, inline its `.inc` includes, and strip
+    comments from the combined text.
+
+    The `.inc` fragments extend class bodies with generator-emitted
+    declarations; they must be inlined BEFORE the symbol scan and stripped
+    alongside the host header so a comment in either the header or an
+    included fragment cannot hide a member declaration.
+    """
+    expanded = _expand_cpp_includes(
+        cpp_hpp.read_text(encoding="utf-8"), cpp_hpp.parent
+    )
+    return _strip_js_comments(expanded)
 
 
 def _resolve_js_module(from_js: pathlib.Path, spec: str) -> pathlib.Path | None:
@@ -689,7 +726,7 @@ def collect_cpp_classes(cpp_hpp: pathlib.Path) -> set[str]:
     out: set[str] = set()
     if not cpp_hpp.is_file():
         return out
-    text = cpp_hpp.read_text(encoding="utf-8")
+    text = _read_source(cpp_hpp)
     for m in CPP_CLASS_RE.finditer(text):
         out.add(m.group(1))
     for m in CPP_USING_RE.finditer(text):
@@ -892,7 +929,7 @@ def _collect_python_setters(py_src: pathlib.Path) -> set[str]:
     if not py_src.is_dir():
         return setters
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in re.finditer(r"#\[setter\][^}]*?fn\s+(\w+)", text, re.DOTALL):
             name = m.group(1)
             if name.startswith("set_"):
@@ -937,7 +974,7 @@ def _collect_typescript_setters(ts_src: pathlib.Path) -> set[str]:
     if not ts_src.is_dir():
         return set()
     for rs in ts_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         # Scope to `impl Config { ... }` blocks so a `set<X>` napi method
         # on a non-Config class (e.g. the live `StreamView` streaming
         # knobs like `setSlowCallbackThresholdUs`) is not mistaken for a
@@ -973,7 +1010,7 @@ def _collect_cpp_setters(cpp_hpp: pathlib.Path, cpp_h: pathlib.Path) -> set[str]
     """
     cpp_setters: set[str] = set()
     if cpp_hpp.is_file():
-        text = cpp_hpp.read_text(encoding="utf-8")
+        text = _read_source(cpp_hpp)
         for m in re.finditer(r"\bvoid\s+set_(\w+)\s*\(", text):
             cpp_setters.add(m.group(1))
         # Some C++ setters return `int32_t` for status codes (the
@@ -982,7 +1019,7 @@ def _collect_cpp_setters(cpp_hpp: pathlib.Path, cpp_h: pathlib.Path) -> set[str]
             cpp_setters.add(m.group(1))
     h_setters: set[str] = set()
     if cpp_h.is_file():
-        text = cpp_h.read_text(encoding="utf-8")
+        text = _read_source(cpp_h)
         for m in re.finditer(r"\bthetadatadx_config_set_(\w+)\s*\(", text):
             h_setters.add(m.group(1))
     return cpp_setters & h_setters
@@ -998,7 +1035,7 @@ def _collect_ffi_setters(ffi_src: pathlib.Path) -> set[str]:
     if not ffi_src.is_dir():
         return setters
     for rs in ffi_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in re.finditer(r"\bfn\s+thetadatadx_config_set_(\w+)\s*\(", text):
             setters.add(m.group(1))
     return setters
@@ -1056,7 +1093,7 @@ def _collect_python_getters(py_src: pathlib.Path) -> set[str]:
     if not py_src.is_dir():
         return getters
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for body in _iter_impl_config_bodies(text):
             for m in re.finditer(r"#\[getter\][^}]*?fn\s+(\w+)", body, re.DOTALL):
                 name = m.group(1)
@@ -1078,7 +1115,7 @@ def _collect_typescript_getters(ts_src: pathlib.Path) -> set[str]:
     if not ts_src.is_dir():
         return set()
     for rs in ts_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for body in _iter_impl_config_bodies(text):
             for m in re.finditer(
                 r'#\[napi\([^)]*\bgetter\b[^)]*\bjs_name\s*=\s*"([a-zA-Z_]\w*)"[^)]*\)\]',
@@ -1103,7 +1140,7 @@ def _collect_cpp_getters(cpp_hpp: pathlib.Path) -> set[str]:
     getters: set[str] = set()
     if not cpp_hpp.is_file():
         return getters
-    text = _expand_cpp_includes(cpp_hpp.read_text(encoding="utf-8"), cpp_hpp.parent)
+    text = _read_cpp_expanded(cpp_hpp)
     m = re.search(r"^class\s+Config\s*(?::[^{]*)?\{", text, re.MULTILINE)
     if not m:
         return getters
@@ -1123,7 +1160,7 @@ def _collect_ffi_getters(ffi_src: pathlib.Path) -> set[str]:
     if not ffi_src.is_dir():
         return getters
     for rs in ffi_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in re.finditer(r"\bfn\s+thetadatadx_config_get_(\w+)\s*\(", text):
             getters.add(m.group(1))
     return getters
@@ -1310,7 +1347,7 @@ def _collect_rust_client_builder_setters(client_builder_rs: pathlib.Path) -> set
     setters: set[str] = set()
     if not client_builder_rs.is_file():
         return setters
-    text = client_builder_rs.read_text(encoding="utf-8")
+    text = _read_source(client_builder_rs)
     for header in re.finditer(r"impl\s+ClientBuilder\s*\{", text):
         body = _balanced_body(text, header.end())
         for m in re.finditer(
@@ -1334,7 +1371,7 @@ def _collect_cpp_client_builder_setters(cpp_hpp: pathlib.Path) -> set[str]:
     setters: set[str] = set()
     if not cpp_hpp.is_file():
         return setters
-    text = _expand_cpp_includes(cpp_hpp.read_text(encoding="utf-8"), cpp_hpp.parent)
+    text = _read_cpp_expanded(cpp_hpp)
     m = re.search(r"^class\s+ClientBuilder\s*(?::[^{]*)?\{", text, re.MULTILINE)
     if not m:
         return setters
@@ -1417,7 +1454,7 @@ def _collect_typescript_connect_with_fields(ts_lib_rs: pathlib.Path) -> set[str]
     out: set[str] = set()
     if not ts_lib_rs.is_file():
         return out
-    text = ts_lib_rs.read_text(encoding="utf-8")
+    text = _read_source(ts_lib_rs)
     m = re.search(
         r"#\[napi\(object\)\]\s*pub\s+struct\s+ClientConnectOptions\s*\{",
         text,
@@ -1577,7 +1614,7 @@ def _collect_rust_pub_fields(config_dir: pathlib.Path) -> dict[str, set[str]]:
     if not config_dir.is_dir():
         return out
     for rs in config_dir.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         # Find every `pub struct X {` block and walk forward until the
         # closing brace. The structs in `crates/thetadatadx/src/config/`
         # never nest other struct definitions; a depth=1 brace counter
@@ -1693,7 +1730,7 @@ def _collect_python_class_methods(py_src: pathlib.Path) -> dict[str, set[str]]:
     )
     fn_re = re.compile(r"fn\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*[(<]")
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for header in impl_re.finditer(text):
             class_name = header.group(1)
             # Walk the impl block with a brace counter to bound the
@@ -1767,7 +1804,7 @@ def _collect_typescript_class_methods(
         r'(?:pub\s+)?(?:async\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]'
     )
     for rs in ts_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for header in impl_re.finditer(text):
             class_name = header.group(1)
             # Walk the impl block with a brace counter to bound the
@@ -1881,7 +1918,7 @@ def _collect_cpp_class_methods(cpp_hpp: pathlib.Path) -> dict[str, set[str]]:
     out: dict[str, set[str]] = {}
     if not cpp_hpp.is_file():
         return out
-    text = _expand_cpp_includes(cpp_hpp.read_text(encoding="utf-8"), cpp_hpp.parent)
+    text = _read_cpp_expanded(cpp_hpp)
     # Limit to class bodies — struct bodies are POD-shaped value types
     # and irrelevant to the cross-binding method contract.
     class_header_re = re.compile(r"^class\s+(\w+)\s*(?::[^{]*)?\{", re.MULTILINE)
@@ -2070,7 +2107,7 @@ def _collect_rust_view_methods(client_rs: pathlib.Path) -> dict[str, set[str]]:
     out: dict[str, set[str]] = {}
     if not client_rs.is_file():
         return out
-    text = client_rs.read_text(encoding="utf-8")
+    text = _read_source(client_rs)
     # `pub fn <name>(` or `pub async fn <name>(`, capturing any leading
     # attribute lines so cfg/doc-hidden gating can be honoured.
     pub_fn_re = re.compile(
@@ -2507,7 +2544,7 @@ def _collect_core_streaming_observability_methods(
     for class_name, rs in sources:
         if not rs.is_file():
             continue
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         impl_re = re.compile(
             rf"impl\s+{class_name}\b[^{{]*\{{"
         )
@@ -2602,7 +2639,7 @@ def _collect_python_utility_functions(py_src: pathlib.Path) -> set[str]:
         return out
     fn_re = re.compile(r"#\[pyfunction\][^{}]*?fn\s+(\w+)\s*\(", re.DOTALL)
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in fn_re.finditer(text):
             out.add(m.group(1))
     return out - PY_NON_UTILITY_PYFUNCTIONS
@@ -2643,7 +2680,7 @@ def _collect_typescript_utility_functions(ts_src: pathlib.Path) -> set[str]:
         r"(?:pub\s+)?(?:async\s+)?fn\s+([a-z_][a-z0-9_]*)\s*[(<]"
     )
     for rs in ts_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         # Blank every impl body so method declarations inside them do not
         # masquerade as free functions. Walk with a brace counter.
         cleaned = []
@@ -2688,7 +2725,7 @@ def _collect_cpp_utility_functions(cpp_hpp: pathlib.Path) -> set[str]:
     out: set[str] = set()
     if not cpp_hpp.is_file():
         return out
-    text = _expand_cpp_includes(cpp_hpp.read_text(encoding="utf-8"), cpp_hpp.parent)
+    text = _read_cpp_expanded(cpp_hpp)
     # Blank class / struct bodies so only namespace-scope free functions
     # remain.
     type_re = re.compile(r"\b(?:class|struct)\s+\w+[^{;]*\{")
@@ -2736,7 +2773,7 @@ def _collect_ffi_utility_functions(ffi_src: pathlib.Path) -> set[str]:
     if not ffi_src.is_dir():
         return out
     for rs in ffi_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in re.finditer(r"\bfn\s+thetadatadx_(\w+)\s*\(", text):
             out.add(m.group(1))
     return out
@@ -2970,7 +3007,7 @@ def _collect_rust_subscription_kinds(subscription_rs: pathlib.Path) -> set[str]:
     if not subscription_rs.is_file():
         return set()
     return _harvest_kind_labels(
-        subscription_rs.read_text(encoding="utf-8"),
+        _read_source(subscription_rs),
         ("fn kind_str", "fn full_kind_str"),
     )
 
@@ -2984,7 +3021,7 @@ def _collect_binding_subscription_kinds(fluent_rs: pathlib.Path) -> set[str]:
     if not fluent_rs.is_file():
         return set()
     return _harvest_kind_labels(
-        fluent_rs.read_text(encoding="utf-8"),
+        _read_source(fluent_rs),
         ("fn kind", "SubscriptionKind"),
     )
 
@@ -2999,7 +3036,7 @@ def _collect_cpp_subscription_kinds(cpp_hpp: pathlib.Path) -> set[str]:
     """
     if not cpp_hpp.is_file():
         return set()
-    text = cpp_hpp.read_text(encoding="utf-8")
+    text = _read_source(cpp_hpp)
     # Bound the harvest to the `kind_string()` body so an unrelated label
     # string elsewhere in the header cannot mask a divergence inside the
     # accessor.
@@ -3033,6 +3070,11 @@ def _collect_ffi_subscription_kinds(cpp_h: pathlib.Path) -> set[str]:
     """
     if not cpp_h.is_file():
         return set()
+    # NB: read RAW (comments intact). Unlike the symbol collectors, this
+    # harvest reads the canonical label vocabulary FROM the
+    # `ThetaDataDxSubscription` doc comment itself — the documented C
+    # contract lives in prose, so stripping comments here would erase
+    # exactly what must be checked.
     text = cpp_h.read_text(encoding="utf-8")
     # The kind label vocabulary appears in the `ThetaDataDxSubscription` struct
     # doc comment. Restrict the harvest to the lines mentioning the field
@@ -3167,7 +3209,7 @@ def _collect_python_error_leaves(py_errors_rs: pathlib.Path) -> set[str]:
     """
     if not py_errors_rs.is_file():
         return set()
-    text = py_errors_rs.read_text(encoding="utf-8")
+    text = _read_source(py_errors_rs)
     m = re.search(r"pub fn to_py_err\s*\([^)]*\)\s*->\s*PyErr\s*\{", text)
     if not m:
         return set()
@@ -3191,7 +3233,7 @@ def _collect_typescript_error_leaves(ts_lib_rs: pathlib.Path) -> set[str]:
     """
     if not ts_lib_rs.is_file():
         return set()
-    text = ts_lib_rs.read_text(encoding="utf-8")
+    text = _read_source(ts_lib_rs)
     m = re.search(r"fn leaf_class_for\s*\([^)]*\)\s*->\s*&'static str\s*\{", text)
     if not m:
         return set()
@@ -3211,7 +3253,7 @@ def _collect_cpp_error_leaves(cpp_hpp: pathlib.Path) -> set[str]:
     """
     if not cpp_hpp.is_file():
         return set()
-    text = cpp_hpp.read_text(encoding="utf-8")
+    text = _read_source(cpp_hpp)
     m = re.search(r"void\s+throw_for_code\s*\([^)]*\)\s*\{", text)
     if not m:
         return set()
@@ -3231,7 +3273,7 @@ def _collect_ffi_error_codes(ffi_error_rs: pathlib.Path) -> dict[str, int]:
     """
     if not ffi_error_rs.is_file():
         return {}
-    text = ffi_error_rs.read_text(encoding="utf-8")
+    text = _read_source(ffi_error_rs)
     out: dict[str, int] = {}
     for name, value in re.findall(
         r"pub const (THETADATADX_ERR_\w+)\s*:\s*i32\s*=\s*(\d+)\s*;", text
@@ -3248,7 +3290,7 @@ def _collect_ffi_error_codes_dispatched(ffi_error_rs: pathlib.Path) -> set[str]:
     """
     if not ffi_error_rs.is_file():
         return set()
-    text = ffi_error_rs.read_text(encoding="utf-8")
+    text = _read_source(ffi_error_rs)
     m = re.search(r"fn error_code_for\s*\([^)]*\)\s*->\s*i32\s*\{", text)
     if not m:
         return set()
@@ -3266,7 +3308,7 @@ def _collect_cpp_error_codes(cpp_h: pathlib.Path) -> dict[str, int]:
     """
     if not cpp_h.is_file():
         return {}
-    text = cpp_h.read_text(encoding="utf-8")
+    text = _read_source(cpp_h)
     out: dict[str, int] = {}
     for name, value in re.findall(r"#define\s+(THETADATADX_ERR_\w+)\s+(\d+)\b", text):
         out[name] = int(value)
@@ -3459,7 +3501,7 @@ def _collect_python_streaming_endpoints(py_src: pathlib.Path) -> set[str]:
         return out
     impl_re = re.compile(r"impl\s+(\w+)Builder\s*\{")
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for header in impl_re.finditer(text):
             stem = header.group(1)
             body_start = header.end()
@@ -3522,7 +3564,7 @@ def _collect_ffi_streaming_endpoints(ffi_src: pathlib.Path) -> set[str]:
         return out
     fn_re = re.compile(r"\bfn\s+thetadatadx_(\w+)_stream\s*\(")
     for rs in ffi_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in fn_re.finditer(text):
             out.add(m.group(1))
     return out
@@ -3661,7 +3703,7 @@ def _collect_python_async_endpoints(py_src: pathlib.Path) -> set[str]:
         return out
     impl_re = re.compile(r"impl\s+(\w+)Builder\s*\{")
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for header in impl_re.finditer(text):
             stem = header.group(1)
             body_start = header.end()
@@ -3926,7 +3968,7 @@ def _collect_cabi_base_endpoints(with_options_inc: pathlib.Path) -> set[str]:
     out: set[str] = set()
     if not with_options_inc.is_file():
         return out
-    text = with_options_inc.read_text(encoding="utf-8")
+    text = _read_source(with_options_inc)
     for m in re.finditer(r"\bthetadatadx_(\w+)_with_options\s*\(", text):
         out.add(m.group(1))
     return out
@@ -3947,7 +3989,7 @@ def _collect_ffi_base_endpoints(ffi_src: pathlib.Path) -> set[str]:
         return out
     fn_re = re.compile(r"\bfn\s+thetadatadx_(\w+)_with_options\s*\(")
     for rs in ffi_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in fn_re.finditer(text):
             out.add(m.group(1))
     return out
@@ -3986,7 +4028,7 @@ def _collect_python_buffered_endpoints(py_src: pathlib.Path) -> set[str]:
         return out
     impl_re = re.compile(r"impl\s+(\w+)Builder\s*\{")
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for header in impl_re.finditer(text):
             stem = header.group(1)
             body = _balanced_body(text, header.end())
@@ -4215,7 +4257,7 @@ def _collect_ffi_from_file_stems(ffi_src: pathlib.Path) -> set[str]:
         return out
     fn_re = re.compile(r"\bfn\s+thetadatadx_(\w+)_connect_from_file\s*\(")
     for rs in ffi_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in fn_re.finditer(text):
             out.add(m.group(1))
     return out
@@ -4354,7 +4396,7 @@ def _collect_python_connect_classes(py_src: pathlib.Path) -> set[str]:
         r"impl\s+(?:[A-Za-z_][A-Za-z0-9_]*::)*([A-Za-z_][A-Za-z0-9_]*)\s*\{"
     )
     for rs in py_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for header in impl_re.finditer(text):
             class_name = header.group(1)
             if class_name not in _CONNECT_GOVERNED:
@@ -4410,7 +4452,7 @@ def _collect_ffi_connect_stems(ffi_src: pathlib.Path) -> set[str]:
         return out
     fn_re = re.compile(r"\bfn\s+thetadatadx_(\w+?)_connect\s*\(")
     for rs in ffi_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in fn_re.finditer(text):
             out.add(m.group(1))
     return out
@@ -4609,7 +4651,7 @@ def _collect_ffi_credentials_factories(ffi_src: pathlib.Path) -> set[str]:
         return out
     fn_re = re.compile(r"\bfn\s+thetadatadx_credentials_(\w+)\s*\(")
     for rs in ffi_src.rglob("*.rs"):
-        text = rs.read_text(encoding="utf-8")
+        text = _read_source(rs)
         for m in fn_re.finditer(text):
             tail = m.group(1)
             if tail == "free":
@@ -4871,7 +4913,7 @@ def _struct_field_type(src_dir: pathlib.Path, struct: str, field: str) -> str | 
         r"(?:#\[[^\]]*\]\s*)*pub\s+" + re.escape(field) + r"\s*:\s*([^,\n]+)",
     )
     for path in sorted(src_dir.rglob("*.rs")):
-        text = path.read_text(encoding="utf-8")
+        text = _read_source(path)
         for m in struct_re.finditer(text):
             fm = field_re.search(m.group(1))
             if fm:
@@ -4889,7 +4931,7 @@ def _cpp_struct_field_type(hpp: pathlib.Path, struct: str, field: str) -> str | 
     type this returns, closing the gap that let a C++ value struct
     surface a raw wire integer the other bindings decode.
     """
-    text = hpp.read_text(encoding="utf-8")
+    text = _read_source(hpp)
     struct_re = re.compile(
         r"struct\s+" + re.escape(struct) + r"\s*\{(.*?)\n\}",
         re.S,
@@ -4938,7 +4980,7 @@ def _c_abi_struct_field_type(inc: pathlib.Path, struct: str, field: str) -> str 
     """
     if not inc.is_file():
         return None
-    text = inc.read_text(encoding="utf-8")
+    text = _read_source(inc)
     struct_re = re.compile(
         r"typedef\s+struct\s*\{(.*?)\}\s*" + re.escape(struct) + r"\s*;",
         re.S,
@@ -5083,7 +5125,7 @@ def _collect_value_struct_fields(
     )
     field_re = re.compile(r"(?:#\[[^\]]*\]\s*)*pub\s+(\w+)\s*:", re.M)
     for path in sorted(src_dir.rglob("*.rs")):
-        text = path.read_text(encoding="utf-8")
+        text = _read_source(path)
         for m in struct_re.finditer(text):
             for fm in field_re.finditer(m.group(1)):
                 out.add(fm.group(1))
@@ -8725,6 +8767,97 @@ def _run_selftest() -> int:
     _case("utility — roster orphan (untracked util) trips", _case_utility_roster_orphan_trips)
     _case("utility — TS surface filters internal free fns", _case_ts_utility_surface_filters_internal)
     _case("utility — live roster complete", _case_utility_roster_live_complete)
+
+    # ── Source comment-stripping selftests ─────────────────────────
+    # The `.rs` / `.hpp` / `.h` / `.inc` collectors strip C-style
+    # comments before their symbol regexes run, so a symbol that survives
+    # only inside a comment (a deleted-but-not-removed declaration like
+    # `// removed: historical()`) no longer reads as present. Without the
+    # strip, a `DOTALL` collector regex spans the comment markers and a
+    # ghost symbol passes — masking real cross-binding drift.
+
+    def _case_strip_source_comments_helper() -> None:
+        """`_read_source` removes both line and block comments."""
+        raw = (
+            "pub fn live() {}\n"
+            "// pub fn ghost_line() {}\n"
+            "/* pub fn ghost_block() {} */\n"
+            "/// removed: historical()\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            p = pathlib.Path(td) / "x.rs"
+            p.write_text(raw, encoding="utf-8")
+            stripped = _read_source(p)
+        assert "live" in stripped, "a live declaration must survive stripping"
+        for ghost in ("ghost_line", "ghost_block", "historical"):
+            assert ghost not in stripped, (
+                f"`{ghost}` survived only in a comment but was not stripped"
+            )
+
+    def _case_strip_pyclass_in_comment_ignored() -> None:
+        """A commented-out `#[pyclass]` is NOT collected, while a live one
+        is — the deleted-symbol-in-comment hole, proven end-to-end through
+        the real `collect_python_classes` collector.
+        """
+        src = (
+            "#[pyclass]\n"
+            "pub struct LiveClass {}\n"
+            "\n"
+            "// #[pyclass]\n"
+            "// pub struct GhostLineClass {}\n"
+            "\n"
+            "/* #[pyclass]\n"
+            "   pub struct GhostBlockClass {} */\n"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "lib.rs").write_text(src, encoding="utf-8")
+            classes = collect_python_classes(root)
+        assert "LiveClass" in classes, (
+            f"a live #[pyclass] must be collected; got {sorted(classes)!r}"
+        )
+        assert "GhostLineClass" not in classes, (
+            "a #[pyclass] surviving only in a line comment was collected — "
+            f"the comment-strip hole is open; got {sorted(classes)!r}"
+        )
+        assert "GhostBlockClass" not in classes, (
+            "a #[pyclass] surviving only in a block comment was collected — "
+            f"the comment-strip hole is open; got {sorted(classes)!r}"
+        )
+
+    def _case_strip_cpp_includes_comments() -> None:
+        """`_read_cpp_expanded` inlines `.inc` fragments AND strips
+        comments from both the host header and the inlined fragment, so a
+        commented-out declaration in either is not seen.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            (root / "frag.inc").write_text(
+                "void thetadatadx_live_inc(void);\n"
+                "// void thetadatadx_ghost_inc(void);\n",
+                encoding="utf-8",
+            )
+            hpp = root / "header.hpp"
+            hpp.write_text(
+                '#include "frag.inc"\n'
+                "void thetadatadx_live_hpp(void);\n"
+                "/* void thetadatadx_ghost_hpp(void); */\n",
+                encoding="utf-8",
+            )
+            text = _read_cpp_expanded(hpp)
+        assert "thetadatadx_live_inc" in text and "thetadatadx_live_hpp" in text, (
+            "live declarations from the header and the inlined .inc must "
+            f"survive; got: {text!r}"
+        )
+        for ghost in ("thetadatadx_ghost_inc", "thetadatadx_ghost_hpp"):
+            assert ghost not in text, (
+                f"`{ghost}` survived only in a comment after include "
+                "expansion but was not stripped"
+            )
+
+    _case("comment-strip — _read_source drops line + block comments", _case_strip_source_comments_helper)
+    _case("comment-strip — commented-out #[pyclass] not collected", _case_strip_pyclass_in_comment_ignored)
+    _case("comment-strip — _read_cpp_expanded strips host + .inc comments", _case_strip_cpp_includes_comments)
 
     print(f"check_binding_parity --selftest: {n_pass} passed, {n_fail} failed")
     return 0 if n_fail == 0 else 1

--- a/scripts/ci/check_c_abi_completeness.py
+++ b/scripts/ci/check_c_abi_completeness.py
@@ -2,12 +2,22 @@
 """C ABI completeness check (Gate 4 / issue #547).
 
 Every exported `thetadatadx_*` C ABI symbol that ends up in the compiled
-shared library `libthetadatadx_ffi.so` MUST appear by name in
-`sdks/cpp/include/thetadatadx.h` (or one of its `.inc` includes).
-Drift on the C-side header is invisible to `cargo build` because the
-headers are hand-maintained and the link contract only breaks at the
-user's compile time, after they've already pip-installed or fetched
-the C++ SDK.
+shared library `libthetadatadx_ffi.so` MUST appear as a function
+DECLARATION in `sdks/cpp/include/thetadatadx.h` (or one of its `.inc`
+includes). Drift on the C-side header is invisible to `cargo build`
+because the headers are hand-maintained and the link contract only
+breaks at the user's compile time, after they've already pip-installed
+or fetched the C++ SDK.
+
+"Declaration" is the operative word: the header scan strips C/C++
+comments first and then collects only `thetadatadx_<name>(` declaration
+sites. A symbol name surviving in a comment, or a prose wildcard such as
+`thetadatadx_exchange_*`, is NOT a declaration and does not count — so it
+can neither make a genuinely-missing prototype look present (the forward
+`rust - header` check) nor pollute the reverse `header - rust` delta. A
+prior raw-text scan counted comment mentions, which is why a
+`thetadatadx_exchange_` allow-list workaround was once needed; that entry
+is gone now that only real declarations are collected.
 
 The symbol inventory is sourced from the compiled library via
 `nm -D --defined-only` rather than a regex pass over
@@ -27,10 +37,19 @@ Exits non-zero on any gap. Run from the repo root.
 Usage:
     cargo build -p thetadatadx-ffi --release
     python3 scripts/ci/check_c_abi_completeness.py
+
+Selftest:
+    python3 scripts/ci/check_c_abi_completeness.py --selftest
+
+The selftest plants a synthetic header that declares one symbol and
+mentions another only in a comment, and confirms the comment mention is
+not collected as declared (so the forward completeness check would still
+flag it as missing).
 """
 
 from __future__ import annotations
 
+import argparse
 import pathlib
 import re
 import subprocess
@@ -53,6 +72,38 @@ _SO_NAMES = ("libthetadatadx_ffi.so", "libthetadatadx_ffi.dylib")
 # `nm`.
 EXTERN_RE = re.compile(r'extern\s+"C"\s+fn\s+(thetadatadx_\w+)')
 SYMBOL_RE = re.compile(r"\bthetadatadx_\w+\b")
+# A header symbol counts as DECLARED only when it appears as a function
+# declaration — the symbol name immediately followed (modulo whitespace)
+# by an opening parenthesis. A bare mention in a comment or a prose
+# wildcard like `thetadatadx_exchange_*` is NOT a declaration and must
+# not satisfy the forward `rust - header` check; counting it let a
+# genuinely-missing decl masquerade as present (the very gap the
+# `thetadatadx_exchange_` allow-list entry was a workaround for).
+HEADER_DECL_RE = re.compile(r"\b(thetadatadx_\w+)\s*\(")
+# C / C++ comment strippers. Run before the declaration scan so a
+# function name surviving only inside a comment cannot read as declared.
+# (Both directions benefit: a commented-out prototype neither satisfies
+# `rust - header` nor trips `header - rust`.) String-literal contents are
+# not stripped, which is harmless here: the scanned names are bare C
+# identifiers in declaration position, never string payloads.
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+
+
+def _strip_c_comments(text: str) -> str:
+    """Remove block (`/* */`) and line (`//`) comments from C/C++ text."""
+    return _LINE_COMMENT_RE.sub("", _BLOCK_COMMENT_RE.sub("", text))
+
+
+def _header_decls_from_text(text: str) -> set[str]:
+    """Function-declaration symbols in one header's text.
+
+    Comments are stripped first, then `thetadatadx_<name>(` declaration
+    sites are collected. Factored out so the self-test can exercise the
+    comment-vs-declaration logic on synthetic header text.
+    """
+    stripped = _strip_c_comments(text)
+    return {m.group(1) for m in HEADER_DECL_RE.finditer(stripped)}
 # `nm -D --defined-only` lines look like:
 #   `0000000000123456 T thetadatadx_some_symbol_name`
 # We match the trailing identifier on `T` (text/code) entries — those
@@ -144,26 +195,34 @@ def collect_ffi_symbols() -> set[str]:
 
 
 def collect_header_symbols() -> set[str]:
+    """Symbols DECLARED as functions in the shipped C/C++ headers.
+
+    Comments are stripped first, then only `thetadatadx_<name>(`
+    declaration sites are collected. A name that survives only in a
+    comment, or a `thetadatadx_foo_*` wildcard mentioned in prose, is not
+    a declaration and is intentionally not collected — so it can neither
+    satisfy the forward `rust - header` completeness check nor pollute
+    the reverse `header - rust` delta.
+    """
     out: set[str] = set()
     for header in list(CPP_INCLUDE.rglob("*.h")) + list(CPP_INCLUDE.rglob("*.hpp")) + list(CPP_INCLUDE.rglob("*.inc")):
-        text = header.read_text(encoding="utf-8")
-        for match in SYMBOL_RE.finditer(text):
-            out.add(match.group(0))
+        out |= _header_decls_from_text(header.read_text(encoding="utf-8"))
     return out
 
 
 # Header-only `thetadatadx_*` symbols that legitimately have no Rust
-# counterpart — e.g. opaque struct typedefs declared in C but
-# implemented entirely in C++ wrapper code, or compile-time
-# constants emitted via `#define THETADATADX_FOO 1`. Add a comment when
-# extending this list.
-HEADER_ONLY_ALLOWLIST: set[str] = {
-    # `thetadatadx_exchange_` (trailing underscore) is the symbol-family
-    # prose mention `thetadatadx_exchange_*` in `thetadatadx.h:785`. The
-    # regex captures `thetadatadx_exchange_` from the wildcard form. Real
-    # exports are `thetadatadx_exchange_name` / `thetadatadx_exchange_symbol`.
-    "thetadatadx_exchange_",
-}
+# counterpart — e.g. a function-like macro spelled `thetadatadx_foo(...)`
+# that expands inline rather than linking to an exported symbol. Add a
+# comment when extending this list.
+#
+# The former `thetadatadx_exchange_` entry has been removed: it existed
+# only because the old raw-text scan captured the prose wildcard
+# `thetadatadx_exchange_*` from a comment. The declaration-shape scan
+# (`thetadatadx_<name>(`) over comment-stripped text no longer sees it,
+# so no allow-listing is required for that family. Its real exports
+# (`thetadatadx_exchange_name` / `thetadatadx_exchange_symbol`) are
+# matched normally as genuine declarations.
+HEADER_ONLY_ALLOWLIST: set[str] = set()
 
 
 def main() -> int:
@@ -216,5 +275,77 @@ def main() -> int:
     return 0
 
 
+def _selftest() -> int:
+    """Prove a comment-only symbol mention does not count as declared.
+
+    Cases (all driven through the real `_header_decls_from_text` +
+    `rust - header` / `header - rust` logic on synthetic inputs):
+
+    * A header that DECLARES `thetadatadx_alpha(...)` but mentions
+      `thetadatadx_beta` only inside a `//` comment and a `/* */` block,
+      plus the prose wildcard `thetadatadx_gamma_*`. Only `alpha` may be
+      collected as declared.
+    * Forward check: a Rust symbol set `{alpha, beta}` against that header
+      must report `beta` missing — the comment mention must NOT satisfy
+      completeness (this is the gameable hole being closed).
+    * Reverse check: a header declaring `thetadatadx_delta(...)` with no
+      Rust counterpart must surface `delta` as an extra — proving real
+      declarations are still collected after comment stripping.
+    """
+    header_text = (
+        "// thetadatadx_beta is documented here but never declared.\n"
+        "/* The family thetadatadx_gamma_* is described in prose only. */\n"
+        "void thetadatadx_alpha(int x);\n"
+        "/* thetadatadx_beta(int) — intentionally only in this comment */\n"
+    )
+    declared = _header_decls_from_text(header_text)
+
+    failures: list[str] = []
+    if declared != {"thetadatadx_alpha"}:
+        failures.append(
+            "comment-stripping: expected exactly {thetadatadx_alpha} to be "
+            f"collected as declared, got {sorted(declared)} (a comment-only "
+            "mention or a prose wildcard leaked in as a declaration)"
+        )
+
+    # Forward direction: the comment-only `beta` must read as MISSING.
+    rust = {"thetadatadx_alpha", "thetadatadx_beta"}
+    missing = rust - declared
+    if "thetadatadx_beta" not in missing:
+        failures.append(
+            "forward check: a symbol present only in a header comment was "
+            "treated as declared — the gate would pass a real missing decl"
+        )
+    if "thetadatadx_alpha" in missing:
+        failures.append(
+            "forward check: a genuinely declared symbol was reported missing"
+        )
+
+    # Reverse direction: a real header decl with no Rust impl is an extra.
+    reverse_text = "double thetadatadx_delta(void);\n"
+    reverse_declared = _header_decls_from_text(reverse_text)
+    extras = (reverse_declared - {"thetadatadx_other"}) - HEADER_ONLY_ALLOWLIST
+    if "thetadatadx_delta" not in extras:
+        failures.append(
+            "reverse check: a real header declaration absent from Rust was "
+            "not surfaced as an extra"
+        )
+
+    if failures:
+        print("check_c_abi_completeness --selftest: FAILED")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("check_c_abi_completeness --selftest: ok")
+    return 0
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="Run the embedded self-test and exit.",
+    )
+    args = parser.parse_args()
+    sys.exit(_selftest() if args.selftest else main())

--- a/scripts/ci/check_no_re_framing.py
+++ b/scripts/ci/check_no_re_framing.py
@@ -127,16 +127,35 @@ SELF_NAME = pathlib.Path(__file__).name
 # terminal" (allow-listed below), so an explicit "Java terminal" hit is
 # a drift signal, not a parity reference.
 FORBIDDEN_PATTERNS = (
-    re.compile(r"java[\s\-_]+terminal", re.IGNORECASE),
-    re.compile(r"\.toBytes\b"),
-    re.compile(r"\.fromBytes\b"),
-    re.compile(r"\bFITReader\.java\b"),
-    re.compile(r"\bFIE\.java\b"),
-    re.compile(r"\b\w+\.java\b"),
+    # `java`-then-`terminal` with any (or no) separator: catches
+    # `Java terminal`, `Java-terminal`, `java_terminal`, AND the
+    # separator-free camelCase `JavaTerminal`. The separator is
+    # zero-or-more (`*`) precisely so the glued camelCase spelling cannot
+    # dodge the gate. `JVM terminal` / `Theta Terminal` remain
+    # allow-listed and are stripped before matching.
+    re.compile(r"java[\s\-_]*terminal", re.IGNORECASE),
+    re.compile(r"\.toBytes\b", re.IGNORECASE),
+    re.compile(r"\.fromBytes\b", re.IGNORECASE),
+    re.compile(r"\bFITReader\.java\b", re.IGNORECASE),
+    re.compile(r"\bFIE\.java\b", re.IGNORECASE),
+    # Any `<identifier>.java` source reference, in any casing
+    # (`Contract.java`, `CONTRACT.JAVA`): a named Java source is
+    # provenance a reader could only have from decompilation.
+    re.compile(r"\b\w+\.java\b", re.IGNORECASE),
     re.compile(r"\bjavap\b", re.IGNORECASE),
     re.compile(r"decompil", re.IGNORECASE),
-    re.compile(r"reverse[- ]engineer", re.IGNORECASE),
-    re.compile(r"jar\s+build", re.IGNORECASE),
+    # The reverse-engineering vocabulary itself, with any separator
+    # (`reverse-engineer`, `reverse engineer`, `reverse_engineer`,
+    # `reversed engineering`). `revers(e|ed)` + separator(s) + `engineer`.
+    re.compile(r"revers(?:e|ed)[\s\-_]+engineer", re.IGNORECASE),
+    # The abbreviated form: `RE'd` / `RE-d` ("we RE'd the wire format").
+    # Bounded to the uppercase `RE` token followed by a straight or curly
+    # apostrophe or a hyphen and a trailing `d`, so ordinary contractions
+    # (`we're`, `they'd`) and words like `pre-d...` do not trip: the `RE`
+    # must stand alone (`(?<![A-Za-z])RE`) and the match must end on a
+    # word boundary.
+    re.compile(r"(?<![A-Za-z])RE['’\-]d\b"),
+    re.compile(r"jar[\s\-_]+build", re.IGNORECASE),
     re.compile(r"verified-live\s+against\s+terminal", re.IGNORECASE),
     # Jar-provenance: the act of citing the vendor jar, the terminal jar,
     # the local extraction path it was pulled from, or any bare `.jar`
@@ -251,10 +270,18 @@ def _selftest() -> int:
       catches the spelling variants the curated scan missed.
     * A C++ header (`sdks/cpp/include`) naming a decompiled `.java` source
       — must be flagged, proving non-Rust extensions are in scope.
+    * A file carrying the spelling variants the older patterns missed —
+      the separator-free camelCase `JavaTerminal`, the abbreviated `RE'd`
+      / `RE-d`, the `reversed engineering` conjugation, an uppercase
+      `.JAVA` source, and a hyphenated `jar-build` note — every one must
+      be flagged.
     * A clean file that names only the allow-listed "JVM terminal" /
       "Theta Terminal" parity reference — must pass.
     * A clean file whose factual wire description shares a line with the
       allow-listed parity reference — must pass.
+    * A clean file of ordinary contractions (`they'd`, `we're`,
+      `PRE-decode`, `CORE-d`) — must pass, proving the tuned `RE'd`
+      pattern does not false-positive.
     """
     import tempfile
 
@@ -278,6 +305,17 @@ def _selftest() -> int:
         "// Field order mirrors `Contract.java` from the decompiled layout.\n"
         "struct OhlcTick { double open; };\n"
     )
+    # Spelling variants the older patterns let through: the separator-free
+    # camelCase `JavaTerminal`, the abbreviated `RE'd` / `RE-d`, the
+    # `reversed engineering` conjugation, an uppercase `.JAVA` source, and
+    # the hyphenated `jar-build` provenance note. Each must trip.
+    leaky_variants = (
+        "/// Mirrors the JavaTerminal envelope layout.\n"
+        "/// We RE'd the framing, then RE-d the deadline handshake.\n"
+        "/// Layout reversed engineering notes for the OHLC packet.\n"
+        "/// Source: `Contract.JAVA` decompiled output.\n"
+        "/// Checked against the terminal jar-build `202605221`.\n"
+    )
     clean = (
         "//! Matches the JVM terminal byte-for-byte on the wire.\n"
         "/// Parity reference: the JVM terminal connects with a 2000 ms deadline.\n"
@@ -285,6 +323,13 @@ def _selftest() -> int:
     vendor_line = (
         "/// The wire format caps the encoded root at 16 bytes, matching the\n"
         "/// JVM terminal. Decoded against the Theta Terminal parity reference.\n"
+    )
+    # Ordinary English contractions and unrelated `RE`-adjacent text that
+    # must NOT trip the abbreviated `RE'd` pattern. Guards against the
+    # false-positive class the tuned boundary is designed to avoid.
+    clean_contractions = (
+        "/// They'd already cached the handshake; we're done before the deadline.\n"
+        "/// The PRE-decode buffer and a CORE-d helper stay untouched.\n"
     )
 
     with tempfile.TemporaryDirectory() as td:
@@ -313,6 +358,14 @@ def _selftest() -> int:
         vendor_path = root / "sdks" / "python" / "src" / "vendor.rs"
         vendor_path.parent.mkdir(parents=True, exist_ok=True)
         vendor_path.write_text(vendor_line, encoding="utf-8")
+
+        variants_path = root / "crates" / "thetadatadx" / "src" / "variants.rs"
+        variants_path.parent.mkdir(parents=True, exist_ok=True)
+        variants_path.write_text(leaky_variants, encoding="utf-8")
+
+        contractions_path = root / "ffi" / "src" / "contractions.rs"
+        contractions_path.parent.mkdir(parents=True, exist_ok=True)
+        contractions_path.write_text(clean_contractions, encoding="utf-8")
 
         hits = _scan(root)
 
@@ -345,6 +398,52 @@ def _selftest() -> int:
             return 1
         if any(rel.name == "vendor.rs" for (rel, _, _, _) in hits):
             print("selftest FAILED: an allow-listed parity-reference file was flagged")
+            return 1
+
+        # Spelling-variant coverage: every new variant must surface at
+        # least one hit on its own line.
+        variant_matches = {
+            m for (rel, _, m, _) in hits if rel.name == "variants.rs"
+        }
+        variant_checks = {
+            "JavaTerminal (camelCase, no separator)": any(
+                "javaterminal" in m.lower().replace(" ", "") for m in variant_matches
+            ),
+            "RE'd / RE-d abbreviation": any(
+                re.fullmatch(r"RE['’\-]d", m) for m in variant_matches
+            ),
+            "reversed engineering conjugation": any(
+                m.lower().startswith("reversed") and "engineer" in m.lower()
+                for m in variant_matches
+            ),
+            "uppercase .JAVA source": any(
+                m.lower().endswith(".java") for m in variant_matches
+            ),
+            "jar-build hyphenated provenance": any(
+                m.lower().startswith("jar") and "build" in m.lower()
+                for m in variant_matches
+            ),
+        }
+        unmet = [label for label, ok in variant_checks.items() if not ok]
+        if unmet:
+            print(
+                "selftest FAILED: these RE-framing spelling variants slipped "
+                f"through: {unmet!r} (matched: {sorted(variant_matches)!r})"
+            )
+            return 1
+
+        # The tuned `RE'd` pattern must NOT fire on ordinary contractions
+        # or `RE`-adjacent words.
+        if any(rel.name == "contractions.rs" for (rel, _, _, _) in hits):
+            bad = [
+                (m, line)
+                for (rel, _, m, line) in hits
+                if rel.name == "contractions.rs"
+            ]
+            print(
+                "selftest FAILED: the `RE'd` pattern false-positived on an "
+                f"ordinary contraction: {bad!r}"
+            )
             return 1
 
     print("selftest: ok")

--- a/scripts/ci/check_public_surface_leak.py
+++ b/scripts/ci/check_public_surface_leak.py
@@ -75,6 +75,14 @@ SCAN_GLOBS = (
     "sdks/typescript/index.js",
     "sdks/typescript/streaming-session.d.ts",
     "sdks/typescript/streaming-session.js",
+    # Per-SDK READMEs ship verbatim as the package long-description: the
+    # Python README becomes the PyPI page (`pyproject.toml` `readme =
+    # "README.md"`), the TypeScript README is packed into the npm tarball
+    # (npm always includes `README.md`), and the C++ README ships with the
+    # source SDK. They are as user-facing as the headers and stubs, so an
+    # internal-name leak in any of them reaches every reader of the
+    # package page.
+    "sdks/*/README.md",
 )
 
 
@@ -96,23 +104,45 @@ EXEMPT_PATH_FRAGMENTS = (
 
 
 # Internal-name tokens that must never appear in the shipped surface.
-# Matched case-sensitively on a word boundary so `mddS` vendor casing
-# and unrelated substrings do not trip. The list mirrors the standing
-# public-prose ban: internal Rust module names, runtime crates, and
-# dispatch primitives.
-FORBIDDEN_TOKENS = (
-    "tdbe",
-    "tokio",
-    "crossbeam",
-    "parking_lot",
-    "disruptor",
-    "block_on",
-    "os_pipe",
-    "allow_threads",
+# Matched case-insensitively on a word boundary, so a `Tokio` /
+# `Crossbeam` / `TDBE` capitalisation slips through no more than the
+# lower-case spelling does. The list mirrors the standing public-prose
+# ban: internal Rust module names, runtime crates, and dispatch
+# primitives. Single-token entries whose internal separator can be
+# spelled with a space, hyphen, or underscore (`parking_lot` /
+# `parking lot`, `block_on` / `block-on`, `os_pipe`, `crossbeam` /
+# `cross beam`) carry a flexible `[\s_-]?` separator so a reflowed or
+# re-hyphenated rendering cannot dodge the gate.
+#
+# Vendor terms (`fpss`, `mdds`) are deliberately ABSENT from this list
+# and never matched here — case-insensitivity is therefore safe for
+# them: there is no forbidden pattern a vendor word can satisfy. The
+# allow-list below is a second, belt-and-braces guard for the case where
+# an impl-IP token genuinely shares a line with a vendor name.
+FORBIDDEN_PATTERNS = (
+    r"tdbe",
+    r"tokio",
+    r"cross[\s_-]?beam",
+    r"parking[\s_-]?lot",
+    r"disruptor",
+    r"block[\s_-]?on",
+    r"os[\s_-]?pipe",
+    r"allow_threads",
+    r"Python::detach",
+    r"ingest[\s_-]?ring",
+    r"dispatch[\s_-]?consumer",
 )
 
+# Each pattern is wrapped in identifier-boundary guards so a token glued
+# to a surrounding identifier (`mytokio`, `tokiox`, `block_once`) does
+# not trip. `Python::detach` is bounded on both ends by the `Python`
+# prefix and the `detach` suffix; the literal `::` sits safely inside the
+# alternative, so the same boundary guards apply unchanged.
 FORBIDDEN_RE = re.compile(
-    r"(?<![A-Za-z0-9_])(" + "|".join(re.escape(t) for t in FORBIDDEN_TOKENS) + r")(?![A-Za-z0-9_])"
+    r"(?<![A-Za-z0-9_])("
+    + "|".join(f"(?:{p})" for p in FORBIDDEN_PATTERNS)
+    + r")(?![A-Za-z0-9_])",
+    re.IGNORECASE,
 )
 
 
@@ -150,17 +180,23 @@ def _iter_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
             yield candidate
 
 
+_ALLOWLISTED_RE = re.compile(
+    "|".join(re.escape(name) for name in ALLOWLISTED_VENDOR_NAMES),
+    re.IGNORECASE,
+)
+
+
 def _strip_allowlisted(line: str) -> str:
     """Remove every allow-listed vendor name from `line`.
 
     Forbidden-token matching runs against the residue. A line whose only
     matches come from vendor names is thereby cleared, while a real leak
-    sharing a line with a vendor name still trips.
+    sharing a line with a vendor name still trips. The strip is
+    case-insensitive to match the case-insensitive forbidden scan: a
+    vendor name in any casing (`FPSS`, `Mdds`) is cleared just as the
+    lower-case spelling is.
     """
-    residue = line
-    for name in ALLOWLISTED_VENDOR_NAMES:
-        residue = residue.replace(name, " ")
-    return residue
+    return _ALLOWLISTED_RE.sub(" ", line)
 
 
 def _scan_line(line: str) -> list[str]:
@@ -187,11 +223,22 @@ def _scan(root: pathlib.Path) -> list[tuple[pathlib.Path, int, str, str]]:
 def _selftest() -> int:
     """Plant leaks in synthetic shipped stubs and confirm the gate fires.
 
-    Three cases:
+    Cases:
 
-    * A stub naming `tdbe` and `tokio` — must be flagged (2 hits).
+    * A header naming `tdbe` and `tokio` — must be flagged (2 hits).
     * A clean stub — must pass.
-    * A stub mentioning only allow-listed vendor names — must pass.
+    * A stub mentioning only allow-listed vendor names (in mixed casing)
+      — must pass.
+    * A header carrying mixed-case and separator-variant impl-IP tokens
+      (`Tokio`, `Crossbeam`, `Python::detach`, `TDBE`, `parking-lot`,
+      `block on`, `cross beam`, `os-pipe`, `ingest ring`,
+      `dispatch consumer`) — every one must be flagged, proving the
+      case-insensitive scan, the new phrases, and the flexible
+      separators all bite.
+    * A shipped README (`sdks/python/README.md`) naming an internal
+      runtime crate — must be flagged, proving `sdks/*/README.md` is in
+      the scan set (the PyPI / npm long-description leak that previously
+      went unscanned).
     """
     import tempfile
 
@@ -205,9 +252,31 @@ def _selftest() -> int:
         '    """Open a session against the Theta Terminal (fpss feed)."""\n'
         "    ...\n"
     )
+    # Vendor names in deliberately mixed casing: the case-insensitive
+    # allow-list strip must clear them so the line passes.
     vendor_only = (
-        "// The fpss and mdds feeds expose FIC / FIT data.\n"
+        "// The FPSS and Mdds feeds expose FIC / FIT data.\n"
         "// Interp3 curve interpolation is part of the public surface.\n"
+    )
+    # Each line carries exactly one impl-IP spelling the OLD gate let
+    # through: a capitalised token, a `::`-bearing token, or a token
+    # whose internal separator was respelled as a space or hyphen.
+    case_and_separator_variants = (
+        "/* dispatched on a Tokio runtime */\n"
+        "/* a Crossbeam channel feeds the consumer */\n"
+        "/* releases the GIL via Python::detach */\n"
+        "/* layout-compatible with the TDBE engine */\n"
+        "/* guarded by a parking-lot mutex */\n"
+        "/* the reader will block on the socket: block on it */\n"
+        "/* a cross beam queue */\n"
+        "/* drained through an os-pipe */\n"
+        "/* events arrive on the ingest ring */\n"
+        "/* serviced by the dispatch consumer */\n"
+    )
+    leaky_readme = (
+        "# thetadatadx (Python)\n"
+        "\n"
+        "Ticks are decoded on a tokio runtime and handed to Python.\n"
     )
 
     with tempfile.TemporaryDirectory() as td:
@@ -225,6 +294,14 @@ def _selftest() -> int:
         vendor.parent.mkdir(parents=True, exist_ok=True)
         vendor.write_text(vendor_only, encoding="utf-8")
 
+        variants = root / "sdks" / "cpp" / "include" / "variants.h"
+        variants.parent.mkdir(parents=True, exist_ok=True)
+        variants.write_text(case_and_separator_variants, encoding="utf-8")
+
+        readme = root / "sdks" / "python" / "README.md"
+        readme.parent.mkdir(parents=True, exist_ok=True)
+        readme.write_text(leaky_readme, encoding="utf-8")
+
         # A test file naming internals must be ignored even though it
         # lives under the SDK tree — proves the exclusion works.
         test_file = root / "sdks" / "python" / "tests" / "test_no_gil.py"
@@ -233,11 +310,13 @@ def _selftest() -> int:
 
         hits = _scan(root)
 
-        tokens = sorted(token for (_, _, token, _) in hits)
-        if tokens != ["tdbe", "tokio"]:
+        header_tokens = sorted(
+            token.lower() for (rel, _, token, _) in hits if rel.name == "leaky.h"
+        )
+        if header_tokens != ["tdbe", "tokio"]:
             print(
                 "selftest FAILED: expected exactly tdbe + tokio from the "
-                f"leaky header, got {tokens!r}"
+                f"leaky header, got {header_tokens!r}"
             )
             return 1
         if any("tests/" in rel.as_posix() for (rel, _, _, _) in hits):
@@ -248,6 +327,39 @@ def _selftest() -> int:
             return 1
         if any(rel.name == "index.d.ts" for (rel, _, _, _) in hits):
             print("selftest FAILED: a vendor-only stub was flagged")
+            return 1
+
+        # Every mixed-case / separator-variant spelling must be caught.
+        variant_tokens = {
+            re.sub(r"[\s_-]", "", token.lower())
+            for (rel, _, token, _) in hits
+            if rel.name == "variants.h"
+        }
+        expected_variants = {
+            "tokio",
+            "crossbeam",
+            "python::detach",
+            "tdbe",
+            "parkinglot",
+            "blockon",
+            "ospipe",
+            "ingestring",
+            "dispatchconsumer",
+        }
+        missing = expected_variants - variant_tokens
+        if missing:
+            print(
+                "selftest FAILED: case/separator-variant impl-IP tokens "
+                f"slipped through: {sorted(missing)!r}"
+            )
+            return 1
+
+        # The shipped README must be scanned and its leak flagged.
+        if not any(rel.name == "README.md" for (rel, _, _, _) in hits):
+            print(
+                "selftest FAILED: the impl-IP leak in the shipped "
+                "sdks/*/README.md long-description was not flagged"
+            )
             return 1
 
     print("selftest: ok")

--- a/scripts/ci/check_version_sync.py
+++ b/scripts/ci/check_version_sync.py
@@ -12,19 +12,46 @@ ages while git tags advance.
 
 This script fails CI when any tracked version disagrees with the
 canonical ``crates/thetadatadx/Cargo.toml`` version.
+
+The published Python wheel is covered too. ``sdks/python/pyproject.toml``
+declares ``dynamic = ["version"]`` with the maturin backend, so the wheel
+version is read from ``sdks/python/Cargo.toml`` ``[package].version`` at
+build time rather than from any literal in ``pyproject.toml``; the gate
+asserts that crate version against the canonical one.
+
+Run::
+
+    python3 scripts/ci/check_version_sync.py
+
+Selftest::
+
+    python3 scripts/ci/check_version_sync.py --selftest
+
+The selftest exercises the two checks whose coverage was widened — the
+full-version documentation-pin comparison and the Python-wheel
+``Cargo.toml`` version read — against synthetic inputs, proving a stale
+pre-release pin and a drifted wheel crate version are both caught.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 CANONICAL_CARGO = ROOT / "crates" / "thetadatadx" / "Cargo.toml"
 CMAKE_LISTS = ROOT / "sdks" / "cpp" / "CMakeLists.txt"
 PY_INIT = ROOT / "sdks" / "python" / "python" / "thetadatadx" / "__init__.py"
+# The published Python wheel version is NOT pinned in `pyproject.toml`
+# (it declares `dynamic = ["version"]` with `build-backend = "maturin"`);
+# maturin reads it from the binding crate's `[package].version`. The gate
+# must therefore assert THIS file against the canonical version, or the
+# wheel uploaded to PyPI can age independently of every other artifact.
+PY_CARGO = ROOT / "sdks" / "python" / "Cargo.toml"
 
 # Accepted values for the `__version__` fallback in the Python SDK
 # `__init__.py`. `"unknown"` is the canonical sentinel — anything that
@@ -73,7 +100,7 @@ def cmake_project_version(path: Path) -> str | None:
 
 
 # U5 closure: the same gate scans documentation pins for the
-# `thetadatadx = "<major>"` shape. Drift between the canonical Cargo
+# `thetadatadx = "<version>"` shape. Drift between the canonical Cargo
 # version and a doc pin (README.md, docs-site quickstart /
 # installation) silently aged the docs across v9 → v10 — this gate
 # now catches that case.
@@ -82,12 +109,16 @@ DOC_PIN_PATHS = (
     ROOT / "docs-site" / "docs" / "articles" / "getting-started.md",
     ROOT / "docs-site" / "docs" / "examples" / "dataframes.md",
 )
-# Match `thetadatadx = "<MAJOR>"` (Cargo.toml-ish pin) and
-# `thetadatadx = { version = "<MAJOR>", ... }` (Cargo.toml feature
-# pin). Both shapes have a single major-version-only literal that
-# must match the canonical major.
+# Match `thetadatadx = "<VERSION>"` (Cargo.toml-ish pin) and
+# `thetadatadx = { version = "<VERSION>", ... }` (Cargo.toml feature
+# pin). Capture the FULL quoted literal — including any pre-release
+# suffix (`13.0.0-rc.5`) — not just the major. A major-only capture let
+# a stale pre-release pin (`13.0.0-rc.1`) pass against a canonical
+# `13.0.0-rc.5` because both share the major `13`; comparing the full
+# version closes that hole so a doc that pins an aged release fails the
+# gate.
 DOC_PIN_RE = re.compile(
-    r'thetadatadx\s*=\s*(?:"(\d+)(?:[.,)\'" ]|$)|\{\s*version\s*=\s*"(\d+)(?:[.,)\'" ]|$))'
+    r'thetadatadx\s*=\s*(?:"([^"]+)"|\{\s*version\s*=\s*"([^"]+)")'
 )
 
 
@@ -130,7 +161,7 @@ def python_init_fallback_mismatches(canonical: str) -> list[str]:
     return issues
 
 
-def doc_pin_mismatches(canonical_major: str) -> list[str]:
+def doc_pin_mismatches(canonical: str) -> list[str]:
     issues: list[str] = []
     for path in DOC_PIN_PATHS:
         if not path.is_file():
@@ -140,17 +171,16 @@ def doc_pin_mismatches(canonical_major: str) -> list[str]:
             if not match:
                 continue
             pinned = match.group(1) or match.group(2)
-            if pinned != canonical_major:
+            if pinned != canonical:
                 issues.append(
                     f"{path.relative_to(ROOT)}:{lineno} pins "
-                    f'`thetadatadx = "{pinned}"`, expected major {canonical_major}'
+                    f'`thetadatadx = "{pinned}"`, expected {canonical}'
                 )
     return issues
 
 
 def main() -> int:
     canonical = cargo_version(CANONICAL_CARGO)
-    canonical_major = canonical.split(".", 1)[0]
     print(f"canonical version (Cargo.toml): {canonical}")
 
     failures: list[str] = []
@@ -176,6 +206,27 @@ def main() -> int:
                 f"{package_json_version(platform_pkg)}, expected {canonical}"
             )
 
+    # Published Python wheel version. `sdks/python/pyproject.toml` is
+    # `dynamic = ["version"]` + maturin, so the wheel version is taken
+    # from `sdks/python/Cargo.toml` `[package].version` at build time, not
+    # from any literal in `pyproject.toml`. Asserting that crate version
+    # is what stops the PyPI wheel from silently aging while every other
+    # tracked artifact advances.
+    if PY_CARGO.is_file():
+        py_cargo_version = cargo_version(PY_CARGO)
+        if py_cargo_version != canonical:
+            failures.append(
+                f"{PY_CARGO.relative_to(ROOT)} [package] version is "
+                f"{py_cargo_version}, expected {canonical} "
+                "(this is the version maturin stamps on the published "
+                "Python wheel via pyproject.toml `dynamic = [\"version\"]`)"
+            )
+    else:
+        failures.append(
+            f"{PY_CARGO.relative_to(ROOT)}: not found — the published "
+            "Python wheel version cannot be verified"
+        )
+
     # CMake project version must match the canonical crates Cargo
     # version. CMake's `project(... VERSION ...)` only accepts a numeric
     # `major.minor.patch`, so on a pre-release (e.g. `13.0.0-rc.1`) it
@@ -195,8 +246,9 @@ def main() -> int:
             f"{cmake_version}, expected {canonical_base}"
         )
 
-    # U5 closure: documentation pins must match the canonical major.
-    failures.extend(doc_pin_mismatches(canonical_major))
+    # U5 closure: documentation pins must match the canonical version in
+    # full (including any pre-release suffix), not merely the major.
+    failures.extend(doc_pin_mismatches(canonical))
 
     # M4 closure (post-#572 audit): Python SDK `__version__` fallback
     # must be the `"unknown"` sentinel, not a numeric literal that
@@ -213,5 +265,145 @@ def main() -> int:
     return 0
 
 
+def _selftest() -> int:
+    """Exercise the two widened checks against synthetic inputs.
+
+    Cases:
+
+    * A doc file that pins a stale pre-release (`thetadatadx =
+      "13.0.0-rc.1"`) against canonical `13.0.0-rc.5` — must be flagged.
+      The old major-only capture passed it because both share major `13`;
+      the full-version capture must now catch it. The feature-pin shape
+      (`{ version = "..." }`) is covered too.
+    * A doc file pinning the exact canonical version — must pass.
+    * A synthetic Python binding `Cargo.toml` whose `[package].version`
+      drifts from canonical — `cargo_version` must read the full
+      pre-release literal and the mismatch must be detected. A matching
+      crate version must compare equal. This is the published-wheel
+      version that `pyproject.toml`'s `dynamic = ["version"]` + maturin
+      stamps onto the PyPI upload.
+    """
+    global DOC_PIN_PATHS
+
+    canonical = "13.0.0-rc.5"
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+
+        # --- Documentation pin: full-version comparison ---------------
+        stale_doc = root / "README.md"
+        stale_doc.write_text(
+            "Install with\n\n"
+            "```toml\n"
+            '[dependencies]\n'
+            'thetadatadx = "13.0.0-rc.1"\n'
+            "```\n",
+            encoding="utf-8",
+        )
+        stale_feature_doc = root / "features.md"
+        stale_feature_doc.write_text(
+            'thetadatadx = { version = "13.0.0-rc.1", features = ["frames"] }\n',
+            encoding="utf-8",
+        )
+        clean_doc = root / "clean.md"
+        clean_doc.write_text(
+            'thetadatadx = "13.0.0-rc.5"\n',
+            encoding="utf-8",
+        )
+
+        saved_paths = DOC_PIN_PATHS
+        DOC_PIN_PATHS = (stale_doc, stale_feature_doc, clean_doc)
+        try:
+            # `doc_pin_mismatches` formats paths relative to the real
+            # ROOT; the synthetic temp paths are not under ROOT, so derive
+            # the diagnostics from the regex + comparison directly here to
+            # keep the selftest hermetic, while still proving the captured
+            # literal is the FULL version (not the major).
+            pin_issues: list[str] = []
+            for path in DOC_PIN_PATHS:
+                for line in path.read_text().splitlines():
+                    m = DOC_PIN_RE.search(line)
+                    if not m:
+                        continue
+                    pinned = m.group(1) or m.group(2)
+                    if pinned != canonical:
+                        pin_issues.append((path.name, pinned))
+        finally:
+            DOC_PIN_PATHS = saved_paths
+
+        stale_flagged = {name for name, _ in pin_issues}
+        if "README.md" not in stale_flagged:
+            failures.append(
+                "doc-pin: stale plain pre-release pin `13.0.0-rc.1` was not "
+                "flagged against canonical 13.0.0-rc.5 (full-version "
+                "comparison regressed)"
+            )
+        if "features.md" not in stale_flagged:
+            failures.append(
+                "doc-pin: stale feature pin `{ version = \"13.0.0-rc.1\" }` "
+                "was not flagged"
+            )
+        if any(pinned != "13.0.0-rc.1" for _, pinned in pin_issues):
+            failures.append(
+                f"doc-pin: captured an unexpected literal: {pin_issues!r} "
+                "(the full pre-release string must be captured verbatim)"
+            )
+        if "clean.md" in stale_flagged:
+            failures.append(
+                "doc-pin: a pin matching the canonical version was wrongly "
+                "flagged"
+            )
+
+        # --- Python wheel version (maturin reads Cargo.toml) ----------
+        drifted_cargo = root / "py_cargo_drift.toml"
+        drifted_cargo.write_text(
+            '[package]\n'
+            'name = "thetadatadx-py"\n'
+            'version = "13.0.0-rc.1"\n'
+            'edition = "2021"\n',
+            encoding="utf-8",
+        )
+        matched_cargo = root / "py_cargo_ok.toml"
+        matched_cargo.write_text(
+            '[package]\n'
+            'name = "thetadatadx-py"\n'
+            'version = "13.0.0-rc.5"\n'
+            'edition = "2021"\n',
+            encoding="utf-8",
+        )
+        if cargo_version(drifted_cargo) != "13.0.0-rc.1":
+            failures.append(
+                "py-wheel: cargo_version did not read the full pre-release "
+                f"literal (got {cargo_version(drifted_cargo)!r})"
+            )
+        if cargo_version(drifted_cargo) == canonical:
+            failures.append(
+                "py-wheel: a drifted Python crate version compared equal to "
+                "canonical (the wheel-version assertion would not fire)"
+            )
+        if cargo_version(matched_cargo) != canonical:
+            failures.append(
+                "py-wheel: a matching Python crate version did not compare "
+                "equal to canonical"
+            )
+
+    if failures:
+        print("check_version_sync --selftest: FAILED")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("check_version_sync --selftest: ok")
+    return 0
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="Run the embedded self-test and exit.",
+    )
+    args = parser.parse_args()
+    sys.exit(_selftest() if args.selftest else main())


### PR DESCRIPTION
Five CI guard scripts pass today but each lets real drift or an internal-name leak slip through. This closes those holes while keeping every gate green on the current HEAD and extending each script's self-test to prove the newly-covered case is caught.

## scripts/ci/check_public_surface_leak.py
- Forbidden impl-IP tokens now match case-insensitively, so `Tokio` / `Crossbeam` / `Python::detach` / `TDBE` no longer slip past the lower-case-only scan. Vendor terms (`fpss`, `mdds`) are absent from the forbidden set, so case-insensitivity is safe for them; the allow-list strip is also case-insensitive as a second guard.
- Added the missing phrases `ingest ring`, `dispatch consumer`, `Python::detach`, and made internal separators flexible (`parking[\s_-]?lot`, `block[\s_-]?on`, `cross[\s_-]?beam`, `os[\s_-]?pipe`) so a reflowed or re-hyphenated rendering cannot dodge the gate.
- Added `sdks/*/README.md` to the scan set: the Python README ships as the PyPI long-description, the TypeScript README is packed into the npm tarball, and the C++ README ships with the source SDK. All three are clean of impl-IP on HEAD.

## scripts/ci/check_version_sync.py
- Added an assertion on `sdks/python/Cargo.toml` `[package].version`. `sdks/python/pyproject.toml` declares `dynamic = ["version"]` with maturin, so the published wheel version comes from that crate, which the gate previously never read.
- The documentation-pin regex now captures and compares the FULL version (including the pre-release suffix) rather than the major only, so a stale `13.0.0-rc.1` pin no longer passes against canonical `13.0.0-rc.5`. This surfaced a real drift: `README.md` pinned `13.0.0-rc.1`, corrected here to the canonical version (the one non-`scripts/ci/` file touched).

## scripts/ci/check_c_abi_completeness.py
- The header scan now strips C/C++ comments and counts a symbol as declared only when it appears as a `thetadatadx_<name>(` declaration. A name surviving only in a comment, or a prose wildcard like `thetadatadx_exchange_*`, no longer satisfies the forward completeness check. The obsolete `thetadatadx_exchange_` allow-list entry (a comment-mention workaround) is removed. The bidirectional nm-vs-header logic and the absent-`.so` loud warning are unchanged.

## scripts/ci/check_no_re_framing.py
- Catches the separator-free camelCase `JavaTerminal`, the abbreviated `RE'd` / `RE-d` (bounded to avoid false-positiving on contractions like `they'd` or words like `CORE-d`), the `reversed engineering` conjugation, and hyphen/underscore separators on `jar-build`. The `.java` and conjugation patterns now match case-insensitively.

## scripts/ci/check_binding_parity.py
- The `.rs` / `.hpp` / `.h` / `.inc` collectors strip C-style comments before their symbol regexes run, so a deleted symbol left behind in a comment cannot read as present and mask cross-binding drift. The one collector that intentionally harvests the documented label vocabulary from a doc comment keeps its raw read, with a rationale comment at the call site.

## Verification
- All five live runs exit 0 on HEAD (the FFI release `.so` was built so the C-ABI gate uses the nm inventory: 333 symbols, clean).
- Self-tests: surface-leak, version-sync (new), c-abi (new), re-framing all pass; parity is 149 passed / 0 failed (146 existing + 3 new comment-stripping cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)