### PR TITLE
ci: grant paths-filter PR read, add an aggregator gate job, and repair the live chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   merge_group:
   schedule:
     # Off-peak, off-minute nightly run of the full heavy lane so the
@@ -43,6 +43,13 @@ jobs:
     name: Detect changed paths
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # paths-filter calls the GitHub REST API on pull_request events to
+    # diff the head against the base, which needs pull-requests: read.
+    # contents: read is restated so the workflow-level grant is not
+    # dropped when the job declares its own permission block.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       ffi: ${{ steps.filter.outputs.ffi }}
@@ -768,3 +775,73 @@ jobs:
           body_path: ${{ steps.release_notes.outputs.body_path }}
           files: |
             release-assets/*
+
+  # ═══════════════════════════════════════════════════════════════
+  # AGGREGATOR GATE. A single roll-up status that summarizes every job
+  # above. This is the one check branch protection should require: it
+  # runs with `if: always()`, depends on every other job, and fails
+  # unless every dependency finished `success` or `skipped`. A heavy
+  # job that legitimately skips on a path-irrelevant PR counts as a
+  # pass; a real `failure` or `cancelled` in any dependency fails the
+  # gate. Requiring this one job (instead of a hand-maintained list of
+  # per-job names) means a conditionally-skipped required check can no
+  # longer leave the merge gate permanently unsatisfiable, and a newly
+  # added job is covered the moment it appears in `needs` below.
+  # ═══════════════════════════════════════════════════════════════
+  ci-gate:
+    name: CI gate
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - changes
+      - fmt
+      - clippy
+      - core-test
+      - c-abi-completeness
+      - binding-parity
+      - wire-schema-drift
+      - safety-comments
+      - public-surface-leak
+      - doc-defaults
+      - no-re-framing
+      - docs-consistency
+      - version-sync
+      - cargo-deny
+      - lint-matrix
+      - test
+      - feature-tests
+      - rustdoc
+      - bench
+      - semver
+      - surfaces
+      - build-ffi
+      - sdk-bindings
+      - cpp-tests
+      - publish-crate
+      - release
+    steps:
+      - name: Fail unless every dependency succeeded or was skipped
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          bad = sorted(
+              name
+              for name, data in needs.items()
+              if data.get("result") not in ("success", "skipped")
+          )
+          for name in sorted(needs):
+              print(f"{name}: {needs[name].get('result')}")
+          if bad:
+              joined = ", ".join(bad)
+              sys.exit(f"CI gate failed: {joined} did not succeed or skip")
+          print("CI gate passed: every dependency succeeded or was skipped")
+          PY

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -113,7 +113,7 @@ jobs:
           cargo test --features live-tests --test flatfiles_byte_match -- --nocapture
   endpoint-validation:
     name: Full Endpoint Validation (${{ matrix.os }})
-    needs: smoke
+    needs: [preflight, smoke]
     if: ${{ needs.preflight.outputs.has_live_secrets == 'true' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
@@ -157,7 +157,7 @@ jobs:
         run: ./build/cpp/thetadatadx_validate creds.txt
   release-validation:
     name: Full Release Validation
-    needs: endpoint-validation
+    needs: [preflight, endpoint-validation]
     if: ${{ needs.preflight.outputs.has_live_secrets == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -183,7 +183,7 @@ jobs:
 
   fpss-soak:
     name: FPSS Reconnect Soak
-    needs: release-validation
+    needs: [preflight, release-validation]
     if: ${{ needs.preflight.outputs.has_live_secrets == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -23,7 +23,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   merge_group:
   schedule:
     - cron: "23 6 * * *"
@@ -47,6 +47,13 @@ jobs:
     name: Detect changed paths
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # paths-filter calls the GitHub REST API on pull_request events to
+    # diff the head against the base, which needs pull-requests: read.
+    # contents: read is restated so the workflow-level grant is not
+    # dropped when the job declares its own permission block.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       perf: ${{ steps.filter.outputs.perf }}
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   merge_group:
   schedule:
     - cron: "23 6 * * *"
@@ -33,6 +33,13 @@ jobs:
     name: Detect changed paths
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # paths-filter calls the GitHub REST API on pull_request events to
+    # diff the head against the base, which needs pull-requests: read.
+    # contents: read is restated so the workflow-level grant is not
+    # dropped when the job declares its own permission block.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       python: ${{ steps.filter.outputs.python }}
     steps:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -11,7 +11,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review, labeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   merge_group:
   schedule:
     - cron: "23 6 * * *"
@@ -19,7 +19,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: typescript-${{ github.workflow }}-${{ github.ref }}
@@ -33,6 +32,13 @@ jobs:
     name: Detect changed paths
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # paths-filter calls the GitHub REST API on pull_request events to
+    # diff the head against the base, which needs pull-requests: read.
+    # contents: read is restated so the workflow-level grant is not
+    # dropped when the job declares its own permission block.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       typescript: ${{ steps.filter.outputs.typescript }}
     steps:


### PR DESCRIPTION
Four workflow fixes, all confined to .github/workflows/.

## paths-filter PR read permission

The changes job uses dorny/paths-filter, which calls the GitHub REST API on pull_request events to diff the head against the base. The workflows granted only contents: read, so that call could fail on PRs. This adds a job-level permissions block with contents: read and pull-requests: read to the changes job in ci.yml, python.yml, typescript.yml, and perf-gate.yml. contents: read is restated because a job-level permissions block replaces the workflow-level grant rather than extending it.

## Aggregator gate job

ci.yml had no roll-up job, so the merge gate's integrity depended on a hand-maintained list of per-job required checks in branch protection, and a heavy job that conditionally skips on a path-irrelevant PR reports skipped (a skipped required check is never satisfied, which can wedge the queue). This adds one job, ci-gate, that runs with if: always(), depends on every other job in ci.yml, and fails unless every dependency result is success or skipped. A real failure or cancelled in any dependency fails the gate; a legitimate skip passes.

## live.yml chain repair

endpoint-validation, release-validation, and fpss-soak each gate on needs.preflight.outputs.has_live_secrets == 'true' but did not list preflight in their needs, so needs.preflight was undefined and the condition was always false. preflight is now added to each of the three jobs' needs, preserving the existing sequential dependency.

## Least privilege and label symmetry

typescript.yml declared id-token: write at the workflow level, but only the publish job needs it (and already declares it at job level). The workflow-level grant is removed so every other job runs without it; publish keeps it. unlabeled is added to the pull_request types in all four tiered workflows so removing the full-ci label re-evaluates the run, matching the existing labeled trigger.

## Verification

actionlint is clean on all edited workflows. The ci-gate needs list was checked to match the ci.yml job set exactly (26 dependencies, none missing, none spurious).

## Maintainer follow-up: branch protection

ci-gate is intended to become the single required status check. After this merges, update branch protection to require ci-gate and remove the old per-job required check names, so the merge gate keys on the one roll-up that summarizes the whole CI run instead of a list that drifts as jobs are added or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)