### PR TITLE
docs: drop the format_contract helpers from streaming examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,26 +85,16 @@ typed event classes:
 import time
 from thetadatadx import Contract, Quote, Trade
 
-def format_contract(contract):
-    parts = [contract.symbol]
-    if contract.expiration is not None:
-        parts.append(str(contract.expiration))
-    if contract.strike is not None:
-        parts.append(f"{contract.strike:g}")
-    if contract.right is not None:
-        parts.append(contract.right)
-    return " ".join(parts)
-
 def on_event(event):
     match event:
         case Trade(price=px, size=sz, exchange=ex, ms_of_day=ms, sequence=seq, condition=cond, contract=c):
             print(
-                f"{format_contract(c)} trade price={px:.2f} size={sz} "
+                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} trade price={px:.2f} size={sz} "
                 f"exchange={ex} ms_of_day={ms} sequence={seq} condition={cond}"
             )
         case Quote(bid=b, ask=a, bid_size=bs, ask_size=asz, bid_exchange=bx, ask_exchange=ax, ms_of_day=ms, contract=c):
             print(
-                f"{format_contract(c)} quote bid={b:.2f} ask={a:.2f} "
+                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} quote bid={b:.2f} ask={a:.2f} "
                 f"bid_size={bs} ask_size={asz} bid_exchange={bx} "
                 f"ask_exchange={ax} ms_of_day={ms}"
             )
