### PR TITLE
bench: max per-binding streaming throughput — batching, free-threaded, Arrow levers

### DIFF
--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -2616,11 +2616,19 @@ def _check_core_streaming_method_rows(
 
 # Internal `#[pyfunction]`s that are NOT part of the public utility
 # surface: decode-bench hooks, the FPSS-method introspection helper, and
-# the offline streaming-saturation bench hook, all used by tests /
+# the offline streaming-saturation bench hooks (per-event baseline plus the
+# batched-delivery and Arrow-columnar throughput levers), all used by tests /
 # external benchmarking tooling. Excluded from the Python utility roster
 # so they are not mistaken for untracked utilities.
 PY_NON_UTILITY_PYFUNCTIONS: frozenset[str] = frozenset(
-    {"decode_response_bytes", "blocked_fpss_methods", "__bench_flood_events"}
+    {
+        "decode_response_bytes",
+        "blocked_fpss_methods",
+        "__bench_flood_events",
+        "__bench_flood_events_batched_calls",
+        "__bench_flood_events_batched_list",
+        "__bench_flood_events_arrow",
+    }
 )
 
 
@@ -2857,18 +2865,19 @@ def _is_ts_internal_free_fn(name: str) -> bool:
 
     The JS shim emits a `<tick>_tick_to_arrow_ipc` free function per tick
     type for the zero-copy Arrow boundary, plus small numeric-coercion
-    helpers (`bigint_to_i32`). The offline streaming-saturation bench hook
-    (`__bench_flood_events`, exported as `__benchFloodEvents`) pushes
-    synthetic events through the real tsfn path for benchmarking. None of
-    these are part of the standalone utility roster the `[[utility]]` rows
-    track, so they are excluded from the TypeScript utility surface — the
-    same carve-out the Python bench hooks get via
-    `PY_NON_UTILITY_PYFUNCTIONS`.
+    helpers (`bigint_to_i32`). The offline streaming-saturation bench hooks
+    (`__bench_flood_events` / `__bench_flood_events_batched`, exported as
+    `__benchFloodEvents` / `__benchFloodEventsBatched`) push synthetic events
+    through the real tsfn path for benchmarking. None of these are part of
+    the standalone utility roster the `[[utility]]` rows track, so they are
+    excluded from the TypeScript utility surface — the same carve-out the
+    Python bench hooks get via `PY_NON_UTILITY_PYFUNCTIONS`.
     """
     return (
         name.endswith("_to_arrow_ipc")
         or name == "bigint_to_i32"
         or name == "__bench_flood_events"
+        or name == "__bench_flood_events_batched"
     )
 
 

--- a/scripts/ci/check_binding_parity.py
+++ b/scripts/ci/check_binding_parity.py
@@ -2866,18 +2866,24 @@ def _is_ts_internal_free_fn(name: str) -> bool:
     The JS shim emits a `<tick>_tick_to_arrow_ipc` free function per tick
     type for the zero-copy Arrow boundary, plus small numeric-coercion
     helpers (`bigint_to_i32`). The offline streaming-saturation bench hooks
-    (`__bench_flood_events` / `__bench_flood_events_batched`, exported as
-    `__benchFloodEvents` / `__benchFloodEventsBatched`) push synthetic events
-    through the real tsfn path for benchmarking. None of these are part of
-    the standalone utility roster the `[[utility]]` rows track, so they are
+    (`__bench_flood_events` / `__bench_flood_events_batched` /
+    `__bench_flood_events_arrow_ipc`, exported as `__benchFloodEvents` /
+    `__benchFloodEventsBatched` / `__benchFloodEventsArrowIpc`) push synthetic
+    events through the real tsfn path for benchmarking. None of these are part
+    of the standalone utility roster the `[[utility]]` rows track, so they are
     excluded from the TypeScript utility surface — the same carve-out the
     Python bench hooks get via `PY_NON_UTILITY_PYFUNCTIONS`.
+
+    Note `*_to_arrow_ipc` already matches the `<tick>_tick_to_arrow_ipc`
+    family; `__bench_flood_events_arrow_ipc` is listed explicitly for clarity
+    even though the suffix rule would also catch it.
     """
     return (
         name.endswith("_to_arrow_ipc")
         or name == "bigint_to_i32"
         or name == "__bench_flood_events"
         or name == "__bench_flood_events_batched"
+        or name == "__bench_flood_events_arrow_ipc"
     )
 
 

--- a/sdks/python/benches/streaming_throughput_levers_py.py
+++ b/sdks/python/benches/streaming_throughput_levers_py.py
@@ -1,0 +1,178 @@
+"""Python streaming throughput — optimization levers (offline, no network).
+
+Measures the TRUE MAX Python streaming throughput by amortizing the
+per-event language-boundary crossing three ways, against the per-event
+baseline (~201k events/s) the companion `streaming_throughput_py.py`
+records. All variants drive the SAME LMAX Disruptor pipeline (131_072-slot
+ring = production default); only the boundary-crossing shape changes.
+
+Variants
+--------
+1. per_event              — baseline: 1 GIL attach + 1 marshal + 1 call1 / event.
+2. batched_calls[B]       — Lever 1a: 1 GIL attach per batch of B, then B
+                            marshals + B call1s inside it (amortize the GIL
+                            acquire only).
+3. batched_list[B]        — Lever 1b: 1 GIL attach per batch, marshal B events
+                            into one Python list, ONE call1(list) (amortize
+                            GIL acquire + call dispatch).
+4. arrow[B]               — Lever 3: 1 GIL attach per batch, build ONE Arrow
+                            RecordBatch from B TradeTick rows, export zero-copy
+                            to a pyarrow.Table over the C-Stream Interface, ONE
+                            call1(table). DIFFERENT delivery model: Python gets
+                            a columnar Table, not B event objects.
+
+Batch sweep: 256 / 1024 / 4096 (override via THETADX_BATCHES env, comma-sep).
+
+Methodology (matches the per-event bench + the core Rust bench)
+---------------------------------------------------------------
+* EVENTS_PER_ITER = 100_000 events per sample.
+* Timed region = publish loop + drain, measured INSIDE Rust and returned as
+  elapsed_ns. Interpreter spin-up, ring allocation, consumer-thread spawn run
+  before the timed region opens and are excluded.
+* Warmup samples discarded; median (p50) reported with min/max.
+* Every sample asserts delivered == EVENTS_PER_ITER (zero-drop). For Arrow,
+  the callback also tallies pyarrow.Table.num_rows so the consumed row count
+  is checked == EVENTS_PER_ITER (receive-side zero-drop).
+
+Run (standard GIL):
+    VIRTUAL_ENV=/tmp/cta-pyvenv /tmp/cta-pyvenv/bin/python \
+        sdks/python/benches/streaming_throughput_levers_py.py
+
+Run (free-threaded, Lever 2):
+    PYTHON_GIL=0 VIRTUAL_ENV=/tmp/cta-pyvenv-ft /tmp/cta-pyvenv-ft/bin/python \
+        sdks/python/benches/streaming_throughput_levers_py.py
+
+Output: line-delimited per-sample, then one `JSON {...}` summary per variant.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import statistics
+import sys
+
+import thetadatadx
+
+EVENTS_PER_ITER = 100_000
+WARMUP_SAMPLES = 3
+MEASURED_SAMPLES = 12
+BATCHES = [int(x) for x in os.environ.get("THETADX_BATCHES", "256,1024,4096").split(",")]
+
+
+def gil_enabled() -> bool:
+    fn = getattr(sys, "_is_gil_enabled", None)
+    return bool(fn()) if fn else True
+
+
+def summarize(name: str, eps_list: list[float], nspe_list: list[float], extra: dict) -> dict:
+    p50 = statistics.median(eps_list)
+    return {
+        "variant": name,
+        "events_per_sec_p50": p50,
+        "events_per_sec_min": min(eps_list),
+        "events_per_sec_max": max(eps_list),
+        "ns_per_event_p50": statistics.median(nspe_list),
+        "events_per_iter": EVENTS_PER_ITER,
+        "warmup_samples": WARMUP_SAMPLES,
+        "measured_samples": MEASURED_SAMPLES,
+        "zero_drop_verified": True,
+        **extra,
+    }
+
+
+def run_variant(name, call_one, verify_received=None) -> dict:
+    """`call_one()` runs one flood and returns (delivered, elapsed_ns).
+    `verify_received()` (optional) returns the receive-side count to assert
+    == EVENTS_PER_ITER (used by the list/arrow variants)."""
+    for _ in range(WARMUP_SAMPLES):
+        delivered, _ = call_one()
+        if delivered != EVENTS_PER_ITER:
+            print(f"FATAL[{name}]: warmup delivered {delivered} != {EVENTS_PER_ITER}", file=sys.stderr)
+            sys.exit(1)
+        if verify_received is not None:
+            got = verify_received()
+            if got != EVENTS_PER_ITER:
+                print(f"FATAL[{name}]: warmup received {got} != {EVENTS_PER_ITER}", file=sys.stderr)
+                sys.exit(1)
+
+    eps_list, nspe_list = [], []
+    for i in range(MEASURED_SAMPLES):
+        delivered, elapsed_ns = call_one()
+        if delivered != EVENTS_PER_ITER:
+            print(f"FATAL[{name}]: sample {i} delivered {delivered} != {EVENTS_PER_ITER}", file=sys.stderr)
+            sys.exit(1)
+        if verify_received is not None:
+            got = verify_received()
+            if got != EVENTS_PER_ITER:
+                print(f"FATAL[{name}]: sample {i} received {got} != {EVENTS_PER_ITER}", file=sys.stderr)
+                sys.exit(1)
+        eps = EVENTS_PER_ITER / (elapsed_ns / 1e9)
+        eps_list.append(eps)
+        nspe_list.append(elapsed_ns / EVENTS_PER_ITER)
+    p50 = statistics.median(eps_list)
+    print(f"  {name:28s}: p50 {p50/1e6:7.3f} Melem/s  {statistics.median(nspe_list):8.2f} ns/event  (zero-drop {MEASURED_SAMPLES}x)")
+    return eps_list, nspe_list
+
+
+def main() -> int:
+    ft = not gil_enabled()
+    print(f"# Python {platform.python_version()} ({'FREE-THREADED' if ft else 'standard GIL'}), "
+          f"events/iter={EVENTS_PER_ITER}, warmup={WARMUP_SAMPLES}, samples={MEASURED_SAMPLES}")
+
+    summaries = []
+
+    # 1. per-event baseline
+    def noop(_e):
+        return None
+    eps, nspe = run_variant("per_event", lambda: thetadatadx.__bench_flood_events(EVENTS_PER_ITER, noop))
+    summaries.append(summarize("per_event", eps, nspe, {"batch_size": 1}))
+
+    # 2 + 3 + 4: batch sweep
+    for B in BATCHES:
+        # Lever 1a: batched calls (callback receives one event per call).
+        eps, nspe = run_variant(
+            f"batched_calls[{B}]",
+            lambda B=B: thetadatadx.__bench_flood_events_batched_calls(EVENTS_PER_ITER, B, noop),
+        )
+        summaries.append(summarize(f"batched_calls", eps, nspe, {"batch_size": B}))
+
+        # Lever 1b: batched list (callback receives a list of events per call).
+        recv = {"n": 0}
+        def list_cb(lst, _r=recv):
+            _r["n"] += len(lst)
+        def list_one(B=B, _r=recv):
+            _r["n"] = 0
+            return thetadatadx.__bench_flood_events_batched_list(EVENTS_PER_ITER, B, list_cb)
+        eps, nspe = run_variant(
+            f"batched_list[{B}]", list_one, verify_received=lambda _r=recv: _r["n"]
+        )
+        summaries.append(summarize("batched_list", eps, nspe, {"batch_size": B}))
+
+        # Lever 3: Arrow columnar batch (callback receives a pyarrow.Table).
+        arecv = {"rows": 0}
+        def arrow_cb(table, _r=arecv):
+            _r["rows"] += table.num_rows
+        def arrow_one(B=B, _r=arecv):
+            _r["rows"] = 0
+            return thetadatadx.__bench_flood_events_arrow(EVENTS_PER_ITER, B, arrow_cb)
+        eps, nspe = run_variant(
+            f"arrow[{B}]", arrow_one, verify_received=lambda _r=arecv: _r["rows"]
+        )
+        summaries.append(summarize("arrow", eps, nspe, {"batch_size": B}))
+
+    machine = {
+        "python": platform.python_version(),
+        "gil": "disabled" if ft else "enabled",
+        "impl": platform.python_implementation(),
+    }
+    print("")
+    for s in summaries:
+        s["machine"] = machine
+        print("JSON " + json.dumps(s))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdks/python/src/bench_streaming.rs
+++ b/sdks/python/src/bench_streaming.rs
@@ -1,35 +1,51 @@
-//! Offline saturation bench hook for the Python streaming callback path.
+//! Offline saturation bench hooks for the Python streaming callback path.
 //!
-//! `__bench_flood_events(n, callback)` drives the same LMAX Disruptor
-//! pipeline the live FPSS consumer uses (single producer, single
-//! consumer thread, `RING_SIZE` slots) and, for every delivered event,
-//! runs the identical per-event handover the generated `start_streaming`
-//! dispatcher runs in production:
+//! All hooks drive the SAME LMAX Disruptor pipeline the live FPSS consumer
+//! uses (single producer, single consumer thread, `RING_SIZE` slots). They
+//! differ only in HOW the consumer hands events across the Python boundary,
+//! so the numbers isolate the boundary-crossing cost (the Disruptor itself
+//! runs ~39 M events/s in the core Rust bench, far above the boundary, so it
+//! is never the bottleneck here).
 //!
-//! 1. `Python::attach` to acquire the GIL on the consumer thread (the
-//!    production granularity is per-event, not per-batch — see
-//!    `_generated/streaming_methods.rs`, where the FPSS callback closure
-//!    re-attaches for each delivered event);
-//! 2. `fpss_event_to_typed(py, event)` — the exact borrowed-`&StreamEvent`
-//!    → typed `#[pyclass]` marshal the production path calls, reused here
-//!    rather than reimplemented;
-//! 3. `callback.call1(py, (typed,))` — the same `call1` 1-tuple vectorcall
-//!    the dispatcher uses.
+//! - [`__bench_flood_events`] — PER-EVENT baseline. For every delivered
+//!   event: `Python::attach` (per-event, the production granularity — see
+//!   `_generated/streaming_methods.rs`), `fpss_event_to_typed` (the exact
+//!   production marshal, reused), `call1((typed,))` (the production
+//!   1-tuple vectorcall).
 //!
-//! The publish loop retries on `RingBufferFull` so every attempted event
-//! is delivered (no silent drops); the delivered count is returned to the
-//! caller, which asserts `delivered == n`. The returned wall-clock is the
-//! publish-loop + drain duration measured on the consumer thread side via
-//! the shared delivery counter — interpreter spin-up, ring allocation,
-//! and thread spawn are excluded (they run before the timed region opens),
-//! mirroring the `iter_custom` setup-exclusion in the core Rust bench
-//! `crates/thetadatadx/benches/streaming_throughput.rs`.
+//! - [`__bench_flood_events_batched_calls`] — LEVER 1a. Amortize only the
+//!   GIL acquire: the consumer buffers `batch_size` events, then takes ONE
+//!   `Python::attach` and loops `call1((typed,))` per event inside it. Same
+//!   per-event marshal + per-event call as the baseline; the only thing
+//!   removed is the per-event GIL reacquisition.
 //!
-//! This is a bench-only `#[pyfunction]`, NOT part of the public utility
-//! surface. It is enrolled in `PY_NON_UTILITY_PYFUNCTIONS` in
-//! `scripts/ci/check_binding_parity.py` alongside the other offline
-//! hooks (`decode_response_bytes`, `blocked_fpss_methods`) so the parity
-//! gate does not mistake it for an untracked cross-binding utility.
+//! - [`__bench_flood_events_batched_list`] — LEVER 1b. Amortize the GIL
+//!   acquire AND the call dispatch: the consumer buffers `batch_size`
+//!   events, marshals them into one Python `list`, and fires ONE
+//!   `call1((list,))` per batch. One boundary crossing per batch.
+//!
+//! - [`__bench_flood_events_arrow`] — LEVER 3. Columnar bulk delivery: the
+//!   consumer buffers `batch_size` events as `TradeTick` rows, builds ONE
+//!   Arrow `RecordBatch`, and hands it to Python zero-copy over the Arrow C
+//!   Stream Interface via the SDK's own `trade_tick_slice_to_arrow_table`
+//!   (the same path `<TickList>.to_arrow()` uses). This is a DIFFERENT
+//!   delivery model than the per-event callback — Python receives a
+//!   columnar `pyarrow.Table`, not N typed event objects — so its number is
+//!   the columnar bulk ceiling, not a like-for-like callback rate.
+//!
+//! Every hook retries the publish on `RingBufferFull` so all `n` events are
+//! delivered (no silent drops); the delivered count is returned and the
+//! caller asserts `delivered == n`. The returned wall clock is the publish
+//! loop + drain, measured on the consumer side; interpreter spin-up, ring
+//! allocation, and thread spawn run before the timed region opens and are
+//! excluded (mirroring the `iter_custom` setup-exclusion in the core Rust
+//! bench `crates/thetadatadx/benches/streaming_throughput.rs`).
+//!
+//! These are bench-only `#[pyfunction]`s, NOT part of the public utility
+//! surface. They are enrolled in `PY_NON_UTILITY_PYFUNCTIONS` in
+//! `scripts/ci/check_binding_parity.py` alongside the other offline hooks so
+//! the parity gate does not mistake them for untracked cross-binding
+//! utilities.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -37,12 +53,14 @@ use std::time::{Duration, Instant};
 
 use disruptor::{build_single_producer, BusySpin, Producer, Sequence};
 use pyo3::prelude::*;
+use pyo3::types::PyList;
 
 use thetadatadx::fpss::protocol::Contract;
 use thetadatadx::fpss::{StreamData, StreamEvent};
 use thetadatadx::Price;
 
 use crate::fpss_event_to_typed;
+use crate::slice_arrow::trade_tick_slice_to_arrow_table;
 
 /// Disruptor ring size. Matches the production default
 /// `FpssConfig::ring_size = 131_072` (see `crates/thetadatadx/src/config/fpss.rs`)
@@ -91,93 +109,302 @@ fn make_event(contract: &Arc<Contract>, idx: u64) -> StreamEvent {
     })
 }
 
-/// Flood `n` synthetic `Trade` events through the real Disruptor pipeline,
-/// firing the production Python callback path (`Python::attach` →
-/// `fpss_event_to_typed` → `call1`) for each delivered event.
-///
-/// Returns `(delivered, elapsed_ns)`:
-/// - `delivered` is the number of events the consumer actually fired the
-///   callback for; the caller asserts `delivered == n` (zero-drop).
-/// - `elapsed_ns` is the publish-loop + drain wall clock in nanoseconds,
-///   measured on the consumer side. Setup (ring build, thread spawn) is
-///   excluded — it runs before the timed region opens.
-///
-/// The GIL is released across the whole flood via `py.detach` so the
-/// consumer thread can re-acquire it per event exactly as the live
-/// dispatcher does; without this the producer would deadlock against the
-/// consumer's `Python::attach`.
-#[pyfunction]
-pub(crate) fn __bench_flood_events(
-    py: Python<'_>,
-    n: u64,
-    callback: Py<PyAny>,
-) -> PyResult<(u64, u64)> {
-    let callback = Arc::new(callback);
-    let dispatch_cb = Arc::clone(&callback);
+/// Project a `&StreamEvent::Data(Trade)` into the historical `TradeTick`
+/// row shape the Arrow builder consumes. Non-trade events are skipped
+/// (the bench only floods trades). Field-for-field copy — same columns the
+/// `TradeTick` Arrow schema declares.
+#[inline]
+fn trade_event_to_tick(event: &StreamEvent) -> Option<thetadatadx::TradeTick> {
+    match event {
+        StreamEvent::Data(StreamData::Trade {
+            ms_of_day,
+            sequence,
+            ext_condition1,
+            ext_condition2,
+            ext_condition3,
+            ext_condition4,
+            condition,
+            size,
+            exchange,
+            price,
+            condition_flags,
+            price_flags,
+            volume_type,
+            records_back,
+            date,
+            ..
+        }) => Some(thetadatadx::TradeTick {
+            ms_of_day: *ms_of_day,
+            sequence: *sequence,
+            ext_condition1: *ext_condition1,
+            ext_condition2: *ext_condition2,
+            ext_condition3: *ext_condition3,
+            ext_condition4: *ext_condition4,
+            condition: *condition,
+            size: *size,
+            exchange: *exchange,
+            price: *price,
+            condition_flags: *condition_flags,
+            price_flags: *price_flags,
+            volume_type: *volume_type,
+            records_back: *records_back,
+            date: *date,
+            // Stock trade: no option fields. `TradeTick` uses sentinel
+            // values for absent option metadata (the Arrow builder maps
+            // these sentinels to nulls): `0` expiration, `0.0` strike,
+            // `'\0'` right.
+            expiration: 0,
+            strike: 0.0,
+            right: '\0',
+        }),
+        _ => None,
+    }
+}
 
+/// Build the Disruptor + consumer thread with a user-supplied consumer
+/// `body`, drive `n` synthetic trades through the publish loop (retry on
+/// overflow so every event is delivered), and return `(delivered,
+/// elapsed_ns)`. `body` runs on the consumer thread for every delivered
+/// event; `flush` runs once after the publish loop drains so a batching
+/// body can emit its final partial batch. Setup (ring build, thread spawn)
+/// is excluded from the timed region.
+fn run_pipeline<B, F>(py: Python<'_>, n: u64, body: B, flush: F) -> (u64, u64)
+where
+    B: FnMut(&StreamEvent) + Send + 'static,
+    F: FnOnce() + Send,
+{
     let delivered = Arc::new(AtomicU64::new(0));
     let delivered_consumer = Arc::clone(&delivered);
-
-    // Allocate the contract once; the publish closure clones the Arc per
-    // event (refcount bump only). Same shape as the FPSS contract cache.
     let contract = Arc::new(Contract::stock("SPY"));
 
-    // Build the Disruptor + consumer thread BEFORE the timed region. The
-    // consumer body is the production handover: per-event GIL acquire,
-    // typed-pyclass marshal, `call1`. Wrapped in `catch_unwind` to match
-    // the live SSOT pipeline (a panicking callback must not abort the
-    // consumer). `record_panic` accounting is the only production detail
-    // intentionally omitted — it is a relaxed atomic add off the timed
-    // path and would not change the ceiling.
+    let mut body = body;
     let factory = || RingSlot { event: None };
     let mut producer = build_single_producer(RING_SIZE, factory, BusySpin)
         .handle_events_with(move |slot: &RingSlot, _seq: Sequence, _eob: bool| {
             if let Some(ref evt) = slot.event {
                 delivered_consumer.fetch_add(1, Ordering::Relaxed);
-                Python::attach(|py| {
-                    let typed = match fpss_event_to_typed(py, evt) {
-                        Ok(obj) => obj,
-                        Err(err) => {
-                            err.write_unraisable(py, None);
-                            return;
-                        }
-                    };
-                    if let Err(err) = dispatch_cb.call1(py, (typed,)) {
-                        err.write_unraisable(py, None);
-                    }
-                });
+                body(evt);
             }
         })
         .build();
 
     // Release the GIL for the whole flood: the consumer thread re-acquires
-    // it per event via `Python::attach`. Holding it here would deadlock the
-    // consumer. The timed region is the publish loop + producer drop
-    // (which blocks until the consumer has drained every slot), so the
-    // elapsed wall clock covers exactly the per-event marshal+callback
-    // cost across all `n` events.
+    // it (per event or per batch, depending on `body`). Holding it here
+    // would deadlock the consumer against its own `Python::attach`.
     let elapsed: Duration = py.detach(|| {
         let start = Instant::now();
         for i in 0..n {
             loop {
                 let evt = make_event(&contract, i);
-                if producer
-                    .try_publish(|slot| {
-                        slot.event = Some(evt);
-                    })
-                    .is_ok()
-                {
+                if producer.try_publish(|slot| slot.event = Some(evt)).is_ok() {
                     break;
                 }
                 std::hint::spin_loop();
             }
         }
-        // Dropping the producer joins the consumer thread, so by the time
-        // this returns every published event has been delivered and the
-        // callback has fired for each.
+        // Dropping the producer joins the consumer thread, so every
+        // published event has been handed to `body` by the time this
+        // returns. `flush` then emits any buffered partial batch.
         drop(producer);
+        flush();
         start.elapsed()
     });
 
-    Ok((delivered.load(Ordering::Relaxed), elapsed.as_nanos() as u64))
+    (delivered.load(Ordering::Relaxed), elapsed.as_nanos() as u64)
+}
+
+/// PER-EVENT baseline. One `Python::attach` + one `fpss_event_to_typed` +
+/// one `call1` per delivered event. Returns `(delivered, elapsed_ns)`; the
+/// caller asserts `delivered == n` (zero-drop).
+#[pyfunction]
+pub(crate) fn __bench_flood_events(py: Python<'_>, n: u64, callback: Py<PyAny>) -> PyResult<(u64, u64)> {
+    let dispatch_cb = Arc::new(callback);
+    let body = move |evt: &StreamEvent| {
+        Python::attach(|py| {
+            let typed = match fpss_event_to_typed(py, evt) {
+                Ok(obj) => obj,
+                Err(err) => {
+                    err.write_unraisable(py, None);
+                    return;
+                }
+            };
+            if let Err(err) = dispatch_cb.call1(py, (typed,)) {
+                err.write_unraisable(py, None);
+            }
+        });
+    };
+    Ok(run_pipeline(py, n, body, || {}))
+}
+
+/// Marshal + dispatch one buffered batch under ONE GIL acquisition, one
+/// `call1((typed,))` per event (Lever 1a emit). Clears `events`.
+fn emit_batch_calls(events: &mut Vec<StreamEvent>, cb: &Py<PyAny>) {
+    if events.is_empty() {
+        return;
+    }
+    Python::attach(|py| {
+        for evt in events.iter() {
+            match fpss_event_to_typed(py, evt) {
+                Ok(typed) => {
+                    if let Err(err) = cb.call1(py, (typed,)) {
+                        err.write_unraisable(py, None);
+                    }
+                }
+                Err(err) => err.write_unraisable(py, None),
+            }
+        }
+    });
+    events.clear();
+}
+
+/// LEVER 1a — amortize the GIL acquire only. The consumer buffers
+/// `batch_size` borrowed events (cloned into an owned buffer so they
+/// outlive the ring slot), then takes ONE `Python::attach` and fires one
+/// `call1((typed,))` per event inside it. Per-event marshal + per-event
+/// call are unchanged from the baseline; only the per-event GIL
+/// reacquisition is removed.
+#[pyfunction]
+pub(crate) fn __bench_flood_events_batched_calls(
+    py: Python<'_>,
+    n: u64,
+    batch_size: u64,
+    callback: Py<PyAny>,
+) -> PyResult<(u64, u64)> {
+    let dispatch_cb = Arc::new(callback);
+    let cap = batch_size.max(1) as usize;
+    let buf: Arc<std::sync::Mutex<Vec<StreamEvent>>> =
+        Arc::new(std::sync::Mutex::new(Vec::with_capacity(cap)));
+
+    let flush_buf = Arc::clone(&buf);
+    let flush_cb = Arc::clone(&dispatch_cb);
+    let body = move |evt: &StreamEvent| {
+        let mut v = buf.lock().unwrap_or_else(|e| e.into_inner());
+        v.push(evt.clone());
+        if v.len() >= cap {
+            emit_batch_calls(&mut v, &dispatch_cb);
+        }
+    };
+    let flush = move || {
+        let mut v = flush_buf.lock().unwrap_or_else(|e| e.into_inner());
+        emit_batch_calls(&mut v, &flush_cb);
+    };
+    Ok(run_pipeline(py, n, body, flush))
+}
+
+/// Marshal one buffered batch into a single Python `list` and fire ONE
+/// `call1((list,))` (Lever 1b emit). Clears `events`.
+fn emit_batch_list(events: &mut Vec<StreamEvent>, cb: &Py<PyAny>) {
+    if events.is_empty() {
+        return;
+    }
+    Python::attach(|py| {
+        let items: Vec<Py<PyAny>> = events
+            .iter()
+            .filter_map(|evt| match fpss_event_to_typed(py, evt) {
+                Ok(typed) => Some(typed),
+                Err(err) => {
+                    err.write_unraisable(py, None);
+                    None
+                }
+            })
+            .collect();
+        match PyList::new(py, items) {
+            Ok(list) => {
+                if let Err(err) = cb.call1(py, (list,)) {
+                    err.write_unraisable(py, None);
+                }
+            }
+            Err(err) => err.write_unraisable(py, None),
+        }
+    });
+    events.clear();
+}
+
+/// LEVER 1b — amortize the GIL acquire AND the call dispatch. The consumer
+/// buffers `batch_size` events, marshals them into one Python `list` of
+/// typed event objects, and fires ONE `call1((list,))` per batch. One
+/// boundary crossing per batch instead of per event.
+#[pyfunction]
+pub(crate) fn __bench_flood_events_batched_list(
+    py: Python<'_>,
+    n: u64,
+    batch_size: u64,
+    callback: Py<PyAny>,
+) -> PyResult<(u64, u64)> {
+    let dispatch_cb = Arc::new(callback);
+    let cap = batch_size.max(1) as usize;
+    let buf: Arc<std::sync::Mutex<Vec<StreamEvent>>> =
+        Arc::new(std::sync::Mutex::new(Vec::with_capacity(cap)));
+
+    let flush_buf = Arc::clone(&buf);
+    let flush_cb = Arc::clone(&dispatch_cb);
+    let body = move |evt: &StreamEvent| {
+        let mut v = buf.lock().unwrap_or_else(|e| e.into_inner());
+        v.push(evt.clone());
+        if v.len() >= cap {
+            emit_batch_list(&mut v, &dispatch_cb);
+        }
+    };
+    let flush = move || {
+        let mut v = flush_buf.lock().unwrap_or_else(|e| e.into_inner());
+        emit_batch_list(&mut v, &flush_cb);
+    };
+    Ok(run_pipeline(py, n, body, flush))
+}
+
+/// LEVER 3 — columnar bulk delivery over the Arrow C Stream Interface. The
+/// consumer buffers `batch_size` events as `TradeTick` rows, builds ONE
+/// Arrow `RecordBatch` via the SDK's `trade_tick_slice_to_arrow_table`
+/// (zero-copy export to a `pyarrow.Table` over `FFI_ArrowArrayStream`), and
+/// fires ONE `call1((table,))` per batch.
+///
+/// DIFFERENT delivery model than the per-event callback: Python receives a
+/// columnar `pyarrow.Table`, not typed event objects. The number is the
+/// columnar bulk ceiling, not a like-for-like callback rate.
+#[pyfunction]
+pub(crate) fn __bench_flood_events_arrow(
+    py: Python<'_>,
+    n: u64,
+    batch_size: u64,
+    callback: Py<PyAny>,
+) -> PyResult<(u64, u64)> {
+    let dispatch_cb = Arc::new(callback);
+    let cap = batch_size.max(1) as usize;
+    let buf: Arc<std::sync::Mutex<Vec<thetadatadx::TradeTick>>> =
+        Arc::new(std::sync::Mutex::new(Vec::with_capacity(cap)));
+
+    let flush_buf = Arc::clone(&buf);
+    let flush_cb = Arc::clone(&dispatch_cb);
+    let body = move |evt: &StreamEvent| {
+        if let Some(tick) = trade_event_to_tick(evt) {
+            let mut v = buf.lock().unwrap_or_else(|e| e.into_inner());
+            v.push(tick);
+            if v.len() >= cap {
+                emit_batch_arrow(&mut v, &dispatch_cb);
+            }
+        }
+    };
+    let flush = move || {
+        let mut v = flush_buf.lock().unwrap_or_else(|e| e.into_inner());
+        emit_batch_arrow(&mut v, &flush_cb);
+    };
+    Ok(run_pipeline(py, n, body, flush))
+}
+
+/// Build one Arrow `RecordBatch` from a buffered `TradeTick` slice and hand
+/// it to Python zero-copy via the SDK's `trade_tick_slice_to_arrow_table`,
+/// then fire ONE `call1((table,))` (Lever 3 emit). Clears `rows`.
+fn emit_batch_arrow(rows: &mut Vec<thetadatadx::TradeTick>, cb: &Py<PyAny>) {
+    if rows.is_empty() {
+        return;
+    }
+    Python::attach(|py| match trade_tick_slice_to_arrow_table(py, rows) {
+        Ok(table) => {
+            if let Err(err) = cb.call1(py, (table,)) {
+                err.write_unraisable(py, None);
+            }
+        }
+        Err(err) => err.write_unraisable(py, None),
+    });
+    rows.clear();
 }

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -2557,9 +2557,19 @@ fn thetadatadx_py(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Introspection helper for the offline `HistoricalClient` block-list
     // coverage test. Mirrors `mdds_client::FPSS_TOUCHING_METHODS`.
     m.add_function(wrap_pyfunction!(mdds_client::blocked_fpss_methods, m)?)?;
-    // Offline streaming-saturation bench hook (no network). Drives the real
-    // Disruptor pipeline + the production per-event GIL/marshal/callback path.
+    // Offline streaming-saturation bench hooks (no network). Drive the real
+    // Disruptor pipeline + the production per-event GIL/marshal/callback path,
+    // plus the batched-delivery and Arrow-columnar throughput levers.
     // Bench-only; enrolled in `PY_NON_UTILITY_PYFUNCTIONS` in the parity gate.
     m.add_function(wrap_pyfunction!(bench_streaming::__bench_flood_events, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        bench_streaming::__bench_flood_events_batched_calls,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        bench_streaming::__bench_flood_events_batched_list,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(bench_streaming::__bench_flood_events_arrow, m)?)?;
     Ok(())
 }

--- a/sdks/typescript/benches/streaming_throughput_arrow.mjs
+++ b/sdks/typescript/benches/streaming_throughput_arrow.mjs
@@ -1,0 +1,167 @@
+// TypeScript streaming throughput — Arrow columnar batch lever (offline, no network).
+//
+// Lever 3 for TypeScript: the columnar analogue of the Python Arrow lever.
+// The per-event and array-batch models cap TypeScript at ~0.3M events/s
+// because each event still materializes a full StreamEvent JS object. This
+// path bypasses per-event JS-object construction entirely:
+//
+//   - Rust accumulates `batch_size` synthetic trade events into a TradeTick
+//     RecordBatch and serializes ONE Arrow IPC byte buffer per batch (the
+//     same `TicksArrowExt::to_arrow` -> `arrow_ipc::StreamWriter` path the
+//     SDK's `tradeTickToArrowIpc` export uses).
+//   - The buffer crosses the ThreadsafeFunction boundary ONCE per batch as a
+//     napi `Buffer` (NOT N JS objects).
+//   - Node consumes it columnar via `apache-arrow` (`tableFromIPC`) as a
+//     Table; no per-event StreamEvent object is ever built on the JS side.
+//
+// DIFFERENT delivery model than the per-event / array-batch callbacks — Node
+// receives a columnar Arrow Table, not typed event objects — so the number
+// is the columnar bulk ceiling, the TypeScript analogue of the Python Arrow
+// row.
+//
+// Methodology (matches the other levers)
+// --------------------------------------
+// * EVENTS_PER_ITER = 100_000 events/sample; batch sweep 256 / 1024 / 4096
+//   (override via THETADX_BATCHES, comma-sep).
+// * `process.hrtime.bigint()` brackets "flood started" to "JS side has
+//   consumed Arrow rows totalling N". Rust marshal + tsfn.call run on a
+//   worker thread; module load / addon init excluded.
+// * Warmup samples discarded; median (p50) reported with min/max.
+// * Zero-drop two ways: the export returns the count of non-Ok tsfn.call
+//   statuses (asserted 0) AND the apache-arrow Table.numRows summed across
+//   all batch buffers is asserted === N (receive-side columnar check).
+//
+// `apache-arrow` is a devDependency (added for this bench driver). If it is
+// not installed the bench exits with a clear message rather than a silent skip.
+//
+// Run:
+//   node sdks/typescript/benches/streaming_throughput_arrow.mjs
+//
+// Output: line-delimited per-sample summary, then one `JSON {...}` per variant.
+
+import os from 'node:os';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+let mod;
+try {
+  mod = await import('../index.js');
+} catch (err) {
+  console.error('FAIL: native addon not built; run `npm run build` first');
+  console.error(err);
+  process.exit(1);
+}
+if (typeof mod.__benchFloodEventsArrowIpc !== 'function') {
+  console.error('FAIL: __benchFloodEventsArrowIpc not found on the addon. Rebuild with `npm run build`.');
+  process.exit(1);
+}
+
+let tableFromIPC;
+try {
+  ({ tableFromIPC } = require('apache-arrow'));
+} catch {
+  console.error('FAIL: apache-arrow not installed. Run `npm install` (it is a devDependency for this bench).');
+  process.exit(1);
+}
+
+const EVENTS_PER_ITER = 100_000;
+const WARMUP_SAMPLES = 3;
+const MEASURED_SAMPLES = 12;
+const BATCHES = (process.env.THETADX_BATCHES || '256,1024,4096')
+  .split(',')
+  .map((s) => parseInt(s, 10));
+
+function median(xs) {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+// One Arrow-batch flood: B trade events per Arrow IPC buffer per tsfn hop.
+// The JS callback decodes each buffer columnar via apache-arrow and tallies
+// the row count — the same columnar consume path a real integrator uses.
+async function runArrow(batchSize) {
+  let rows = 0;
+  let resolveAll;
+  const allConsumed = new Promise((r) => (resolveAll = r));
+  const cb = (ipcBuffer) => {
+    // Columnar decode: NO per-event JS object construction. tableFromIPC
+    // aliases the buffer's columnar arrays into an Arrow Table.
+    const table = tableFromIPC(ipcBuffer);
+    rows += table.numRows;
+    if (rows >= EVENTS_PER_ITER) resolveAll();
+  };
+  const start = process.hrtime.bigint();
+  const flood = mod.__benchFloodEventsArrowIpc(EVENTS_PER_ITER, batchSize, cb);
+  const [drops] = await Promise.all([flood, allConsumed]);
+  const end = process.hrtime.bigint();
+  const elapsedNs = Number(end - start);
+  return {
+    eventsPerSec: EVENTS_PER_ITER / (elapsedNs / 1e9),
+    nsPerEvent: elapsedNs / EVENTS_PER_ITER,
+    drops: Number(drops),
+    received: rows,
+  };
+}
+
+async function runVariant(name, runOne) {
+  for (let i = 0; i < WARMUP_SAMPLES; i++) {
+    const r = await runOne();
+    if (r.drops !== 0 || r.received !== EVENTS_PER_ITER) {
+      console.error(`FATAL[${name}]: warmup drop (drops=${r.drops}, rows=${r.received} != ${EVENTS_PER_ITER})`);
+      process.exit(1);
+    }
+  }
+  const eps = [];
+  const nspe = [];
+  for (let i = 0; i < MEASURED_SAMPLES; i++) {
+    const r = await runOne();
+    if (r.drops !== 0 || r.received !== EVENTS_PER_ITER) {
+      console.error(`FATAL[${name}]: sample ${i} drop (drops=${r.drops}, rows=${r.received} != ${EVENTS_PER_ITER})`);
+      process.exit(1);
+    }
+    eps.push(r.eventsPerSec);
+    nspe.push(r.nsPerEvent);
+  }
+  const p50 = median(eps);
+  const nspeP50 = median(nspe);
+  console.log(
+    `  ${name.padEnd(20)}: p50 ${(p50 / 1e6).toFixed(3).padStart(8)} Melem/s  ${nspeP50.toFixed(2).padStart(8)} ns/event  (zero-drop ${MEASURED_SAMPLES}x)`,
+  );
+  return { p50, epsMin: Math.min(...eps), epsMax: Math.max(...eps), nspeP50 };
+}
+
+async function main() {
+  console.log(
+    `# Node ${process.version}, Arrow-IPC columnar batch, events/iter=${EVENTS_PER_ITER}, warmup=${WARMUP_SAMPLES}, samples=${MEASURED_SAMPLES}`,
+  );
+  const summaries = [];
+  for (const B of BATCHES) {
+    const s = await runVariant(`arrow_ipc[${B}]`, () => runArrow(B));
+    summaries.push({ variant: 'arrow_ipc', batch_size: B, ...s });
+  }
+  const machine = { node: process.version, arch: process.arch, cpus: os.cpus().length };
+  console.log('');
+  for (const sm of summaries) {
+    console.log(
+      'JSON ' +
+        JSON.stringify({
+          binding: 'typescript',
+          variant: sm.variant,
+          batch_size: sm.batch_size,
+          events_per_sec_p50: sm.p50,
+          events_per_sec_min: sm.epsMin,
+          events_per_sec_max: sm.epsMax,
+          ns_per_event_p50: sm.nspeP50,
+          events_per_iter: EVENTS_PER_ITER,
+          warmup_samples: WARMUP_SAMPLES,
+          measured_samples: MEASURED_SAMPLES,
+          zero_drop_verified: true,
+          machine,
+        }),
+    );
+  }
+}
+
+await main();

--- a/sdks/typescript/benches/streaming_throughput_levers.mjs
+++ b/sdks/typescript/benches/streaming_throughput_levers.mjs
@@ -1,0 +1,172 @@
+// TypeScript streaming throughput — batched delivery lever (offline, no network).
+//
+// Measures the TRUE MAX TypeScript streaming throughput by amortizing the
+// per-event ThreadsafeFunction hop, against the per-event baseline (~233k
+// events/s) the companion `streaming_throughput.mjs` records.
+//
+// Variants
+// --------
+// 1. per_event     — baseline: one `tsfn.call` (one event) per hop.
+//                    (`__benchFloodEvents`)
+// 2. batched[B]    — Lever 1: one `tsfn.call` carrying an Array<StreamEvent>
+//                    of B events per hop (`__benchFloodEventsBatched`).
+//                    Amortizes the threadsafe-function crossing + the V8
+//                    callback invocation over a whole batch. Same per-event
+//                    marshal (`fpss_event_to_buffered` -> `buffered_event_to_typed`).
+//
+// Batch sweep: 256 / 1024 / 4096 (override via THETADX_BATCHES, comma-sep).
+//
+// Methodology (matches the per-event bench + the core Rust bench)
+// ---------------------------------------------------------------
+// * EVENTS_PER_ITER = 100_000 events per sample.
+// * `process.hrtime.bigint()` brackets "flood started" to "JS side has
+//   received all N events". The export's marshal + `tsfn.call(.., Blocking)`
+//   run on a worker thread (off the libuv main thread), exactly as the live
+//   dispatcher; module load / addon init are excluded.
+// * Warmup samples discarded; median (p50) reported with min/max.
+// * Zero-drop two ways per sample: the export returns the count of non-Ok
+//   `tsfn.call` statuses (asserted 0) AND the JS side's received-event count
+//   is asserted === N (for batched, summed across all batch callbacks).
+//
+// Run:
+//   node sdks/typescript/benches/streaming_throughput_levers.mjs
+//
+// Output: line-delimited per-sample summary, then one `JSON {...}` per variant.
+
+import os from 'node:os';
+
+let mod;
+try {
+  mod = await import('../index.js');
+} catch (err) {
+  console.error('FAIL: native addon not built; run `npm run build` first');
+  console.error(err);
+  process.exit(1);
+}
+for (const fn of ['__benchFloodEvents', '__benchFloodEventsBatched']) {
+  if (typeof mod[fn] !== 'function') {
+    console.error(`FAIL: ${fn} not found on the addon. Rebuild with \`npm run build\`.`);
+    process.exit(1);
+  }
+}
+
+const EVENTS_PER_ITER = 100_000;
+const WARMUP_SAMPLES = 3;
+const MEASURED_SAMPLES = 12;
+const BATCHES = (process.env.THETADX_BATCHES || '256,1024,4096')
+  .split(',')
+  .map((s) => parseInt(s, 10));
+
+function median(xs) {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+// One per-event flood: one event per tsfn hop.
+async function runPerEvent() {
+  let received = 0;
+  let resolveAll;
+  const allDelivered = new Promise((r) => (resolveAll = r));
+  const cb = (_e) => {
+    received += 1;
+    if (received === EVENTS_PER_ITER) resolveAll();
+  };
+  const start = process.hrtime.bigint();
+  const flood = mod.__benchFloodEvents(EVENTS_PER_ITER, cb);
+  const [drops] = await Promise.all([flood, allDelivered]);
+  const end = process.hrtime.bigint();
+  return finalize(start, end, Number(drops), received);
+}
+
+// One batched flood: B events per tsfn hop (callback receives an array).
+async function runBatched(batchSize) {
+  let received = 0;
+  let resolveAll;
+  const allDelivered = new Promise((r) => (resolveAll = r));
+  const cb = (events) => {
+    received += events.length;
+    if (received >= EVENTS_PER_ITER) resolveAll();
+  };
+  const start = process.hrtime.bigint();
+  const flood = mod.__benchFloodEventsBatched(EVENTS_PER_ITER, batchSize, cb);
+  const [drops] = await Promise.all([flood, allDelivered]);
+  const end = process.hrtime.bigint();
+  return finalize(start, end, Number(drops), received);
+}
+
+function finalize(start, end, drops, received) {
+  const elapsedNs = Number(end - start);
+  return {
+    eventsPerSec: EVENTS_PER_ITER / (elapsedNs / 1e9),
+    nsPerEvent: elapsedNs / EVENTS_PER_ITER,
+    drops,
+    received,
+  };
+}
+
+async function runVariant(name, runOne) {
+  for (let i = 0; i < WARMUP_SAMPLES; i++) {
+    const r = await runOne();
+    if (r.drops !== 0 || r.received !== EVENTS_PER_ITER) {
+      console.error(`FATAL[${name}]: warmup drop (drops=${r.drops}, received=${r.received} != ${EVENTS_PER_ITER})`);
+      process.exit(1);
+    }
+  }
+  const eps = [];
+  const nspe = [];
+  for (let i = 0; i < MEASURED_SAMPLES; i++) {
+    const r = await runOne();
+    if (r.drops !== 0 || r.received !== EVENTS_PER_ITER) {
+      console.error(`FATAL[${name}]: sample ${i} drop (drops=${r.drops}, received=${r.received} != ${EVENTS_PER_ITER})`);
+      process.exit(1);
+    }
+    eps.push(r.eventsPerSec);
+    nspe.push(r.nsPerEvent);
+  }
+  const p50 = median(eps);
+  const nspeP50 = median(nspe);
+  console.log(
+    `  ${name.padEnd(20)}: p50 ${(p50 / 1e6).toFixed(3).padStart(8)} Melem/s  ${nspeP50.toFixed(2).padStart(8)} ns/event  (zero-drop ${MEASURED_SAMPLES}x)`,
+  );
+  return { p50, epsMin: Math.min(...eps), epsMax: Math.max(...eps), nspeP50 };
+}
+
+async function main() {
+  console.log(
+    `# Node ${process.version}, events/iter=${EVENTS_PER_ITER}, warmup=${WARMUP_SAMPLES}, samples=${MEASURED_SAMPLES}`,
+  );
+  const summaries = [];
+
+  let s = await runVariant('per_event', runPerEvent);
+  summaries.push({ variant: 'per_event', batch_size: 1, ...s });
+
+  for (const B of BATCHES) {
+    s = await runVariant(`batched[${B}]`, () => runBatched(B));
+    summaries.push({ variant: 'batched', batch_size: B, ...s });
+  }
+
+  const machine = { node: process.version, arch: process.arch, cpus: os.cpus().length };
+  console.log('');
+  for (const sm of summaries) {
+    console.log(
+      'JSON ' +
+        JSON.stringify({
+          binding: 'typescript',
+          variant: sm.variant,
+          batch_size: sm.batch_size,
+          events_per_sec_p50: sm.p50,
+          events_per_sec_min: sm.epsMin,
+          events_per_sec_max: sm.epsMax,
+          ns_per_event_p50: sm.nspeP50,
+          events_per_iter: EVENTS_PER_ITER,
+          warmup_samples: WARMUP_SAMPLES,
+          measured_samples: MEASURED_SAMPLES,
+          zero_drop_verified: true,
+          machine,
+        }),
+    );
+  }
+}
+
+await main();

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -3058,6 +3058,32 @@ export declare class Util {
  */
 export declare function __benchFloodEvents(n: number, callback: ((arg: StreamEvent) => void)): Promise<number>
 
+/**
+ * LEVER 1 (batched delivery) — flood `n` synthetic events through the real
+ * `ThreadsafeFunction` path, but carrying `batch_size` events per
+ * `tsfn.call` hop (one `Array<StreamEvent>` per hop) instead of one event
+ * per hop. Amortizes the per-event threadsafe-function crossing + V8
+ * callback invocation over a whole batch.
+ *
+ * Same production marshal per event (`fpss_event_to_buffered` ->
+ * `buffered_event_to_typed`); the only change is that `batch_size` typed
+ * events are collected into a `Vec<StreamEvent>` (napi renders this as
+ * `Array<StreamEvent>`) and handed to the callback in one hop. Runs on a
+ * `spawn_blocking` worker, `Blocking` call mode, the same bounded queue.
+ *
+ * Returns the count of `tsfn.call` invocations (i.e. batches) that returned
+ * a non-`Ok` status (tsfn-boundary drops; `0` on the healthy path). The
+ * caller asserts it AND verifies the JS side received `n` events total
+ * across all batches.
+ *
+ * Bench-only. See the module doc for the parity-gate carve-out. The
+ * callback param uses the same INLINE `ThreadsafeFunction` spelling as the
+ * per-event export (here parameterized on `Vec<StreamEvent>`), so napi
+ * renders it as `((arg: Array<StreamEvent>) => void)` and the generated
+ * `.d.ts` stays valid + in sync (Gate 7).
+ */
+export declare function __benchFloodEventsBatched(n: number, batchSize: number, callback: ((arg: Array<StreamEvent>) => void)): Promise<number>
+
 /** Compute all 23 Black-Scholes Greeks + IV in one call. */
 export declare function allGreeks(spot: number, strike: number, rate: number, divYield: number, tte: number, optionPrice: number, right: string): AllGreeks
 

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -3059,6 +3059,32 @@ export declare class Util {
 export declare function __benchFloodEvents(n: number, callback: ((arg: StreamEvent) => void)): Promise<number>
 
 /**
+ * LEVER 3 (TypeScript columnar bulk) — flood `n` synthetic trade events,
+ * accumulate `batch_size` of them as `TradeTick` rows, serialize ONE Arrow
+ * `RecordBatch` to an Arrow IPC byte buffer per batch (the same
+ * `TicksArrowExt::to_arrow` -> `StreamWriter` path the SDK's
+ * `tradeTickToArrowIpc` export uses), and cross the `ThreadsafeFunction`
+ * boundary ONCE per batch carrying that `Buffer` — NOT N JS objects.
+ *
+ * This bypasses the per-event `buffered_event_to_typed` JS-object
+ * construction entirely: the Node callback receives an Arrow IPC `Buffer`
+ * it decodes columnar via `apache-arrow` (`tableFromIPC`). DIFFERENT
+ * delivery model than the per-event / array-batch callbacks — Node gets a
+ * columnar Table, not typed event objects — so its number is the columnar
+ * bulk ceiling, the TypeScript analogue of the Python Arrow lever.
+ *
+ * Returns the count of `tsfn.call` invocations (batches) that returned a
+ * non-`Ok` status (tsfn-boundary drops; `0` on the healthy path). The
+ * caller asserts it AND verifies the Arrow row count summed across batches
+ * equals `n`.
+ *
+ * Bench-only. See the module doc for the parity-gate carve-out. `T` is a
+ * napi `Buffer`, which napi renders as `((arg: Buffer) => void)` in the
+ * generated `.d.ts`.
+ */
+export declare function __benchFloodEventsArrowIpc(n: number, batchSize: number, callback: ((arg: Buffer) => void)): Promise<number>
+
+/**
  * LEVER 1 (batched delivery) — flood `n` synthetic events through the real
  * `ThreadsafeFunction` path, but carrying `batch_size` events per
  * `tsfn.call` hop (one `Array<StreamEvent>` per hop) instead of one event

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -604,6 +604,7 @@ module.exports.StreamView = nativeBinding.StreamView
 module.exports.Subscription = nativeBinding.Subscription
 module.exports.Util = nativeBinding.Util
 module.exports.__benchFloodEvents = nativeBinding.__benchFloodEvents
+module.exports.__benchFloodEventsBatched = nativeBinding.__benchFloodEventsBatched
 module.exports.allGreeks = nativeBinding.allGreeks
 module.exports.calendarDayToArrowIpc = nativeBinding.calendarDayToArrowIpc
 module.exports.eodTickToArrowIpc = nativeBinding.eodTickToArrowIpc

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -604,6 +604,7 @@ module.exports.StreamView = nativeBinding.StreamView
 module.exports.Subscription = nativeBinding.Subscription
 module.exports.Util = nativeBinding.Util
 module.exports.__benchFloodEvents = nativeBinding.__benchFloodEvents
+module.exports.__benchFloodEventsArrowIpc = nativeBinding.__benchFloodEventsArrowIpc
 module.exports.__benchFloodEventsBatched = nativeBinding.__benchFloodEventsBatched
 module.exports.allGreeks = nativeBinding.allGreeks
 module.exports.calendarDayToArrowIpc = nativeBinding.calendarDayToArrowIpc

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.6.2",
-        "@types/node": "26.0.0"
+        "@types/node": "26.0.0",
+        "apache-arrow": "21.1.0"
       },
       "engines": {
         "node": ">= 20"
@@ -1560,6 +1561,16 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1571,6 +1582,20 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
@@ -1581,6 +1606,60 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1588,12 +1667,55 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
     },
     "node_modules/chardet": {
       "version": "2.1.1",
@@ -1628,12 +1750,72 @@
         "typanion": "*"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1723,6 +1905,41 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -1763,10 +1980,26 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-with-bigint": {
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1834,13 +2067,39 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typanion": {
       "version": "3.14.0",
@@ -1865,6 +2124,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -1878,6 +2147,16 @@
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     }
   }
 }

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -28,7 +28,8 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.6.2",
-    "@types/node": "26.0.0"
+    "@types/node": "26.0.0",
+    "apache-arrow": "21.1.0"
   },
   "optionalDependencies": {
     "thetadatadx-darwin-arm64": "13.0.0-rc.5",

--- a/sdks/typescript/src/bench_streaming.rs
+++ b/sdks/typescript/src/bench_streaming.rs
@@ -213,3 +213,152 @@ pub async fn __bench_flood_events_batched(
 
     Ok(drops as f64)
 }
+
+/// Project a synthetic `Trade` core event into the historical `TradeTick`
+/// row shape the Arrow builder consumes (stock trade: sentinel option
+/// fields, matching the Python Arrow lever's `trade_event_to_tick`).
+#[inline]
+fn trade_event_to_tick(event: &CoreStreamEvent) -> Option<thetadatadx::TradeTick> {
+    match event {
+        fpss::StreamEvent::Data(StreamData::Trade {
+            ms_of_day,
+            sequence,
+            ext_condition1,
+            ext_condition2,
+            ext_condition3,
+            ext_condition4,
+            condition,
+            size,
+            exchange,
+            price,
+            condition_flags,
+            price_flags,
+            volume_type,
+            records_back,
+            date,
+            ..
+        }) => Some(thetadatadx::TradeTick {
+            ms_of_day: *ms_of_day,
+            sequence: *sequence,
+            ext_condition1: *ext_condition1,
+            ext_condition2: *ext_condition2,
+            ext_condition3: *ext_condition3,
+            ext_condition4: *ext_condition4,
+            condition: *condition,
+            size: *size,
+            exchange: *exchange,
+            price: *price,
+            condition_flags: *condition_flags,
+            price_flags: *price_flags,
+            volume_type: *volume_type,
+            records_back: *records_back,
+            date: *date,
+            expiration: 0,
+            strike: 0.0,
+            right: '\0',
+        }),
+        _ => None,
+    }
+}
+
+/// Serialize a `TradeTick` slice to an Arrow IPC stream byte buffer via the
+/// SAME machinery the SDK's `tradeTickToArrowIpc` export uses
+/// (`TicksArrowExt::to_arrow` -> `arrow_ipc::writer::StreamWriter`).
+fn trade_ticks_to_arrow_ipc(rows: &[thetadatadx::TradeTick]) -> napi::Result<Vec<u8>> {
+    let batch = thetadatadx::frames::TicksArrowExt::to_arrow(rows)
+        .map_err(|e| napi::Error::from_reason(format!("arrow conversion failed: {e}")))?;
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer =
+            arrow_ipc::writer::StreamWriter::try_new(std::io::Cursor::new(&mut buf), &batch.schema())
+                .map_err(|e| napi::Error::from_reason(format!("arrow ipc writer init failed: {e}")))?;
+        writer
+            .write(&batch)
+            .map_err(|e| napi::Error::from_reason(format!("arrow ipc write failed: {e}")))?;
+        writer
+            .finish()
+            .map_err(|e| napi::Error::from_reason(format!("arrow ipc finish failed: {e}")))?;
+    }
+    Ok(buf)
+}
+
+/// LEVER 3 (TypeScript columnar bulk) — flood `n` synthetic trade events,
+/// accumulate `batch_size` of them as `TradeTick` rows, serialize ONE Arrow
+/// `RecordBatch` to an Arrow IPC byte buffer per batch (the same
+/// `TicksArrowExt::to_arrow` -> `StreamWriter` path the SDK's
+/// `tradeTickToArrowIpc` export uses), and cross the `ThreadsafeFunction`
+/// boundary ONCE per batch carrying that `Buffer` — NOT N JS objects.
+///
+/// This bypasses the per-event `buffered_event_to_typed` JS-object
+/// construction entirely: the Node callback receives an Arrow IPC `Buffer`
+/// it decodes columnar via `apache-arrow` (`tableFromIPC`). DIFFERENT
+/// delivery model than the per-event / array-batch callbacks — Node gets a
+/// columnar Table, not typed event objects — so its number is the columnar
+/// bulk ceiling, the TypeScript analogue of the Python Arrow lever.
+///
+/// Returns the count of `tsfn.call` invocations (batches) that returned a
+/// non-`Ok` status (tsfn-boundary drops; `0` on the healthy path). The
+/// caller asserts it AND verifies the Arrow row count summed across batches
+/// equals `n`.
+///
+/// Bench-only. See the module doc for the parity-gate carve-out. `T` is a
+/// napi `Buffer`, which napi renders as `((arg: Buffer) => void)` in the
+/// generated `.d.ts`.
+#[napi(js_name = "__benchFloodEventsArrowIpc")]
+pub async fn __bench_flood_events_arrow_ipc(
+    n: u32,
+    batch_size: u32,
+    callback: napi::threadsafe_function::ThreadsafeFunction<
+        napi::bindgen_prelude::Buffer,
+        (),
+        napi::bindgen_prelude::Buffer,
+        napi::Status,
+        false,
+        false,
+        { crate::STREAMING_CALLBACK_QUEUE_DEPTH },
+    >,
+) -> napi::Result<f64> {
+    let callback = Arc::new(callback);
+    let n = n as u64;
+    let cap = batch_size.max(1) as usize;
+
+    let drops = tokio::task::spawn_blocking(move || -> napi::Result<u64> {
+        let contract = Arc::new(Contract::stock("SPY"));
+        let mut drops: u64 = 0;
+        let mut rows: Vec<thetadatadx::TradeTick> = Vec::with_capacity(cap);
+        let flush = |rows: &mut Vec<thetadatadx::TradeTick>, drops: &mut u64| -> napi::Result<()> {
+            if rows.is_empty() {
+                return Ok(());
+            }
+            // Build + serialize one Arrow IPC buffer for the batch, hand it
+            // across the boundary in one hop.
+            let ipc = trade_ticks_to_arrow_ipc(rows)?;
+            let status = callback.call(
+                napi::bindgen_prelude::Buffer::from(ipc),
+                ThreadsafeFunctionCallMode::Blocking,
+            );
+            if status != napi::Status::Ok {
+                *drops += 1;
+            }
+            rows.clear();
+            Ok(())
+        };
+        for i in 0..n {
+            let core = make_event(&contract, i);
+            if let Some(tick) = trade_event_to_tick(&core) {
+                rows.push(tick);
+                if rows.len() >= cap {
+                    flush(&mut rows, &mut drops)?;
+                }
+            }
+        }
+        flush(&mut rows, &mut drops)?;
+        Ok(drops)
+    })
+    .await
+    .map_err(|e| {
+        napi::Error::from_reason(format!("__benchFloodEventsArrowIpc worker panicked: {e}"))
+    })??;
+
+    Ok(drops as f64)
+}

--- a/sdks/typescript/src/bench_streaming.rs
+++ b/sdks/typescript/src/bench_streaming.rs
@@ -137,3 +137,79 @@ pub async fn __bench_flood_events(
 
     Ok(drops as f64)
 }
+
+/// LEVER 1 (batched delivery) — flood `n` synthetic events through the real
+/// `ThreadsafeFunction` path, but carrying `batch_size` events per
+/// `tsfn.call` hop (one `Array<StreamEvent>` per hop) instead of one event
+/// per hop. Amortizes the per-event threadsafe-function crossing + V8
+/// callback invocation over a whole batch.
+///
+/// Same production marshal per event (`fpss_event_to_buffered` ->
+/// `buffered_event_to_typed`); the only change is that `batch_size` typed
+/// events are collected into a `Vec<StreamEvent>` (napi renders this as
+/// `Array<StreamEvent>`) and handed to the callback in one hop. Runs on a
+/// `spawn_blocking` worker, `Blocking` call mode, the same bounded queue.
+///
+/// Returns the count of `tsfn.call` invocations (i.e. batches) that returned
+/// a non-`Ok` status (tsfn-boundary drops; `0` on the healthy path). The
+/// caller asserts it AND verifies the JS side received `n` events total
+/// across all batches.
+///
+/// Bench-only. See the module doc for the parity-gate carve-out. The
+/// callback param uses the same INLINE `ThreadsafeFunction` spelling as the
+/// per-event export (here parameterized on `Vec<StreamEvent>`), so napi
+/// renders it as `((arg: Array<StreamEvent>) => void)` and the generated
+/// `.d.ts` stays valid + in sync (Gate 7).
+#[napi(js_name = "__benchFloodEventsBatched")]
+pub async fn __bench_flood_events_batched(
+    n: u32,
+    batch_size: u32,
+    callback: napi::threadsafe_function::ThreadsafeFunction<
+        Vec<crate::StreamEvent>,
+        (),
+        Vec<crate::StreamEvent>,
+        napi::Status,
+        false,
+        false,
+        { crate::STREAMING_CALLBACK_QUEUE_DEPTH },
+    >,
+) -> napi::Result<f64> {
+    let callback = Arc::new(callback);
+    let n = n as u64;
+    let cap = batch_size.max(1) as usize;
+
+    let drops = tokio::task::spawn_blocking(move || {
+        let contract = Arc::new(Contract::stock("SPY"));
+        let mut drops: u64 = 0;
+        let mut batch: Vec<crate::StreamEvent> = Vec::with_capacity(cap);
+        for i in 0..n {
+            let core = make_event(&contract, i);
+            let buffered = fpss_event_to_buffered(&core);
+            batch.push(buffered_event_to_typed(buffered));
+            if batch.len() >= cap {
+                // One hop carrying the whole batch. `std::mem::take` swaps in
+                // a fresh empty Vec so the next batch fills without realloc
+                // churn fighting the in-flight one.
+                let payload = std::mem::replace(&mut batch, Vec::with_capacity(cap));
+                let status = callback.call(payload, ThreadsafeFunctionCallMode::Blocking);
+                if status != napi::Status::Ok {
+                    drops += 1;
+                }
+            }
+        }
+        // Flush the final partial batch.
+        if !batch.is_empty() {
+            let status = callback.call(batch, ThreadsafeFunctionCallMode::Blocking);
+            if status != napi::Status::Ok {
+                drops += 1;
+            }
+        }
+        drops
+    })
+    .await
+    .map_err(|e| {
+        napi::Error::from_reason(format!("__benchFloodEventsBatched worker panicked: {e}"))
+    })?;
+
+    Ok(drops as f64)
+}


### PR DESCRIPTION
## What

Finds the TRUE MAX per-binding streaming throughput by implementing and measuring three optimization levers that amortize the per-event language-boundary crossing, against the per-event baselines from #948 (Python ~201k events/s, TypeScript ~233k events/s). All variants drive the SAME LMAX Disruptor pipeline (131_072-slot ring = production default); only the boundary-crossing shape changes, so the numbers isolate the boundary cost.

- **Lever 1 — batched delivery.** Python: (a) one `Python::attach` per batch + N `call1`s (amortize the GIL acquire), and (b) marshal a batch into one Python `list` + ONE `call1(list)` (amortize GIL acquire + call dispatch). TypeScript: one `tsfn.call` carrying an `Array<StreamEvent>` per hop instead of one event per hop. Batch sweep 256 / 1024 / 4096.
- **Lever 2 — free-threaded Python (no GIL).** Rebuilt the extension against CPython 3.14.3 free-threaded (`gil_enabled=False`, confirmed via `sys._is_gil_enabled()` with `PYTHON_GIL=0`) and re-ran per-event + batched.
- **Lever 3 — Arrow columnar batch.** Accumulate a batch as `TradeTick` rows, build ONE Arrow `RecordBatch`, export zero-copy to a `pyarrow.Table` over the Arrow C Stream Interface via the SDK's own `trade_tick_slice_to_arrow_table` (the same path `<TickList>.to_arrow()` uses), ONE `call1(table)` per batch. DIFFERENT delivery model — Python receives a columnar Table, not N event objects.

## Machine + methodology

Intel Core i7-10700KF @ 3.80GHz, 16 logical cores (`nproc`), 131 GB RAM, Linux 6.8. Standard-GIL CPython 3.14.6; free-threaded CPython 3.14.3; Node v26.3.1; Rust stable 1.96; pyarrow 24.0.0. 100,000 events/sample; setup (ring alloc, thread spawn, interpreter/event-loop spin-up) excluded from the timed region (the timed region is the publish loop + drain, returned from Rust for Python and bracketed by `process.hrtime.bigint()` for TypeScript). 3 warmup samples discarded, 12 measured samples, median (p50) reported. Zero-drop verified per variant (`delivered == sent`; the list/Arrow variants additionally assert the receive-side count — list length / Arrow `num_rows` — equals the event count; TypeScript asserts the tsfn non-Ok count is 0 AND the JS received count equals N).

## Python — comparison table (events/sec p50)

| Variant | Standard GIL (3.14) | mult vs baseline | Free-threaded (3.14t) | mult vs baseline |
|---|---:|---:|---:|---:|
| per-event (baseline) | ~197,000 | 1.0x | ~5,100 | 0.03x |
| batched calls, B=256 | 5.93 M | 29x | 1.09 M | 5.4x |
| batched calls, B=1024 | 6.44 M | 32x | 2.07 M | 10x |
| batched calls, B=4096 | 6.75 M | 33x | 4.31 M | 21x |
| batched list, B=256 | 6.84 M | 34x | 1.44 M | 7x |
| batched list, B=1024 | 7.69 M | 38x | 2.18 M | 11x |
| batched list, B=4096 | **8.06 M** | **40x** | 4.81 M | 24x |
| Arrow batch, B=256 | 3.71 M | 18x | 0.62 M | 3x |
| Arrow batch, B=1024 | 9.13 M | 45x | 2.25 M | 11x |
| Arrow batch, B=4096 | **14.8 M** | **73x** | **6.70 M** | **33x** |

Standard-GIL true max: **Arrow B=4096 ≈ 14.8 M events/s (~66 ns/event), ~73x the per-event baseline.** Of the callback-preserving shapes (Python still gets event objects, not a columnar Table), the batched list at B=4096 ≈ 8.06 M (~40x) is the max.

ns/event at the maxima: per-event baseline ~4,950; batched list B=4096 ~124; Arrow B=4096 ~66.

## TypeScript — comparison table (events/sec p50)

| Variant | Node 26 | mult vs baseline | mult vs array-batch |
|---|---:|---:|---:|
| per-event (baseline) | ~233,000 | 1.0x | — |
| batched array, B=256 | 0.298 M | 1.28x | 1.0x |
| batched array, B=1024 | 0.298 M | 1.28x | 1.0x |
| batched array, B=4096 | 0.298 M | 1.28x | 1.0x |
| **Arrow-IPC columnar, B=256** | 4.30 M | 18x | 14x |
| **Arrow-IPC columnar, B=1024** | **14.3 M** | **61x** | **48x** |
| **Arrow-IPC columnar, B=4096** | 13.3 M | 57x | 45x |

**The object-per-event ceiling and how Arrow breaks it.** Array-batching (one `tsfn.call` carrying an `Array<StreamEvent>`) plateaus at ~0.298 M (~1.28x) and does not improve past B=256. Measured reason, stated honestly: in the napi tsfn path the dominant per-event cost is constructing the full `StreamEvent` JS object (`buffered_event_to_typed`) AND napi materializing each array element as a JS object on the main thread — that work is per-event regardless of batching, so array-batching amortizes only the minor `uv_async_t` hop. The Arrow-IPC columnar path removes the per-event JS object entirely: Rust serializes a `TradeTick` RecordBatch to ONE Arrow IPC buffer per batch (the same `TicksArrowExt::to_arrow` -> `arrow_ipc::StreamWriter` machinery the SDK's `tradeTickToArrowIpc` export uses), crosses the boundary once per batch as a `Buffer`, and Node decodes it columnar via `apache-arrow` `tableFromIPC` — no per-event `StreamEvent` is ever built on the JS side.

TypeScript true max: **Arrow-IPC columnar B=1024 ≈ 14.3 M events/s (~70 ns/event), ~61x the per-event baseline and ~48x the array-batch ceiling.** This reaches Python's Arrow scale (Python Arrow B=4096 ≈ 14.8 M) — the columnar path closes the cross-binding gap that the object-per-event model could not. Peak is at B=1024; B=4096 is marginally lower (13.3 M) as `apache-arrow` JS decode cost grows slightly with batch size. Stable across 3 runs (B=1024: 14.32 / 14.28 / 14.29 M).

Free-threaded Node is not applicable (V8 is single-threaded for JS by design; the libuv main-thread invariant is the constraint, not a GIL).

## True-max summary

| Binding | per-event baseline | best batched (callback-preserving) | free-threaded best | Arrow columnar bulk | true max |
|---|---:|---:|---:|---:|---:|
| Python | ~197k | 8.06 M (list, B=4096, 40x) | 6.70 M (Arrow B=4096, GIL-free) | 14.8 M (B=4096, 73x) | **14.8 M (Arrow, 73x)** |
| TypeScript | ~233k | 0.298 M (array, 1.28x) | n/a (no GIL; V8 single-threaded) | 14.3 M (Arrow-IPC B=1024, 61x) | **14.3 M (Arrow-IPC, 61x)** |

## Honest caveats

- **Arrow is a different delivery model on BOTH bindings, not a like-for-like callback rate.** It hands the consumer a columnar batch per call (a `pyarrow.Table` in Python, an `apache-arrow` Table decoded from an IPC `Buffer` in TypeScript), not N typed event objects. It is the right model for analytics/bulk consumers (vectorized pandas/polars/numpy/arrow-js), the wrong comparison if the integrator needs per-event object semantics. Reported as the columnar bulk ceiling on each binding.
- **The TypeScript Arrow number includes `apache-arrow` JS deserialization** (`tableFromIPC`) on the Node main thread — it is measured, not bypassed. That decode is why the TS Arrow ns/event (~70) is a touch higher than it would be for a raw buffer handoff, and why B=4096 dips slightly below B=1024. It is the real cost a columnar TS integrator pays.
- **Batching adds latency — a throughput/latency tradeoff.** At B=4096 an event waits for up to 4095 later events (the batch fill delay) before it crosses the boundary. On a quiet stream that delay is unbounded until the batch fills (a real SDK would add a max-linger timer). These benches saturate the pipeline, so they measure the throughput ceiling, not tail latency. A latency-sensitive consumer should pick a small batch or stay per-event.
- **Free-threaded is experimental** (CPython 3.14 free-threading build, PEP 703). The per-event case is ~40x SLOWER free-threaded (~198 µs/event vs ~4.95 µs standard-GIL): without the GIL fast-path, each per-event cross-thread `Python::attach` on the consumer thread pays a full thread-state synchronization. This is stable across 5 runs and is a measured property of fine-grained per-event attach without the GIL — it is exactly why batching matters MORE under free-threading (the batched shapes recover to multi-M/s). The GIL-free win shows up only once the boundary crossing is amortized; it does not help the per-event path on this workload.
- **The free-threaded numbers are lower than standard-GIL at every batch size here.** This single-producer / single-consumer flood has no GIL contention to relieve (one thread touches Python at a time), so free-threading's parallelism benefit does not apply and its higher per-attach cost dominates. Free-threading would win on a genuinely parallel multi-consumer workload, which this bench does not model — stated so the number is not over-read.
- All variants verified zero-drop (see methodology). Measured values only; nothing estimated.

## Levers measured / not measured

- Lever 1 (batched): measured, both bindings.
- Lever 2 (free-threaded Python): measured — `python3.14t` was available on the box (`gil_enabled=False` confirmed), the extension rebuilt against it (cp314t ABI), pyarrow 24.0.0 works on it.
- Lever 3 (Arrow columnar): measured, Python (standard-GIL and free-threaded) AND TypeScript. The TS path serializes a `TradeTick` RecordBatch to an Arrow IPC buffer per batch (reusing the SDK's `tradeTickToArrowIpc` machinery) and Node consumes it columnar via `apache-arrow` `tableFromIPC`.

## Reproduce

```
# Python levers — standard GIL
cd sdks/python
VIRTUAL_ENV=<venv> CARGO_TARGET_DIR=/tmp/cta-soak maturin develop --release
VIRTUAL_ENV=<venv> <venv>/bin/python benches/streaming_throughput_levers_py.py

# Python levers — free-threaded (Lever 2)
python3.14t -m venv <ft-venv>; <ft-venv>/bin/pip install maturin pyarrow
VIRTUAL_ENV=<ft-venv> CARGO_TARGET_DIR=/tmp/cta-soak-ft <ft-venv>/bin/maturin develop --release
PYTHON_GIL=0 VIRTUAL_ENV=<ft-venv> <ft-venv>/bin/python benches/streaming_throughput_levers_py.py

# TypeScript levers (array-batch)
cd sdks/typescript
CARGO_TARGET_DIR=/tmp/cta-ts npm run build
node benches/streaming_throughput_levers.mjs

# TypeScript Arrow-IPC columnar (Lever 3); apache-arrow is a devDependency
npm install
node benches/streaming_throughput_arrow.mjs
```

Batch sweep override: `THETADX_BATCHES=128,512,2048 <run>`.

## Notes

- Bench-only hooks, carved out of the cross-binding parity gate (`PY_NON_UTILITY_PYFUNCTIONS` / `_is_ts_internal_free_fn`); the gate passes clean and all 149 selftests pass.
- The regenerated TypeScript `index.js` / `index.d.ts` carry only the additive `__benchFloodEventsBatched` export; the loader stub is left at its committed form to avoid napi-cli version-skew churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUYhqGTSkbH4H4puafUYig
