### PR TITLE
fix(ts): bound the streaming callback queue so backpressure and drop counters work

### DIFF
--- a/crates/thetadatadx/build_support_bin/sdk_surface/templates/typescript/start_streaming_body.rs.tmpl
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/templates/typescript/start_streaming_body.rs.tmpl
@@ -49,22 +49,21 @@
                     // execute V8 (libuv invariant). The FPSS TLS reader
                     // thread itself never touches V8: the streaming ring
                     // sits between the reader and the consumer that runs
-                    // this closure, so a slow JS callback at most fills
-                    // the ring and bumps `droppedEventCount()` — it
-                    // cannot back-pressure the TLS reader and trigger a
-                    // vendor-side disconnect.
+                    // this closure.
                     let buffered = fpss_event_to_buffered(event);
                     let typed = buffered_event_to_typed(buffered);
-                    // `Blocking` so the dispatcher waits if the
-                    // napi tsfn queue is full instead of silently
-                    // discarding the event. The streaming ring already absorbs
-                    // FPSS-side bursts; the only path where the tsfn
-                    // queue fills is a stalled Node event loop, and a
-                    // bounded blocking back-pressure is preferable to a
-                    // double-drop (ring + tsfn).
+                    // `Blocking`, paired with the bounded
+                    // `STREAMING_CALLBACK_QUEUE_DEPTH` on `TsfnCallback`,
+                    // makes this consumer wait once the call queue is full
+                    // rather than parking an unbounded backlog of events
+                    // behind a slow JS callback. While the consumer waits it
+                    // stops draining the ring, so the ring fills and the FPSS
+                    // reader accounts the overflow on `droppedEventCount()`;
+                    // the reader itself is never blocked, so the upstream
+                    // connection stays healthy.
                     //
-                    // `ErrorStrategy::Fatal` (the `false` const generic on
-                    // `TsfnCallback`) means we pass `T` directly, not
+                    // `ErrorStrategy::Fatal` (the fifth `false` const generic
+                    // on `TsfnCallback`) means we pass `T` directly, not
                     // `Result<T, _>` — exceptions in the JS callback are
                     // the JS side's problem, surfaced through Node's own
                     // `uncaughtException`.

--- a/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
@@ -46,10 +46,12 @@ fn ts_streaming_method(method: &MethodSpec) -> String {
                  panics or throws is isolated and does not interrupt\n\
                  the stream.\n\
                  \n\
-                 Backpressure: a slow callback causes incoming events\n\
-                 to queue and, once the buffer is full, newly arriving\n\
-                 events are dropped. The dropped count is observable\n\
-                 via `droppedEventCount()`. The receive path is never\n\
+                 Backpressure: a slow callback first fills a bounded\n\
+                 delivery queue and then the event ring behind it, at\n\
+                 which point the oldest events are dropped and counted by\n\
+                 `droppedEventCount()` while `ringOccupancy()` reports the\n\
+                 in-flight depth. Watch those two signals to detect a\n\
+                 callback that cannot keep up. The receive path is never\n\
                  blocked by a slow callback, so the upstream connection\n\
                  stays healthy regardless of callback speed.",
             );