@@ -121,15 +111,6 @@ with client.streaming(on_event) as session:
 ```typescript
 import { Contract, Client } from 'thetadatadx';
 
-const formatContract = (contract: {
-  symbol: string;
-  expiration?: number;
-  strike?: number;
-  right?: string;
-}) => [contract.symbol, contract.expiration, contract.strike, contract.right]
-  .filter((value) => value != null)
-  .join(' ');
-
 async function main() {
   // Pass your API key directly. Add mddsType: "STAGE" to target staging.
   const client = await Client.connectWith({ apiKey: 'td1_...' });
@@ -138,13 +119,13 @@ async function main() {
     if (event.kind === 'trade' && event.trade) {
       const { contract, price, size, exchange, msOfDay, sequence, condition } = event.trade;
       console.log(
-        `${formatContract(contract)} trade price=${price} size=${size} ` +
+        `${contract.symbol} ${contract.expiration} ${contract.strike} ${contract.right} trade price=${price} size=${size} ` +
         `exchange=${exchange} ms_of_day=${msOfDay} sequence=${sequence} condition=${condition}`,
       );
     } else if (event.kind === 'quote' && event.quote) {
       const { contract, bid, ask, bidSize, askSize, bidExchange, askExchange, msOfDay } = event.quote;
       console.log(
-        `${formatContract(contract)} quote bid=${bid} ask=${ask} ` +
+        `${contract.symbol} ${contract.expiration} ${contract.strike} ${contract.right} quote bid=${bid} ask=${ask} ` +
         `bid_size=${bidSize} ask_size=${askSize} bid_exchange=${bidExchange} ` +
         `ask_exchange=${askExchange} ms_of_day=${msOfDay}`,
       );

--- a/crates/thetadatadx/README.md
+++ b/crates/thetadatadx/README.md
@@ -94,20 +94,6 @@ One authentication, one connection. Historical queries work immediately; the str
 use thetadatadx::streaming::{StreamData, StreamEvent};
 use thetadatadx::prelude::*;
 
-fn format_contract(contract: &Contract) -> String {
-    let mut label = contract.symbol.to_string();
-    if let Some(expiration) = contract.expiration {
-        label.push_str(&format!(" {expiration}"));
-    }
-    if let Some(strike) = contract.strike_dollars() {
-        label.push_str(&format!(" {strike}"));
-    }
-    if let Some(right) = contract.right() {
-        label.push_str(&format!(" {}", right.as_char()));
-    }
-    label
-}
-
 client.stream().start_streaming(|event: &StreamEvent| {
     match event {
         StreamEvent::Data(StreamData::Trade {
@@ -121,8 +107,7 @@ client.stream().start_streaming(|event: &StreamEvent| {
             ..
         }) => {
             println!(
-                "{} trade price={price} size={size} exchange={exchange} ms_of_day={ms_of_day} sequence={sequence} condition={condition}",
-                format_contract(contract),
+                "{contract} trade price={price} size={size} exchange={exchange} ms_of_day={ms_of_day} sequence={sequence} condition={condition}",
             );
         }
         StreamEvent::Data(StreamData::Quote {
@@ -137,8 +122,7 @@ client.stream().start_streaming(|event: &StreamEvent| {
             ..
         }) => {
             println!(
-                "{} quote bid={bid} ask={ask} bid_size={bid_size} ask_size={ask_size} bid_exchange={bid_exchange} ask_exchange={ask_exchange} ms_of_day={ms_of_day}",
-                format_contract(contract),
+                "{contract} quote bid={bid} ask={ask} bid_size={bid_size} ask_size={ask_size} bid_exchange={bid_exchange} ask_exchange={ask_exchange} ms_of_day={ms_of_day}",
             );
         }
         _ => {}

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -114,19 +114,11 @@ int main() {
     auto config = thetadatadx::Config::production();
 
     thetadatadx::StreamingClient fpss(creds, config);
-    auto format_contract = [](const auto& contract) {
-        std::ostringstream out;
-        out << (contract.symbol ? contract.symbol : "<pending>");
-        if (contract.has_expiration) out << ' ' << contract.expiration;
-        if (auto strike = thetadatadx::strike(contract)) out << ' ' << *strike;
-        if (auto right = thetadatadx::right(contract)) out << ' ' << *right;
-        return out.str();
-    };
 
-    fpss.set_callback([format_contract](const thetadatadx::StreamEvent& event) {
+    fpss.set_callback([](const thetadatadx::StreamEvent& event) {
         switch (event.kind) {
             case THETADATADX_FPSS_TRADE:
-                std::cout << format_contract(event.trade.contract)
+                std::cout << event.trade.contract.symbol
                           << " trade price=" << event.trade.price
                           << " size=" << event.trade.size
                           << " exchange=" << event.trade.exchange
@@ -136,7 +128,7 @@ int main() {
                           << '\n';
                 break;
             case THETADATADX_FPSS_QUOTE:
-                std::cout << format_contract(event.quote.contract)
+                std::cout << event.quote.contract.symbol
                           << " quote bid=" << event.quote.bid
                           << " ask=" << event.quote.ask
                           << " bid_size=" << event.quote.bid_size

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -125,26 +125,16 @@ Real-time quotes and trades flow through the same client. Register a callback an
 import time
 from thetadatadx import Contract, Quote, Trade
 
-def format_contract(contract):
-    parts = [contract.symbol]
-    if contract.expiration is not None:
-        parts.append(str(contract.expiration))
-    if contract.strike is not None:
-        parts.append(f"{contract.strike:g}")
-    if contract.right is not None:
-        parts.append(contract.right)
-    return " ".join(parts)
-
 def on_event(event):
     match event:
         case Trade(price=px, size=sz, exchange=ex, ms_of_day=ms, sequence=seq, condition=cond, contract=c):
             print(
-                f"{format_contract(c)} trade price={px:.2f} size={sz} "
+                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} trade price={px:.2f} size={sz} "
                 f"exchange={ex} ms_of_day={ms} sequence={seq} condition={cond}"
             )
         case Quote(bid=b, ask=a, bid_size=bs, ask_size=asz, bid_exchange=bx, ask_exchange=ax, ms_of_day=ms, contract=c):
             print(
-                f"{format_contract(c)} quote bid={b:.2f} ask={a:.2f} "
+                f"{c.symbol} {c.expiration} {c.strike:g} {c.right} quote bid={b:.2f} ask={a:.2f} "
                 f"bid_size={bs} ask_size={asz} bid_exchange={bx} "
                 f"ask_exchange={ax} ms_of_day={ms}"
             )

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -83,26 +83,18 @@ Real-time quotes and trades flow through the same client. Register a callback wi
 import { Contract, Client } from 'thetadatadx';
 
 const client = await Client.connectWith({ apiKey: 'td1_...' });
-const formatContract = (contract: {
-  symbol: string;
-  expiration?: number;
-  strike?: number;
-  right?: string;
-}) => [contract.symbol, contract.expiration, contract.strike, contract.right]
-  .filter((value) => value != null)
-  .join(' ');
 
 await client.stream.startStreaming((event) => {
   if (event.kind === 'trade' && event.trade) {
     const { contract, price, size, exchange, msOfDay, sequence, condition } = event.trade;
     console.log(
-      `${formatContract(contract)} trade price=${price} size=${size} ` +
+      `${contract.symbol} ${contract.expiration} ${contract.strike} ${contract.right} trade price=${price} size=${size} ` +
       `exchange=${exchange} ms_of_day=${msOfDay} sequence=${sequence} condition=${condition}`,
     );
   } else if (event.kind === 'quote' && event.quote) {
     const { contract, bid, ask, bidSize, askSize, bidExchange, askExchange, msOfDay } = event.quote;
     console.log(
-      `${formatContract(contract)} quote bid=${bid} ask=${ask} ` +
+      `${contract.symbol} ${contract.expiration} ${contract.strike} ${contract.right} quote bid=${bid} ask=${ask} ` +
       `bid_size=${bidSize} ask_size=${askSize} bid_exchange=${bidExchange} ` +
       `ask_exchange=${askExchange} ms_of_day=${msOfDay}`,
     );


### PR DESCRIPTION
The contract returned by streaming and historical calls is already a typed structure, so the examples read its fields directly instead of a hand-rolled formatter. Removes the helper from all five package READMEs (root, python, typescript, cpp, crates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)