@@ -63,9 +65,18 @@ fn ts_streaming_method(method: &MethodSpec) -> String {
             // `spawn_blocking` so the Node event loop is never frozen for
             // the handshake. napi-rs maps the `napi::Result<()>` on an
             // `async fn` to a `Promise<void>`.
+            // The callback parameter is spelled with the inline
+            // `ThreadsafeFunction<StreamEvent, …>` rather than the
+            // `TsfnCallback` alias so napi-rs emits a typed
+            // `(event: StreamEvent) => void` signature into `index.d.ts`. The
+            // const generics match `TsfnCallback` exactly so the value
+            // coerces into `Arc<TsfnCallback>` in the body; the seventh,
+            // `STREAMING_CALLBACK_QUEUE_DEPTH`, bounds the call queue so the
+            // `Blocking` mode on the dispatcher applies real back-pressure
+            // instead of letting a slow callback grow the queue without limit.
             writeln!(
                 out,
-                "    pub async fn {}(&self, callback: napi::threadsafe_function::ThreadsafeFunction<StreamEvent, (), StreamEvent, napi::Status, false>) -> napi::Result<()> {{",
+                "    pub async fn {}(&self, callback: napi::threadsafe_function::ThreadsafeFunction<StreamEvent, (), StreamEvent, napi::Status, false, false, {{ crate::STREAMING_CALLBACK_QUEUE_DEPTH }}>) -> napi::Result<()> {{",
                 method.name
             )
             .unwrap();

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -2550,11 +2550,13 @@ export declare class StreamingClient {
    * thread, so the callback may use any JS API safely. A callback that
    * panics or throws is isolated and does not interrupt the stream.
    *
-   * Backpressure: a slow callback causes incoming events to queue and,
-   * once the buffer is full, newly arriving events are dropped, observable
-   * via `droppedEventCount()`. The receive path is never blocked by a
-   * slow callback, so the upstream connection stays healthy regardless
-   * of callback speed.
+   * Backpressure: a slow callback first fills a bounded delivery queue
+   * and then the event ring behind it, at which point the oldest events
+   * are dropped and counted by `droppedEventCount()` while
+   * `ringOccupancy()` reports the in-flight depth. Watch those two
+   * signals to detect a callback that cannot keep up. The receive path
+   * is never blocked by a slow callback, so the upstream connection
+   * stays healthy regardless of callback speed.
    */
   startStreaming(callback: ((arg: StreamEvent) => void)): Promise<void>
   /**
@@ -2848,10 +2850,12 @@ export declare class StreamView {
    * panics or throws is isolated and does not interrupt
    * the stream.
    *
-   * Backpressure: a slow callback causes incoming events
-   * to queue and, once the buffer is full, newly arriving
-   * events are dropped. The dropped count is observable
-   * via `droppedEventCount()`. The receive path is never
+   * Backpressure: a slow callback first fills a bounded
+   * delivery queue and then the event ring behind it, at
+   * which point the oldest events are dropped and counted by
+   * `droppedEventCount()` while `ringOccupancy()` reports the
+   * in-flight depth. Watch those two signals to detect a
+   * callback that cannot keep up. The receive path is never
    * blocked by a slow callback, so the upstream connection
    * stays healthy regardless of callback speed.
    */

--- a/sdks/typescript/src/_generated/streaming_methods.rs
+++ b/sdks/typescript/src/_generated/streaming_methods.rs
@@ -10,14 +10,16 @@ impl StreamView {
     /// panics or throws is isolated and does not interrupt
     /// the stream.
     ///
-    /// Backpressure: a slow callback causes incoming events
-    /// to queue and, once the buffer is full, newly arriving
-    /// events are dropped. The dropped count is observable
-    /// via `droppedEventCount()`. The receive path is never
+    /// Backpressure: a slow callback first fills a bounded
+    /// delivery queue and then the event ring behind it, at
+    /// which point the oldest events are dropped and counted by
+    /// `droppedEventCount()` while `ringOccupancy()` reports the
+    /// in-flight depth. Watch those two signals to detect a
+    /// callback that cannot keep up. The receive path is never
     /// blocked by a slow callback, so the upstream connection
     /// stays healthy regardless of callback speed.
     #[napi(js_name = "startStreaming")]
-    pub async fn start_streaming(&self, callback: napi::threadsafe_function::ThreadsafeFunction<StreamEvent, (), StreamEvent, napi::Status, false>) -> napi::Result<()> {
+    pub async fn start_streaming(&self, callback: napi::threadsafe_function::ThreadsafeFunction<StreamEvent, (), StreamEvent, napi::Status, false, false, { crate::STREAMING_CALLBACK_QUEUE_DEPTH }>) -> napi::Result<()> {
         // Bind the callback behind a cheap `Arc` so the FPSS callback
         // closure (`Fn(&StreamEvent) + Send + 'static`) can clone the
         // handle into each per-event invocation. `ThreadsafeFunction`
@@ -69,22 +71,21 @@ impl StreamView {
                     // execute V8 (libuv invariant). The FPSS TLS reader
                     // thread itself never touches V8: the streaming ring
                     // sits between the reader and the consumer that runs
-                    // this closure, so a slow JS callback at most fills
-                    // the ring and bumps `droppedEventCount()` — it
-                    // cannot back-pressure the TLS reader and trigger a
-                    // vendor-side disconnect.
+                    // this closure.
                     let buffered = fpss_event_to_buffered(event);
                     let typed = buffered_event_to_typed(buffered);
-                    // `Blocking` so the dispatcher waits if the
-                    // napi tsfn queue is full instead of silently
-                    // discarding the event. The streaming ring already absorbs
-                    // FPSS-side bursts; the only path where the tsfn
-                    // queue fills is a stalled Node event loop, and a
-                    // bounded blocking back-pressure is preferable to a
-                    // double-drop (ring + tsfn).
+                    // `Blocking`, paired with the bounded
+                    // `STREAMING_CALLBACK_QUEUE_DEPTH` on `TsfnCallback`,
+                    // makes this consumer wait once the call queue is full
+                    // rather than parking an unbounded backlog of events
+                    // behind a slow JS callback. While the consumer waits it
+                    // stops draining the ring, so the ring fills and the FPSS
+                    // reader accounts the overflow on `droppedEventCount()`;
+                    // the reader itself is never blocked, so the upstream
+                    // connection stays healthy.
                     //
-                    // `ErrorStrategy::Fatal` (the `false` const generic on
-                    // `TsfnCallback`) means we pass `T` directly, not
+                    // `ErrorStrategy::Fatal` (the fifth `false` const generic
+                    // on `TsfnCallback`) means we pass `T` directly, not
                     // `Result<T, _>` — exceptions in the JS callback are
                     // the JS side's problem, surfaced through Node's own
                     // `uncaughtException`.

--- a/sdks/typescript/src/fpss_client.rs
+++ b/sdks/typescript/src/fpss_client.rs
@@ -323,12 +323,15 @@ impl StreamingClient {
                             // object on the dispatcher thread, then hand it
                             // to the `ThreadsafeFunction`, which routes the
                             // call onto the Node main thread (the only
-                            // thread allowed to execute V8). `Blocking`
-                            // applies bounded back-pressure when the tsfn
-                            // queue is full instead of dropping the event;
-                            // the FPSS TLS reader is never blocked, so a
-                            // slow JS callback at most fills the ring and
-                            // bumps `droppedEventCount()`.
+                            // thread allowed to execute V8). The call queue
+                            // is bounded (`STREAMING_CALLBACK_QUEUE_DEPTH`),
+                            // so `Blocking` makes this consumer wait once the
+                            // queue is full rather than parking an unbounded
+                            // backlog behind a slow JS callback. While the
+                            // consumer waits it stops draining the ring, so
+                            // the ring fills and the FPSS reader accounts the
+                            // overflow on `droppedEventCount()`. The reader
+                            // itself is never blocked.
                             let buffered = fpss_event_to_buffered(event);
                             let typed = buffered_event_to_typed(buffered);
                             dispatch_cb.call(
@@ -417,11 +420,13 @@ impl StreamingClient {
     /// thread, so the callback may use any JS API safely. A callback that
     /// panics or throws is isolated and does not interrupt the stream.
     ///
-    /// Backpressure: a slow callback causes incoming events to queue and,
-    /// once the buffer is full, newly arriving events are dropped, observable
-    /// via `droppedEventCount()`. The receive path is never blocked by a
-    /// slow callback, so the upstream connection stays healthy regardless
-    /// of callback speed.
+    /// Backpressure: a slow callback first fills a bounded delivery queue
+    /// and then the event ring behind it, at which point the oldest events
+    /// are dropped and counted by `droppedEventCount()` while
+    /// `ringOccupancy()` reports the in-flight depth. Watch those two
+    /// signals to detect a callback that cannot keep up. The receive path
+    /// is never blocked by a slow callback, so the upstream connection
+    /// stays healthy regardless of callback speed.
     #[napi(js_name = "startStreaming")]
     pub async fn start_streaming(
         &self,
@@ -430,13 +435,20 @@ impl StreamingClient {
         // `TsfnCallback` alias so napi-rs emits a typed
         // `(event: StreamEvent) => void` signature into `index.d.ts`. A bare
         // alias name would surface in the published types as an unresolved
-        // identifier, leaving the callback parameter untyped for callers.
+        // identifier, leaving the callback parameter untyped for callers. The
+        // const generics match `TsfnCallback` exactly so the value coerces
+        // into `Arc<TsfnCallback>` below; the seventh,
+        // `STREAMING_CALLBACK_QUEUE_DEPTH`, bounds the call queue so the
+        // `Blocking` mode on the dispatcher applies real back-pressure
+        // instead of letting a slow callback grow the queue without limit.
         callback: napi::threadsafe_function::ThreadsafeFunction<
             StreamEvent,
             (),
             StreamEvent,
             napi::Status,
             false,
+            false,
+            { crate::STREAMING_CALLBACK_QUEUE_DEPTH },
         >,
     ) -> napi::Result<()> {
         self.start_with_callback(Arc::new(callback)).await

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -582,14 +582,41 @@ include!("_generated/utility_functions.rs");
 
 // ── Unified Client client ──
 
+/// Bound on the number of `StreamEvent` deliveries that may sit in the
+/// napi callback queue between the streaming consumer thread and the Node
+/// main thread before the consumer is made to wait.
+///
+/// This queue is the second buffer on the delivery path. The first is the
+/// streaming event ring (the `streamingRingSize` setting, 65536 slots by
+/// default), drained by the consumer thread; the consumer hands each event
+/// to the callback queue here, and the registered JS function runs later on
+/// the Node main thread. A bound is required for the `Blocking` call mode to
+/// mean anything: with an unbounded queue the `call` never waits, so the
+/// consumer drains the ring as fast as it arrives and parks the backlog in
+/// this queue instead, where it is invisible to `ringOccupancy()` and
+/// `droppedEventCount()` and grows without limit behind a persistently slow
+/// JS callback. A finite bound makes a full queue block the consumer, which
+/// lets the ring fill and the I/O reader account the overflow on
+/// `droppedEventCount()`, the same observable back-pressure the bindings
+/// that run the callback directly on the consumer thread already have.
+///
+/// The depth matches the default ring size so a healthy callback has a full
+/// ring's worth of headroom before the consumer ever waits, while a wedged
+/// callback can pin at most this many in-flight events.
+pub(crate) const STREAMING_CALLBACK_QUEUE_DEPTH: usize = 65_536;
+
 /// `ThreadsafeFunction` that owns a JS callback reference and routes
 /// `StreamEvent` deliveries onto the Node main thread via napi-rs's
-/// internal `uv_async_t` queue. The const generic `false` selects
+/// internal `uv_async_t` queue. The fifth const generic `false` selects
 /// `ErrorStrategy::Fatal`, so the napi-rs `call` API takes the
 /// `StreamEvent` directly (not a `Result`) and the JS side relies on
-/// its own try/catch for user-callback failures. The two `StreamEvent`
-/// type parameters are the wire payload and the JS-call arg type
-/// respectively; both are the same concrete object here.
+/// its own try/catch for user-callback failures. The sixth (`false`) keeps
+/// the function strong, so a pending event holds the event loop open until
+/// it drains rather than being abandoned at shutdown. The seventh,
+/// [`STREAMING_CALLBACK_QUEUE_DEPTH`], bounds the call queue so the
+/// `Blocking` call mode applies real back-pressure (see that constant). The
+/// two `StreamEvent` type parameters are the wire payload and the JS-call
+/// arg type respectively; both are the same concrete object here.
 ///
 /// napi-rs is the only safe path: Node's libuv requires JS callbacks
 /// on the main thread, so calling V8 from any other thread is
@@ -602,6 +629,8 @@ pub(crate) type TsfnCallback = napi::threadsafe_function::ThreadsafeFunction<
     StreamEvent,
     napi::Status,
     false,
+    false,
+    STREAMING_CALLBACK_QUEUE_DEPTH,
 >;
 
 #[napi]
@@ -1177,6 +1206,66 @@ impl StreamView {
 }
 
 // `Client` is the public name (rename complete; no alias).
+
+#[cfg(test)]
+mod callback_queue_tests {
+    use super::*;
+
+    /// Recover the `MaxQueueSize` const generic from a concrete
+    /// `ThreadsafeFunction` type so the test reads the bound that is
+    /// actually compiled into [`TsfnCallback`], not a value re-typed by
+    /// hand. A change to the alias that drops the seventh generic (back to
+    /// the napi default of `0`, an unbounded queue) is observed here.
+    const fn max_queue_size<
+        T: 'static,
+        Return: 'static + napi::bindgen_prelude::FromNapiValue,
+        CallJsBackArgs: 'static + napi::bindgen_prelude::JsValuesTupleIntoVec,
+        ErrorStatus: AsRef<str> + From<napi::Status>,
+        const CALLEE_HANDLED: bool,
+        const WEAK: bool,
+        const MAX_QUEUE_SIZE: usize,
+    >(
+        _: std::marker::PhantomData<
+            napi::threadsafe_function::ThreadsafeFunction<
+                T,
+                Return,
+                CallJsBackArgs,
+                ErrorStatus,
+                CALLEE_HANDLED,
+                WEAK,
+                MAX_QUEUE_SIZE,
+            >,
+        >,
+    ) -> usize {
+        MAX_QUEUE_SIZE
+    }
+
+    /// The streaming callback queue must be bounded: a zero (unbounded)
+    /// queue lets the `Blocking` call mode return without ever waiting, so
+    /// a persistently slow JS callback grows the queue without limit while
+    /// `ringOccupancy()` and `droppedEventCount()` stay flat. A finite
+    /// bound is what couples a slow consumer back to the ring and the drop
+    /// counter.
+    #[test]
+    fn streaming_callback_queue_is_bounded() {
+        // Read the bound off the alias type rather than the bare constant
+        // so the check fails if the seventh generic is dropped, even if the
+        // constant itself is left untouched.
+        let alias_depth = max_queue_size(std::marker::PhantomData::<TsfnCallback>);
+        assert_eq!(
+            alias_depth, STREAMING_CALLBACK_QUEUE_DEPTH,
+            "TsfnCallback must carry STREAMING_CALLBACK_QUEUE_DEPTH as its MaxQueueSize"
+        );
+        assert_ne!(
+            alias_depth, 0,
+            "an unbounded (zero) queue defeats the Blocking back-pressure"
+        );
+        assert_eq!(
+            alias_depth, 65_536,
+            "the queue depth must match its documented value (one default ring)"
+        );
+    }
+}
 
 #[cfg(test)]
 mod connect_options_tests {


### PR DESCRIPTION
The TypeScript streaming callback handle (`TsfnCallback`) inherited the napi default `MaxQueueSize` of 0, which is an unbounded call queue. The streaming consumer thread converts each event to the typed object and calls the handle in `Blocking` mode, but with an unbounded queue `Blocking` never waits: the consumer drains the event ring as fast as events arrive and parks the backlog in the napi queue instead. A persistently slow JS callback therefore grows that queue without limit while `ringOccupancy()` stays low and `droppedEventCount()` stays 0, so the two operator signals documented to watch never move. The Python and C++ bindings run the user callback directly on the consumer thread, so they backpressure into the ring and increment the drop counter; the TypeScript binding diverged from that contract.

This gives `TsfnCallback` an explicit bounded `MaxQueueSize` through a new `STREAMING_CALLBACK_QUEUE_DEPTH` constant (65536, one default event ring) as the seventh const generic, and spells the same bound on the two inline `startStreaming` callback parameter types so the value still coerces into `Arc<TsfnCallback>`. With a finite queue the `Blocking` call mode makes the consumer wait once the queue is full; while it waits it stops draining the ring, the ring fills, and the I/O reader accounts the overflow on `droppedEventCount()`. That restores the same observable back-pressure and drop semantics the other bindings already have. The depth is large enough that a healthy callback has a full ring of headroom before the consumer ever waits, and finite so a wedged callback can pin at most that many in-flight events instead of growing memory without bound.

`MaxQueueSize` is a compile-time const generic and cannot read the runtime `streamingRingSize`, so the depth is fixed and matched to the default ring size to keep the two buffers the same scale. napi-rs drops the integer const generic from the generated `index.d.ts` (only the boolean const generics surface there), so the published callback signature is unchanged; the only `index.d.ts` change is the reworded backpressure docstrings. The now-accurate source comments and docstrings describe the queue-then-ring fill order and name `ringOccupancy()` and `droppedEventCount()` as the signals that reflect consumer-to-JS lag.

## Verification
- napi addon builds; `index.d.ts` callback signature unchanged (only the backpressure docstrings reworded)
- `cargo clippy -p thetadatadx-napi --all-targets -- -D warnings` clean
- `cargo test -p thetadatadx-napi --lib`: 8 passed (includes a new guard that reads the bound back off the `TsfnCallback` type, failing loudly if the seventh generic is ever dropped)
- TS unit tests: 191 passed, 0 failed
- `generate_sdk_surfaces --check` green (the generated `streaming_methods.rs` is reproduced from its emitter and template)
- `check_binding_parity.py --selftest`: 146 passed, 0 failed
- `check_lockfile_drift.py` green; Cargo.lock and package-lock.json untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)