### PR TITLE
feat(streaming): add a pull-based Arrow RecordBatch reader alongside the per-event callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,7 +3459,9 @@ dependencies = [
 name = "thetadatadx-ffi"
 version = "13.0.0-rc.5"
 dependencies = [
+ "arrow-array",
  "arrow-ipc",
+ "arrow-schema",
  "disruptor",
  "thetadatadx",
  "tokio",

--- a/crates/thetadatadx/build_support_bin/sdk_surface/python.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/python.rs
@@ -168,6 +168,48 @@ fn python_streaming_method(method: &MethodSpec) -> String {
             out.push_str("        self.client.stream().is_streaming()\n");
             out.push_str("    }\n");
         }
+        MethodKind::Batches => {
+            // Thin entry: forward the optional tuning knobs to the
+            // hand-written `RecordBatchStream` constructor (the protocol
+            // surface — sync + async iteration, context managers — is
+            // intrinsic Python shape, not a per-endpoint projection, so the
+            // reader object itself is hand-written; only this entry is
+            // generated so the cross-binding surface stays in lockstep).
+            push_rust_doc_comment(
+                &mut out,
+                "    ",
+                "Open a pull-based columnar reader over the live stream.\n\
+                 \n\
+                 Returns a `RecordBatchStream` — a sibling to the per-event\n\
+                 `start_streaming(callback)`. The same subscriptions feed it,\n\
+                 but market-data events arrive as `pyarrow.RecordBatch`\n\
+                 values under a fixed schema. The reader is both a\n\
+                 synchronous `Iterable` (the blocking pull releases the GIL)\n\
+                 and an `AsyncIterable` (`async for`), and a sync / async\n\
+                 context manager that closes the stream on exit. Subscribe on\n\
+                 this same surface first, then open the reader.\n\
+                 \n\
+                 `batch_size` rows per batch (default 65536); `linger_ms`\n\
+                 flushes a partial batch on a quiet stream (default 50);\n\
+                 `backpressure` is `\"block\"` (default, lossless) or\n\
+                 `\"drop_oldest\"`; `capacity` bounds the drop-oldest buffer.",
+            );
+            out.push_str(
+                "    #[pyo3(signature = (*, batch_size=None, linger_ms=None, backpressure=None, capacity=None))]\n",
+            );
+            writeln!(out, "    fn {}(", method.name).unwrap();
+            out.push_str("        &self,\n");
+            out.push_str("        py: Python<'_>,\n");
+            out.push_str("        batch_size: Option<usize>,\n");
+            out.push_str("        linger_ms: Option<u64>,\n");
+            out.push_str("        backpressure: Option<&str>,\n");
+            out.push_str("        capacity: Option<usize>,\n");
+            out.push_str("    ) -> PyResult<crate::streaming_batches::RecordBatchStream> {\n");
+            out.push_str(
+                "        crate::streaming_batches::open_reader(py, &self.client, batch_size, linger_ms, backpressure, capacity)\n",
+            );
+            out.push_str("    }\n");
+        }
         MethodKind::StockContractCall => {
             let param = &method.params[0];
             writeln!(

--- a/crates/thetadatadx/build_support_bin/sdk_surface/spec.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/spec.rs
@@ -43,6 +43,7 @@ pub(super) struct MethodSpec {
 pub(super) enum MethodKind {
     StartStreaming,
     IsStreaming,
+    Batches,
     StockContractCall,
     OptionContractCall,
     FullCall,
@@ -231,6 +232,17 @@ fn validate_method_spec(method: &MethodSpec) -> Result<(), Box<dyn std::error::E
     let shape: MethodShape<'_> = match method.kind {
         MethodKind::StartStreaming => (Some("start_streaming"), &[PY, TS], true, &[]),
         MethodKind::IsStreaming => (Some("is_streaming"), &[PY, TS], true, &[]),
+        // The pull-based Arrow `RecordBatch` reader, a sibling to the
+        // per-event callback. The Python + TypeScript entries are generated
+        // (PY, TS). The C++ entry is hand-written on the `Stream` class —
+        // the same hand-written class that carries `set_callback`, distinct
+        // from the generated `StreamingClient` the `cpp_fpss` target feeds —
+        // so C++ is intentionally NOT in this generated set; it is tracked
+        // for parity directly. The tuning knobs (batch_size / linger /
+        // backpressure / capacity) are language-native optional parameters
+        // wired in each per-language surface, not positional spec params, so
+        // the layout here is empty.
+        MethodKind::Batches => (Some("batches"), &[PY, TS], true, &[]),
         MethodKind::StockContractCall => (
             None,
             &[PY, TS, CPP],

--- a/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
@@ -90,6 +90,44 @@ fn ts_streaming_method(method: &MethodSpec) -> String {
             out.push_str("        self.client.stream().is_streaming()\n");
             out.push_str("    }\n");
         }
+        MethodKind::Batches => {
+            // Thin entry: forward the optional tuning knobs to the
+            // hand-written `RecordBatchStreamHandle` constructor. The
+            // package's JS wrapper decodes the handle's Arrow IPC buffers
+            // with apache-arrow and presents the `AsyncIterable<RecordBatch>`
+            // + `Symbol.asyncDispose` surface; only this entry is generated
+            // so the cross-binding surface stays in lockstep. `async`
+            // because the FPSS connect runs on a blocking worker.
+            push_rust_doc_comment(
+                &mut out,
+                "    ",
+                "Open a pull-based columnar reader over the live stream.\n\
+                 \n\
+                 Returns a reader handle — a sibling to the per-event\n\
+                 `startStreaming(callback)`. The same subscriptions feed it,\n\
+                 but market-data events arrive as apache-arrow `RecordBatch`\n\
+                 values under a fixed schema, consumed with `for await`. The\n\
+                 reader closes (unsubscribes + tears down) on `close()` or\n\
+                 `Symbol.asyncDispose`. Subscribe on this same surface first,\n\
+                 then open the reader.\n\
+                 \n\
+                 `batchSize` rows per batch (default 65536); `lingerMs`\n\
+                 flushes a partial batch on a quiet stream (default 50);\n\
+                 `backpressure` is `\"block\"` (default, lossless) or\n\
+                 `\"dropOldest\"`; `capacity` bounds the drop-oldest buffer.",
+            );
+            writeln!(out, "    #[napi(js_name = \"batches\")]").unwrap();
+            writeln!(
+                out,
+                "    pub async fn {}(&self, batch_size: Option<u32>, linger_ms: Option<u32>, backpressure: Option<String>, capacity: Option<u32>) -> napi::Result<crate::streaming_batches::RecordBatchStreamHandle> {{",
+                method.name
+            )
+            .unwrap();
+            out.push_str(
+                "        crate::streaming_batches::open_handle(std::sync::Arc::clone(&self.client), batch_size, linger_ms, backpressure, capacity).await\n",
+            );
+            out.push_str("    }\n");
+        }
         MethodKind::StockContractCall => {
             let param = &method.params[0];
             let js_name = to_ts_camel_case(&method.name);

--- a/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
+++ b/crates/thetadatadx/build_support_bin/sdk_surface/typescript.rs
@@ -119,12 +119,13 @@ fn ts_streaming_method(method: &MethodSpec) -> String {
             writeln!(out, "    #[napi(js_name = \"batches\")]").unwrap();
             writeln!(
                 out,
-                "    pub async fn {}(&self, batch_size: Option<u32>, linger_ms: Option<u32>, backpressure: Option<String>, capacity: Option<u32>) -> napi::Result<crate::streaming_batches::RecordBatchStreamHandle> {{",
+                "    pub async fn {}(&self, options: Option<crate::streaming_batches::BatchesOptions>) -> napi::Result<crate::streaming_batches::RecordBatchStreamHandle> {{",
                 method.name
             )
             .unwrap();
+            out.push_str("        let options = options.unwrap_or_default();\n");
             out.push_str(
-                "        crate::streaming_batches::open_handle(std::sync::Arc::clone(&self.client), batch_size, linger_ms, backpressure, capacity).await\n",
+                "        crate::streaming_batches::open_handle(std::sync::Arc::clone(&self.client), options.batch_size, options.linger_ms, options.backpressure, options.capacity).await\n",
             );
             out.push_str("    }\n");
         }

--- a/crates/thetadatadx/sdk_surface.toml
+++ b/crates/thetadatadx/sdk_surface.toml
@@ -26,6 +26,15 @@ kind = "is_streaming"
 doc = "Whether the streaming connection is active."
 targets = ["python_unified", "typescript_napi"]
 
+[[methods]]
+name = "batches"
+kind = "batches"
+doc = "Open a pull-based columnar reader over the live stream, a sibling to the per-event callback. Returns a reader of Apache Arrow record batches under a fixed schema; the same subscriptions feed it. Tune batch_size, linger, and backpressure on the returned builder/reader."
+# C++ is intentionally absent: its `batches()` is hand-written on the `Stream`
+# class (the same hand-written class as `set_callback`), not the generated
+# `StreamingClient` the cpp_fpss target feeds. C++ parity is tracked directly.
+targets = ["python_unified", "typescript_napi"]
+
 #  — typed subscribe_* / unsubscribe_* methods deleted.
 # The polymorphic `subscribe(Subscription)` / `subscribe_many([...])` /
 # `unsubscribe(Subscription)` / `unsubscribe_many([...])` paths are

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -324,6 +324,18 @@ impl StreamingState {
         }
     }
 
+    /// The current stop generation.
+    ///
+    /// Bumped by every [`Self::quiesce`]. The columnar reader captures the
+    /// value its session was installed at and compares it here on close, so it
+    /// quiesces only while its own session is still the live one; once a
+    /// teardown (a stop / reconnect / another reader) has advanced the
+    /// generation, the reader's close no longer matches and leaves the current
+    /// session to its owner.
+    pub(crate) fn stop_generation(&self) -> u64 {
+        self.stop_generation.load(Ordering::Acquire)
+    }
+
     /// Test-only: the current streaming-slot variant as a static label, so a
     /// test can assert the `Idle → Live → Stopped` transition `quiesce` drives
     /// without naming the private `Arc<StreamingClient>` payload.
@@ -343,12 +355,6 @@ impl StreamingState {
             *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()),
             DispatcherSession::Idle
         )
-    }
-
-    /// Test-only: the current stop generation.
-    #[cfg(test)]
-    fn stop_generation_value(&self) -> u64 {
-        self.stop_generation.load(Ordering::Acquire)
     }
 }
 
@@ -523,7 +529,7 @@ impl Client {
             },
             None,
         )
-        .map(|_client| ())
+        .map(|(_client, _generation)| ())
     }
 
     /// Start FPSS streaming with a custom dispatcher consumer body.
@@ -546,6 +552,14 @@ impl Client {
     /// lock, so a teardown racing the start never sees a `Running` session
     /// without its hook.
     ///
+    /// On success returns the live client and the stop-generation the session
+    /// was installed at. The columnar reader stamps that generation so its
+    /// close tears down only the session it started, never a later session
+    /// that replaced it (see [`crate::fpss::batch_reader::RecordBatchStream`]).
+    /// The value is the generation the install was validated against, so it
+    /// identifies this session even if a teardown bumps the generation right
+    /// after the install commits.
+    ///
     /// # Errors
     ///
     /// Returns an error on network, authentication, or parsing failure, or
@@ -554,7 +568,7 @@ impl Client {
         &self,
         dispatcher_body: B,
         on_teardown: Option<Box<dyn FnOnce() + Send>>,
-    ) -> Result<Arc<StreamingClient>, Error>
+    ) -> Result<(Arc<StreamingClient>, u64), Error>
     where
         B: FnOnce(Arc<StreamingClient>) + Send + 'static,
     {
@@ -710,7 +724,7 @@ impl Client {
                     on_teardown,
                 };
                 let _ = gate.set(true);
-                Ok(client_arc)
+                Ok((client_arc, gen_at_entry))
             }
             Err(install_err) => {
                 // Shut down the client so the dispatcher sees a clean
@@ -744,6 +758,9 @@ impl Client {
     ///
     /// Returns an error on network, authentication, or parsing failure, or
     /// when a stream is already active on this client.
+    /// On success returns the live client and the stop-generation the columnar
+    /// session was installed at, so the reader can stamp the session it owns
+    /// and refuse to tear down a later session that replaced it.
     #[cfg(feature = "arrow")]
     pub(crate) fn start_streaming_batches(
         &self,
@@ -751,7 +768,7 @@ impl Client {
         batch_size: usize,
         linger: std::time::Duration,
         backpressure: crate::fpss::batch_reader::Backpressure,
-    ) -> Result<Arc<StreamingClient>, Error> {
+    ) -> Result<(Arc<StreamingClient>, u64), Error> {
         // Teardown wake hook: a `Block` dispatcher can be parked in the batch
         // queue's `flush` wait, which the FPSS shutdown does not touch. Any
         // teardown that runs `quiesce` directly (a `Client` drop /
@@ -2514,7 +2531,7 @@ mod tests {
         let state = StreamingState::new();
         assert_eq!(state.slot_label(), "Idle");
         assert!(state.dispatcher_is_idle());
-        let gen0 = state.stop_generation_value();
+        let gen0 = state.stop_generation();
 
         state.quiesce();
 
@@ -2528,17 +2545,17 @@ mod tests {
             "quiesce must leave the dispatcher Idle"
         );
         assert!(
-            state.stop_generation_value() > gen0,
+            state.stop_generation() > gen0,
             "quiesce must bump the stop generation (resurrection guard)"
         );
 
         // Idempotent: a second close (e.g. binding close() then the core Drop)
         // is a harmless no-op beyond bumping the generation again.
-        let gen1 = state.stop_generation_value();
+        let gen1 = state.stop_generation();
         state.quiesce();
         assert_eq!(state.slot_label(), "Stopped");
         assert!(state.dispatcher_is_idle());
-        assert!(state.stop_generation_value() > gen1);
+        assert!(state.stop_generation() > gen1);
     }
 
     /// `quiesce` retires a `Running` dispatcher session — joining its thread
@@ -2643,6 +2660,94 @@ mod tests {
         assert!(
             state.dispatcher_is_idle(),
             "after quiesce the dispatcher session is retired to Idle"
+        );
+    }
+
+    /// A columnar reader's close must tear down ONLY the session it started.
+    /// `RecordBatchStream::close_shared` quiesces the owning state only when
+    /// `state.stop_generation() == self.owned_generation`; this exercises that
+    /// guard directly against the mixed-mode supersession sequence.
+    ///
+    /// Sequence modeled: reader R starts its session and stamps the generation
+    /// it owns; R's session is then retired (a `stop_streaming`, which advances
+    /// the generation); a NEW session is installed on the same state (the
+    /// callback session a caller can legitimately start once the slot is no
+    /// longer `Live`). When R is finally dropped, its stamp no longer matches
+    /// the live generation, so its close must NOT retire the newer session.
+    #[test]
+    fn stale_generation_reader_does_not_tear_down_a_newer_session() {
+        let state = StreamingState::new();
+
+        // R installs its session and stamps the generation it owns.
+        let r_handle = std::thread::spawn(|| {});
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle: r_handle,
+            on_teardown: None,
+        };
+        let r_owned_generation = state.stop_generation();
+
+        // R's session is retired by a stop (advances the generation).
+        state.quiesce();
+        assert!(state.dispatcher_is_idle());
+        assert_ne!(
+            state.stop_generation(),
+            r_owned_generation,
+            "the stop must advance the generation past R's stamp"
+        );
+
+        // A NEW session is installed on the same client (e.g. a callback
+        // session, valid now that the slot is no longer Live).
+        let newer_handle = std::thread::spawn(|| {});
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle: newer_handle,
+            on_teardown: None,
+        };
+
+        // R is dropped now. Its close guard: quiesce ONLY if the live
+        // generation still matches R's stamp. It does not, so R must leave the
+        // newer session alone.
+        let r_close_would_quiesce = state.stop_generation() == r_owned_generation;
+        assert!(
+            !r_close_would_quiesce,
+            "a stale-generation reader must not quiesce"
+        );
+        if r_close_would_quiesce {
+            state.quiesce();
+        }
+        assert!(
+            !state.dispatcher_is_idle(),
+            "R's stale close must leave the newer session Running, not retire it"
+        );
+
+        // Tidy up the still-Running newer session so its thread is joined.
+        state.quiesce();
+    }
+
+    /// The matching-generation reader (the normal single-reader close) DOES
+    /// quiesce: when no teardown has advanced the generation, the live session
+    /// is still the one this reader started, so its close retires it. Guards
+    /// against the stamp over-suppressing the common path.
+    #[test]
+    fn matching_generation_reader_quiesces_its_own_session() {
+        let state = StreamingState::new();
+        let handle = std::thread::spawn(|| {});
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle,
+            on_teardown: None,
+        };
+        let owned_generation = state.stop_generation();
+
+        // Nothing advanced the generation, so the reader's close guard matches
+        // and quiesces its own session.
+        let close_would_quiesce = state.stop_generation() == owned_generation;
+        assert!(
+            close_would_quiesce,
+            "an un-superseded reader's stamp must still match the live generation"
+        );
+        state.quiesce();
+        assert!(
+            state.dispatcher_is_idle(),
+            "the matching-generation close retires its own session"
         );
     }
 

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -216,6 +216,17 @@ pub(crate) struct StreamingState {
     dispatcher: Mutex<DispatcherSession>,
 }
 
+/// The deferred, lock-free part of a teardown, extracted under the dispatcher
+/// lock by [`StreamingState::extract_for_teardown_locked`] and finished by
+/// [`StreamingState::run_teardown`] with no lock held.
+struct TeardownWork {
+    /// The retired session's live client, to shut down (drains its threads and
+    /// ring). `None` when the slot was not `Live`.
+    client: Option<Arc<StreamingClient>>,
+    /// The retired dispatcher session, to wake (columnar) and join.
+    session: DispatcherSession,
+}
+
 impl StreamingState {
     /// A fresh, never-started streaming state.
     fn new() -> Self {
@@ -239,40 +250,58 @@ impl StreamingState {
     /// no-ops the rest.
     pub(crate) fn quiesce(&self) {
         // Direct teardown (stop_streaming / reconnect / Client drop): retire
-        // whatever session is currently live, unconditionally. The entire
-        // transition runs under the dispatcher lock; see `retire_locked`.
-        let mut guard = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
-        self.retire_locked(&mut guard);
+        // whatever session is currently live, unconditionally.
+        if let Some(work) = self.extract_for_teardown_locked(None) {
+            self.run_teardown(work);
+        }
     }
 
     /// Retire the live session ONLY if the live stop-generation still equals
     /// `expected_gen`, atomically with the generation re-check.
     ///
     /// This is the columnar reader's close gate. The generation re-check, the
-    /// slot swap, and the dispatcher retire all happen under the one dispatcher
-    /// lock that also serialises `start_dispatcher`'s install and the bump in
-    /// `retire_locked`, so a racing `stop_streaming` + `start_streaming` either
-    /// fully precedes this locked section (the generation has advanced, so the
-    /// re-check fails and this is a no-op, leaving the newer session to its
-    /// owner) or fully follows it (this reader's session is already retired).
-    /// A bare compare on the generation atomic alone would not close the window
-    /// between the reader's earlier read and the teardown; guarding the check
-    /// and the teardown together does.
+    /// generation bump, the slot swap, and the dispatcher-session extraction
+    /// all happen under the one dispatcher lock that also serialises
+    /// `start_dispatcher`'s install and the bump in
+    /// [`Self::extract_for_teardown_locked`], so a racing `stop_streaming` +
+    /// `start_streaming` either fully precedes this locked section (the
+    /// generation has advanced, so the re-check fails and this is a no-op,
+    /// leaving the newer session to its owner) or fully follows it (this
+    /// reader's session is already retired). A bare compare on the generation
+    /// atomic alone would not close the window between the reader's earlier
+    /// read and the teardown; guarding the check and the extraction together
+    /// does. The slow part (client shutdown + dispatcher join) runs AFTER the
+    /// lock is released, so it never holds the lock a callback might need.
     #[cfg(any(feature = "arrow", test))]
     pub(crate) fn quiesce_if_owned(&self, expected_gen: u64) {
-        let mut guard = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
-        if self.stop_generation.load(Ordering::Acquire) == expected_gen {
-            self.retire_locked(&mut guard);
+        if let Some(work) = self.extract_for_teardown_locked(Some(expected_gen)) {
+            self.run_teardown(work);
         }
     }
 
-    /// The teardown itself, run while holding the dispatcher lock: bump the
-    /// generation, swap the slot to `Stopped`, shut the live client, and retire
-    /// the dispatcher session (waking a parked columnar dispatcher first, then
-    /// joining it). Holding the lock across the whole transition makes the
-    /// generation bump, the slot swap, and the dispatcher retire one atomic
-    /// step with respect to `start_dispatcher` and the reader-close gate.
-    fn retire_locked(&self, guard: &mut std::sync::MutexGuard<'_, DispatcherSession>) {
+    /// The atomic part of teardown, run under the dispatcher lock: optionally
+    /// gate on `expected_gen`, bump the generation, swap the slot to `Stopped`,
+    /// and extract the previous live client and dispatcher session. Returns the
+    /// extracted work for [`Self::run_teardown`] to finish OUTSIDE the lock, or
+    /// `None` when the generation gate did not match.
+    ///
+    /// Only the bump + swap + extraction are under the lock — exactly the part
+    /// that must be atomic with the generation gate and with
+    /// `start_dispatcher`. The client shutdown and the dispatcher join, which
+    /// can block while the dispatcher drains already-buffered events through
+    /// user callbacks, are deliberately NOT done here: a callback may call
+    /// `is_streaming` / `connection_status` / `stop_streaming`, which take this
+    /// same lock, so holding it across the join would deadlock.
+    fn extract_for_teardown_locked(&self, expected_gen: Option<u64>) -> Option<TeardownWork> {
+        let mut guard = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        // The columnar reader-close gate: only retire while this reader's
+        // session is still the live one. Checked under the lock so it is atomic
+        // with the bump + swap + extraction below.
+        if let Some(expected) = expected_gen {
+            if self.stop_generation.load(Ordering::Acquire) != expected {
+                return None;
+            }
+        }
         // Bump the stop generation BEFORE the slot swap so any in-flight
         // `start_streaming*()` that snapshotted the previous value will fail
         // its install check and not resurrect the slot to `Live` after this
@@ -285,47 +314,52 @@ impl StreamingState {
         // previous `Arc<StreamingSlot>` and is the one that runs the shutdown
         // sequence.
         let prev = self.state.swap(Arc::new(StreamingSlot::Stopped));
+        let client = match &*prev {
+            StreamingSlot::Live { client } => {
+                // Capture the drain flag BEFORE the shutdown signal and PUSH it
+                // onto the retired-generations list (rather than overwriting a
+                // single slot). Stacked stop/start/stop cycles layer multiple
+                // in-flight generations on top of each other; an earlier
+                // still-firing session's flag must NOT be lost when a later
+                // session retires before the earlier one has drained.
+                // `await_drain()` waits for ALL entries, and lazily GCs flags
+                // that have flipped to `true`, so a long-lived handle does not
+                // accumulate `Arc<AtomicBool>` entries past their useful
+                // lifetime.
+                self.prev_drained
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push(client.drained_flag());
+                Some(Arc::clone(client))
+            }
+            StreamingSlot::Idle | StreamingSlot::Stopped => None,
+        };
+        // Extract the dispatcher session so the join runs outside the lock.
+        let session = std::mem::replace(&mut *guard, DispatcherSession::Idle);
+        Some(TeardownWork { client, session })
+    }
 
-        // Drop the FPSS client signal so its reader thread + event ring
-        // consumer drain and exit. The actual join happens in
-        // `StreamingClient::Drop` when the last `Arc<StreamingClient>` is
-        // dropped (typically with `prev` going out of scope at end of scope).
-        if let StreamingSlot::Live { client } = &*prev {
-            // Capture the drain flag BEFORE the shutdown signal and PUSH it
-            // onto the retired-generations list (rather than overwriting a
-            // single slot). Stacked stop/start/stop cycles layer multiple
-            // in-flight generations on top of each other; an earlier
-            // still-firing session's flag must NOT be lost when a later session
-            // retires before the earlier one has drained. `await_drain()` waits
-            // for ALL entries, and lazily GCs flags that have flipped to
-            // `true`, so a long-lived handle does not accumulate
-            // `Arc<AtomicBool>` entries past their useful lifetime.
-            self.prev_drained
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .push(client.drained_flag());
+    /// The slow part of teardown, run with NO lock held: shut the live client,
+    /// wake a parked columnar dispatcher, and join the dispatcher thread.
+    ///
+    /// Holding no lock here is what keeps the teardown deadlock-free: while the
+    /// client is shut down it keeps draining already-ring-buffered events
+    /// through user callbacks until it observes the shutdown, and such a
+    /// callback may call `is_streaming` / `connection_status` /
+    /// `stop_streaming`, all of which take the dispatcher lock. With the lock
+    /// released, those calls proceed, the dispatcher reaches its shutdown exit,
+    /// and the join below returns.
+    fn run_teardown(&self, work: TeardownWork) {
+        let TeardownWork { client, session } = work;
+        // Shut the FPSS client signal so its reader thread + event ring
+        // consumer drain and exit.
+        if let Some(client) = client {
             client.shutdown();
         }
-
-        // Retire the dispatcher session through the held guard (no re-lock).
-        // Join the dispatcher thread after the producer-drop signal has
-        // propagated through the ring shutdown to the poller, letting the
-        // iterator's `for ... in &client` loop see a clean `Ok(None)` and exit.
-        // Joining closes the race where a callback could still fire after
-        // `is_streaming()` observed `false`. The dispatcher thread never takes
-        // this dispatcher lock, so joining while holding it cannot deadlock.
-        //
-        // Dispatcher panic state is derived from `JoinHandle::join()`:
-        // `Err(_)` means the dispatcher thread panicked in the event-iteration
-        // machinery (distinct from user-callback panics caught by
-        // `poll_batch`'s per-invocation `catch_unwind`). Record as
-        // `DispatcherSession::Failed` so `is_streaming` / `connection_status`
-        // see the failure even though the slot is now `Stopped`.
-        let prev_session = std::mem::replace(&mut **guard, DispatcherSession::Idle);
         if let DispatcherSession::Running {
             handle,
             on_teardown,
-        } = prev_session
+        } = session
         {
             // Wake a dispatcher parked on its own backpressure primitive BEFORE
             // joining it. The per-event callback dispatcher parks only on the
@@ -335,9 +369,7 @@ impl StreamingState {
             // touch; its hook stores `closed` (under the queue lock) and
             // notifies, so the parked flush returns and the join below completes
             // instead of hanging. The hook runs the SAME wakeup the reader's own
-            // close path runs, so every teardown route converges on it. The
-            // hook takes the queue lock, never this dispatcher lock, so it
-            // cannot invert against the held guard.
+            // close path runs, so every teardown route converges on it.
             if let Some(wake) = on_teardown {
                 wake();
             }
@@ -345,16 +377,25 @@ impl StreamingState {
             // (or, for the pull reader, a dispatcher-thread drop) called this.
             // Detach in that case; `await_drain` still observes quiescence via
             // the `prev_drained` flags.
+            //
+            // Dispatcher panic state is derived from `JoinHandle::join()`:
+            // `Err(_)` means the dispatcher thread panicked in the
+            // event-iteration machinery (distinct from user-callback panics
+            // caught by `poll_batch`'s per-invocation `catch_unwind`). Record as
+            // `DispatcherSession::Failed` so `is_streaming` / `connection_status`
+            // see the failure even though the slot is now `Stopped`. The Failed
+            // state is published by RE-ACQUIRING the lock, which is safe now
+            // that the join has completed and the lock is free.
             if handle.thread().id() != std::thread::current().id() {
-                let join_result = handle.join();
-                if let Err(payload) = join_result {
+                if let Err(payload) = handle.join() {
                     let reason = downcast_panic_payload(payload);
                     tracing::error!(
                         target: "thetadatadx::client",
                         reason = %reason,
                         "thetadatadx-fpss-dispatcher panicked; session marked as failed",
                     );
-                    **guard = DispatcherSession::Failed { reason };
+                    *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) =
+                        DispatcherSession::Failed { reason };
                 }
             }
         }
@@ -2697,6 +2738,78 @@ mod tests {
             state.dispatcher_is_idle(),
             "after quiesce the dispatcher session is retired to Idle"
         );
+    }
+
+    /// Teardown must not deadlock when a user callback firing during the
+    /// post-shutdown drain calls into the client (e.g. `is_streaming()`), which
+    /// takes the dispatcher lock. The client shutdown keeps draining
+    /// already-buffered events through callbacks until the shutdown is observed;
+    /// if the teardown held the dispatcher lock across the dispatcher join, such
+    /// a callback would block on the lock forever, the dispatcher would never
+    /// exit, and the join would never return.
+    ///
+    /// This models that exactly without a network: the dispatcher thread, once
+    /// the teardown signals it (via the wake hook, standing in for the shutdown
+    /// being observed), calls `dispatcher_is_idle()` — which acquires and
+    /// releases the dispatcher lock, exactly as `is_streaming()` does — and only
+    /// then exits. The teardown runs on a side thread under a watchdog and must
+    /// COMPLETE: with shutdown + join OUTSIDE the lock the callback acquires the
+    /// free lock, the thread exits, and the join returns. If the join held the
+    /// lock (the pre-fix regression) the callback would block and the watchdog
+    /// would fire.
+    #[test]
+    fn teardown_does_not_deadlock_when_a_callback_takes_the_dispatcher_lock() {
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+
+        let state = Arc::new(StreamingState::new());
+
+        // The wake hook stands in for `client.shutdown()` being observed by the
+        // dispatcher: it releases the dispatcher thread to run its "callback".
+        let released = Arc::new(AtomicBool::new(false));
+
+        // Dispatcher thread: wait until teardown releases it, then do exactly
+        // what an `is_streaming()` call in a user callback does — take and drop
+        // the dispatcher lock — before exiting. If teardown still holds the lock
+        // at that point, this blocks forever.
+        let dispatcher = {
+            let state = Arc::clone(&state);
+            let released = Arc::clone(&released);
+            std::thread::spawn(move || {
+                while !released.load(O::Acquire) {
+                    std::hint::spin_loop();
+                }
+                // Acquires + releases the dispatcher lock, like is_streaming().
+                let _ = state.dispatcher_is_idle();
+            })
+        };
+
+        let wake_released = Arc::clone(&released);
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle: dispatcher,
+            on_teardown: Some(Box::new(move || wake_released.store(true, O::Release))),
+        };
+
+        // Drive teardown on a side thread so a hung join is caught by the
+        // watchdog rather than wedging the suite.
+        let done = Arc::new(AtomicBool::new(false));
+        let done_t = Arc::clone(&done);
+        let state_t = Arc::clone(&state);
+        let teardown = std::thread::spawn(move || {
+            state_t.quiesce();
+            done_t.store(true, O::Release);
+        });
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !done.load(O::Acquire) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "teardown deadlocked: it held the dispatcher lock across the \
+                 dispatcher join while a callback was blocked acquiring that lock"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        teardown.join().expect("teardown thread");
+        assert!(state.dispatcher_is_idle());
     }
 
     /// A columnar reader's close must tear down ONLY the session it started.

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -355,6 +355,40 @@ impl Client {
         F: FnMut(&StreamEvent) + Send + 'static,
         S: FnMut(&mut dyn FnMut() -> crate::PollOutcome) -> crate::PollOutcome + Send + 'static,
     {
+        // The callback path's dispatcher body drives the scoped drain with
+        // the user handler. The connect / spawn / install / rollback
+        // sequence is shared with the columnar `batches()` path via
+        // `start_dispatcher`; only the per-thread consumer body differs.
+        let mut scope = scope;
+        self.start_dispatcher(move |client| {
+            client.for_each_scoped(|event| handler(event), &mut scope);
+        })
+        .map(|_client| ())
+    }
+
+    /// Start FPSS streaming with a custom dispatcher consumer body.
+    ///
+    /// Factors the connect / spawn / install / rollback sequence shared by
+    /// the per-event callback path ([`Self::start_streaming_scoped`]) and
+    /// the columnar pull path ([`Self::start_streaming_batches`]). The
+    /// `dispatcher_body` closure runs on the dispatcher thread once the
+    /// streaming slot is installed; it owns the consumer loop (typically
+    /// [`crate::fpss::StreamingClient::for_each_scoped`]) and returns when
+    /// the ring shuts down. The single-flight gate, startup gate, install,
+    /// and failure rollback are identical across both consumers, so they
+    /// live here once.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network, authentication, or parsing failure, or
+    /// when a stream is already active on this client.
+    pub(crate) fn start_dispatcher<B>(
+        &self,
+        dispatcher_body: B,
+    ) -> Result<Arc<StreamingClient>, Error>
+    where
+        B: FnOnce(Arc<StreamingClient>) + Send + 'static,
+    {
         // Single-flight gate: `dispatcher` mutex serialises the entire
         // connect-spawn-install sequence so two concurrent starts cannot
         // each spawn a dispatcher and race to overwrite the Running
@@ -409,8 +443,8 @@ impl Client {
             .map_err(crate::error::Error::from)?;
         let client_arc = Arc::new(client);
 
-        // Spawn the dispatcher behind a startup gate so the callback
-        // does not fire until the streaming slot is installed. This
+        // Spawn the dispatcher behind a startup gate so the consumer body
+        // does not run until the streaming slot is installed. This
         // closes two windows simultaneously:
         //
         //   1. `is_streaming()` / `connection_status()` cannot observe
@@ -423,8 +457,8 @@ impl Client {
         //      first event.
         //
         // The gate also lets the install-failure rollback signal the
-        // dispatcher to fall through without ever invoking the user
-        // callback.
+        // dispatcher to fall through without ever running the consumer
+        // body.
         //
         // `OnceLock::wait()` (stable since Rust 1.87, below our 1.88 MSRV) blocks the
         // dispatcher until the spawn site calls `.set(true)` (go) or
@@ -432,25 +466,22 @@ impl Client {
         let gate: Arc<OnceLock<bool>> = Arc::new(OnceLock::new());
         let gate_for_dispatcher = Arc::clone(&gate);
         let dispatcher_client = Arc::clone(&client_arc);
-        let mut scope = scope;
         let dispatcher_handle = std::thread::Builder::new()
             .name("thetadatadx-fpss-dispatcher".into())
             .spawn(move || {
                 if !*gate_for_dispatcher.wait() {
                     return;
                 }
-                // `StreamingClient::for_each_scoped` drives `poll_batch`, which
-                // wraps each callback invocation in its own
-                // `catch_unwind`.  A panic in the handler is caught,
-                // recorded via `panic_count()`, and does not stop event
-                // delivery for subsequent events.  The outer
+                // The consumer body drives `StreamingClient::for_each_scoped`,
+                // which drives `poll_batch`, which wraps each callback
+                // invocation in its own `catch_unwind`.  A panic in the
+                // handler is caught, recorded via `panic_count()`, and does
+                // not stop event delivery for subsequent events.  The outer
                 // `catch_unwind` below guards only the event-iteration
                 // machinery itself (ring mutex poison, OOM in the polling
-                // path, etc.) — not user-callback panics. `scope` brackets
-                // each batch drain; for the identity scope it is a direct
-                // call, identical to `for_each`.
+                // path, etc.) — not user-callback panics.
                 let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    dispatcher_client.for_each_scoped(|event| handler(event), &mut scope);
+                    dispatcher_body(dispatcher_client);
                 }));
                 if outcome.is_err() {
                     tracing::error!(
@@ -502,7 +533,7 @@ impl Client {
                     handle: dispatcher_handle,
                 };
                 let _ = gate.set(true);
-                Ok(())
+                Ok(client_arc)
             }
             Err(install_err) => {
                 // Shut down the client so the dispatcher sees a clean
@@ -518,6 +549,51 @@ impl Client {
                 Err(install_err)
             }
         }
+    }
+
+    /// Start FPSS streaming in columnar pull mode, routing decoded
+    /// market-data events into the Arrow batch sink behind `shared`.
+    ///
+    /// Reuses the connect / install / dispatcher machinery via
+    /// [`Self::start_dispatcher`]; the dispatcher thread owns a
+    /// [`crate::fpss::batch_reader::BatchSink`] and drives the scoped drain
+    /// with it instead of a user callback. The sink appends one row per data
+    /// event, flushes on `batch_size` / `linger` / shutdown, and publishes a
+    /// terminal marker when the drain loop returns. The returned
+    /// [`crate::fpss::batch_reader::RecordBatchStream`] reads finished
+    /// batches off the same `shared` queue.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network, authentication, or parsing failure, or
+    /// when a stream is already active on this client.
+    #[cfg(feature = "arrow")]
+    pub(crate) fn start_streaming_batches(
+        &self,
+        shared: Arc<crate::fpss::batch_reader::Shared>,
+        batch_size: usize,
+        linger: std::time::Duration,
+        backpressure: crate::fpss::batch_reader::Backpressure,
+    ) -> Result<Arc<StreamingClient>, Error> {
+        self.start_dispatcher(move |client| {
+            let sink =
+                crate::fpss::batch_reader::BatchSink::new(shared, batch_size, linger, backpressure);
+            // The handler and the scope each take a short, non-overlapping
+            // lock on the sink's accumulator (see `BatchSink`), so cloning
+            // the sink (an `Arc` bundle) into both closures plus the
+            // post-loop finish is sound and the drain path stays lock-free
+            // between events.
+            let handler_sink = sink.clone();
+            let scope_sink = sink.clone();
+            client.for_each_scoped(
+                move |event| handler_sink.on_event(event),
+                move |drain| scope_sink.scope_drain(drain),
+            );
+            // The drain loop returned: the stream shut down. Flush the final
+            // partial batch and publish the terminal end-of-stream marker so
+            // the reader sees `finished` after consuming every queued batch.
+            sink.finish();
+        })
     }
 
     /// Atomically swap the slot to a fresh `Live` state.
@@ -1801,6 +1877,42 @@ impl StreamSurface<'_> {
         I: IntoIterator<Item = Subscription>,
     {
         self.0.unsubscribe_many(subs)
+    }
+
+    /// Open a pull-based columnar reader over the live stream — a sibling to
+    /// the per-event [`Self::start_streaming`] callback.
+    ///
+    /// Returns a [`BatchReaderBuilder`](crate::streaming::BatchReaderBuilder)
+    /// to tune `batch_size` / `linger` / `backpressure`; call
+    /// [`build`](crate::streaming::BatchReaderBuilder::build) to start FPSS
+    /// and obtain a
+    /// [`RecordBatchStream`](crate::streaming::RecordBatchStream) of Apache
+    /// Arrow `RecordBatch` values. Subscriptions are managed on this same
+    /// surface ([`Self::subscribe`] / [`Self::subscribe_many`]); subscribe
+    /// first, then open the reader. The batch schema is fixed for the
+    /// subscription and identical across every batch.
+    ///
+    /// Like the callback path, FPSS connects when the reader is built, so
+    /// this is an alternative to [`Self::start_streaming`], not a concurrent
+    /// consumer of the same session.
+    ///
+    /// ```rust,no_run
+    /// # use thetadatadx::Client;
+    /// # use thetadatadx::fpss::protocol::Contract;
+    /// # use futures::StreamExt;
+    /// # async fn doc(client: &Client) -> Result<(), thetadatadx::Error> {
+    /// client.stream().subscribe(Contract::stock("AAPL").trade())?;
+    /// let mut batches = client.stream().batches().batch_size(8_192).build()?;
+    /// while let Some(batch) = batches.next().await {
+    ///     let batch = batch?;
+    ///     println!("{} rows", batch.num_rows());
+    /// }
+    /// # Ok(()) }
+    /// ```
+    #[cfg(feature = "arrow")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arrow")))]
+    pub fn batches(&self) -> crate::streaming::BatchReaderBuilder<'_> {
+        crate::streaming::BatchReaderBuilder::new(self.0)
     }
 
     /// Get all active per-contract subscriptions.

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -286,7 +286,24 @@ impl StreamingState {
             &mut *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()),
             DispatcherSession::Idle,
         );
-        if let DispatcherSession::Running { handle } = prev_session {
+        if let DispatcherSession::Running {
+            handle,
+            on_teardown,
+        } = prev_session
+        {
+            // Wake a dispatcher parked on its own backpressure primitive BEFORE
+            // joining it. The per-event callback dispatcher parks only on the
+            // event ring, which `client.shutdown()` above already signalled, so
+            // it installs no hook. The columnar pull dispatcher can be parked in
+            // its bounded-queue `flush` wait, which the FPSS shutdown does NOT
+            // touch; its hook stores `closed` (under the queue lock) and
+            // notifies, so the parked flush returns and the join below completes
+            // instead of hanging. The hook runs the SAME wakeup the reader's own
+            // close path runs, so every teardown route converges on it. No lock
+            // is held here, so the wake cannot invert against the dispatcher.
+            if let Some(wake) = on_teardown {
+                wake();
+            }
             // Avoid blocking the consumer thread joining itself when a callback
             // (or, for the pull reader, a dispatcher-thread drop) called this.
             // Detach in that case; `await_drain` still observes quiescence via
@@ -497,9 +514,15 @@ impl Client {
         // sequence is shared with the columnar `batches()` path via
         // `start_dispatcher`; only the per-thread consumer body differs.
         let mut scope = scope;
-        self.start_dispatcher(move |client| {
-            client.for_each_scoped(|event| handler(event), &mut scope);
-        })
+        // The callback dispatcher parks only on the event ring, which the
+        // client shutdown signals during teardown, so it needs no extra wake
+        // hook.
+        self.start_dispatcher(
+            move |client| {
+                client.for_each_scoped(|event| handler(event), &mut scope);
+            },
+            None,
+        )
         .map(|_client| ())
     }
 
@@ -515,6 +538,14 @@ impl Client {
     /// and failure rollback are identical across both consumers, so they
     /// live here once.
     ///
+    /// `on_teardown` is the optional dispatcher wakeup hook (see
+    /// [`DispatcherSession::Running`]). The callback path passes `None`; the
+    /// columnar path passes a hook that releases a dispatcher parked on the
+    /// batch queue so a direct `stop_streaming` / drop can join it. It is
+    /// installed atomically with the `Running` transition under the dispatcher
+    /// lock, so a teardown racing the start never sees a `Running` session
+    /// without its hook.
+    ///
     /// # Errors
     ///
     /// Returns an error on network, authentication, or parsing failure, or
@@ -522,6 +553,7 @@ impl Client {
     pub(crate) fn start_dispatcher<B>(
         &self,
         dispatcher_body: B,
+        on_teardown: Option<Box<dyn FnOnce() + Send>>,
     ) -> Result<Arc<StreamingClient>, Error>
     where
         B: FnOnce(Arc<StreamingClient>) + Send + 'static,
@@ -669,9 +701,13 @@ impl Client {
             Ok(()) => {
                 // Publish the Running variant before opening the gate so
                 // `stop_streaming` finds the JoinHandle regardless of how
-                // quickly the dispatcher thread starts executing.
+                // quickly the dispatcher thread starts executing. The teardown
+                // wake hook is installed in the same transition, so a quiesce
+                // racing this start never observes a `Running` session lacking
+                // its hook.
                 *dispatcher_guard = DispatcherSession::Running {
                     handle: dispatcher_handle,
+                    on_teardown,
                 };
                 let _ = gate.set(true);
                 Ok(client_arc)
@@ -716,25 +752,42 @@ impl Client {
         linger: std::time::Duration,
         backpressure: crate::fpss::batch_reader::Backpressure,
     ) -> Result<Arc<StreamingClient>, Error> {
-        self.start_dispatcher(move |client| {
-            let sink =
-                crate::fpss::batch_reader::BatchSink::new(shared, batch_size, linger, backpressure);
-            // The handler and the scope each take a short, non-overlapping
-            // lock on the sink's accumulator (see `BatchSink`), so cloning
-            // the sink (an `Arc` bundle) into both closures plus the
-            // post-loop finish is sound and the drain path stays lock-free
-            // between events.
-            let handler_sink = sink.clone();
-            let scope_sink = sink.clone();
-            client.for_each_scoped(
-                move |event| handler_sink.on_event(event),
-                move |drain| scope_sink.scope_drain(drain),
-            );
-            // The drain loop returned: the stream shut down. Flush the final
-            // partial batch and publish the terminal end-of-stream marker so
-            // the reader sees `finished` after consuming every queued batch.
-            sink.finish();
-        })
+        // Teardown wake hook: a `Block` dispatcher can be parked in the batch
+        // queue's `flush` wait, which the FPSS shutdown does not touch. Any
+        // teardown that runs `quiesce` directly (a `Client` drop /
+        // `stop_streaming` / `reconnect_streaming`, not just the reader's own
+        // close) invokes this just before joining the dispatcher, so the parked
+        // flush is released and the join completes. It runs the SAME wakeup the
+        // reader's `close_shared` runs, so the two routes converge; it is
+        // idempotent, so a close that already woke is harmless.
+        let wake_shared = Arc::clone(&shared);
+        let on_teardown: Box<dyn FnOnce() + Send> = Box::new(move || wake_shared.close_and_wake());
+        self.start_dispatcher(
+            move |client| {
+                let sink = crate::fpss::batch_reader::BatchSink::new(
+                    shared,
+                    batch_size,
+                    linger,
+                    backpressure,
+                );
+                // The handler and the scope each take a short, non-overlapping
+                // lock on the sink's accumulator (see `BatchSink`), so cloning
+                // the sink (an `Arc` bundle) into both closures plus the
+                // post-loop finish is sound and the drain path stays lock-free
+                // between events.
+                let handler_sink = sink.clone();
+                let scope_sink = sink.clone();
+                client.for_each_scoped(
+                    move |event| handler_sink.on_event(event),
+                    move |drain| scope_sink.scope_drain(drain),
+                );
+                // The drain loop returned: the stream shut down. Flush the final
+                // partial batch and publish the terminal end-of-stream marker so
+                // the reader sees `finished` after consuming every queued batch.
+                sink.finish();
+            },
+            Some(on_teardown),
+        )
     }
 
     /// A weak handle to this client's streaming lifecycle state, for the
@@ -2499,8 +2552,10 @@ mod tests {
     fn quiesce_retires_a_running_dispatcher() {
         let state = StreamingState::new();
         let handle = std::thread::spawn(|| { /* exits immediately */ });
-        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) =
-            DispatcherSession::Running { handle };
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle,
+            on_teardown: None,
+        };
         assert!(
             !state.dispatcher_is_idle(),
             "precondition: Running installed"
@@ -2512,6 +2567,82 @@ mod tests {
             state.dispatcher_is_idle(),
             "quiesce must join the dispatcher thread and reset the session to \
              Idle so the client is reusable"
+        );
+    }
+
+    /// quiesce must not deadlock joining a columnar dispatcher parked in its
+    /// bounded-queue `Block` flush wait on a teardown that bypasses the
+    /// reader's own close (a `Client` drop / `stop_streaming` /
+    /// `reconnect_streaming`, which call quiesce DIRECTLY). The FPSS shutdown
+    /// signals the event ring but not the batch queue, so the only thing that
+    /// releases the parked flush is the wake hook quiesce runs before the join.
+    ///
+    /// This builds the exact deadlock geometry without a network: a real
+    /// producer thread fills a depth-1 `Block` queue and parks in `flush`, that
+    /// thread is installed as the `Running` dispatcher with the columnar wake
+    /// hook (`Shared::close_and_wake`), and quiesce is driven on a side thread
+    /// under a watchdog. With the hook the parked flush is woken, the producer
+    /// thread exits, and the join completes well within the deadline; without
+    /// it (the pre-fix `on_teardown: None`) the producer stays parked and the
+    /// join hangs past the watchdog, failing the test instead of wedging the
+    /// suite.
+    #[cfg(feature = "arrow")]
+    #[test]
+    fn quiesce_does_not_deadlock_on_a_parked_block_dispatcher() {
+        use crate::fpss::batch_reader::test_harness::{harness, trade};
+        use crate::fpss::batch_reader::Backpressure;
+        use crate::fpss::protocol::Contract;
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+
+        // Depth-1 Block queue, no reader: the producer fills it then parks.
+        let (producer, reader) =
+            harness(1, std::time::Duration::from_millis(50), Backpressure::Block);
+        let shared = reader.shared_handle();
+        let contract = Arc::new(Contract::stock("SPY"));
+
+        // Producer thread: floods the queue and parks in `flush`. After the
+        // wake hook fires it returns promptly (post-close flushes drop and
+        // return), so the join can complete.
+        let feeder = std::thread::spawn(move || {
+            for i in 0..256 {
+                producer.feed(&trade(&contract, i));
+            }
+        });
+        // Let the producer fill the depth-1 queue and park in the Block wait.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Install that real thread as the columnar dispatcher session, WITH the
+        // wake hook the live columnar path installs.
+        let state = Arc::new(StreamingState::new());
+        let wake_shared = Arc::clone(&shared);
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle: feeder,
+            on_teardown: Some(Box::new(move || wake_shared.close_and_wake())),
+        };
+
+        // Drive quiesce on a side thread so a hung join is caught by the
+        // watchdog rather than wedging the whole test binary.
+        let done = Arc::new(AtomicBool::new(false));
+        let done_t = Arc::clone(&done);
+        let state_t = Arc::clone(&state);
+        let quiescer = std::thread::spawn(move || {
+            state_t.quiesce();
+            done_t.store(true, O::Release);
+        });
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !done.load(O::Acquire) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "quiesce deadlocked joining a parked Block dispatcher: the \
+                 teardown wake hook did not release the parked flush"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        quiescer.join().expect("quiescer thread");
+        assert!(
+            state.dispatcher_is_idle(),
+            "after quiesce the dispatcher session is retired to Idle"
         );
     }
 

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -394,8 +394,21 @@ impl StreamingState {
                         reason = %reason,
                         "thetadatadx-fpss-dispatcher panicked; session marked as failed",
                     );
-                    *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) =
-                        DispatcherSession::Failed { reason };
+                    // Record `Failed` ONLY if no newer session was installed
+                    // since the extract left the slot `Idle`. The lock was
+                    // released across the join, so a `start_dispatcher` may have
+                    // installed a fresh `Running` session in that window; the
+                    // panic belongs to the now-superseded OLD session, so
+                    // overwriting the slot unconditionally would clobber the new
+                    // session's `JoinHandle` (orphaning its thread) and falsely
+                    // report a healthy live session as failed. Writing `Failed`
+                    // only while the slot is still `Idle` records the panic for
+                    // the common no-race case and leaves any newer session
+                    // untouched.
+                    let mut guard = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+                    if matches!(*guard, DispatcherSession::Idle) {
+                        *guard = DispatcherSession::Failed { reason };
+                    }
                 }
             }
         }
@@ -2810,6 +2823,106 @@ mod tests {
         }
         teardown.join().expect("teardown thread");
         assert!(state.dispatcher_is_idle());
+    }
+
+    /// A join panic on the OLD dispatcher must not clobber a NEWER session
+    /// installed during the lock-free join window. `run_teardown` releases the
+    /// dispatcher lock across the join, so a `start_dispatcher` can install a
+    /// fresh `Running` session before the join returns. If the old dispatcher
+    /// then panics, the `Failed` write must NOT overwrite that newer session —
+    /// it would orphan the new session's `JoinHandle` and report a healthy live
+    /// session as failed. The write is now conditional on the slot still being
+    /// `Idle` (the state extract left it), so a newer session is left alone.
+    ///
+    /// Modeled deterministically: build a `TeardownWork` whose `Running`
+    /// session's handle panics only after a NEW session has been installed,
+    /// then run the teardown; the new session must still be `Running`
+    /// afterward.
+    #[test]
+    fn join_panic_does_not_clobber_a_newer_session() {
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+
+        let state = Arc::new(StreamingState::new());
+
+        // The teardown wake hook fires just before the join; the test uses it
+        // as the signal that the join window has opened.
+        let join_window_open = Arc::new(AtomicBool::new(false));
+        // Set by the test once the NEW session is installed; the old handle
+        // waits for it, then panics, so the new session is guaranteed in place
+        // before the join returns and the conditional `Failed` write runs.
+        let new_installed = Arc::new(AtomicBool::new(false));
+
+        // OLD dispatcher handle: wait until the new session is installed, then
+        // panic so `handle.join()` returns Err.
+        let old_handle = {
+            let new_installed = Arc::clone(&new_installed);
+            std::thread::spawn(move || {
+                while !new_installed.load(O::Acquire) {
+                    std::hint::spin_loop();
+                }
+                panic!("old dispatcher panicked in event-iteration machinery");
+            })
+        };
+        let work = TeardownWork {
+            client: None,
+            session: DispatcherSession::Running {
+                handle: old_handle,
+                on_teardown: Some({
+                    let join_window_open = Arc::clone(&join_window_open);
+                    Box::new(move || join_window_open.store(true, O::Release))
+                }),
+            },
+        };
+
+        // Run the teardown on a side thread (its join blocks until the old
+        // handle panics, which the test gates below).
+        let done = Arc::new(AtomicBool::new(false));
+        let teardown = {
+            let state = Arc::clone(&state);
+            let done = Arc::clone(&done);
+            std::thread::spawn(move || {
+                state.run_teardown(work);
+                done.store(true, O::Release);
+            })
+        };
+
+        // Wait until the teardown opens the join window (wake hook fired), then
+        // install a NEW Running session into the slot the extract left Idle,
+        // exactly as a racing `start_dispatcher` would.
+        while !join_window_open.load(O::Acquire) {
+            std::hint::spin_loop();
+        }
+        let new_handle = std::thread::spawn(|| {});
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle: new_handle,
+            on_teardown: None,
+        };
+        // Release the old handle to panic; the join now returns Err and the
+        // conditional `Failed` write runs against the slot holding the NEW
+        // Running session.
+        new_installed.store(true, O::Release);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !done.load(O::Acquire) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "teardown did not complete"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        teardown.join().expect("teardown thread");
+
+        // The newer session must survive: a join panic on the superseded old
+        // session must not flip the live session to Failed.
+        let guard = state.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(
+            matches!(*guard, DispatcherSession::Running { .. }),
+            "a newer session installed during the join window must not be \
+             clobbered by the old dispatcher's join-panic Failed write"
+        );
+        drop(guard);
+        // Tidy: retire the surviving session so its thread is joined.
+        state.quiesce();
     }
 
     /// A columnar reader's close must tear down ONLY the session it started.

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -227,6 +227,28 @@ struct TeardownWork {
     session: DispatcherSession,
 }
 
+/// Whether a retiring dispatcher session should register its drain flag for
+/// [`StreamingState::await_drain`].
+///
+/// `await_drain` waits for an in-flight per-event user CALLBACK to finish
+/// firing. Only the callback session has such a callback, so only it registers
+/// a flag. The columnar (batches) pull session has no callback — and its
+/// `drained` flag stays unset until the reader's `Arc<StreamingClient>` is
+/// dropped rather than merely closed — so registering it would make a manual
+/// `await_drain` time out spuriously while a closed-but-not-dropped columnar
+/// reader is alive. The columnar session is distinguished by being the only
+/// session that installs a teardown wake hook (to release a producer parked on
+/// the batch queue); the callback session installs none. A non-`Running`
+/// session has nothing to wait on.
+fn session_registers_drain_flag(session: &DispatcherSession) -> bool {
+    match session {
+        // Callback session: a wake hook is never installed -> register.
+        // Columnar session: a wake hook IS installed -> do not register.
+        DispatcherSession::Running { on_teardown, .. } => on_teardown.is_none(),
+        DispatcherSession::Idle | DispatcherSession::Failed { .. } => false,
+    }
+}
+
 impl StreamingState {
     /// A fresh, never-started streaming state.
     fn new() -> Self {
@@ -310,26 +332,43 @@ impl StreamingState {
         // dispatcher lock, so it is also mutually exclusive with
         // `start_dispatcher`'s generation snapshot and the reader-close gate.
         self.stop_generation.fetch_add(1, Ordering::AcqRel);
+        // Whether the session being retired should register its drain flag for
+        // `await_drain`. `await_drain` exists to wait for a user CALLBACK to
+        // finish firing; the columnar (batches) pull session has no callback,
+        // so its flag must NOT be registered (see the push below).
+        let register_drain_flag = session_registers_drain_flag(&guard);
         // Atomically swap to `Stopped`; whichever caller wins the swap owns the
         // previous `Arc<StreamingSlot>` and is the one that runs the shutdown
         // sequence.
         let prev = self.state.swap(Arc::new(StreamingSlot::Stopped));
         let client = match &*prev {
             StreamingSlot::Live { client } => {
-                // Capture the drain flag BEFORE the shutdown signal and PUSH it
-                // onto the retired-generations list (rather than overwriting a
-                // single slot). Stacked stop/start/stop cycles layer multiple
-                // in-flight generations on top of each other; an earlier
-                // still-firing session's flag must NOT be lost when a later
-                // session retires before the earlier one has drained.
-                // `await_drain()` waits for ALL entries, and lazily GCs flags
-                // that have flipped to `true`, so a long-lived handle does not
-                // accumulate `Arc<AtomicBool>` entries past their useful
-                // lifetime.
-                self.prev_drained
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .push(client.drained_flag());
+                // Register the drain flag for `await_drain` ONLY for a callback
+                // session. `await_drain` waits for in-flight user callbacks to
+                // finish; the columnar session has no callback, and its
+                // `drained` flag stays unset until the reader's
+                // `Arc<StreamingClient>` is dropped (not merely closed), so
+                // registering it would make a manual `await_drain` while a
+                // closed-but-not-dropped columnar reader is alive time out
+                // spuriously. Skipping it leaves the callback path's
+                // `await_drain` unchanged.
+                //
+                // For a callback session: capture the drain flag BEFORE the
+                // shutdown signal and PUSH it onto the retired-generations list
+                // (rather than overwriting a single slot). Stacked
+                // stop/start/stop cycles layer multiple in-flight generations
+                // on top of each other; an earlier still-firing session's flag
+                // must NOT be lost when a later session retires before the
+                // earlier one has drained. `await_drain()` waits for ALL
+                // entries, and lazily GCs flags that have flipped to `true`, so
+                // a long-lived handle does not accumulate `Arc<AtomicBool>`
+                // entries past their useful lifetime.
+                if register_drain_flag {
+                    self.prev_drained
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .push(client.drained_flag());
+                }
                 Some(Arc::clone(client))
             }
             StreamingSlot::Idle | StreamingSlot::Stopped => None,
@@ -1232,6 +1271,12 @@ impl Client {
     }
 
     /// Wait for **every** retired streaming session to drain.
+    ///
+    /// Pertains to the per-event callback surface: it waits for in-flight user
+    /// callbacks of retired sessions to finish firing. The columnar (batches)
+    /// pull path has no callback and registers nothing here, so `await_drain`
+    /// is a no-op (returns immediately) for a columnar-only client; the
+    /// columnar reader's own close / drop is its teardown barrier.
     ///
     /// Stacked `stop → start → stop` cycles layer multiple in-flight
     /// generations on top of each other before any one of them drains;
@@ -2923,6 +2968,85 @@ mod tests {
         drop(guard);
         // Tidy: retire the surviving session so its thread is joined.
         state.quiesce();
+    }
+
+    /// `await_drain` must not be made to time out spuriously by the columnar
+    /// path: a retiring columnar session has no user callback to wait for, so
+    /// it must NOT register a drain flag, whereas a callback session MUST. This
+    /// pins `session_registers_drain_flag` (the single decision the teardown
+    /// uses) for both session shapes, and models the `await_drain` consequence
+    /// on the retired-generations Vec (the production `await_drain` runs the
+    /// same `retain` + `is_empty` cadence over it; building a real Live session
+    /// needs a network credential, so the Vec is exercised directly, as the
+    /// other `await_drain` tests do).
+    #[test]
+    fn columnar_session_does_not_register_a_drain_flag() {
+        // The decision itself: columnar (has wake hook) does not register;
+        // callback (no wake hook) does.
+        let columnar = DispatcherSession::Running {
+            handle: std::thread::spawn(|| {}),
+            on_teardown: Some(Box::new(|| {})),
+        };
+        let callback = DispatcherSession::Running {
+            handle: std::thread::spawn(|| {}),
+            on_teardown: None,
+        };
+        assert!(
+            !session_registers_drain_flag(&columnar),
+            "a columnar session has no callback to drain-wait for"
+        );
+        assert!(
+            session_registers_drain_flag(&callback),
+            "a callback session must register its drain flag for await_drain"
+        );
+        // A non-Running session has nothing to wait on.
+        assert!(!session_registers_drain_flag(&DispatcherSession::Idle));
+
+        // The await_drain consequence, modeled on the retired-generations Vec.
+        // Columnar teardown registers nothing, so await_drain (retain +
+        // is_empty) reports drained immediately — no spurious timeout while a
+        // closed-but-not-dropped columnar reader is alive.
+        let prev_drained: Mutex<Vec<Arc<AtomicBool>>> = Mutex::new(Vec::new());
+        if session_registers_drain_flag(&columnar) {
+            prev_drained
+                .lock()
+                .unwrap()
+                .push(Arc::new(AtomicBool::new(false)));
+        }
+        {
+            let mut g = prev_drained.lock().unwrap();
+            g.retain(|f| !f.load(Ordering::Acquire));
+            assert!(
+                g.is_empty(),
+                "columnar teardown must leave nothing for await_drain to block on"
+            );
+        }
+
+        // Callback teardown registers a still-unflipped flag, so await_drain
+        // correctly does NOT report drained until the callback finishes (no
+        // regression to the callback path).
+        if session_registers_drain_flag(&callback) {
+            prev_drained
+                .lock()
+                .unwrap()
+                .push(Arc::new(AtomicBool::new(false)));
+        }
+        {
+            let mut g = prev_drained.lock().unwrap();
+            g.retain(|f| !f.load(Ordering::Acquire));
+            assert_eq!(
+                g.len(),
+                1,
+                "callback teardown registers a flag await_drain must wait on"
+            );
+        }
+
+        // Detach the trivial threads.
+        for s in [columnar, callback] {
+            if let DispatcherSession::Running { handle, .. } = s {
+                let _ = handle.join();
+            }
+        }
     }
 
     /// A columnar reader's close must tear down ONLY the session it started.

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -148,6 +148,27 @@ pub struct Client {
     /// so subsequent `DirectConfig` mutations cannot retroactively change
     /// retry behavior for already-issued requests.
     flatfiles_config: crate::config::FlatFilesConfig,
+    /// Streaming lifecycle state, held behind an `Arc` so a teardown that
+    /// outlives the borrowed [`StreamSurface`] — notably the pull-based
+    /// [`crate::fpss::batch_reader::RecordBatchStream`], whose `close` / drop
+    /// fire after the `&Client` borrow has ended — can quiesce the same state
+    /// cells [`Self::stop_streaming`] does, through a [`std::sync::Weak`]. The
+    /// callback path reaches it through `&self`; both routes funnel through
+    /// [`StreamingState::quiesce`], so the two delivery modes leave the client
+    /// in the same truthful, reusable state.
+    streaming: Arc<StreamingState>,
+}
+
+/// The streaming lifecycle state of a [`Client`].
+///
+/// Factored out of [`Client`] so it can be shared (via `Arc`) with a
+/// pull-based reader whose teardown outlives the `&Client` borrow that opened
+/// it. Both [`Client::stop_streaming`] and the batch reader's close drive
+/// [`Self::quiesce`], the single transition that swaps the slot to `Stopped`,
+/// retires the dispatcher session, and records the drain flag — so streaming
+/// status stays truthful and the client stays reusable regardless of which
+/// delivery mode (callback or columnar pull) ran.
+pub(crate) struct StreamingState {
     /// Streaming-side state machine. See [`StreamingSlot`] for the
     /// `Idle → Live → Stopped` lifecycle. The
     /// [`ArcSwap`] makes `is_streaming` / `connection_status` /
@@ -155,9 +176,9 @@ pub struct Client {
     /// took two `Mutex` locks plus an `AtomicBool` for the same answer.
     state: ArcSwap<StreamingSlot>,
     /// Quiescence flags of every superseded streaming session that has
-    /// not yet drained, captured during [`Self::stop_streaming`] /
-    /// [`Self::reconnect_streaming`] before the `Live → Stopped` swap
-    /// drops the previous `Arc<StreamingClient>`. [`Self::await_drain`]
+    /// not yet drained, captured during [`Client::stop_streaming`] /
+    /// [`Client::reconnect_streaming`] before the `Live → Stopped` swap
+    /// drops the previous `Arc<StreamingClient>`. [`Client::await_drain`]
     /// waits for **every** entry to flip to `true` before reporting
     /// quiescence; completed flags are GC'd lazily on each poll.
     ///
@@ -172,7 +193,7 @@ pub struct Client {
     /// FFI `ctx`. The Vec preserves every retired generation until its
     /// own flag is observed `true`.
     prev_drained: Mutex<Vec<Arc<AtomicBool>>>,
-    /// Monotonic counter incremented by every [`Self::stop_streaming`].
+    /// Monotonic counter incremented by every [`Client::stop_streaming`].
     ///
     /// Each `start_streaming*()` snapshots this value at entry and
     /// re-checks it after the FPSS connect completes. If the snapshot
@@ -193,6 +214,125 @@ pub struct Client {
     /// from `JoinHandle::join()` returning `Err(_)` rather than a
     /// separate atomic flag.
     dispatcher: Mutex<DispatcherSession>,
+}
+
+impl StreamingState {
+    /// A fresh, never-started streaming state.
+    fn new() -> Self {
+        Self {
+            state: ArcSwap::from_pointee(StreamingSlot::Idle),
+            prev_drained: Mutex::new(Vec::new()),
+            stop_generation: AtomicU64::new(0),
+            dispatcher: Mutex::new(DispatcherSession::Idle),
+        }
+    }
+
+    /// Quiesce the streaming session: swap the slot to `Stopped`, retire the
+    /// dispatcher session, and record the previous generation's drain flag.
+    ///
+    /// This is the single teardown both delivery modes share —
+    /// [`Client::stop_streaming`] (callback path) and the pull reader's close
+    /// (columnar path) both call it — so after either one the slot is
+    /// `Stopped`, the dispatcher is `Idle` (or `Failed` if it panicked), and
+    /// `is_streaming` / `connection_status` report the truth. Idempotent:
+    /// calling it on an already-`Stopped` state bumps the generation and
+    /// no-ops the rest.
+    pub(crate) fn quiesce(&self) {
+        // Bump the stop generation BEFORE the slot swap so any in-flight
+        // `start_streaming*()` that snapshotted the previous value will fail
+        // its install check and not resurrect the slot to `Live` after this
+        // returns. AcqRel because the ordering relative to the `state.swap`
+        // below is what closes the resurrection race.
+        self.stop_generation.fetch_add(1, Ordering::AcqRel);
+        // Atomically swap to `Stopped`; whichever caller wins the swap owns the
+        // previous `Arc<StreamingSlot>` and is the one that runs the shutdown
+        // sequence.
+        let prev = self.state.swap(Arc::new(StreamingSlot::Stopped));
+
+        // Drop the FPSS client signal so its reader thread + event ring
+        // consumer drain and exit. The actual join happens in
+        // `StreamingClient::Drop` when the last `Arc<StreamingClient>` is
+        // dropped (typically with `prev` going out of scope at end of scope).
+        if let StreamingSlot::Live { client } = &*prev {
+            // Capture the drain flag BEFORE the shutdown signal and PUSH it
+            // onto the retired-generations list (rather than overwriting a
+            // single slot). Stacked stop/start/stop cycles layer multiple
+            // in-flight generations on top of each other; an earlier
+            // still-firing session's flag must NOT be lost when a later session
+            // retires before the earlier one has drained. `await_drain()` waits
+            // for ALL entries, and lazily GCs flags that have flipped to
+            // `true`, so a long-lived handle does not accumulate
+            // `Arc<AtomicBool>` entries past their useful lifetime.
+            self.prev_drained
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(client.drained_flag());
+            client.shutdown();
+        }
+
+        // Join the dispatcher thread (if any) after the producer-drop signal
+        // has propagated through the ring shutdown to the poller, letting the
+        // iterator's `for ... in &client` loop see a clean `Ok(None)` and exit.
+        // Joining here closes the race where a callback could still fire after
+        // `is_streaming()` observed `false`.
+        //
+        // Dispatcher panic state is derived from `JoinHandle::join()`:
+        // `Err(_)` means the dispatcher thread panicked in the event-iteration
+        // machinery (distinct from user-callback panics caught by
+        // `poll_batch`'s per-invocation `catch_unwind`). Record as
+        // `DispatcherSession::Failed` so `is_streaming` / `connection_status`
+        // see the failure even though the slot is now `Stopped`.
+        let prev_session = std::mem::replace(
+            &mut *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()),
+            DispatcherSession::Idle,
+        );
+        if let DispatcherSession::Running { handle } = prev_session {
+            // Avoid blocking the consumer thread joining itself when a callback
+            // (or, for the pull reader, a dispatcher-thread drop) called this.
+            // Detach in that case; `await_drain` still observes quiescence via
+            // the `prev_drained` flags.
+            if handle.thread().id() != std::thread::current().id() {
+                let join_result = handle.join();
+                if let Err(payload) = join_result {
+                    let reason = downcast_panic_payload(payload);
+                    tracing::error!(
+                        target: "thetadatadx::client",
+                        reason = %reason,
+                        "thetadatadx-fpss-dispatcher panicked; session marked as failed",
+                    );
+                    *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) =
+                        DispatcherSession::Failed { reason };
+                }
+            }
+        }
+    }
+
+    /// Test-only: the current streaming-slot variant as a static label, so a
+    /// test can assert the `Idle → Live → Stopped` transition `quiesce` drives
+    /// without naming the private `Arc<StreamingClient>` payload.
+    #[cfg(test)]
+    fn slot_label(&self) -> &'static str {
+        match &**self.state.load() {
+            StreamingSlot::Idle => "Idle",
+            StreamingSlot::Live { .. } => "Live",
+            StreamingSlot::Stopped => "Stopped",
+        }
+    }
+
+    /// Test-only: whether the dispatcher session is currently `Idle`.
+    #[cfg(test)]
+    fn dispatcher_is_idle(&self) -> bool {
+        matches!(
+            *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()),
+            DispatcherSession::Idle
+        )
+    }
+
+    /// Test-only: the current stop generation.
+    #[cfg(test)]
+    fn stop_generation_value(&self) -> u64 {
+        self.stop_generation.load(Ordering::Acquire)
+    }
 }
 
 impl Client {
@@ -263,10 +403,7 @@ impl Client {
             historical,
             creds: creds.clone(),
             flatfiles_config,
-            state: ArcSwap::from_pointee(StreamingSlot::Idle),
-            prev_drained: Mutex::new(Vec::new()),
-            stop_generation: AtomicU64::new(0),
-            dispatcher: Mutex::new(DispatcherSession::Idle),
+            streaming: Arc::new(StreamingState::new()),
         })
     }
 
@@ -396,10 +533,14 @@ impl Client {
         // (typically tens of milliseconds); a second concurrent start
         // is rejected upfront by the `is_streaming` fast path or by
         // `install_live` once it observes a `Live` slot.
-        let mut dispatcher_guard = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        let mut dispatcher_guard = self
+            .streaming
+            .dispatcher
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         // Reject a second concurrent start before paying the connect cost.
-        if matches!(&**self.state.load(), StreamingSlot::Live { .. }) {
+        if matches!(&**self.streaming.state.load(), StreamingSlot::Live { .. }) {
             return Err(Self::already_streaming());
         }
 
@@ -407,7 +548,7 @@ impl Client {
         // thread calls `stop_streaming()` between this load and the
         // post-connect `install_live`, the install path observes the
         // mismatch and refuses to resurrect the slot to `Live`.
-        let gen_at_entry = self.stop_generation.load(Ordering::Acquire);
+        let gen_at_entry = self.streaming.stop_generation.load(Ordering::Acquire);
 
         let config = self.historical.config();
         let client = StreamingClient::builder(&self.creds, &config.streaming.hosts)
@@ -596,6 +737,21 @@ impl Client {
         })
     }
 
+    /// A weak handle to this client's streaming lifecycle state, for the
+    /// pull-based [`crate::fpss::batch_reader::RecordBatchStream`] to quiesce
+    /// the session on close.
+    ///
+    /// Weak (not strong) so the reader never keeps the client's streaming
+    /// state alive past the client itself: if the client is dropped first, its
+    /// own `Drop` quiesces and the reader's later close finds nothing to
+    /// upgrade and is a no-op; in the common order (reader closed first) the
+    /// upgrade succeeds and resets the slot to `Stopped`, making
+    /// `is_streaming` / `connection_status` truthful and the client reusable.
+    #[cfg(feature = "arrow")]
+    pub(crate) fn streaming_state_weak(&self) -> std::sync::Weak<StreamingState> {
+        Arc::downgrade(&self.streaming)
+    }
+
     /// Atomically swap the slot to a fresh `Live` state.
     ///
     /// Rejects the install when:
@@ -621,8 +777,8 @@ impl Client {
         // `&Arc<T>` directly for non-Eq T; we instead read, decide,
         // and rcu the state. The `rcu` closure is retried until the
         // swap is observed atomically.
-        let stop_gen = &self.stop_generation;
-        let prev = self.state.rcu(|current| match &**current {
+        let stop_gen = &self.streaming.stop_generation;
+        let prev = self.streaming.state.rcu(|current| match &**current {
             StreamingSlot::Live { .. } => Arc::clone(current),
             _ => {
                 // Re-check the stop generation INSIDE the rcu closure.
@@ -646,7 +802,7 @@ impl Client {
         // mismatch, the cell was left at its current value (Stopped or
         // Idle). Distinguish from "successful install" by re-reading
         // the cell — if it does not point to our `new`, we lost.
-        if !Arc::ptr_eq(&self.state.load_full(), &new) {
+        if !Arc::ptr_eq(&self.streaming.state.load_full(), &new) {
             return Err(Self::stopped_during_start());
         }
         Ok(())
@@ -661,7 +817,7 @@ impl Client {
     /// per-drop log would amplify under sustained overflow.
     #[must_use]
     pub(crate) fn dropped_event_count(&self) -> u64 {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => client.dropped_count(),
             StreamingSlot::Idle | StreamingSlot::Stopped => 0,
@@ -682,7 +838,7 @@ impl Client {
     /// from your own monitoring thread at any cadence.
     #[must_use]
     pub(crate) fn ring_occupancy(&self) -> usize {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => client.ring_occupancy(),
             StreamingSlot::Idle | StreamingSlot::Stopped => 0,
@@ -699,7 +855,7 @@ impl Client {
     /// [`Self::dropped_event_count`]).
     #[must_use]
     pub(crate) fn ring_capacity(&self) -> usize {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => client.ring_capacity(),
             StreamingSlot::Idle | StreamingSlot::Stopped => 0,
@@ -717,7 +873,7 @@ impl Client {
     /// connection.
     #[must_use]
     pub(crate) fn millis_since_last_event(&self) -> Option<u64> {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => client.millis_since_last_event(),
             StreamingSlot::Idle | StreamingSlot::Stopped => None,
@@ -731,7 +887,7 @@ impl Client {
     /// correlating against their own pipeline timestamps.
     #[must_use]
     pub(crate) fn last_event_received_at_unix_nanos(&self) -> i64 {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => client.last_event_received_at_unix_nanos(),
             StreamingSlot::Idle | StreamingSlot::Stopped => 0,
@@ -743,7 +899,7 @@ impl Client {
     /// auto-reconnects. Returns `None` when streaming has not started.
     #[must_use]
     pub(crate) fn last_connected_addr(&self) -> Option<String> {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => Some(client.last_connected_addr()),
             StreamingSlot::Idle | StreamingSlot::Stopped => None,
@@ -759,7 +915,7 @@ impl Client {
     /// instead of this counter. Returns `0` when streaming has not started.
     #[must_use]
     pub(crate) fn panic_count(&self) -> u64 {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => client.panic_count(),
             StreamingSlot::Idle | StreamingSlot::Stopped => 0,
@@ -774,7 +930,7 @@ impl Client {
     #[cfg(feature = "__internal")]
     #[doc(hidden)]
     pub(crate) fn record_panic(&self) {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         if let StreamingSlot::Live { client } = &**snap {
             client.record_panic();
         }
@@ -796,7 +952,7 @@ impl Client {
     /// [`Self::start_streaming`] the threshold defaults back to
     /// disabled (callers must re-arm).
     pub(crate) fn set_slow_callback_threshold(&self, threshold: Duration) {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         if let StreamingSlot::Live { client } = &**snap {
             client.set_slow_callback_threshold(threshold);
         }
@@ -808,7 +964,7 @@ impl Client {
     /// watchdog is disabled or when streaming has not started.
     #[must_use]
     pub(crate) fn slow_callback_count(&self) -> u64 {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => client.slow_callback_count(),
             StreamingSlot::Idle | StreamingSlot::Stopped => 0,
@@ -830,9 +986,13 @@ impl Client {
     /// context, replacing the callback closure, or asserting the old
     /// consumer thread has joined.
     pub(crate) fn is_streaming(&self) -> bool {
-        match &**self.state.load() {
+        match &**self.streaming.state.load() {
             StreamingSlot::Live { .. } => {
-                let session = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+                let session = self
+                    .streaming
+                    .dispatcher
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
                 !matches!(*session, DispatcherSession::Failed { .. })
             }
             StreamingSlot::Idle | StreamingSlot::Stopped => false,
@@ -849,9 +1009,13 @@ impl Client {
     /// reporting "authenticated with no deliveries". Returns `false`
     /// before streaming starts and after it stops.
     pub(crate) fn is_authenticated(&self) -> bool {
-        match &**self.state.load() {
+        match &**self.streaming.state.load() {
             StreamingSlot::Live { client } => {
-                let session = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+                let session = self
+                    .streaming
+                    .dispatcher
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
                 client.is_authenticated() && !matches!(*session, DispatcherSession::Failed { .. })
             }
             StreamingSlot::Idle | StreamingSlot::Stopped => false,
@@ -888,7 +1052,7 @@ impl Client {
     /// does not leak `Arc<AtomicBool>` entries.
     #[must_use]
     pub(crate) fn prev_drained_is_set(&self) -> bool {
-        match self.prev_drained.try_lock() {
+        match self.streaming.prev_drained.try_lock() {
             Ok(mut guard) => {
                 guard.retain(|f| !f.load(Ordering::Acquire));
                 !guard.is_empty()
@@ -926,6 +1090,7 @@ impl Client {
         loop {
             let all_drained = {
                 let mut guard = self
+                    .streaming
                     .prev_drained
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -951,7 +1116,7 @@ impl Client {
         &self,
         f: impl FnOnce(&StreamingClient) -> Result<R, Error>,
     ) -> Result<R, Error> {
-        let snap = self.state.load();
+        let snap = self.streaming.state.load();
         match &**snap {
             StreamingSlot::Live { client } => f(client.as_ref()),
             StreamingSlot::Idle | StreamingSlot::Stopped => Err(Error::Fpss {
@@ -1074,77 +1239,11 @@ impl Client {
     /// callback closure, or otherwise rely on the old user callback
     /// having stopped firing.
     pub(crate) fn stop_streaming(&self) {
-        // Bump the stop generation BEFORE the slot swap so any
-        // in-flight `start_streaming*()` that snapshotted the previous
-        // value will fail its install check and not resurrect the
-        // slot to `Live` after this returns. AcqRel because the
-        // ordering relative to the `state.swap` below is what closes
-        // the resurrection race.
-        self.stop_generation.fetch_add(1, Ordering::AcqRel);
-        // Atomically swap to `Stopped`; whichever caller wins the swap
-        // owns the previous `Arc<StreamingSlot>` and is the one that
-        // runs the shutdown sequence.
-        let prev = self.state.swap(Arc::new(StreamingSlot::Stopped));
-
-        // Drop the FPSS client signal so its reader thread + event ring
-        // consumer drain and exit. The actual join happens in
-        // `StreamingClient::Drop` when the last `Arc<StreamingClient>` is dropped
-        // (typically with `prev` going out of scope at end of scope).
-        if let StreamingSlot::Live { client } = &*prev {
-            // Capture the drain flag BEFORE the shutdown signal and
-            // PUSH it onto the retired-generations list (rather than
-            // overwriting a single slot). Stacked stop/start/stop
-            // cycles layer multiple in-flight generations on top of
-            // each other; an earlier still-firing session's flag must
-            // NOT be lost when a later session retires before the
-            // earlier one has drained. `await_drain()` waits for ALL
-            // entries, and lazily GCs flags that have flipped to
-            // `true`, so a long-lived handle does not accumulate
-            // `Arc<AtomicBool>` entries past their useful lifetime.
-            self.prev_drained
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .push(client.drained_flag());
-            client.shutdown();
-        }
-
-        // Join the dispatcher thread (if any) after the producer-drop
-        // signal has propagated through the ring shutdown to the
-        // poller, letting the iterator's `for ... in &client` loop see
-        // a clean `Ok(None)` and exit. Joining here closes the race
-        // where a callback could still fire after `is_streaming()`
-        // observed `false`.
-        //
-        // Dispatcher panic state is derived from `JoinHandle::join()`:
-        // `Err(_)` means the dispatcher thread panicked in the
-        // event-iteration machinery (distinct from user-callback panics
-        // caught by `poll_batch`'s per-invocation `catch_unwind`).
-        // Record as `DispatcherSession::Failed` so `is_streaming` /
-        // `connection_status` see the failure even though the slot is
-        // now `Stopped`.
-        let prev_session = std::mem::replace(
-            &mut *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()),
-            DispatcherSession::Idle,
-        );
-        if let DispatcherSession::Running { handle } = prev_session {
-            // Avoid blocking the consumer thread joining itself when a
-            // callback called `stop_streaming()`. Detach in that case;
-            // `await_drain` still observes quiescence via the
-            // `prev_drained` flags.
-            if handle.thread().id() != std::thread::current().id() {
-                let join_result = handle.join();
-                if let Err(payload) = join_result {
-                    let reason = downcast_panic_payload(payload);
-                    tracing::error!(
-                        target: "thetadatadx::client",
-                        reason = %reason,
-                        "thetadatadx-fpss-dispatcher panicked; session marked as failed",
-                    );
-                    *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) =
-                        DispatcherSession::Failed { reason };
-                }
-            }
-        }
+        // Single shared teardown: swap the slot to `Stopped`, retire the
+        // dispatcher session, record the drain flag. The pull reader's close
+        // drives the same [`StreamingState::quiesce`], so the callback and
+        // columnar paths leave the client identically truthful and reusable.
+        self.streaming.quiesce();
     }
 
     /// Reconnect the streaming connection, re-subscribing all previous subscriptions.
@@ -1203,7 +1302,7 @@ impl Client {
     {
         metrics::counter!("thetadatadx.fpss.reconnects").increment(1);
         // 1. Save active subscriptions before stopping
-        let saved_subs = match &**self.state.load() {
+        let saved_subs = match &**self.streaming.state.load() {
             StreamingSlot::Live { client } => (
                 client.active_subscriptions(),
                 client.active_full_subscriptions(),
@@ -1290,7 +1389,7 @@ impl Client {
 
     /// Get the current streaming connection status.
     pub(crate) fn connection_status(&self) -> ConnectionStatus {
-        match &**self.state.load() {
+        match &**self.streaming.state.load() {
             StreamingSlot::Idle => ConnectionStatus::NotStarted,
             StreamingSlot::Stopped => ConnectionStatus::Disconnected,
             StreamingSlot::Live { client } => {
@@ -1301,7 +1400,11 @@ impl Client {
                 // see a visible failed state instead of "Connected
                 // with no deliveries".
                 let failed_reason: Option<String> = {
-                    let session = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+                    let session = self
+                        .streaming
+                        .dispatcher
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
                     match &*session {
                         DispatcherSession::Failed { reason } => Some(reason.clone()),
                         _ => None,
@@ -2343,6 +2446,73 @@ mod tests {
         let prev = cell.swap(Arc::new(SlotMarker::Stopped));
         assert!(matches!(&*prev, SlotMarker::Live(2)));
         assert_eq!(variant(&cell.load()), "Stopped");
+    }
+
+    /// [`StreamingState::quiesce`] is the single teardown both delivery modes
+    /// share. From a never-started state it leaves the slot `Stopped`, the
+    /// dispatcher `Idle`, and bumps the stop generation (the resurrection
+    /// guard). This is the state the pull reader's close now lands the client
+    /// in — truthful and reusable — instead of leaving a stale `Live` slot and
+    /// a `Running` dispatcher with an exited thread. The `Live`-slot shutdown
+    /// branch shares its body with the callback path's `stop_streaming`, which
+    /// the FPSS integration tests exercise against a real connection.
+    #[test]
+    fn quiesce_from_idle_lands_stopped_and_idle() {
+        let state = StreamingState::new();
+        assert_eq!(state.slot_label(), "Idle");
+        assert!(state.dispatcher_is_idle());
+        let gen0 = state.stop_generation_value();
+
+        state.quiesce();
+
+        assert_eq!(
+            state.slot_label(),
+            "Stopped",
+            "quiesce must swap the slot to Stopped"
+        );
+        assert!(
+            state.dispatcher_is_idle(),
+            "quiesce must leave the dispatcher Idle"
+        );
+        assert!(
+            state.stop_generation_value() > gen0,
+            "quiesce must bump the stop generation (resurrection guard)"
+        );
+
+        // Idempotent: a second close (e.g. binding close() then the core Drop)
+        // is a harmless no-op beyond bumping the generation again.
+        let gen1 = state.stop_generation_value();
+        state.quiesce();
+        assert_eq!(state.slot_label(), "Stopped");
+        assert!(state.dispatcher_is_idle());
+        assert!(state.stop_generation_value() > gen1);
+    }
+
+    /// `quiesce` retires a `Running` dispatcher session — joining its thread
+    /// and resetting it to `Idle` — which is what makes the client reusable
+    /// after a pull reader closes: a later `start_streaming*` / `batches()`
+    /// installs a fresh dispatcher instead of finding a stale `Running` one
+    /// behind an exited thread. Driven with a real (immediately-exiting)
+    /// thread and the slot left out of `Live` so the join branch is what is
+    /// under test, deterministically and without a network.
+    #[test]
+    fn quiesce_retires_a_running_dispatcher() {
+        let state = StreamingState::new();
+        let handle = std::thread::spawn(|| { /* exits immediately */ });
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) =
+            DispatcherSession::Running { handle };
+        assert!(
+            !state.dispatcher_is_idle(),
+            "precondition: Running installed"
+        );
+
+        state.quiesce();
+
+        assert!(
+            state.dispatcher_is_idle(),
+            "quiesce must join the dispatcher thread and reset the session to \
+             Idle so the client is reusable"
+        );
     }
 
     /// Concurrent `start` race: only one caller observes the install,

--- a/crates/thetadatadx/src/client.rs
+++ b/crates/thetadatadx/src/client.rs
@@ -238,11 +238,48 @@ impl StreamingState {
     /// calling it on an already-`Stopped` state bumps the generation and
     /// no-ops the rest.
     pub(crate) fn quiesce(&self) {
+        // Direct teardown (stop_streaming / reconnect / Client drop): retire
+        // whatever session is currently live, unconditionally. The entire
+        // transition runs under the dispatcher lock; see `retire_locked`.
+        let mut guard = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        self.retire_locked(&mut guard);
+    }
+
+    /// Retire the live session ONLY if the live stop-generation still equals
+    /// `expected_gen`, atomically with the generation re-check.
+    ///
+    /// This is the columnar reader's close gate. The generation re-check, the
+    /// slot swap, and the dispatcher retire all happen under the one dispatcher
+    /// lock that also serialises `start_dispatcher`'s install and the bump in
+    /// `retire_locked`, so a racing `stop_streaming` + `start_streaming` either
+    /// fully precedes this locked section (the generation has advanced, so the
+    /// re-check fails and this is a no-op, leaving the newer session to its
+    /// owner) or fully follows it (this reader's session is already retired).
+    /// A bare compare on the generation atomic alone would not close the window
+    /// between the reader's earlier read and the teardown; guarding the check
+    /// and the teardown together does.
+    #[cfg(any(feature = "arrow", test))]
+    pub(crate) fn quiesce_if_owned(&self, expected_gen: u64) {
+        let mut guard = self.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+        if self.stop_generation.load(Ordering::Acquire) == expected_gen {
+            self.retire_locked(&mut guard);
+        }
+    }
+
+    /// The teardown itself, run while holding the dispatcher lock: bump the
+    /// generation, swap the slot to `Stopped`, shut the live client, and retire
+    /// the dispatcher session (waking a parked columnar dispatcher first, then
+    /// joining it). Holding the lock across the whole transition makes the
+    /// generation bump, the slot swap, and the dispatcher retire one atomic
+    /// step with respect to `start_dispatcher` and the reader-close gate.
+    fn retire_locked(&self, guard: &mut std::sync::MutexGuard<'_, DispatcherSession>) {
         // Bump the stop generation BEFORE the slot swap so any in-flight
         // `start_streaming*()` that snapshotted the previous value will fail
         // its install check and not resurrect the slot to `Live` after this
         // returns. AcqRel because the ordering relative to the `state.swap`
-        // below is what closes the resurrection race.
+        // below is what closes the resurrection race. The bump is under the
+        // dispatcher lock, so it is also mutually exclusive with
+        // `start_dispatcher`'s generation snapshot and the reader-close gate.
         self.stop_generation.fetch_add(1, Ordering::AcqRel);
         // Atomically swap to `Stopped`; whichever caller wins the swap owns the
         // previous `Arc<StreamingSlot>` and is the one that runs the shutdown
@@ -270,11 +307,13 @@ impl StreamingState {
             client.shutdown();
         }
 
-        // Join the dispatcher thread (if any) after the producer-drop signal
-        // has propagated through the ring shutdown to the poller, letting the
+        // Retire the dispatcher session through the held guard (no re-lock).
+        // Join the dispatcher thread after the producer-drop signal has
+        // propagated through the ring shutdown to the poller, letting the
         // iterator's `for ... in &client` loop see a clean `Ok(None)` and exit.
-        // Joining here closes the race where a callback could still fire after
-        // `is_streaming()` observed `false`.
+        // Joining closes the race where a callback could still fire after
+        // `is_streaming()` observed `false`. The dispatcher thread never takes
+        // this dispatcher lock, so joining while holding it cannot deadlock.
         //
         // Dispatcher panic state is derived from `JoinHandle::join()`:
         // `Err(_)` means the dispatcher thread panicked in the event-iteration
@@ -282,10 +321,7 @@ impl StreamingState {
         // `poll_batch`'s per-invocation `catch_unwind`). Record as
         // `DispatcherSession::Failed` so `is_streaming` / `connection_status`
         // see the failure even though the slot is now `Stopped`.
-        let prev_session = std::mem::replace(
-            &mut *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()),
-            DispatcherSession::Idle,
-        );
+        let prev_session = std::mem::replace(&mut **guard, DispatcherSession::Idle);
         if let DispatcherSession::Running {
             handle,
             on_teardown,
@@ -299,8 +335,9 @@ impl StreamingState {
             // touch; its hook stores `closed` (under the queue lock) and
             // notifies, so the parked flush returns and the join below completes
             // instead of hanging. The hook runs the SAME wakeup the reader's own
-            // close path runs, so every teardown route converges on it. No lock
-            // is held here, so the wake cannot invert against the dispatcher.
+            // close path runs, so every teardown route converges on it. The
+            // hook takes the queue lock, never this dispatcher lock, so it
+            // cannot invert against the held guard.
             if let Some(wake) = on_teardown {
                 wake();
             }
@@ -317,8 +354,7 @@ impl StreamingState {
                         reason = %reason,
                         "thetadatadx-fpss-dispatcher panicked; session marked as failed",
                     );
-                    *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) =
-                        DispatcherSession::Failed { reason };
+                    **guard = DispatcherSession::Failed { reason };
                 }
             }
         }
@@ -326,13 +362,13 @@ impl StreamingState {
 
     /// The current stop generation.
     ///
-    /// Bumped by every [`Self::quiesce`]. The columnar reader captures the
-    /// value its session was installed at and compares it here on close, so it
-    /// quiesces only while its own session is still the live one; once a
-    /// teardown (a stop / reconnect / another reader) has advanced the
-    /// generation, the reader's close no longer matches and leaves the current
-    /// session to its owner.
-    pub(crate) fn stop_generation(&self) -> u64 {
+    /// Bumped by every teardown. The columnar reader captures the value its
+    /// session was installed at (returned from the start path) and passes it
+    /// to [`Self::quiesce_if_owned`] on close, so it retires only its own
+    /// session. This read accessor exists for tests; the live close path
+    /// compares the generation internally inside `quiesce_if_owned`.
+    #[cfg(test)]
+    fn stop_generation(&self) -> u64 {
         self.stop_generation.load(Ordering::Acquire)
     }
 
@@ -2664,16 +2700,17 @@ mod tests {
     }
 
     /// A columnar reader's close must tear down ONLY the session it started.
-    /// `RecordBatchStream::close_shared` quiesces the owning state only when
-    /// `state.stop_generation() == self.owned_generation`; this exercises that
-    /// guard directly against the mixed-mode supersession sequence.
+    /// `RecordBatchStream::close_shared` calls
+    /// `state.quiesce_if_owned(self.owned_generation)`; this exercises that
+    /// method directly against the mixed-mode supersession sequence.
     ///
     /// Sequence modeled: reader R starts its session and stamps the generation
     /// it owns; R's session is then retired (a `stop_streaming`, which advances
     /// the generation); a NEW session is installed on the same state (the
     /// callback session a caller can legitimately start once the slot is no
     /// longer `Live`). When R is finally dropped, its stamp no longer matches
-    /// the live generation, so its close must NOT retire the newer session.
+    /// the live generation, so `quiesce_if_owned` must NOT retire the newer
+    /// session.
     #[test]
     fn stale_generation_reader_does_not_tear_down_a_newer_session() {
         let state = StreamingState::new();
@@ -2703,17 +2740,9 @@ mod tests {
             on_teardown: None,
         };
 
-        // R is dropped now. Its close guard: quiesce ONLY if the live
-        // generation still matches R's stamp. It does not, so R must leave the
-        // newer session alone.
-        let r_close_would_quiesce = state.stop_generation() == r_owned_generation;
-        assert!(
-            !r_close_would_quiesce,
-            "a stale-generation reader must not quiesce"
-        );
-        if r_close_would_quiesce {
-            state.quiesce();
-        }
+        // R's drop runs its close gate against its stale stamp: it must leave
+        // the newer session alone.
+        state.quiesce_if_owned(r_owned_generation);
         assert!(
             !state.dispatcher_is_idle(),
             "R's stale close must leave the newer session Running, not retire it"
@@ -2724,9 +2753,9 @@ mod tests {
     }
 
     /// The matching-generation reader (the normal single-reader close) DOES
-    /// quiesce: when no teardown has advanced the generation, the live session
-    /// is still the one this reader started, so its close retires it. Guards
-    /// against the stamp over-suppressing the common path.
+    /// retire: when no teardown has advanced the generation, the live session
+    /// is still the one this reader started, so `quiesce_if_owned` retires it.
+    /// Guards against the stamp over-suppressing the common path.
     #[test]
     fn matching_generation_reader_quiesces_its_own_session() {
         let state = StreamingState::new();
@@ -2737,18 +2766,103 @@ mod tests {
         };
         let owned_generation = state.stop_generation();
 
-        // Nothing advanced the generation, so the reader's close guard matches
-        // and quiesces its own session.
-        let close_would_quiesce = state.stop_generation() == owned_generation;
-        assert!(
-            close_would_quiesce,
-            "an un-superseded reader's stamp must still match the live generation"
-        );
-        state.quiesce();
+        // Nothing advanced the generation, so the reader's stamp still matches
+        // and its close retires its own session.
+        state.quiesce_if_owned(owned_generation);
         assert!(
             state.dispatcher_is_idle(),
             "the matching-generation close retires its own session"
         );
+    }
+
+    /// The reader-close gate does its generation re-check and its teardown
+    /// under the SAME dispatcher-lock acquisition, so they are atomic against a
+    /// racing stop + start. A non-atomic check-then-act (read the generation,
+    /// release, then separately retire) could read a still-matching generation,
+    /// have a `stop_streaming` + `start_streaming` install a newer session in
+    /// the gap, then retire that newer session it does not own.
+    ///
+    /// A cross-thread interleaving in that ~2-op gap is too narrow to hit
+    /// reliably, so this asserts the structural guarantee directly (the same
+    /// approach the lost-wakeup test uses): while the test holds the dispatcher
+    /// lock, a concurrent `quiesce_if_owned` cannot even reach its generation
+    /// check (it blocks on the lock); and when the test advances the generation
+    /// under that held lock and then releases, the gate observes the advanced
+    /// generation and no-ops. The re-check and the retire therefore cannot
+    /// straddle a teardown: any teardown is either fully before (gate sees the
+    /// new generation, no-op) or fully after (gate already ran) the gate's
+    /// single locked section.
+    #[test]
+    fn quiesce_if_owned_rechecks_generation_under_the_dispatcher_lock() {
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+
+        let state = Arc::new(StreamingState::new());
+
+        // R's session at generation G, stamped by R.
+        let r_handle = std::thread::spawn(|| {});
+        *state.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) = DispatcherSession::Running {
+            handle: r_handle,
+            on_teardown: None,
+        };
+        let r_owned_generation = state.stop_generation();
+
+        let gate_returned = Arc::new(AtomicBool::new(false));
+
+        // Hold the dispatcher lock for the whole observation window. A correct
+        // `quiesce_if_owned` cannot reach its generation check or its retire
+        // while this is held.
+        let mut guard = state.dispatcher.lock().unwrap_or_else(|e| e.into_inner());
+
+        let gate = {
+            let state = Arc::clone(&state);
+            let gate_returned = Arc::clone(&gate_returned);
+            std::thread::spawn(move || {
+                // Blocks on the dispatcher lock until the test releases it.
+                state.quiesce_if_owned(r_owned_generation);
+                gate_returned.store(true, O::Release);
+            })
+        };
+
+        // Give the gate thread time to park on the lock. With the check under
+        // the lock it cannot have returned.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            !gate_returned.load(O::Acquire),
+            "quiesce_if_owned must block on the dispatcher lock before its \
+             generation check; it cannot check-then-act outside the lock"
+        );
+
+        // Under the held lock, model a stop + start that advanced past R's
+        // stamp and installed a NEWER session. Advancing the generation here is
+        // exactly what a `stop_streaming` does; doing it under the lock the gate
+        // is waiting on is what makes the gate's later re-check see the new
+        // value atomically.
+        state
+            .stop_generation
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        let newer = std::thread::spawn(|| {});
+        *guard = DispatcherSession::Running {
+            handle: newer,
+            on_teardown: None,
+        };
+        assert_ne!(
+            state
+                .stop_generation
+                .load(std::sync::atomic::Ordering::Acquire),
+            r_owned_generation,
+            "the modeled stop advanced the generation past R's stamp"
+        );
+
+        // Release the lock: the gate now acquires it, re-checks the generation
+        // (advanced -> mismatch), and must NOT retire the newer session.
+        drop(guard);
+        gate.join().expect("gate thread");
+        assert!(
+            !state.dispatcher_is_idle(),
+            "after R's stale gate ran, the newer session must still be Running"
+        );
+
+        state.quiesce(); // tidy the surviving session's thread
     }
 
     /// Concurrent `start` race: only one caller observes the install,

--- a/crates/thetadatadx/src/fpss/batch_reader.rs
+++ b/crates/thetadatadx/src/fpss/batch_reader.rs
@@ -51,7 +51,7 @@
 
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, Once, Weak};
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
 
@@ -60,7 +60,7 @@ use arrow_schema::Schema;
 
 use super::batch_schema::{stream_batch_schema, StreamBatchBuilder};
 use super::{StreamEvent, StreamingClient};
-use crate::client::Client;
+use crate::client::{Client, StreamingState};
 use crate::streaming::StreamError;
 
 /// Default rows per batch when [`BatchReaderBuilder::batch_size`] is not set.
@@ -395,12 +395,27 @@ impl BatchSink {
 pub struct RecordBatchStream {
     shared: Arc<Shared>,
     /// The live streaming client backing this reader, shared with the
-    /// dispatcher thread. Closing the reader calls
-    /// [`StreamingClient::shutdown`] on it, which is the authoritative
-    /// teardown: it stops the I/O and ping threads, closes the socket, and
-    /// shuts the ring. The dispatcher then observes ring shutdown, flushes
-    /// the final batch, and exits.
+    /// dispatcher thread. Closing the reader quiesces the owning client (see
+    /// `owner`), which shuts this same underlying client: it stops the I/O and
+    /// ping threads, closes the socket, and shuts the ring. The dispatcher then
+    /// observes ring shutdown, flushes the final batch, and exits. This `Arc`
+    /// is also the shutdown fallback when the owning client is already gone.
     client: Arc<StreamingClient>,
+    /// Weak handle to the owning client's streaming lifecycle state. On close
+    /// the reader upgrades this and calls [`StreamingState::quiesce`] — the
+    /// same teardown the callback surface's `stop_streaming` runs — so after
+    /// the reader closes the client's `state` is `Stopped` and its
+    /// `dispatcher` is `Idle`: `is_streaming` / `connection_status` tell the
+    /// truth and a subsequent `start_streaming*` / `batches()` succeeds rather
+    /// than returning `already_streaming`. Weak so the reader never keeps the
+    /// client's state alive past the client; if the client is already gone the
+    /// upgrade fails and the reset is a no-op (the client's own `Drop` already
+    /// quiesced).
+    owner: Weak<StreamingState>,
+    /// Runs the owner-state reset exactly once, even though `close_shared` is
+    /// `&self` and a binding may call it from several paths (explicit close,
+    /// then free, then the core `Drop`) and from different threads.
+    quiesce_once: Once,
     closed: bool,
 }
 
@@ -441,10 +456,16 @@ impl RecordBatchStream {
             linger,
             backpressure,
         )?;
+        // Capture the owner-state handle only after a successful start, so a
+        // failed build leaves no reference behind. Weak, so the reader's later
+        // close never resurrects or outlives the client's state.
+        let owner = client.streaming_state_weak();
 
         Ok(Self {
             shared,
             client: live,
+            owner,
+            quiesce_once: Once::new(),
             closed: false,
         })
     }
@@ -489,12 +510,37 @@ impl RecordBatchStream {
         // queue BEFORE shutting the client, so a parked flush re-checks
         // `closed`, stops pushing, and lets the dispatcher reach the
         // ring-shutdown exit. Idempotent at the atomic + `shutdown` level.
-        self.shared.closed.store(true, Ordering::Release);
+        //
+        // The store MUST happen while holding `inner`. A Block-mode producer
+        // in `flush` and a blocked consumer in `next_blocking` each check
+        // `closed` under this lock and then park on `cv` (which atomically
+        // releases the lock as it parks). Storing `closed` under the same lock
+        // serialises the store with that check-then-park: the store either
+        // lands before the waiter's check (it observes `closed` and does not
+        // park) or after the waiter has parked (the `notify_all` below wakes
+        // it). Storing without the lock opens a lost-wakeup window — the store
+        // and notify can fall between a waiter's check and its park, leaving
+        // it parked forever.
+        {
+            let _guard = lock(&self.shared.inner);
+            self.shared.closed.store(true, Ordering::Release);
+        }
         self.shared.cv.notify_all();
-        // Authoritative teardown: stop the I/O + ping threads, close the
-        // socket, shut the ring. `StreamingClient::shutdown` is idempotent
-        // and detaches its own join, so it never blocks the caller.
-        self.client.shutdown();
+        // Authoritative teardown, run exactly once. Reset the owning client's
+        // streaming state through the SAME `StreamingState::quiesce` the
+        // callback surface's `stop_streaming` uses: swap the slot to `Stopped`,
+        // shut the live client (stop the I/O + ping threads, close the socket,
+        // shut the ring), and retire the dispatcher session. After this the
+        // client is truthful (`is_streaming` / `connection_status` report a
+        // stopped session) and reusable (a later `start_streaming*` /
+        // `batches()` no longer sees a stale `Live` slot). If the client has
+        // already been dropped the weak upgrade fails — its own `Drop` already
+        // quiesced — so fall back to shutting our own client `Arc` directly,
+        // which is all that remains to do.
+        self.quiesce_once.call_once(|| match self.owner.upgrade() {
+            Some(state) => state.quiesce(),
+            None => self.client.shutdown(),
+        });
     }
 
     /// Adapt this stream into a blocking [`Iterator`] of
@@ -812,15 +858,38 @@ pub(crate) mod test_harness {
 
         /// Signal close so a Block-mode producer parked on a full queue
         /// stops, mirroring [`RecordBatchStream::close`] minus the client
-        /// teardown (there is no live client in the harness).
+        /// teardown (there is no live client in the harness). Stores `closed`
+        /// under `inner` so it serialises with a waiter's under-lock
+        /// check-then-park, matching `RecordBatchStream::close_shared`.
         pub(crate) fn close(&self) {
-            self.shared.closed.store(true, Ordering::Release);
+            {
+                let _guard = super::lock(&self.shared.inner);
+                self.shared.closed.store(true, Ordering::Release);
+            }
             self.shared.cv.notify_all();
         }
 
         /// Reader-side queue depth, for asserting the bound holds.
         pub(crate) fn queued(&self) -> usize {
             super::lock(&self.shared.inner).batches.len()
+        }
+
+        /// Run `f` while holding the `inner` queue lock, for a test that needs
+        /// to prove the close path stores `closed` under this same lock. While
+        /// `f` runs, a concurrent [`Self::close`] must block on its own `inner`
+        /// acquisition before it can store `closed` — the structural guarantee
+        /// that closes the lost-wakeup window. Keeps the private `Queue` type
+        /// out of the helper's signature.
+        pub(crate) fn with_inner_held<R>(&self, f: impl FnOnce() -> R) -> R {
+            let _guard = super::lock(&self.shared.inner);
+            f()
+        }
+
+        /// Read the `closed` flag without taking `inner`, so a test holding the
+        /// `inner` guard can observe whether a concurrent `close` has managed
+        /// to store it yet.
+        pub(crate) fn is_closed(&self) -> bool {
+            self.shared.closed.load(Ordering::Acquire)
         }
     }
 
@@ -1090,6 +1159,72 @@ mod tests {
         assert!(
             out.expect("no error").is_none(),
             "a closed stream's parked pull must return end-of-stream"
+        );
+    }
+
+    /// (f) the close path stores `closed` while holding `inner`.
+    ///
+    /// This is the invariant that closes the lost-wakeup window. A Block-mode
+    /// producer in `flush` (and a blocked consumer in `next_blocking`) checks
+    /// `closed` under `inner` and then parks on `cv`, which atomically releases
+    /// `inner` as it parks — so the producer holds `inner` continuously from
+    /// its check through the park. If `close` stores `closed` WITHOUT `inner`,
+    /// the store + `notify_all` can land in the gap between the producer's
+    /// check and its park; the notify then wakes no one and the producer parks
+    /// forever. Storing `closed` under `inner` serialises the store with that
+    /// check-then-park: it cannot land in the gap, because the producer holds
+    /// the lock across the whole gap.
+    ///
+    /// A timing race here is vanishingly narrow (the kernel futex handoff
+    /// hides it on most runs), so rather than chase it probabilistically this
+    /// asserts the structural guarantee directly: while the test holds `inner`,
+    /// a concurrent `close` MUST NOT be able to store `closed` — it has to
+    /// block on its own `inner` acquisition first. With the pre-fix unlocked
+    /// store this assertion fails immediately and deterministically, because
+    /// the store does not wait for the lock.
+    #[test]
+    fn close_stores_closed_under_the_inner_lock() {
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+
+        let (_producer, reader_a) = harness(1_000, Duration::from_millis(50), Backpressure::Block);
+        let reader_b = super::test_harness::Reader::sharing(&reader_a);
+
+        let close_returned = Arc::new(AtomicBool::new(false));
+        let close_returned_t = Arc::clone(&close_returned);
+
+        // Hold `inner` across the whole observation window so a correct `close`
+        // cannot reach its store. `with_inner_held` keeps the lock for the
+        // duration of the closure.
+        let closer = reader_a.with_inner_held(|| {
+            let closer = thread::spawn(move || {
+                reader_b.close(); // blocks on `inner` until the test releases it
+                close_returned_t.store(true, O::Release);
+            });
+
+            // Give the closer ample time to run. With the store under `inner`
+            // it is parked on the lock the test holds, so `closed` must still
+            // be false and `close` must not have returned. Pre-fix (unlocked
+            // store) the closer stores `closed` immediately and this fails.
+            thread::sleep(Duration::from_millis(50));
+            assert!(
+                !reader_a.is_closed(),
+                "close must not store `closed` while another thread holds \
+                 `inner`; an unlocked store opens the lost-wakeup window this \
+                 guards"
+            );
+            assert!(
+                !close_returned.load(O::Acquire),
+                "close must still be blocked on `inner` while the test holds it"
+            );
+            closer
+        });
+
+        // `inner` released here; the closer now acquires it, stores `closed`,
+        // and returns.
+        closer.join().expect("closer thread");
+        assert!(
+            reader_a.is_closed(),
+            "after the lock is released, close stores `closed`"
         );
     }
 }

--- a/crates/thetadatadx/src/fpss/batch_reader.rs
+++ b/crates/thetadatadx/src/fpss/batch_reader.rs
@@ -502,6 +502,14 @@ pub struct RecordBatchStream {
     /// upgrade fails and the reset is a no-op (the client's own `Drop` already
     /// quiesced).
     owner: Weak<StreamingState>,
+    /// The owning client's stop-generation at the instant this reader's
+    /// session was installed. On close the reader quiesces only if the live
+    /// generation still matches: it identifies the session THIS reader
+    /// started, so a reader whose session was already superseded (by a
+    /// `stop_streaming` / `reconnect_streaming` / a later session on the same
+    /// client) leaves the current session to its owner rather than tearing
+    /// down one it does not own.
+    owned_generation: u64,
     /// Runs the owner-state reset exactly once, even though `close_shared` is
     /// `&self` and a binding may call it from several paths (explicit close,
     /// then free, then the core `Drop`) and from different threads.
@@ -541,7 +549,7 @@ impl RecordBatchStream {
         // is rolled back by the shared start path, so `shared` simply drops
         // here with no thread left behind. On success we hold the live
         // client `Arc` so close / drop can shut the session deterministically.
-        let live = client.start_streaming_batches(
+        let (live, owned_generation) = client.start_streaming_batches(
             Arc::clone(&shared),
             batch_size,
             linger,
@@ -549,13 +557,16 @@ impl RecordBatchStream {
         )?;
         // Capture the owner-state handle only after a successful start, so a
         // failed build leaves no reference behind. Weak, so the reader's later
-        // close never resurrects or outlives the client's state.
+        // close never resurrects or outlives the client's state. The
+        // `owned_generation` stamps the session this reader started so close
+        // only tears that session down, never a later one that replaced it.
         let owner = client.streaming_state_weak();
 
         Ok(Self {
             shared,
             client: live,
             owner,
+            owned_generation,
             quiesce_once: Once::new(),
             closed: false,
         })
@@ -596,29 +607,48 @@ impl RecordBatchStream {
     /// `close()` / context-manager exit, where the reader is shared and a
     /// pull may be blocked: it never needs exclusive ownership, so it cannot
     /// deadlock against the in-flight pull the way a `&mut` close would.
+    ///
+    /// Invariant: this tears down only the session this reader started. If the
+    /// owning client has since moved on to a different session (a
+    /// `stop_streaming` / `reconnect_streaming`, or a later session on the same
+    /// client), that session is left to its current owner.
     pub fn close_shared(&self) {
-        // Set `closed` and wake a Block-mode dispatcher parked on a full queue
-        // (and any parked consumer) BEFORE shutting the client, so a parked
-        // flush re-checks `closed`, stops pushing, and lets the dispatcher
-        // reach the ring-shutdown exit. `close_and_wake` stores `closed` under
-        // `inner` (the lost-wakeup discipline) and notifies. The very same call
-        // is the wake hook the columnar dispatcher installs, so the
-        // quiesce-direct teardown paths get the identical wakeup; see
-        // `Shared::close_and_wake`.
+        // Always signal THIS reader's own queue: set `closed` and wake a
+        // Block-mode dispatcher parked on a full queue (and any parked
+        // consumer), so a parked flush re-checks `closed`, stops pushing, and
+        // the dispatcher reaches the ring-shutdown exit. `close_and_wake`
+        // stores `closed` under `inner` (the lost-wakeup discipline) and
+        // notifies. This same call is the wake hook the columnar dispatcher
+        // installs, so the quiesce-direct teardown paths get the identical
+        // wakeup; see `Shared::close_and_wake`. It acts on this reader's own
+        // `Shared`, so it is correct regardless of which session is now live.
         self.shared.close_and_wake();
         // Authoritative teardown, run exactly once. Reset the owning client's
         // streaming state through the SAME `StreamingState::quiesce` the
         // callback surface's `stop_streaming` uses: swap the slot to `Stopped`,
         // shut the live client (stop the I/O + ping threads, close the socket,
-        // shut the ring), and retire the dispatcher session. After this the
-        // client is truthful (`is_streaming` / `connection_status` report a
-        // stopped session) and reusable (a later `start_streaming*` /
-        // `batches()` no longer sees a stale `Live` slot). If the client has
-        // already been dropped the weak upgrade fails — its own `Drop` already
-        // quiesced — so fall back to shutting our own client `Arc` directly,
-        // which is all that remains to do.
+        // shut the ring), and retire the dispatcher session, leaving the client
+        // truthful (`is_streaming` / `connection_status` report a stopped
+        // session) and reusable.
+        //
+        // But quiesce only when the live generation still matches the one this
+        // reader's session was installed at. Once a teardown has advanced the
+        // generation, the live session is no longer this reader's — quiescing
+        // it would tear down a session this reader does not own (e.g. a
+        // callback session started after this reader was stopped). In that case
+        // the predecessor teardown already retired this reader's session, so
+        // there is nothing left for this reader to do.
+        //
+        // If the client has already been dropped the weak upgrade fails (its
+        // own `Drop` already quiesced); fall back to shutting our own client
+        // `Arc` directly, which is all that remains and only touches this
+        // reader's session.
         self.quiesce_once.call_once(|| match self.owner.upgrade() {
-            Some(state) => state.quiesce(),
+            Some(state) => {
+                if state.stop_generation() == self.owned_generation {
+                    state.quiesce();
+                }
+            }
             None => self.client.shutdown(),
         });
     }

--- a/crates/thetadatadx/src/fpss/batch_reader.rs
+++ b/crates/thetadatadx/src/fpss/batch_reader.rs
@@ -78,6 +78,32 @@ pub const DEFAULT_LINGER: Duration = Duration::from_millis(50);
 /// stall the dispatcher.
 pub const DEFAULT_QUEUE_DEPTH: usize = 4;
 
+/// Upper bound on [`BatchReaderBuilder::batch_size`].
+///
+/// The batch builder preallocates every column of the fixed schema to the
+/// batch size up front, so the prealloc scales linearly with this value
+/// (roughly a few hundred bytes per row across the schema's columns). The
+/// bound caps a single batch's prealloc to a few hundred megabytes — recoverable
+/// rather than an out-of-memory abort — while sitting far above any realistic
+/// streaming batch (it is 16x the default and over a million rows). A larger
+/// request is clamped here rather than honored, which matters because a binding
+/// can hand the core a value an unsigned conversion has wrapped to near the
+/// integer maximum; without this clamp that wrap would drive a multi-hundred-
+/// gigabyte prealloc.
+pub const MAX_BATCH_SIZE: usize = 1_048_576;
+
+/// Upper bound on the bounded-queue depth (the `capacity` of
+/// [`Backpressure::DropOldest`], and the Block-mode queue depth).
+///
+/// The queue preallocates its backing to this many batch slots, and under
+/// `DropOldest` it can hold this many finished batches at once, so the buffered
+/// memory is `capacity * batch_size`. Capping the depth keeps that product
+/// bounded; the default is 4 and any realistic reader needs only a handful of
+/// slots of slack, so this bound is generous while still defending against a
+/// wrapped or fat-fingered value that would otherwise preallocate a deque of
+/// billions of slots.
+pub const MAX_QUEUE_DEPTH: usize = 4_096;
+
 /// What happens when the reader falls behind and the bounded batch queue
 /// fills.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -94,6 +120,30 @@ pub enum Backpressure {
         /// dropped. Must be at least 1; a `0` is treated as 1.
         capacity: usize,
     },
+}
+
+impl Backpressure {
+    /// The bounded-queue depth this policy resolves to, clamped to
+    /// `[1, MAX_QUEUE_DEPTH]`. `Block` uses [`DEFAULT_QUEUE_DEPTH`];
+    /// `DropOldest` uses its `capacity`. Clamping here is the single chokepoint
+    /// every caller (the live reader and the offline test harness) shares, so a
+    /// wrapped or oversized `capacity` from any binding cannot preallocate a
+    /// runaway deque.
+    fn resolved_capacity(self) -> usize {
+        let requested = match self {
+            Backpressure::Block => DEFAULT_QUEUE_DEPTH,
+            Backpressure::DropOldest { capacity } => capacity,
+        };
+        requested.clamp(1, MAX_QUEUE_DEPTH)
+    }
+}
+
+/// Clamp a requested rows-per-batch to `[1, MAX_BATCH_SIZE]`. The single
+/// chokepoint the builder setter and [`RecordBatchStream::start`] share, so a
+/// value any binding produced (including one an unsigned conversion wrapped to
+/// near the integer maximum) cannot drive a catastrophic per-column prealloc.
+fn clamp_batch_size(rows: usize) -> usize {
+    rows.clamp(1, MAX_BATCH_SIZE)
 }
 
 /// Builder for a [`RecordBatchStream`].
@@ -125,9 +175,12 @@ impl<'a> BatchReaderBuilder<'a> {
 
     /// Rows per batch. A batch flushes when it reaches this many rows or
     /// when [`Self::linger`] elapses, whichever comes first. Defaults to
-    /// [`DEFAULT_BATCH_SIZE`]. A `0` is clamped to `1`.
+    /// [`DEFAULT_BATCH_SIZE`]. A `0` is clamped to `1`; a value above
+    /// [`MAX_BATCH_SIZE`] is clamped down to it, so a binding that wrapped an
+    /// out-of-range request into a huge unsigned value cannot drive a
+    /// catastrophic column prealloc.
     pub fn batch_size(mut self, rows: usize) -> Self {
-        self.batch_size = rows.max(1);
+        self.batch_size = clamp_batch_size(rows);
         self
     }
 
@@ -179,6 +232,43 @@ pub(crate) struct Shared {
     /// The fixed schema every batch carries. Cloned to callers via
     /// [`RecordBatchStream::schema`] without locking.
     schema: Arc<Schema>,
+}
+
+impl Shared {
+    /// Signal teardown to the dispatcher and any parked waiter: set `closed`
+    /// (under `inner`, per the lost-wakeup discipline) and wake the queue
+    /// condvar plus any registered async waker.
+    ///
+    /// This is the one place the `closed` predicate is published, so every
+    /// teardown route shares the same wakeup guarantee:
+    ///
+    /// * the reader's own [`RecordBatchStream::close_shared`] calls it, and
+    /// * a teardown that bypasses the reader (a `Client` drop /
+    ///   `stop_streaming` / `reconnect_streaming`, which run
+    ///   `StreamingState::quiesce` directly) calls it through the wake hook the
+    ///   columnar dispatcher installs, BEFORE quiesce joins the dispatcher
+    ///   thread.
+    ///
+    /// Without this hook the latter routes would shut only the FPSS side and
+    /// never the batch queue, so a Block-mode dispatcher parked in `flush` on a
+    /// full queue would wait on `closed` forever and quiesce's join would hang.
+    ///
+    /// Idempotent: storing `closed` again and notifying an empty condvar are
+    /// both no-ops, so it is safe to call from several teardown paths.
+    pub(crate) fn close_and_wake(&self) {
+        // Store under `inner` so it serialises with a waiter's under-lock
+        // check-then-park in `flush` / `next_blocking` (see those sites). A
+        // store outside the lock opens a lost-wakeup window.
+        let waker = {
+            let mut guard = lock(&self.inner);
+            self.closed.store(true, Ordering::Release);
+            guard.waker.take()
+        };
+        self.cv.notify_all();
+        if let Some(w) = waker {
+            w.wake();
+        }
+    }
 }
 
 struct Queue {
@@ -426,10 +516,11 @@ impl RecordBatchStream {
         linger: Duration,
         backpressure: Backpressure,
     ) -> Result<Self, crate::error::Error> {
-        let capacity = match backpressure {
-            Backpressure::Block => DEFAULT_QUEUE_DEPTH.max(1),
-            Backpressure::DropOldest { capacity } => capacity.max(1),
-        };
+        // Clamp both memory-scaling knobs here as well as in the builder, so a
+        // caller that reaches `start` by any path (including a binding that
+        // constructed the values directly) cannot preallocate past the bounds.
+        let batch_size = clamp_batch_size(batch_size);
+        let capacity = backpressure.resolved_capacity();
         let shared = Arc::new(Shared {
             inner: Mutex::new(Queue {
                 batches: VecDeque::with_capacity(capacity),
@@ -506,26 +597,15 @@ impl RecordBatchStream {
     /// pull may be blocked: it never needs exclusive ownership, so it cannot
     /// deadlock against the in-flight pull the way a `&mut` close would.
     pub fn close_shared(&self) {
-        // Set `closed` and wake a Block-mode dispatcher parked on a full
-        // queue BEFORE shutting the client, so a parked flush re-checks
-        // `closed`, stops pushing, and lets the dispatcher reach the
-        // ring-shutdown exit. Idempotent at the atomic + `shutdown` level.
-        //
-        // The store MUST happen while holding `inner`. A Block-mode producer
-        // in `flush` and a blocked consumer in `next_blocking` each check
-        // `closed` under this lock and then park on `cv` (which atomically
-        // releases the lock as it parks). Storing `closed` under the same lock
-        // serialises the store with that check-then-park: the store either
-        // lands before the waiter's check (it observes `closed` and does not
-        // park) or after the waiter has parked (the `notify_all` below wakes
-        // it). Storing without the lock opens a lost-wakeup window — the store
-        // and notify can fall between a waiter's check and its park, leaving
-        // it parked forever.
-        {
-            let _guard = lock(&self.shared.inner);
-            self.shared.closed.store(true, Ordering::Release);
-        }
-        self.shared.cv.notify_all();
+        // Set `closed` and wake a Block-mode dispatcher parked on a full queue
+        // (and any parked consumer) BEFORE shutting the client, so a parked
+        // flush re-checks `closed`, stops pushing, and lets the dispatcher
+        // reach the ring-shutdown exit. `close_and_wake` stores `closed` under
+        // `inner` (the lost-wakeup discipline) and notifies. The very same call
+        // is the wake hook the columnar dispatcher installs, so the
+        // quiesce-direct teardown paths get the identical wakeup; see
+        // `Shared::close_and_wake`.
+        self.shared.close_and_wake();
         // Authoritative teardown, run exactly once. Reset the owning client's
         // streaming state through the SAME `StreamingState::quiesce` the
         // callback surface's `stop_streaming` uses: swap the slot to `Stopped`,
@@ -784,10 +864,7 @@ pub(crate) mod test_harness {
         linger: Duration,
         backpressure: Backpressure,
     ) -> (Producer, Reader) {
-        let capacity = match backpressure {
-            Backpressure::Block => super::DEFAULT_QUEUE_DEPTH.max(1),
-            Backpressure::DropOldest { capacity } => capacity.max(1),
-        };
+        let capacity = backpressure.resolved_capacity();
         let shared = Arc::new(Shared {
             inner: Mutex::new(Queue {
                 batches: VecDeque::with_capacity(capacity),
@@ -813,6 +890,13 @@ pub(crate) mod test_harness {
     }
 
     impl Reader {
+        /// The shared queue handle, so a test outside this module can build the
+        /// teardown wake hook (`shared.close_and_wake`) the columnar dispatcher
+        /// installs and assert quiesce drives it.
+        pub(crate) fn shared_handle(&self) -> Arc<Shared> {
+            Arc::clone(&self.shared)
+        }
+
         /// A second reader handle over the SAME shared queue, modelling two
         /// binding handles (`close()` and `next()`) racing on one core
         /// stream.
@@ -1225,6 +1309,74 @@ mod tests {
         assert!(
             reader_a.is_closed(),
             "after the lock is released, close stores `closed`"
+        );
+    }
+
+    /// (g) batch_size is clamped to `[1, MAX_BATCH_SIZE]`. The builder
+    /// preallocates every column to the batch size, so an unbounded value
+    /// (e.g. a binding wrapping a negative request to a near-maximum unsigned)
+    /// would otherwise drive a multi-hundred-gigabyte prealloc and abort. The
+    /// clamp is the single chokepoint both the builder setter and `start` use.
+    #[test]
+    fn batch_size_is_clamped_to_the_bound() {
+        use super::{clamp_batch_size, MAX_BATCH_SIZE};
+        assert_eq!(clamp_batch_size(0), 1, "zero clamps up to 1");
+        assert_eq!(clamp_batch_size(1), 1);
+        assert_eq!(clamp_batch_size(4_096), 4_096, "an in-range value is kept");
+        assert_eq!(
+            clamp_batch_size(MAX_BATCH_SIZE),
+            MAX_BATCH_SIZE,
+            "the bound itself is kept"
+        );
+        assert_eq!(
+            clamp_batch_size(MAX_BATCH_SIZE + 1),
+            MAX_BATCH_SIZE,
+            "just past the bound clamps down"
+        );
+        assert_eq!(
+            clamp_batch_size(usize::MAX),
+            MAX_BATCH_SIZE,
+            "a wrapped near-maximum value clamps to the bound, not a ruinous alloc"
+        );
+    }
+
+    /// (g) the bounded-queue depth is clamped to `[1, MAX_QUEUE_DEPTH]` for
+    /// both modes. `DropOldest` can hold `capacity` finished batches at once and
+    /// the deque preallocates that many slots, so an unbounded `capacity` would
+    /// preallocate a runaway deque; `Block` resolves to the default depth.
+    #[test]
+    fn capacity_is_clamped_to_the_bound() {
+        use super::{Backpressure, DEFAULT_QUEUE_DEPTH, MAX_QUEUE_DEPTH};
+        assert_eq!(
+            Backpressure::Block.resolved_capacity(),
+            DEFAULT_QUEUE_DEPTH,
+            "Block uses the default depth"
+        );
+        assert_eq!(
+            Backpressure::DropOldest { capacity: 0 }.resolved_capacity(),
+            1,
+            "zero capacity clamps up to 1"
+        );
+        assert_eq!(
+            Backpressure::DropOldest { capacity: 8 }.resolved_capacity(),
+            8,
+            "an in-range capacity is kept"
+        );
+        assert_eq!(
+            Backpressure::DropOldest {
+                capacity: MAX_QUEUE_DEPTH
+            }
+            .resolved_capacity(),
+            MAX_QUEUE_DEPTH,
+            "the bound itself is kept"
+        );
+        assert_eq!(
+            Backpressure::DropOldest {
+                capacity: usize::MAX
+            }
+            .resolved_capacity(),
+            MAX_QUEUE_DEPTH,
+            "a wrapped near-maximum capacity clamps to the bound"
         );
     }
 }

--- a/crates/thetadatadx/src/fpss/batch_reader.rs
+++ b/crates/thetadatadx/src/fpss/batch_reader.rs
@@ -1,0 +1,1095 @@
+//! Pull-based Arrow `RecordBatch` reader over the FPSS stream.
+//!
+//! [`RecordBatchStream`] is a sibling delivery mode to the per-event
+//! callback: instead of pushing one [`StreamEvent`] at a time into a user
+//! closure, it pulls the same market-data events out in columnar Arrow
+//! batches under the fixed [`super::batch_schema::stream_batch_schema`]. The
+//! callback path is unchanged; a caller chooses one or the other per
+//! subscription.
+//!
+//! # Pipeline
+//!
+//! The reader reuses the exact streaming machinery the callback path uses:
+//! `client.stream().batches(..).build()` starts FPSS through the same
+//! connect / install / dispatcher path as `start_streaming`, but the
+//! dispatcher's per-event handler appends each market-data event to a reused
+//! [`super::batch_schema::StreamBatchBuilder`] instead of calling user code.
+//! The dispatcher flushes a [`RecordBatch`] onto a bounded internal queue
+//! whenever the first of these fires:
+//!
+//! * the builder reaches `batch_size` rows,
+//! * `linger` elapses since the first row of the current batch (so a quiet
+//!   stream still delivers a partial batch rather than stalling), or
+//! * the stream shuts down (a final partial batch is flushed before the
+//!   terminal end-of-stream marker).
+//!
+//! The reader side ([`futures_core::Stream`], the [`RecordBatchStream::blocking`]
+//! iterator, or the FFI) pulls finished batches off that queue. The queue is
+//! always bounded; it never grows without limit.
+//!
+//! # Backpressure
+//!
+//! [`Backpressure`] selects what happens when the reader falls behind and
+//! the queue fills:
+//!
+//! * [`Backpressure::Block`] (the default, lossless): the dispatcher blocks
+//!   on a full queue. Because the dispatcher is the ring drainer, blocking
+//!   it stops draining the ring; a full ring then applies backpressure to
+//!   the wire. No event is dropped.
+//! * [`Backpressure::DropOldest`]: the queue is a bounded ring of at most
+//!   `capacity` batches; pushing onto a full queue drops the oldest batch
+//!   and increments the observable [`RecordBatchStream::dropped`] counter.
+//!   The dispatcher never blocks. Drops are counted, never silent.
+//!
+//! # Lifecycle
+//!
+//! Dropping the [`RecordBatchStream`] (or its blocking iterator, or calling
+//! [`RecordBatchStream::close`]) stops the FPSS session through the same
+//! `stop_streaming` path the callback surface uses, which tears the
+//! subscription down and ends the dispatcher. No thread, socket, or
+//! subscription leaks.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::task::{Context, Poll, Waker};
+use std::time::{Duration, Instant};
+
+use arrow_array::RecordBatch;
+use arrow_schema::Schema;
+
+use super::batch_schema::{stream_batch_schema, StreamBatchBuilder};
+use super::{StreamEvent, StreamingClient};
+use crate::client::Client;
+use crate::streaming::StreamError;
+
+/// Default rows per batch when [`BatchReaderBuilder::batch_size`] is not set.
+pub const DEFAULT_BATCH_SIZE: usize = 65_536;
+
+/// Default linger before a partial batch is flushed when
+/// [`BatchReaderBuilder::linger`] is not set.
+pub const DEFAULT_LINGER: Duration = Duration::from_millis(50);
+
+/// Default bounded-queue depth, in batches, for both backpressure modes.
+///
+/// The queue holds finished batches waiting for the reader. A small bound
+/// keeps memory flat (each slot is one full `batch_size` batch) while
+/// leaving enough slack that a reader briefly off-CPU does not immediately
+/// stall the dispatcher.
+pub const DEFAULT_QUEUE_DEPTH: usize = 4;
+
+/// What happens when the reader falls behind and the bounded batch queue
+/// fills.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Backpressure {
+    /// Lossless: block the dispatcher on a full queue, which stops the ring
+    /// drain and applies backpressure to the wire. The default.
+    #[default]
+    Block,
+    /// Bounded buffer: keep at most `capacity` finished batches; on overflow
+    /// drop the oldest and increment [`RecordBatchStream::dropped`]. Never
+    /// blocks the dispatcher.
+    DropOldest {
+        /// Maximum number of finished batches buffered before the oldest is
+        /// dropped. Must be at least 1; a `0` is treated as 1.
+        capacity: usize,
+    },
+}
+
+/// Builder for a [`RecordBatchStream`].
+///
+/// Returned by `client.stream().batches()`. Subscriptions are managed on the
+/// same streaming surface as the callback path (`client.stream().subscribe`),
+/// so a caller subscribes first and then opens the reader, exactly as they
+/// would register a callback.
+#[must_use = "call `.build()` to open the RecordBatch stream"]
+pub struct BatchReaderBuilder<'a> {
+    client: &'a Client,
+    batch_size: usize,
+    linger: Duration,
+    backpressure: Backpressure,
+}
+
+impl<'a> BatchReaderBuilder<'a> {
+    /// Construct a builder over a unified client. The public entry point is
+    /// `client.stream().batches()`; this is the crate-internal constructor
+    /// it calls.
+    pub(crate) fn new(client: &'a Client) -> Self {
+        Self {
+            client,
+            batch_size: DEFAULT_BATCH_SIZE,
+            linger: DEFAULT_LINGER,
+            backpressure: Backpressure::default(),
+        }
+    }
+
+    /// Rows per batch. A batch flushes when it reaches this many rows or
+    /// when [`Self::linger`] elapses, whichever comes first. Defaults to
+    /// [`DEFAULT_BATCH_SIZE`]. A `0` is clamped to `1`.
+    pub fn batch_size(mut self, rows: usize) -> Self {
+        self.batch_size = rows.max(1);
+        self
+    }
+
+    /// Maximum time a partial batch waits before being flushed, so a quiet
+    /// stream still delivers. Defaults to [`DEFAULT_LINGER`].
+    pub fn linger(mut self, linger: Duration) -> Self {
+        self.linger = linger;
+        self
+    }
+
+    /// Backpressure policy for a reader that falls behind. Defaults to
+    /// [`Backpressure::Block`] (lossless).
+    pub fn backpressure(mut self, backpressure: Backpressure) -> Self {
+        self.backpressure = backpressure;
+        self
+    }
+
+    /// Open the reader: start FPSS streaming with a batching dispatcher and
+    /// return the [`RecordBatchStream`] handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network, authentication, or parsing failure
+    /// while establishing the FPSS connection, or if a stream is already
+    /// active on this client.
+    pub fn build(self) -> Result<RecordBatchStream, crate::error::Error> {
+        RecordBatchStream::start(self.client, self.batch_size, self.linger, self.backpressure)
+    }
+}
+
+/// The bounded queue shared between the dispatcher (producer) and the reader
+/// (consumer).
+///
+/// A single mutex guards the deque plus the terminal flags; a `Condvar`
+/// wakes a blocked producer (Block mode) or a blocked blocking-iterator
+/// consumer. The async [`futures_core::Stream`] path additionally stores a
+/// [`Waker`] so the dispatcher can wake a parked async task when a batch
+/// lands or the stream finishes.
+pub(crate) struct Shared {
+    inner: Mutex<Queue>,
+    /// Notifies a consumer that a batch or terminal state is available, and
+    /// notifies a Block-mode producer that a slot freed up.
+    cv: Condvar,
+    /// Observable count of batches dropped under [`Backpressure::DropOldest`].
+    dropped: AtomicU64,
+    /// Set by [`RecordBatchStream::close`] / drop to tell the dispatcher to
+    /// stop draining and exit.
+    closed: AtomicBool,
+    /// The fixed schema every batch carries. Cloned to callers via
+    /// [`RecordBatchStream::schema`] without locking.
+    schema: Arc<Schema>,
+}
+
+struct Queue {
+    /// Finished batches awaiting the reader.
+    batches: VecDeque<RecordBatch>,
+    /// Bound on `batches`; the meaning differs per mode but the deque is
+    /// bounded in both.
+    capacity: usize,
+    /// `true` once the dispatcher has flushed its final batch and will
+    /// produce no more (clean shutdown or close).
+    finished: bool,
+    /// A terminal error from the dispatcher, surfaced once to the reader
+    /// after any already-queued batches are consumed.
+    error: Option<StreamError>,
+    /// Waker for a parked async [`futures_core::Stream`] consumer.
+    waker: Option<Waker>,
+}
+
+/// Mutable batching state, guarded so the dispatcher's two closures — the
+/// per-event handler and the batch scope — can each take a short, separate
+/// borrow without nesting one inside the other.
+struct BatchAccum {
+    builder: StreamBatchBuilder,
+    /// Wall-clock instant the current (non-empty) batch began; `None` while
+    /// the batch is empty. The linger deadline is measured from the first
+    /// row so a steady trickle still flushes on time.
+    batch_started: Option<Instant>,
+}
+
+/// State carried by the batching dispatcher handler + scope. Cloned (by
+/// `Arc`) into both closures; communicates with the reader only through
+/// `shared`.
+///
+/// The handler ([`Self::on_event`]) runs inside the ring drain, which the
+/// scope ([`Self::scope_drain`]) invokes. Both mutate the accumulator, so
+/// the accumulator sits behind its own `Mutex` and each method takes a
+/// short lock it releases before returning. Crucially, `scope_drain` never
+/// holds that lock across the `drain()` call, so the handler's lock and the
+/// scope's lock never overlap and the drain path is lock-free between
+/// events.
+#[derive(Clone)]
+pub(crate) struct BatchSink {
+    shared: Arc<Shared>,
+    accum: Arc<Mutex<BatchAccum>>,
+    batch_size: usize,
+    linger: Duration,
+    backpressure: Backpressure,
+}
+
+impl BatchSink {
+    pub(crate) fn new(
+        shared: Arc<Shared>,
+        batch_size: usize,
+        linger: Duration,
+        backpressure: Backpressure,
+    ) -> Self {
+        Self {
+            shared,
+            accum: Arc::new(Mutex::new(BatchAccum {
+                builder: StreamBatchBuilder::with_capacity(batch_size),
+                batch_started: None,
+            })),
+            batch_size,
+            linger,
+            backpressure,
+        }
+    }
+
+    /// Per-event handler driven by the dispatcher: append one market-data
+    /// row and flush a full batch. Holds the accumulator lock only for the
+    /// append; the flush takes the queue lock after the accumulator lock is
+    /// released.
+    pub(crate) fn on_event(&self, event: &StreamEvent) {
+        let full_batch = {
+            let mut accum = lock(&self.accum);
+            if accum.builder.is_empty() {
+                accum.batch_started = Some(Instant::now());
+            }
+            accum.builder.append(event) && accum.builder.len() >= self.batch_size
+        };
+        if full_batch {
+            self.flush();
+        }
+    }
+
+    /// Run by the dispatcher's batch scope once per drain attempt (including
+    /// empty drains before an idle wait). Enforces the linger flush on a
+    /// quiet stream and signals shutdown when the reader has closed. The
+    /// accumulator lock is taken only for the linger check, never across
+    /// `drain()`, so the handler invoked inside `drain()` never contends
+    /// with this method.
+    pub(crate) fn scope_drain(
+        &self,
+        drain: &mut dyn FnMut() -> crate::PollOutcome,
+    ) -> crate::PollOutcome {
+        if self.shared.closed.load(Ordering::Acquire) {
+            return crate::PollOutcome::Shutdown;
+        }
+        let outcome = drain();
+        let lingered = {
+            let accum = lock(&self.accum);
+            match accum.batch_started {
+                Some(started) => !accum.builder.is_empty() && started.elapsed() >= self.linger,
+                None => false,
+            }
+        };
+        if lingered {
+            self.flush();
+        }
+        if self.shared.closed.load(Ordering::Acquire) {
+            return crate::PollOutcome::Shutdown;
+        }
+        outcome
+    }
+
+    /// Finish the current batch and enqueue it under the backpressure
+    /// policy. A build error becomes the stream's terminal error; a no-row
+    /// builder is a no-op.
+    ///
+    /// Takes the accumulator lock to drain the builder, releases it, then
+    /// takes the queue lock to enqueue — the two locks are never held at
+    /// once, so a Block-mode wait on a full queue cannot stall the handler.
+    fn flush(&self) {
+        let batch = {
+            let mut accum = lock(&self.accum);
+            match accum.builder.finish() {
+                Ok(Some(batch)) => {
+                    accum.batch_started = None;
+                    batch
+                }
+                Ok(None) => return,
+                Err(arrow_err) => {
+                    drop(accum);
+                    // A column-length mismatch while assembling the batch.
+                    // The append discipline makes this unreachable in
+                    // practice; surface it as a protocol-class terminal
+                    // error rather than dropping rows silently.
+                    let err =
+                        StreamError::Protocol(format!("arrow batch assembly failed: {arrow_err}"));
+                    let mut guard = lock(&self.shared.inner);
+                    if guard.error.is_none() {
+                        guard.error = Some(err);
+                    }
+                    let waker = guard.waker.take();
+                    drop(guard);
+                    self.shared.cv.notify_all();
+                    if let Some(w) = waker {
+                        w.wake();
+                    }
+                    return;
+                }
+            }
+        };
+
+        let mut guard = lock(&self.shared.inner);
+        match self.backpressure {
+            Backpressure::Block => {
+                while guard.batches.len() >= guard.capacity {
+                    if self.shared.closed.load(Ordering::Acquire) {
+                        // Reader is gone; drop rather than block forever.
+                        // Teardown, not a DropOldest drop, so no counter bump.
+                        return;
+                    }
+                    guard = self
+                        .shared
+                        .cv
+                        .wait(guard)
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                }
+                guard.batches.push_back(batch);
+            }
+            Backpressure::DropOldest { .. } => {
+                if guard.batches.len() >= guard.capacity {
+                    let _ = guard.batches.pop_front();
+                    self.shared.dropped.fetch_add(1, Ordering::Relaxed);
+                }
+                guard.batches.push_back(batch);
+            }
+        }
+        let waker = guard.waker.take();
+        drop(guard);
+        self.shared.cv.notify_all();
+        if let Some(w) = waker {
+            w.wake();
+        }
+    }
+
+    /// Final flush + terminal marker, run once when the dispatcher's drain
+    /// loop returns (clean shutdown or close).
+    pub(crate) fn finish(&self) {
+        let has_rows = {
+            let accum = lock(&self.accum);
+            !accum.builder.is_empty()
+        };
+        if has_rows {
+            self.flush();
+        }
+        let mut guard = lock(&self.shared.inner);
+        guard.finished = true;
+        let waker = guard.waker.take();
+        drop(guard);
+        self.shared.cv.notify_all();
+        if let Some(w) = waker {
+            w.wake();
+        }
+    }
+}
+
+/// A pull reader of Arrow [`RecordBatch`] values off the FPSS stream.
+///
+/// Implements [`futures_core::Stream`] for async consumption and exposes
+/// [`Self::blocking`] for a synchronous [`Iterator`]. See the module docs
+/// for the pipeline, backpressure, and lifecycle contract.
+pub struct RecordBatchStream {
+    shared: Arc<Shared>,
+    /// The live streaming client backing this reader, shared with the
+    /// dispatcher thread. Closing the reader calls
+    /// [`StreamingClient::shutdown`] on it, which is the authoritative
+    /// teardown: it stops the I/O and ping threads, closes the socket, and
+    /// shuts the ring. The dispatcher then observes ring shutdown, flushes
+    /// the final batch, and exits.
+    client: Arc<StreamingClient>,
+    closed: bool,
+}
+
+impl RecordBatchStream {
+    fn start(
+        client: &Client,
+        batch_size: usize,
+        linger: Duration,
+        backpressure: Backpressure,
+    ) -> Result<Self, crate::error::Error> {
+        let capacity = match backpressure {
+            Backpressure::Block => DEFAULT_QUEUE_DEPTH.max(1),
+            Backpressure::DropOldest { capacity } => capacity.max(1),
+        };
+        let shared = Arc::new(Shared {
+            inner: Mutex::new(Queue {
+                batches: VecDeque::with_capacity(capacity),
+                capacity,
+                finished: false,
+                error: None,
+                waker: None,
+            }),
+            cv: Condvar::new(),
+            dropped: AtomicU64::new(0),
+            closed: AtomicBool::new(false),
+            schema: stream_batch_schema(),
+        });
+
+        // Start FPSS through the same connect / install / dispatcher path
+        // the callback surface uses; the dispatcher runs our batching sink
+        // instead of user code. On a connect / install failure the session
+        // is rolled back by the shared start path, so `shared` simply drops
+        // here with no thread left behind. On success we hold the live
+        // client `Arc` so close / drop can shut the session deterministically.
+        let live = client.start_streaming_batches(
+            Arc::clone(&shared),
+            batch_size,
+            linger,
+            backpressure,
+        )?;
+
+        Ok(Self {
+            shared,
+            client: live,
+            closed: false,
+        })
+    }
+
+    /// The fixed schema every batch this stream yields will carry. Stable
+    /// for the stream's lifetime and identical across all batches, so a
+    /// downstream consumer can concatenate batches without reconciling
+    /// schemas.
+    #[must_use]
+    pub fn schema(&self) -> Arc<Schema> {
+        Arc::clone(&self.shared.schema)
+    }
+
+    /// Number of batches dropped so far under [`Backpressure::DropOldest`].
+    /// Always `0` under [`Backpressure::Block`] (which never drops).
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.shared.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Stop the reader: tear down the FPSS session and let the dispatcher
+    /// exit. Idempotent; [`Drop`] calls it.
+    pub fn close(&mut self) {
+        self.shutdown();
+    }
+
+    /// Signal close through a shared reference, for a caller that holds the
+    /// reader behind an `Arc` and may have a blocking [`Self::next_blocking`]
+    /// in flight on another thread.
+    ///
+    /// Sets the close flag, tears the FPSS session down, and wakes any
+    /// parked producer / consumer — all through `&self`, so it can run
+    /// concurrently with a blocking pull. The pull then unblocks (the
+    /// dispatcher publishes `finished` once the ring shuts down) and returns
+    /// `Ok(None)`. Idempotent; safe to call from any thread, any number of
+    /// times. This is the teardown the language bindings call on their
+    /// `close()` / context-manager exit, where the reader is shared and a
+    /// pull may be blocked: it never needs exclusive ownership, so it cannot
+    /// deadlock against the in-flight pull the way a `&mut` close would.
+    pub fn close_shared(&self) {
+        // Set `closed` and wake a Block-mode dispatcher parked on a full
+        // queue BEFORE shutting the client, so a parked flush re-checks
+        // `closed`, stops pushing, and lets the dispatcher reach the
+        // ring-shutdown exit. Idempotent at the atomic + `shutdown` level.
+        self.shared.closed.store(true, Ordering::Release);
+        self.shared.cv.notify_all();
+        // Authoritative teardown: stop the I/O + ping threads, close the
+        // socket, shut the ring. `StreamingClient::shutdown` is idempotent
+        // and detaches its own join, so it never blocks the caller.
+        self.client.shutdown();
+    }
+
+    /// Adapt this stream into a blocking [`Iterator`] of
+    /// `Result<RecordBatch, StreamError>`.
+    ///
+    /// Each [`Iterator::next`] blocks the calling thread until a batch is
+    /// available, the stream finishes (`None`), or an error surfaces
+    /// (`Some(Err(_))`). This is the synchronous counterpart to the
+    /// [`futures_core::Stream`] impl; use it from a non-async context.
+    #[must_use]
+    pub fn blocking(self) -> BlockingRecordBatchIter {
+        BlockingRecordBatchIter { stream: self }
+    }
+
+    /// Blocking pull of the next batch. Shared by the blocking iterator and
+    /// the FFI. Returns `Ok(None)` at clean end of stream.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces a terminal [`StreamError`] from the dispatcher once all
+    /// queued batches have been drained.
+    pub fn next_blocking(&self) -> Result<Option<RecordBatch>, StreamError> {
+        let mut guard = lock(&self.shared.inner);
+        loop {
+            if let Some(batch) = guard.batches.pop_front() {
+                self.shared.cv.notify_all();
+                return Ok(Some(batch));
+            }
+            if let Some(err) = guard.error.take() {
+                return Err(err);
+            }
+            if guard.finished {
+                return Ok(None);
+            }
+            // A close signalled from another thread ends the pull as soon as
+            // the queue is drained, without waiting for the dispatcher's
+            // terminal `finished` to land — `close_shared` wakes this cv, and
+            // checking `closed` here lets a blocked pull return `None`
+            // promptly so close never appears to hang on a quiet stream.
+            // Any already-queued batches above are still delivered first.
+            if self.shared.closed.load(Ordering::Acquire) {
+                return Ok(None);
+            }
+            guard = self
+                .shared
+                .cv
+                .wait(guard)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    /// Non-blocking poll of the next batch for the async [`futures_core::Stream`]
+    /// impl. Registers `waker` when the queue is momentarily empty.
+    fn poll_next_inner(&self, cx: &Context<'_>) -> Poll<Option<Result<RecordBatch, StreamError>>> {
+        let mut guard = lock(&self.shared.inner);
+        if let Some(batch) = guard.batches.pop_front() {
+            self.shared.cv.notify_all();
+            return Poll::Ready(Some(Ok(batch)));
+        }
+        if let Some(err) = guard.error.take() {
+            return Poll::Ready(Some(Err(err)));
+        }
+        if guard.finished {
+            return Poll::Ready(None);
+        }
+        // Close from another task ends the stream once the queue is drained,
+        // without waiting for the dispatcher's terminal `finished` (see
+        // `next_blocking`).
+        if self.shared.closed.load(Ordering::Acquire) {
+            return Poll::Ready(None);
+        }
+        guard.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+
+    /// Signal close, tear the session down, and wake any parked producer /
+    /// consumer. Safe to call more than once. Delegates to
+    /// [`Self::close_shared`]; the `closed` field is the owner-side
+    /// idempotency guard so a `Drop` after an explicit `close()` is a no-op.
+    fn shutdown(&mut self) {
+        if self.closed {
+            return;
+        }
+        self.closed = true;
+        self.close_shared();
+    }
+}
+
+impl Drop for RecordBatchStream {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+impl futures_core::Stream for RecordBatchStream {
+    type Item = Result<RecordBatch, StreamError>;
+
+    fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // `RecordBatchStream` holds no self-referential state; polling
+        // through a shared reference is sound.
+        self.get_mut().poll_next_inner(cx)
+    }
+}
+
+/// Blocking [`Iterator`] adapter over a [`RecordBatchStream`], returned by
+/// [`RecordBatchStream::blocking`].
+pub struct BlockingRecordBatchIter {
+    stream: RecordBatchStream,
+}
+
+impl BlockingRecordBatchIter {
+    /// The fixed schema every yielded batch carries.
+    #[must_use]
+    pub fn schema(&self) -> Arc<Schema> {
+        self.stream.schema()
+    }
+
+    /// Batches dropped so far under [`Backpressure::DropOldest`].
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.stream.dropped()
+    }
+}
+
+impl Iterator for BlockingRecordBatchIter {
+    type Item = Result<RecordBatch, StreamError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stream.next_blocking() {
+            Ok(Some(batch)) => Some(Ok(batch)),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        }
+    }
+}
+
+/// Blocking [`arrow_array::RecordBatchReader`] view over a
+/// [`RecordBatchStream`].
+///
+/// This is the Arrow-native adapter the FFI and any Rust caller wanting an
+/// `arrow` reader use: it satisfies [`arrow_array::RecordBatchReader`]
+/// (`Iterator<Item = Result<RecordBatch, ArrowError>>` plus `schema()`), so
+/// it plugs straight into `arrow::ffi_stream::FFI_ArrowArrayStream::new`
+/// (the Arrow C Stream Interface) and into `arrow_ipc` writers. A terminal
+/// [`StreamError`] is mapped to [`arrow_schema::ArrowError::ExternalError`]
+/// so it surfaces through the Arrow reader contract.
+pub struct ArrowRecordBatchReader {
+    stream: RecordBatchStream,
+}
+
+impl ArrowRecordBatchReader {
+    /// Wrap a [`RecordBatchStream`] as an Arrow-native blocking reader.
+    #[must_use]
+    pub fn new(stream: RecordBatchStream) -> Self {
+        Self { stream }
+    }
+
+    /// Batches dropped so far under [`Backpressure::DropOldest`].
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.stream.dropped()
+    }
+}
+
+impl Iterator for ArrowRecordBatchReader {
+    type Item = Result<RecordBatch, arrow_schema::ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stream.next_blocking() {
+            Ok(Some(batch)) => Some(Ok(batch)),
+            Ok(None) => None,
+            Err(err) => Some(Err(arrow_schema::ArrowError::ExternalError(Box::new(err)))),
+        }
+    }
+}
+
+impl arrow_array::RecordBatchReader for ArrowRecordBatchReader {
+    fn schema(&self) -> Arc<Schema> {
+        self.stream.schema()
+    }
+}
+
+/// Lock a mutex, recovering the guard on poison. The streaming pipeline
+/// never leaves the protected state inconsistent across a panic boundary, so
+/// a poisoned lock is recovered rather than propagated.
+fn lock<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Offline test harness for the batch pipeline.
+///
+/// The live [`RecordBatchStream`] is fed by the FPSS dispatcher thread,
+/// which needs a real connection. To exercise the batching / linger /
+/// backpressure / reader machinery without a network, this harness wires the
+/// exact same [`Shared`] queue, [`BatchSink`], and reader-side drain logic to
+/// a synthetic producer that the test drives directly — mirroring how the
+/// streaming benches drive the ring offline.
+#[cfg(test)]
+pub(crate) mod test_harness {
+    use super::stream_batch_schema;
+    use super::{Backpressure, BatchSink, Queue, Shared};
+    use crate::fpss::protocol::Contract;
+    use crate::fpss::{StreamData, StreamEvent};
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::{Arc, Condvar, Mutex};
+    use std::time::Duration;
+
+    /// A producer half driving a [`BatchSink`] exactly as the dispatcher
+    /// would: `feed` runs the per-event handler, `tick` runs the batch
+    /// scope's linger pass, and `finish` flushes + marks terminal.
+    pub(crate) struct Producer {
+        sink: BatchSink,
+    }
+
+    impl Producer {
+        /// Append one event through the sink's per-event handler.
+        pub(crate) fn feed(&self, event: &StreamEvent) {
+            self.sink.on_event(event);
+        }
+
+        /// Drive the linger pass once (the scope hook on an idle drain).
+        pub(crate) fn tick(&self) {
+            // An idle drain returns `Drained(0)`; the scope's linger check
+            // runs against it.
+            let mut drain = || crate::PollOutcome::Drained(0);
+            let _ = self.sink.scope_drain(&mut drain);
+        }
+
+        /// Flush the final partial batch and publish the terminal marker.
+        pub(crate) fn finish(self) {
+            self.sink.finish();
+        }
+    }
+
+    /// Build a connected `(producer, reader)` pair sharing one queue, with no
+    /// FPSS connection. The reader is a real [`RecordBatchStream`] whose
+    /// `client` field is left unset by using the blocking reader directly.
+    pub(crate) fn harness(
+        batch_size: usize,
+        linger: Duration,
+        backpressure: Backpressure,
+    ) -> (Producer, Reader) {
+        let capacity = match backpressure {
+            Backpressure::Block => super::DEFAULT_QUEUE_DEPTH.max(1),
+            Backpressure::DropOldest { capacity } => capacity.max(1),
+        };
+        let shared = Arc::new(Shared {
+            inner: Mutex::new(Queue {
+                batches: VecDeque::with_capacity(capacity),
+                capacity,
+                finished: false,
+                error: None,
+                waker: None,
+            }),
+            cv: Condvar::new(),
+            dropped: AtomicU64::new(0),
+            closed: AtomicBool::new(false),
+            schema: stream_batch_schema(),
+        });
+        let sink = BatchSink::new(Arc::clone(&shared), batch_size, linger, backpressure);
+        (Producer { sink }, Reader { shared })
+    }
+
+    /// Reader half over the shared queue, exposing the same blocking pull and
+    /// observability the live [`RecordBatchStream`] / [`BlockingRecordBatchIter`]
+    /// expose, without owning a live client.
+    pub(crate) struct Reader {
+        shared: Arc<Shared>,
+    }
+
+    impl Reader {
+        /// A second reader handle over the SAME shared queue, modelling two
+        /// binding handles (`close()` and `next()`) racing on one core
+        /// stream.
+        pub(crate) fn sharing(other: &Reader) -> Reader {
+            Reader {
+                shared: Arc::clone(&other.shared),
+            }
+        }
+
+        /// Blocking pull of the next batch; `Ok(None)` at clean end.
+        pub(crate) fn next(
+            &self,
+        ) -> Result<Option<arrow_array::RecordBatch>, crate::streaming::StreamError> {
+            let mut guard = super::lock(&self.shared.inner);
+            loop {
+                if let Some(batch) = guard.batches.pop_front() {
+                    self.shared.cv.notify_all();
+                    return Ok(Some(batch));
+                }
+                if let Some(err) = guard.error.take() {
+                    return Err(err);
+                }
+                if guard.finished {
+                    return Ok(None);
+                }
+                // Mirror `RecordBatchStream::next_blocking`: a close ends the
+                // pull once the queue is drained.
+                if self.shared.closed.load(Ordering::Acquire) {
+                    return Ok(None);
+                }
+                guard = self
+                    .shared
+                    .cv
+                    .wait(guard)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            }
+        }
+
+        /// Batches dropped so far under `DropOldest`.
+        pub(crate) fn dropped(&self) -> u64 {
+            self.shared.dropped.load(Ordering::Relaxed)
+        }
+
+        /// Signal close so a Block-mode producer parked on a full queue
+        /// stops, mirroring [`RecordBatchStream::close`] minus the client
+        /// teardown (there is no live client in the harness).
+        pub(crate) fn close(&self) {
+            self.shared.closed.store(true, Ordering::Release);
+            self.shared.cv.notify_all();
+        }
+
+        /// Reader-side queue depth, for asserting the bound holds.
+        pub(crate) fn queued(&self) -> usize {
+            super::lock(&self.shared.inner).batches.len()
+        }
+    }
+
+    /// Synthetic stock trade event carrying a shared contract.
+    pub(crate) fn trade(contract: &Arc<Contract>, idx: u64) -> StreamEvent {
+        StreamEvent::Data(StreamData::Trade {
+            contract: Arc::clone(contract),
+            ms_of_day: (idx % 86_400_000) as i32,
+            sequence: idx as i32,
+            ext_condition1: 0,
+            ext_condition2: 0,
+            ext_condition3: 0,
+            ext_condition4: 0,
+            condition: 0,
+            size: 100,
+            exchange: 0,
+            price: 150.25,
+            condition_flags: 0,
+            price_flags: 0,
+            volume_type: 0,
+            records_back: 0,
+            date: 20240315,
+            received_at_ns: idx,
+        })
+    }
+
+    /// Synthetic stock quote event carrying a shared contract.
+    pub(crate) fn quote(contract: &Arc<Contract>, idx: u64) -> StreamEvent {
+        StreamEvent::Data(StreamData::Quote {
+            contract: Arc::clone(contract),
+            ms_of_day: (idx % 86_400_000) as i32,
+            bid_size: 10,
+            bid_exchange: 1,
+            bid: 150.00,
+            bid_condition: 0,
+            ask_size: 12,
+            ask_exchange: 2,
+            ask: 150.50,
+            ask_condition: 0,
+            date: 20240315,
+            received_at_ns: idx,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_harness::{harness, quote, trade};
+    use super::Backpressure;
+    use crate::fpss::batch_schema::stream_batch_schema;
+    use crate::fpss::protocol::Contract;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    /// (a) zero-drop under Block: every fed row is delivered, summed across
+    /// batches, with no drops.
+    #[test]
+    fn block_mode_delivers_every_row() {
+        let batch_size = 1_000;
+        let total: u64 = 25_000;
+        let (producer, reader) =
+            harness(batch_size, Duration::from_millis(50), Backpressure::Block);
+        let contract = Arc::new(Contract::stock("SPY"));
+
+        // Producer on its own thread so a full queue actually blocks it,
+        // exercising the Block backpressure path against a paced reader.
+        let feeder = thread::spawn(move || {
+            for i in 0..total {
+                producer.feed(&trade(&contract, i));
+            }
+            producer.finish();
+        });
+
+        let mut delivered: u64 = 0;
+        while let Some(batch) = reader.next().expect("no error in block mode") {
+            delivered += batch.num_rows() as u64;
+        }
+        feeder.join().unwrap();
+
+        assert_eq!(delivered, total, "Block mode must deliver every row");
+        assert_eq!(reader.dropped(), 0, "Block mode must never drop");
+    }
+
+    /// (b) DropOldest increments `dropped()` and never blocks the producer
+    /// unboundedly: a producer that floods far past the queue bound while no
+    /// reader pulls still completes, the queue stays bounded, and the drop
+    /// counter is non-zero.
+    #[test]
+    fn drop_oldest_counts_drops_and_never_blocks() {
+        let batch_size = 100;
+        let capacity = 2;
+        let total: u64 = 50_000;
+        let (producer, reader) = harness(
+            batch_size,
+            Duration::from_millis(1),
+            Backpressure::DropOldest { capacity },
+        );
+        let contract = Arc::new(Contract::stock("SPY"));
+
+        // No reader pulls during the flood. If DropOldest ever blocked, this
+        // join would hang; the test's own completion is the "never blocks"
+        // assertion.
+        let feeder = thread::spawn(move || {
+            for i in 0..total {
+                producer.feed(&trade(&contract, i));
+            }
+            producer.finish();
+        });
+        feeder.join().unwrap();
+
+        assert!(
+            reader.queued() <= capacity,
+            "queue must stay within the DropOldest bound (was {})",
+            reader.queued()
+        );
+        assert!(
+            reader.dropped() > 0,
+            "DropOldest must count drops when the reader never pulls"
+        );
+
+        // The freshest batches remain readable after the flood.
+        let mut seen = 0u64;
+        while let Some(batch) = reader.next().expect("no error in drop mode") {
+            seen += batch.num_rows() as u64;
+        }
+        assert!(seen > 0, "the newest buffered batches must remain readable");
+    }
+
+    /// (c) linger flushes a partial batch on a quiet stream: a single row,
+    /// far below `batch_size`, is delivered after the linger elapses without
+    /// any further events.
+    #[test]
+    fn linger_flushes_partial_batch_on_quiet_stream() {
+        let batch_size = 10_000;
+        let linger = Duration::from_millis(20);
+        let (producer, reader) = harness(batch_size, linger, Backpressure::Block);
+        let contract = Arc::new(Contract::stock("SPY"));
+
+        // One row, then quiet. Drive linger ticks as the dispatcher would on
+        // an idle ring until the partial batch flushes.
+        producer.feed(&trade(&contract, 0));
+        let reader_handle = thread::spawn(move || reader.next().expect("no error"));
+
+        // Simulate the idle-drain scope hook firing past the linger window.
+        thread::sleep(linger * 2);
+        producer.tick();
+
+        let batch = reader_handle.join().unwrap().expect("a partial batch");
+        assert_eq!(
+            batch.num_rows(),
+            1,
+            "linger must flush the single buffered row"
+        );
+        producer.finish();
+    }
+
+    /// (d) schema stability across batches: every emitted batch carries the
+    /// exact fixed schema, regardless of which event variants it holds, so
+    /// the output is concat-safe.
+    #[test]
+    fn schema_is_stable_across_batches() {
+        let expected = stream_batch_schema();
+        let batch_size = 4;
+        let (producer, reader) =
+            harness(batch_size, Duration::from_millis(50), Backpressure::Block);
+        let contract = Arc::new(Contract::stock("SPY"));
+
+        let feeder = thread::spawn(move || {
+            // Interleave trade and quote variants across several full
+            // batches so a per-variant schema would diverge if one existed.
+            for i in 0..16 {
+                if i % 2 == 0 {
+                    producer.feed(&trade(&contract, i));
+                } else {
+                    producer.feed(&quote(&contract, i));
+                }
+            }
+            producer.finish();
+        });
+
+        let mut batches = 0;
+        while let Some(batch) = reader.next().expect("no error") {
+            assert_eq!(
+                batch.schema(),
+                expected,
+                "every batch must carry the identical fixed schema"
+            );
+            batches += 1;
+        }
+        feeder.join().unwrap();
+        assert!(batches >= 4, "expected several full batches, got {batches}");
+    }
+
+    /// (e) lifecycle: closing the reader unblocks a producer parked on a full
+    /// Block-mode queue rather than leaking it. Without the close signal the
+    /// producer thread would block forever on the full queue; the join
+    /// returning is the no-leak assertion.
+    #[test]
+    fn close_unblocks_a_parked_block_producer() {
+        let batch_size = 1;
+        let (producer, reader) =
+            harness(batch_size, Duration::from_millis(50), Backpressure::Block);
+        let contract = Arc::new(Contract::stock("SPY"));
+
+        // Flood with no reader: fills the bounded queue, then the producer
+        // parks inside `flush` waiting for a free slot.
+        let feeder = thread::spawn(move || {
+            for i in 0..1_000 {
+                producer.feed(&trade(&contract, i));
+            }
+        });
+
+        // Give the producer time to fill the queue and park.
+        thread::sleep(Duration::from_millis(50));
+        // Close: the parked flush re-checks `closed` and returns.
+        reader.close();
+        feeder
+            .join()
+            .expect("closing the reader must release the parked producer");
+    }
+
+    /// The empty case is valid: a stream that ends before any event yields a
+    /// clean end-of-stream with no batch and no error.
+    #[test]
+    fn empty_stream_ends_clean() {
+        let (producer, reader) = harness(1_000, Duration::from_millis(50), Backpressure::Block);
+        producer.finish();
+        assert!(reader.next().expect("no error").is_none());
+    }
+
+    /// (e, consumer side) close unblocks a reader parked on a blocking pull.
+    /// One handle blocks on a pull of a quiet stream; a second handle sharing
+    /// the same queue signals close (the binding `close()` path racing a
+    /// `next()`), and the blocked pull returns end-of-stream rather than
+    /// hanging. Without the `closed` check in the pull loop the reader would
+    /// wait forever for a `finished` only the dispatcher sets — the deadlock
+    /// this guards against.
+    #[test]
+    fn close_from_another_handle_unblocks_a_parked_pull() {
+        use super::test_harness::Reader;
+        use std::sync::atomic::{AtomicBool, Ordering as O};
+
+        let (producer, reader_a) = harness(1_000, Duration::from_millis(50), Backpressure::Block);
+        let reader_b = Reader::sharing(&reader_a);
+        // Idle producer: never feeds, never finishes, so the only way the
+        // pull returns is the close signal.
+        let _producer = producer;
+
+        let done = Arc::new(AtomicBool::new(false));
+        let done_t = Arc::clone(&done);
+        let puller = thread::spawn(move || {
+            let out = reader_a.next(); // blocks until close
+            done_t.store(true, O::Release);
+            out
+        });
+
+        thread::sleep(Duration::from_millis(50));
+        assert!(
+            !done.load(O::Acquire),
+            "pull must still be parked before close"
+        );
+
+        reader_b.close(); // close from the sibling handle
+
+        let out = puller.join().expect("puller thread");
+        assert!(
+            out.expect("no error").is_none(),
+            "a closed stream's parked pull must return end-of-stream"
+        );
+    }
+}

--- a/crates/thetadatadx/src/fpss/batch_reader.rs
+++ b/crates/thetadatadx/src/fpss/batch_reader.rs
@@ -624,31 +624,28 @@ impl RecordBatchStream {
         // `Shared`, so it is correct regardless of which session is now live.
         self.shared.close_and_wake();
         // Authoritative teardown, run exactly once. Reset the owning client's
-        // streaming state through the SAME `StreamingState::quiesce` the
-        // callback surface's `stop_streaming` uses: swap the slot to `Stopped`,
-        // shut the live client (stop the I/O + ping threads, close the socket,
-        // shut the ring), and retire the dispatcher session, leaving the client
-        // truthful (`is_streaming` / `connection_status` report a stopped
-        // session) and reusable.
+        // streaming state through `StreamingState::quiesce_if_owned`: swap the
+        // slot to `Stopped`, shut the live client (stop the I/O + ping threads,
+        // close the socket, shut the ring), and retire the dispatcher session,
+        // leaving the client truthful (`is_streaming` / `connection_status`
+        // report a stopped session) and reusable.
         //
-        // But quiesce only when the live generation still matches the one this
-        // reader's session was installed at. Once a teardown has advanced the
-        // generation, the live session is no longer this reader's — quiescing
-        // it would tear down a session this reader does not own (e.g. a
-        // callback session started after this reader was stopped). In that case
-        // the predecessor teardown already retired this reader's session, so
-        // there is nothing left for this reader to do.
+        // `quiesce_if_owned` retires only when the live generation still equals
+        // the one this reader's session was installed at, and does the
+        // generation re-check and the teardown ATOMICALLY under the dispatcher
+        // lock. So a teardown that advanced the generation (a `stop_streaming` /
+        // `reconnect_streaming`, or a later session on the same client) either
+        // fully precedes this call (the re-check fails, leaving the newer
+        // session to its owner) or fully follows it (this reader's session is
+        // already retired) — never interleaves with it, which a separate
+        // check-then-quiesce would allow.
         //
         // If the client has already been dropped the weak upgrade fails (its
         // own `Drop` already quiesced); fall back to shutting our own client
         // `Arc` directly, which is all that remains and only touches this
         // reader's session.
         self.quiesce_once.call_once(|| match self.owner.upgrade() {
-            Some(state) => {
-                if state.stop_generation() == self.owned_generation {
-                    state.quiesce();
-                }
-            }
+            Some(state) => state.quiesce_if_owned(self.owned_generation),
             None => self.client.shutdown(),
         });
     }

--- a/crates/thetadatadx/src/fpss/batch_schema.rs
+++ b/crates/thetadatadx/src/fpss/batch_schema.rs
@@ -126,12 +126,19 @@ pub fn stream_batch_schema() -> Arc<Schema> {
 /// accumulator empty for the next batch. Every batch therefore carries the
 /// identical schema instance, which is what makes the output concat-safe.
 ///
-/// Builders preallocate to `capacity` so the steady-state append path does
-/// no reallocation until a batch is flushed.
+/// Builders preallocate to `capacity` so the append path does no reallocation
+/// within a batch. [`Self::finish`] re-sizes the builders back to `capacity`
+/// for the next batch, so this holds for every batch, not just the first:
+/// `arrow` builders' `finish()` swaps their backing buffer out (leaving it at
+/// zero capacity), and re-initializing here restores the preallocation rather
+/// than letting batches 2..N re-grow each column from empty by doubling.
 ///
 /// [`RecordBatchStream`]: super::batch_reader::RecordBatchStream
 pub struct StreamBatchBuilder {
     schema: Arc<Schema>,
+    /// Rows-per-batch preallocation target. Retained so [`Self::finish`] can
+    /// re-size every column builder back to this after each flush.
+    capacity: usize,
     rows: usize,
 
     event_type: StringBuilder,
@@ -187,12 +194,23 @@ impl StreamBatchBuilder {
     /// `capacity` rows.
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacity_and_schema(capacity, stream_batch_schema())
+    }
+
+    /// Create an empty builder with every column preallocated to `capacity`
+    /// rows, reusing an existing schema `Arc` instead of allocating a fresh
+    /// one. [`Self::finish`] uses this to re-size the builders for the next
+    /// batch while keeping the identical schema instance (so the output stays
+    /// concat-safe and no schema is reallocated per batch).
+    #[must_use]
+    fn with_capacity_and_schema(capacity: usize, schema: Arc<Schema>) -> Self {
         // String builders take both an item-count and a byte-count hint;
         // symbols are short roots (a handful of bytes), the discriminator
         // and right tags shorter still, so the byte hints are deliberately
         // small multiples of `capacity`.
         Self {
-            schema: stream_batch_schema(),
+            schema,
+            capacity,
             rows: 0,
             event_type: StringBuilder::with_capacity(capacity, capacity * 8),
             symbol: StringBuilder::with_capacity(capacity, capacity * 8),
@@ -253,6 +271,15 @@ impl StreamBatchBuilder {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.rows == 0
+    }
+
+    /// Test-only: the slot capacity of a representative primitive column
+    /// builder. Every primitive column is preallocated to the same `capacity`,
+    /// so `ms_of_day` stands in for all of them when asserting that
+    /// [`Self::finish`] restores the per-batch preallocation.
+    #[cfg(test)]
+    pub(crate) fn primitive_column_capacity(&self) -> usize {
+        self.ms_of_day.capacity()
     }
 
     /// Append one event if it is a market-data variant, returning `true`
@@ -452,50 +479,61 @@ impl StreamBatchBuilder {
         if self.rows == 0 {
             return Ok(None);
         }
+        // Swap in a freshly pre-sized builder (reusing the same schema `Arc`)
+        // and drain the swapped-out one into the batch. `arrow` builders'
+        // `finish()` takes their backing buffer, leaving capacity at zero, so
+        // re-sizing here is what keeps EVERY batch pre-allocated; without it
+        // only the first batch would be sized and batches 2..N would re-grow
+        // each of the 40 columns from empty by doubling on the dispatcher
+        // thread. Reusing the schema `Arc` keeps the output concat-safe and
+        // avoids reallocating the schema per batch.
+        let mut prev = std::mem::replace(
+            self,
+            Self::with_capacity_and_schema(self.capacity, Arc::clone(&self.schema)),
+        );
         let columns: Vec<ArrayRef> = vec![
-            Arc::new(self.event_type.finish()) as ArrayRef,
-            Arc::new(self.symbol.finish()) as ArrayRef,
-            Arc::new(self.sec_type.finish()) as ArrayRef,
-            Arc::new(self.expiration.finish()) as ArrayRef,
-            Arc::new(self.strike.finish()) as ArrayRef,
-            Arc::new(self.right.finish()) as ArrayRef,
-            Arc::new(self.ms_of_day.finish()) as ArrayRef,
-            Arc::new(self.date.finish()) as ArrayRef,
-            Arc::new(self.received_at_ns.finish()) as ArrayRef,
-            Arc::new(self.bid.finish()) as ArrayRef,
-            Arc::new(self.bid_size.finish()) as ArrayRef,
-            Arc::new(self.bid_exchange.finish()) as ArrayRef,
-            Arc::new(self.bid_condition.finish()) as ArrayRef,
-            Arc::new(self.ask.finish()) as ArrayRef,
-            Arc::new(self.ask_size.finish()) as ArrayRef,
-            Arc::new(self.ask_exchange.finish()) as ArrayRef,
-            Arc::new(self.ask_condition.finish()) as ArrayRef,
-            Arc::new(self.price.finish()) as ArrayRef,
-            Arc::new(self.size.finish()) as ArrayRef,
-            Arc::new(self.exchange.finish()) as ArrayRef,
-            Arc::new(self.sequence.finish()) as ArrayRef,
-            Arc::new(self.condition.finish()) as ArrayRef,
-            Arc::new(self.ext_condition1.finish()) as ArrayRef,
-            Arc::new(self.ext_condition2.finish()) as ArrayRef,
-            Arc::new(self.ext_condition3.finish()) as ArrayRef,
-            Arc::new(self.ext_condition4.finish()) as ArrayRef,
-            Arc::new(self.condition_flags.finish()) as ArrayRef,
-            Arc::new(self.price_flags.finish()) as ArrayRef,
-            Arc::new(self.volume_type.finish()) as ArrayRef,
-            Arc::new(self.records_back.finish()) as ArrayRef,
-            Arc::new(self.open_interest.finish()) as ArrayRef,
-            Arc::new(self.open.finish()) as ArrayRef,
-            Arc::new(self.high.finish()) as ArrayRef,
-            Arc::new(self.low.finish()) as ArrayRef,
-            Arc::new(self.close.finish()) as ArrayRef,
-            Arc::new(self.volume.finish()) as ArrayRef,
-            Arc::new(self.count.finish()) as ArrayRef,
-            Arc::new(self.market_bid.finish()) as ArrayRef,
-            Arc::new(self.market_ask.finish()) as ArrayRef,
-            Arc::new(self.market_price.finish()) as ArrayRef,
+            Arc::new(prev.event_type.finish()) as ArrayRef,
+            Arc::new(prev.symbol.finish()) as ArrayRef,
+            Arc::new(prev.sec_type.finish()) as ArrayRef,
+            Arc::new(prev.expiration.finish()) as ArrayRef,
+            Arc::new(prev.strike.finish()) as ArrayRef,
+            Arc::new(prev.right.finish()) as ArrayRef,
+            Arc::new(prev.ms_of_day.finish()) as ArrayRef,
+            Arc::new(prev.date.finish()) as ArrayRef,
+            Arc::new(prev.received_at_ns.finish()) as ArrayRef,
+            Arc::new(prev.bid.finish()) as ArrayRef,
+            Arc::new(prev.bid_size.finish()) as ArrayRef,
+            Arc::new(prev.bid_exchange.finish()) as ArrayRef,
+            Arc::new(prev.bid_condition.finish()) as ArrayRef,
+            Arc::new(prev.ask.finish()) as ArrayRef,
+            Arc::new(prev.ask_size.finish()) as ArrayRef,
+            Arc::new(prev.ask_exchange.finish()) as ArrayRef,
+            Arc::new(prev.ask_condition.finish()) as ArrayRef,
+            Arc::new(prev.price.finish()) as ArrayRef,
+            Arc::new(prev.size.finish()) as ArrayRef,
+            Arc::new(prev.exchange.finish()) as ArrayRef,
+            Arc::new(prev.sequence.finish()) as ArrayRef,
+            Arc::new(prev.condition.finish()) as ArrayRef,
+            Arc::new(prev.ext_condition1.finish()) as ArrayRef,
+            Arc::new(prev.ext_condition2.finish()) as ArrayRef,
+            Arc::new(prev.ext_condition3.finish()) as ArrayRef,
+            Arc::new(prev.ext_condition4.finish()) as ArrayRef,
+            Arc::new(prev.condition_flags.finish()) as ArrayRef,
+            Arc::new(prev.price_flags.finish()) as ArrayRef,
+            Arc::new(prev.volume_type.finish()) as ArrayRef,
+            Arc::new(prev.records_back.finish()) as ArrayRef,
+            Arc::new(prev.open_interest.finish()) as ArrayRef,
+            Arc::new(prev.open.finish()) as ArrayRef,
+            Arc::new(prev.high.finish()) as ArrayRef,
+            Arc::new(prev.low.finish()) as ArrayRef,
+            Arc::new(prev.close.finish()) as ArrayRef,
+            Arc::new(prev.volume.finish()) as ArrayRef,
+            Arc::new(prev.count.finish()) as ArrayRef,
+            Arc::new(prev.market_bid.finish()) as ArrayRef,
+            Arc::new(prev.market_ask.finish()) as ArrayRef,
+            Arc::new(prev.market_price.finish()) as ArrayRef,
         ];
-        self.rows = 0;
-        let batch = RecordBatch::try_new(Arc::clone(&self.schema), columns)?;
+        let batch = RecordBatch::try_new(Arc::clone(&prev.schema), columns)?;
         Ok(Some(batch))
     }
 
@@ -812,5 +850,81 @@ mod tests {
         ));
         assert!(!appended, "control events are not columnar rows");
         assert!(b.is_empty());
+    }
+
+    /// finish() must restore the per-batch column preallocation, not just for
+    /// the first batch. `arrow` builders' `finish()` takes their backing
+    /// buffer (leaving capacity at zero), so without the re-size in `finish`
+    /// batches 2..N would re-grow every column from empty. This fills and
+    /// flushes several batches and asserts the representative column is
+    /// re-sized to at least the configured capacity each time, before the next
+    /// batch's appends.
+    #[test]
+    fn finish_restores_column_capacity_every_batch() {
+        let capacity = 64;
+        let mut b = StreamBatchBuilder::with_capacity(capacity);
+        let contract = std::sync::Arc::new(Contract::stock("SPY"));
+
+        assert!(
+            b.primitive_column_capacity() >= capacity,
+            "the first batch starts pre-sized"
+        );
+
+        for batch_idx in 0..4 {
+            for _ in 0..capacity {
+                b.append(&trade(&contract));
+            }
+            let produced = b.finish().unwrap().expect("a full batch");
+            assert_eq!(produced.num_rows(), capacity);
+            // The crux: after finish the builders are pre-sized again, so the
+            // next batch appends into preallocated space rather than re-growing
+            // from zero. Pre-fix this is 0 for every batch after the first.
+            assert!(
+                b.primitive_column_capacity() >= capacity,
+                "finish must re-size columns to >= capacity for batch {} (was {})",
+                batch_idx + 1,
+                b.primitive_column_capacity()
+            );
+            assert_eq!(b.len(), 0, "finish resets the row count");
+        }
+    }
+
+    /// Re-sizing in finish() must not change the bytes: batches built across
+    /// several flushes are identical to building each in a fresh builder, so
+    /// the optimization is purely an allocation change, not a correctness one.
+    #[test]
+    fn finish_resize_preserves_batch_contents() {
+        let contract = std::sync::Arc::new(Contract::stock("SPY"));
+        let events = [trade(&contract), quote(&contract), trade(&contract)];
+
+        // Two batches from one reused builder (so the second batch is built
+        // after a finish re-size).
+        let mut reused = StreamBatchBuilder::with_capacity(4);
+        for e in &events {
+            reused.append(e);
+        }
+        let reused_b1 = reused.finish().unwrap().expect("batch 1");
+        for e in &events {
+            reused.append(e);
+        }
+        let reused_b2 = reused.finish().unwrap().expect("batch 2");
+
+        // The same two batches, each from a fresh builder.
+        let mut fresh_a = StreamBatchBuilder::with_capacity(4);
+        for e in &events {
+            fresh_a.append(e);
+        }
+        let fresh_b1 = fresh_a.finish().unwrap().expect("fresh batch 1");
+        let mut fresh_b = StreamBatchBuilder::with_capacity(4);
+        for e in &events {
+            fresh_b.append(e);
+        }
+        let fresh_b2 = fresh_b.finish().unwrap().expect("fresh batch 2");
+
+        assert_eq!(reused_b1, fresh_b1, "first batch is byte-identical");
+        assert_eq!(
+            reused_b2, fresh_b2,
+            "the post-resize batch is byte-identical to a fresh build"
+        );
     }
 }

--- a/crates/thetadatadx/src/fpss/batch_schema.rs
+++ b/crates/thetadatadx/src/fpss/batch_schema.rs
@@ -130,10 +130,12 @@ pub fn stream_batch_schema() -> Arc<Schema> {
 pub(crate) const EST_IPC_BYTES_PER_ROW: usize = 256;
 
 /// Fixed Arrow IPC framing allowance added to the per-row estimate: the schema
-/// message (a flatbuffer over the 40-field schema) plus the record-batch
-/// message header. A few kilobytes comfortably covers both so a small batch is
-/// not under-seeded.
-pub(crate) const EST_IPC_FRAMING_OVERHEAD: usize = 8 * 1024;
+/// message (a flatbuffer over the 40-field schema, which measures ~8.5 KB on
+/// its own) plus the record-batch message header and stream end-of-stream
+/// marker. 16 KB covers the schema preamble for even the smallest batch, so a
+/// one-row batch (whose body is ~9.5 KB) seeds above its real IPC size and does
+/// not trigger the one bounded realloc an 8 KB allowance left it with.
+pub(crate) const EST_IPC_FRAMING_OVERHEAD: usize = 16 * 1024;
 
 /// Estimated serialized size, in bytes, of an Arrow IPC stream carrying a
 /// single batch of `num_rows` rows under [`stream_batch_schema`].

--- a/crates/thetadatadx/src/fpss/batch_schema.rs
+++ b/crates/thetadatadx/src/fpss/batch_schema.rs
@@ -116,6 +116,44 @@ pub fn stream_batch_schema() -> Arc<Schema> {
     ]))
 }
 
+/// Approximate serialized bytes per row, used only to seed the Arrow IPC
+/// output buffer so it is written without re-growing from empty.
+///
+/// Derived from the fixed [`stream_batch_schema`] columns: 23 `Int32` (4 B
+/// each = 92), 11 `Float64` + 1 `UInt64` + 2 `Int64` (8 B each = 112), and 3
+/// `Utf8` columns (offset plus a short value, allowed ~16 B each = 48),
+/// totalling ~252 B; rounded up to 256 to cover per-row validity bits and
+/// alignment. This is a buffer-sizing HINT, never a correctness input — if a
+/// column is added to the schema, bump this alongside it. Sized so a full
+/// batch seeds at or above the real IPC body (no doubling regrow) while a tiny
+/// linger-flushed batch seeds only a few hundred bytes.
+pub(crate) const EST_IPC_BYTES_PER_ROW: usize = 256;
+
+/// Fixed Arrow IPC framing allowance added to the per-row estimate: the schema
+/// message (a flatbuffer over the 40-field schema) plus the record-batch
+/// message header. A few kilobytes comfortably covers both so a small batch is
+/// not under-seeded.
+pub(crate) const EST_IPC_FRAMING_OVERHEAD: usize = 8 * 1024;
+
+/// Estimated serialized size, in bytes, of an Arrow IPC stream carrying a
+/// single batch of `num_rows` rows under [`stream_batch_schema`].
+///
+/// Used to seed the IPC byte buffer in the FFI and TypeScript batch encoders
+/// so the body is written without re-growing the `Vec` from empty. It is keyed
+/// on `num_rows` (the USED size), not on the builder's preallocated buffer
+/// capacity, so a linger-flushed one-row batch seeds a few kilobytes rather
+/// than the batch-size-wide column capacity. A hint only; correctness does not
+/// depend on it.
+///
+/// Re-exported `#[doc(hidden)]` through `crate::streaming` so the binding
+/// encoders (separate crates) can share this one estimate.
+#[must_use]
+pub fn estimated_ipc_len(num_rows: usize) -> usize {
+    num_rows
+        .saturating_mul(EST_IPC_BYTES_PER_ROW)
+        .saturating_add(EST_IPC_FRAMING_OVERHEAD)
+}
+
 /// Column-oriented accumulator that turns a run of [`StreamData`] events
 /// into a single [`RecordBatch`] under [`stream_batch_schema`].
 ///
@@ -925,6 +963,47 @@ mod tests {
         assert_eq!(
             reused_b2, fresh_b2,
             "the post-resize batch is byte-identical to a fresh build"
+        );
+    }
+
+    /// The IPC seed estimate is keyed on the row count, so a tiny linger-flushed
+    /// batch seeds a few kilobytes (not the batch-size-wide column capacity a
+    /// buffer-capacity estimate would report after the per-batch preallocation
+    /// fix), while a full batch seeds large enough to hold the body without a
+    /// doubling regrow. The byte-exact "estimate >= real IPC body" check lives
+    /// in the FFI encoder test (the core crate has no IPC writer dependency).
+    #[test]
+    fn estimated_ipc_len_scales_with_rows_not_capacity() {
+        // A one-row (or empty) batch seeds only the framing overhead plus a
+        // row or two, comfortably under 64 KiB regardless of the configured
+        // batch size.
+        assert!(
+            estimated_ipc_len(0) < 64 * 1024,
+            "empty batch seed must be small"
+        );
+        assert!(
+            estimated_ipc_len(1) < 64 * 1024,
+            "one-row batch seed must be small, not the batch-size-wide capacity"
+        );
+
+        // The estimate grows linearly with rows, so a full batch seeds far
+        // above a tiny one (the property that avoids regrow on large batches).
+        let full = estimated_ipc_len(65_536);
+        assert!(
+            full >= 65_536 * EST_IPC_BYTES_PER_ROW,
+            "a full batch seeds at least the per-row estimate times the rows"
+        );
+        assert!(
+            full > estimated_ipc_len(1) * 1000,
+            "the seed scales with row count"
+        );
+
+        // Saturating arithmetic: a wrapped/huge row count cannot overflow the
+        // estimate into a tiny value.
+        assert_eq!(
+            estimated_ipc_len(usize::MAX),
+            usize::MAX,
+            "the estimate saturates rather than wrapping"
         );
     }
 }

--- a/crates/thetadatadx/src/fpss/batch_schema.rs
+++ b/crates/thetadatadx/src/fpss/batch_schema.rs
@@ -1,0 +1,816 @@
+//! Fixed columnar schema for the streaming Arrow `RecordBatch` reader.
+//!
+//! The per-event callback delivers heterogeneous [`StreamData`] variants
+//! (quote, trade, open-interest, OHLCVC, market-value) one at a time. The
+//! pull-based [`super::batch_reader::RecordBatchStream`] instead delivers
+//! the same market-data events in columnar batches, and the columnar
+//! contract requires a single schema that is FIXED for the lifetime of the
+//! subscription and identical across every batch so a downstream consumer
+//! can concatenate batches without a schema reconciliation pass.
+//!
+//! A live subscription interleaves event variants, so the only lossless,
+//! concat-safe layout is a unified record that can carry any data variant:
+//! a leading `event_type` discriminator, the contract identity columns, the
+//! three fields common to every variant (`ms_of_day`, `date`,
+//! `received_at_ns`), and the union of every per-variant payload column.
+//! Columns that do not apply to a given event are null for that row. This is
+//! the same shape an institutional live feed uses for a multiplexed columnar
+//! channel: one record layout, a type tag, nullable payload columns.
+//!
+//! This module is the single source of truth for that layout. The schema is
+//! built once here; every binding consumes it through the Arrow C Data
+//! Interface (Python / C++) or Arrow IPC (TypeScript), so the column order,
+//! names, and dtypes are defined in exactly one place and cannot drift.
+//!
+//! Control / lifecycle events (login, reconnect, market open/close, …) are
+//! not market data and carry no columnar payload; they are not delivered on
+//! the batch channel. A consumer that needs lifecycle visibility uses the
+//! per-event callback, which is unchanged and remains the sibling delivery
+//! mode.
+
+use std::sync::Arc;
+
+use arrow_array::builder::{
+    Float64Builder, Int32Builder, Int64Builder, StringBuilder, UInt64Builder,
+};
+use arrow_array::{ArrayRef, RecordBatch};
+use arrow_schema::{ArrowError, DataType, Field, Schema};
+
+use super::events::{StreamData, StreamEvent};
+use crate::tdbe::types::enums::Right;
+
+/// Discriminator value written into the `event_type` column for each
+/// market-data variant. Stable string tags so a consumer can filter a
+/// batch by `event_type` without reaching for an enum mapping.
+pub mod event_type {
+    /// `event_type` tag for a [`super::super::StreamData::Quote`] row.
+    pub const QUOTE: &str = "quote";
+    /// `event_type` tag for a [`super::super::StreamData::Trade`] row.
+    pub const TRADE: &str = "trade";
+    /// `event_type` tag for a [`super::super::StreamData::OpenInterest`] row.
+    pub const OPEN_INTEREST: &str = "open_interest";
+    /// `event_type` tag for a [`super::super::StreamData::Ohlcvc`] row.
+    pub const OHLCVC: &str = "ohlcvc";
+    /// `event_type` tag for a [`super::super::StreamData::MarketValue`] row.
+    pub const MARKET_VALUE: &str = "market_value";
+}
+
+/// Build the fixed Arrow schema shared by every batch the streaming reader
+/// emits.
+///
+/// The column order here is the canonical order; [`StreamBatchBuilder`]
+/// assembles its column arrays in exactly this order, and the FFI / binding
+/// layers never reorder. Keeping the order in one function means a new
+/// column is added in one place and every binding picks it up through the
+/// exported schema.
+#[must_use]
+pub fn stream_batch_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        // ── discriminator + contract identity ──
+        Field::new("event_type", DataType::Utf8, false),
+        Field::new("symbol", DataType::Utf8, false),
+        Field::new("sec_type", DataType::Int32, false),
+        Field::new("expiration", DataType::Int32, true),
+        Field::new("strike", DataType::Float64, true),
+        Field::new("right", DataType::Utf8, true),
+        // ── common to every data variant ──
+        Field::new("ms_of_day", DataType::Int32, false),
+        Field::new("date", DataType::Int32, false),
+        Field::new("received_at_ns", DataType::UInt64, false),
+        // ── quote payload ──
+        Field::new("bid", DataType::Float64, true),
+        Field::new("bid_size", DataType::Int32, true),
+        Field::new("bid_exchange", DataType::Int32, true),
+        Field::new("bid_condition", DataType::Int32, true),
+        Field::new("ask", DataType::Float64, true),
+        Field::new("ask_size", DataType::Int32, true),
+        Field::new("ask_exchange", DataType::Int32, true),
+        Field::new("ask_condition", DataType::Int32, true),
+        // ── trade payload ──
+        Field::new("price", DataType::Float64, true),
+        Field::new("size", DataType::Int32, true),
+        Field::new("exchange", DataType::Int32, true),
+        Field::new("sequence", DataType::Int32, true),
+        Field::new("condition", DataType::Int32, true),
+        Field::new("ext_condition1", DataType::Int32, true),
+        Field::new("ext_condition2", DataType::Int32, true),
+        Field::new("ext_condition3", DataType::Int32, true),
+        Field::new("ext_condition4", DataType::Int32, true),
+        Field::new("condition_flags", DataType::Int32, true),
+        Field::new("price_flags", DataType::Int32, true),
+        Field::new("volume_type", DataType::Int32, true),
+        Field::new("records_back", DataType::Int32, true),
+        // ── open-interest payload ──
+        Field::new("open_interest", DataType::Int32, true),
+        // ── OHLCVC payload ──
+        Field::new("open", DataType::Float64, true),
+        Field::new("high", DataType::Float64, true),
+        Field::new("low", DataType::Float64, true),
+        Field::new("close", DataType::Float64, true),
+        Field::new("volume", DataType::Int64, true),
+        Field::new("count", DataType::Int64, true),
+        // ── market-value payload ──
+        Field::new("market_bid", DataType::Float64, true),
+        Field::new("market_ask", DataType::Float64, true),
+        Field::new("market_price", DataType::Float64, true),
+    ]))
+}
+
+/// Column-oriented accumulator that turns a run of [`StreamData`] events
+/// into a single [`RecordBatch`] under [`stream_batch_schema`].
+///
+/// One builder is reused across the lifetime of a [`RecordBatchStream`]:
+/// [`Self::append`] pushes one row per data event, [`Self::len`] reports the
+/// rows buffered so far so the reader can decide when a batch is full, and
+/// [`Self::finish`] drains the builders into a `RecordBatch` and leaves the
+/// accumulator empty for the next batch. Every batch therefore carries the
+/// identical schema instance, which is what makes the output concat-safe.
+///
+/// Builders preallocate to `capacity` so the steady-state append path does
+/// no reallocation until a batch is flushed.
+///
+/// [`RecordBatchStream`]: super::batch_reader::RecordBatchStream
+pub struct StreamBatchBuilder {
+    schema: Arc<Schema>,
+    rows: usize,
+
+    event_type: StringBuilder,
+    symbol: StringBuilder,
+    sec_type: Int32Builder,
+    expiration: Int32Builder,
+    strike: Float64Builder,
+    right: StringBuilder,
+
+    ms_of_day: Int32Builder,
+    date: Int32Builder,
+    received_at_ns: UInt64Builder,
+
+    bid: Float64Builder,
+    bid_size: Int32Builder,
+    bid_exchange: Int32Builder,
+    bid_condition: Int32Builder,
+    ask: Float64Builder,
+    ask_size: Int32Builder,
+    ask_exchange: Int32Builder,
+    ask_condition: Int32Builder,
+
+    price: Float64Builder,
+    size: Int32Builder,
+    exchange: Int32Builder,
+    sequence: Int32Builder,
+    condition: Int32Builder,
+    ext_condition1: Int32Builder,
+    ext_condition2: Int32Builder,
+    ext_condition3: Int32Builder,
+    ext_condition4: Int32Builder,
+    condition_flags: Int32Builder,
+    price_flags: Int32Builder,
+    volume_type: Int32Builder,
+    records_back: Int32Builder,
+
+    open_interest: Int32Builder,
+
+    open: Float64Builder,
+    high: Float64Builder,
+    low: Float64Builder,
+    close: Float64Builder,
+    volume: Int64Builder,
+    count: Int64Builder,
+
+    market_bid: Float64Builder,
+    market_ask: Float64Builder,
+    market_price: Float64Builder,
+}
+
+impl StreamBatchBuilder {
+    /// Create an empty builder with every column preallocated to
+    /// `capacity` rows.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        // String builders take both an item-count and a byte-count hint;
+        // symbols are short roots (a handful of bytes), the discriminator
+        // and right tags shorter still, so the byte hints are deliberately
+        // small multiples of `capacity`.
+        Self {
+            schema: stream_batch_schema(),
+            rows: 0,
+            event_type: StringBuilder::with_capacity(capacity, capacity * 8),
+            symbol: StringBuilder::with_capacity(capacity, capacity * 8),
+            sec_type: Int32Builder::with_capacity(capacity),
+            expiration: Int32Builder::with_capacity(capacity),
+            strike: Float64Builder::with_capacity(capacity),
+            right: StringBuilder::with_capacity(capacity, capacity),
+            ms_of_day: Int32Builder::with_capacity(capacity),
+            date: Int32Builder::with_capacity(capacity),
+            received_at_ns: UInt64Builder::with_capacity(capacity),
+            bid: Float64Builder::with_capacity(capacity),
+            bid_size: Int32Builder::with_capacity(capacity),
+            bid_exchange: Int32Builder::with_capacity(capacity),
+            bid_condition: Int32Builder::with_capacity(capacity),
+            ask: Float64Builder::with_capacity(capacity),
+            ask_size: Int32Builder::with_capacity(capacity),
+            ask_exchange: Int32Builder::with_capacity(capacity),
+            ask_condition: Int32Builder::with_capacity(capacity),
+            price: Float64Builder::with_capacity(capacity),
+            size: Int32Builder::with_capacity(capacity),
+            exchange: Int32Builder::with_capacity(capacity),
+            sequence: Int32Builder::with_capacity(capacity),
+            condition: Int32Builder::with_capacity(capacity),
+            ext_condition1: Int32Builder::with_capacity(capacity),
+            ext_condition2: Int32Builder::with_capacity(capacity),
+            ext_condition3: Int32Builder::with_capacity(capacity),
+            ext_condition4: Int32Builder::with_capacity(capacity),
+            condition_flags: Int32Builder::with_capacity(capacity),
+            price_flags: Int32Builder::with_capacity(capacity),
+            volume_type: Int32Builder::with_capacity(capacity),
+            records_back: Int32Builder::with_capacity(capacity),
+            open_interest: Int32Builder::with_capacity(capacity),
+            open: Float64Builder::with_capacity(capacity),
+            high: Float64Builder::with_capacity(capacity),
+            low: Float64Builder::with_capacity(capacity),
+            close: Float64Builder::with_capacity(capacity),
+            volume: Int64Builder::with_capacity(capacity),
+            count: Int64Builder::with_capacity(capacity),
+            market_bid: Float64Builder::with_capacity(capacity),
+            market_ask: Float64Builder::with_capacity(capacity),
+            market_price: Float64Builder::with_capacity(capacity),
+        }
+    }
+
+    /// The fixed schema every batch this builder produces will carry.
+    #[must_use]
+    pub fn schema(&self) -> Arc<Schema> {
+        Arc::clone(&self.schema)
+    }
+
+    /// Rows buffered since the last [`Self::finish`].
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rows
+    }
+
+    /// Whether any rows are buffered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rows == 0
+    }
+
+    /// Append one event if it is a market-data variant, returning `true`
+    /// when a row was written.
+    ///
+    /// Control events carry no columnar payload and are skipped (returning
+    /// `false`) — they never reach the batch channel, so in practice the
+    /// reader only ever hands data events here, but accepting a
+    /// [`StreamEvent`] keeps the call site on the consumer side simple and
+    /// makes the data/control split explicit in one place.
+    pub fn append(&mut self, event: &StreamEvent) -> bool {
+        let StreamEvent::Data(data) = event else {
+            return false;
+        };
+        self.append_data(data);
+        true
+    }
+
+    /// Append one market-data event as a row, filling the discriminator,
+    /// contract identity, and common columns, the payload columns for the
+    /// matching variant, and a null for every payload column that does not
+    /// apply to this variant.
+    pub fn append_data(&mut self, data: &StreamData) {
+        match data {
+            StreamData::Quote {
+                contract,
+                ms_of_day,
+                bid_size,
+                bid_exchange,
+                bid,
+                bid_condition,
+                ask_size,
+                ask_exchange,
+                ask,
+                ask_condition,
+                date,
+                received_at_ns,
+            } => {
+                self.push_header(
+                    event_type::QUOTE,
+                    contract,
+                    *ms_of_day,
+                    *date,
+                    *received_at_ns,
+                );
+                // quote payload
+                self.bid.append_value(*bid);
+                self.bid_size.append_value(*bid_size);
+                self.bid_exchange.append_value(*bid_exchange);
+                self.bid_condition.append_value(*bid_condition);
+                self.ask.append_value(*ask);
+                self.ask_size.append_value(*ask_size);
+                self.ask_exchange.append_value(*ask_exchange);
+                self.ask_condition.append_value(*ask_condition);
+                // non-quote payloads null
+                self.null_trade();
+                self.null_open_interest();
+                self.null_ohlcvc();
+                self.null_market_value();
+            }
+            StreamData::Trade {
+                contract,
+                ms_of_day,
+                sequence,
+                ext_condition1,
+                ext_condition2,
+                ext_condition3,
+                ext_condition4,
+                condition,
+                size,
+                exchange,
+                price,
+                condition_flags,
+                price_flags,
+                volume_type,
+                records_back,
+                date,
+                received_at_ns,
+            } => {
+                self.push_header(
+                    event_type::TRADE,
+                    contract,
+                    *ms_of_day,
+                    *date,
+                    *received_at_ns,
+                );
+                self.null_quote();
+                // trade payload
+                self.price.append_value(*price);
+                self.size.append_value(*size);
+                self.exchange.append_value(*exchange);
+                self.sequence.append_value(*sequence);
+                self.condition.append_value(*condition);
+                self.ext_condition1.append_value(*ext_condition1);
+                self.ext_condition2.append_value(*ext_condition2);
+                self.ext_condition3.append_value(*ext_condition3);
+                self.ext_condition4.append_value(*ext_condition4);
+                self.condition_flags.append_value(*condition_flags);
+                self.price_flags.append_value(*price_flags);
+                self.volume_type.append_value(*volume_type);
+                self.records_back.append_value(*records_back);
+                self.null_open_interest();
+                self.null_ohlcvc();
+                self.null_market_value();
+            }
+            StreamData::OpenInterest {
+                contract,
+                ms_of_day,
+                open_interest,
+                date,
+                received_at_ns,
+            } => {
+                self.push_header(
+                    event_type::OPEN_INTEREST,
+                    contract,
+                    *ms_of_day,
+                    *date,
+                    *received_at_ns,
+                );
+                self.null_quote();
+                self.null_trade();
+                self.open_interest.append_value(*open_interest);
+                self.null_ohlcvc();
+                self.null_market_value();
+            }
+            StreamData::Ohlcvc {
+                contract,
+                ms_of_day,
+                open,
+                high,
+                low,
+                close,
+                volume,
+                count,
+                date,
+                received_at_ns,
+            } => {
+                self.push_header(
+                    event_type::OHLCVC,
+                    contract,
+                    *ms_of_day,
+                    *date,
+                    *received_at_ns,
+                );
+                self.null_quote();
+                self.null_trade();
+                self.null_open_interest();
+                self.open.append_value(*open);
+                self.high.append_value(*high);
+                self.low.append_value(*low);
+                self.close.append_value(*close);
+                self.volume.append_value(*volume);
+                self.count.append_value(*count);
+                self.null_market_value();
+            }
+            StreamData::MarketValue {
+                contract,
+                ms_of_day,
+                market_bid,
+                market_ask,
+                market_price,
+                date,
+                received_at_ns,
+            } => {
+                self.push_header(
+                    event_type::MARKET_VALUE,
+                    contract,
+                    *ms_of_day,
+                    *date,
+                    *received_at_ns,
+                );
+                self.null_quote();
+                self.null_trade();
+                self.null_open_interest();
+                self.null_ohlcvc();
+                self.market_bid.append_value(*market_bid);
+                self.market_ask.append_value(*market_ask);
+                self.market_price.append_value(*market_price);
+            }
+        }
+        self.rows += 1;
+    }
+
+    /// Drain the buffered rows into a [`RecordBatch`] and reset the
+    /// accumulator so the next batch starts empty.
+    ///
+    /// Returns `Ok(None)` when no rows are buffered, so a caller can call
+    /// this unconditionally on a linger timeout without emitting an empty
+    /// batch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ArrowError`] if the assembled column arrays cannot form
+    /// a `RecordBatch` against the schema (a column-length mismatch, which
+    /// the append discipline above makes unreachable in practice).
+    pub fn finish(&mut self) -> Result<Option<RecordBatch>, ArrowError> {
+        if self.rows == 0 {
+            return Ok(None);
+        }
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(self.event_type.finish()) as ArrayRef,
+            Arc::new(self.symbol.finish()) as ArrayRef,
+            Arc::new(self.sec_type.finish()) as ArrayRef,
+            Arc::new(self.expiration.finish()) as ArrayRef,
+            Arc::new(self.strike.finish()) as ArrayRef,
+            Arc::new(self.right.finish()) as ArrayRef,
+            Arc::new(self.ms_of_day.finish()) as ArrayRef,
+            Arc::new(self.date.finish()) as ArrayRef,
+            Arc::new(self.received_at_ns.finish()) as ArrayRef,
+            Arc::new(self.bid.finish()) as ArrayRef,
+            Arc::new(self.bid_size.finish()) as ArrayRef,
+            Arc::new(self.bid_exchange.finish()) as ArrayRef,
+            Arc::new(self.bid_condition.finish()) as ArrayRef,
+            Arc::new(self.ask.finish()) as ArrayRef,
+            Arc::new(self.ask_size.finish()) as ArrayRef,
+            Arc::new(self.ask_exchange.finish()) as ArrayRef,
+            Arc::new(self.ask_condition.finish()) as ArrayRef,
+            Arc::new(self.price.finish()) as ArrayRef,
+            Arc::new(self.size.finish()) as ArrayRef,
+            Arc::new(self.exchange.finish()) as ArrayRef,
+            Arc::new(self.sequence.finish()) as ArrayRef,
+            Arc::new(self.condition.finish()) as ArrayRef,
+            Arc::new(self.ext_condition1.finish()) as ArrayRef,
+            Arc::new(self.ext_condition2.finish()) as ArrayRef,
+            Arc::new(self.ext_condition3.finish()) as ArrayRef,
+            Arc::new(self.ext_condition4.finish()) as ArrayRef,
+            Arc::new(self.condition_flags.finish()) as ArrayRef,
+            Arc::new(self.price_flags.finish()) as ArrayRef,
+            Arc::new(self.volume_type.finish()) as ArrayRef,
+            Arc::new(self.records_back.finish()) as ArrayRef,
+            Arc::new(self.open_interest.finish()) as ArrayRef,
+            Arc::new(self.open.finish()) as ArrayRef,
+            Arc::new(self.high.finish()) as ArrayRef,
+            Arc::new(self.low.finish()) as ArrayRef,
+            Arc::new(self.close.finish()) as ArrayRef,
+            Arc::new(self.volume.finish()) as ArrayRef,
+            Arc::new(self.count.finish()) as ArrayRef,
+            Arc::new(self.market_bid.finish()) as ArrayRef,
+            Arc::new(self.market_ask.finish()) as ArrayRef,
+            Arc::new(self.market_price.finish()) as ArrayRef,
+        ];
+        self.rows = 0;
+        let batch = RecordBatch::try_new(Arc::clone(&self.schema), columns)?;
+        Ok(Some(batch))
+    }
+
+    /// Write the discriminator, contract identity, and the three columns
+    /// common to every data variant.
+    fn push_header(
+        &mut self,
+        tag: &str,
+        contract: &crate::fpss::protocol::Contract,
+        ms_of_day: i32,
+        date: i32,
+        received_at_ns: u64,
+    ) {
+        self.event_type.append_value(tag);
+        self.symbol.append_value(&*contract.symbol);
+        self.sec_type.append_value(contract.sec_type as i32);
+        // Option columns: expiration / strike / right carry a value only
+        // for option contracts, null otherwise. Strike is reported in
+        // dollars to match the historical tick Arrow schema.
+        match contract.expiration {
+            Some(exp) => self.expiration.append_value(exp),
+            None => self.expiration.append_null(),
+        }
+        match contract.strike_thousandths {
+            Some(strike_thousandths) => self
+                .strike
+                .append_value(f64::from(strike_thousandths) / 1000.0),
+            None => self.strike.append_null(),
+        }
+        match contract.right() {
+            Some(Right::Call) => self.right.append_value("C"),
+            Some(Right::Put) => self.right.append_value("P"),
+            // Event-carried contracts never report `Right::Both`; treat any
+            // non-call/put right as absent rather than guessing a tag.
+            Some(Right::Both) | None => self.right.append_null(),
+        }
+        self.ms_of_day.append_value(ms_of_day);
+        self.date.append_value(date);
+        self.received_at_ns.append_value(received_at_ns);
+    }
+
+    fn null_quote(&mut self) {
+        self.bid.append_null();
+        self.bid_size.append_null();
+        self.bid_exchange.append_null();
+        self.bid_condition.append_null();
+        self.ask.append_null();
+        self.ask_size.append_null();
+        self.ask_exchange.append_null();
+        self.ask_condition.append_null();
+    }
+
+    fn null_trade(&mut self) {
+        self.price.append_null();
+        self.size.append_null();
+        self.exchange.append_null();
+        self.sequence.append_null();
+        self.condition.append_null();
+        self.ext_condition1.append_null();
+        self.ext_condition2.append_null();
+        self.ext_condition3.append_null();
+        self.ext_condition4.append_null();
+        self.condition_flags.append_null();
+        self.price_flags.append_null();
+        self.volume_type.append_null();
+        self.records_back.append_null();
+    }
+
+    fn null_open_interest(&mut self) {
+        self.open_interest.append_null();
+    }
+
+    fn null_ohlcvc(&mut self) {
+        self.open.append_null();
+        self.high.append_null();
+        self.low.append_null();
+        self.close.append_null();
+        self.volume.append_null();
+        self.count.append_null();
+    }
+
+    fn null_market_value(&mut self) {
+        self.market_bid.append_null();
+        self.market_ask.append_null();
+        self.market_price.append_null();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fpss::protocol::Contract;
+    use arrow_array::{Array, Float64Array, Int32Array, StringArray};
+
+    fn trade(contract: &std::sync::Arc<Contract>) -> StreamEvent {
+        StreamEvent::Data(StreamData::Trade {
+            contract: std::sync::Arc::clone(contract),
+            ms_of_day: 100,
+            sequence: 7,
+            ext_condition1: 0,
+            ext_condition2: 0,
+            ext_condition3: 0,
+            ext_condition4: 0,
+            condition: 0,
+            size: 100,
+            exchange: 3,
+            price: 150.25,
+            condition_flags: 0,
+            price_flags: 0,
+            volume_type: 0,
+            records_back: 0,
+            date: 20240315,
+            received_at_ns: 42,
+        })
+    }
+
+    fn quote(contract: &std::sync::Arc<Contract>) -> StreamEvent {
+        StreamEvent::Data(StreamData::Quote {
+            contract: std::sync::Arc::clone(contract),
+            ms_of_day: 200,
+            bid_size: 10,
+            bid_exchange: 1,
+            bid: 150.00,
+            bid_condition: 0,
+            ask_size: 12,
+            ask_exchange: 2,
+            ask: 150.50,
+            ask_condition: 0,
+            date: 20240315,
+            received_at_ns: 43,
+        })
+    }
+
+    /// The discriminator plus contract-identity and common columns are
+    /// non-nullable; the per-variant payload columns are nullable. The fixed
+    /// layout must match this contract so every binding sees the same shape.
+    #[test]
+    fn schema_nullability_matches_contract() {
+        let schema = stream_batch_schema();
+        for f in [
+            "event_type",
+            "symbol",
+            "sec_type",
+            "ms_of_day",
+            "date",
+            "received_at_ns",
+        ] {
+            assert!(
+                !schema.field_with_name(f).unwrap().is_nullable(),
+                "{f} must be non-nullable"
+            );
+        }
+        for f in [
+            "expiration",
+            "strike",
+            "right",
+            "bid",
+            "price",
+            "open_interest",
+            "open",
+            "market_bid",
+        ] {
+            assert!(
+                schema.field_with_name(f).unwrap().is_nullable(),
+                "{f} must be nullable"
+            );
+        }
+    }
+
+    /// A trade row fills the trade payload columns and nulls the quote
+    /// columns; the discriminator carries the trade tag.
+    #[test]
+    fn trade_row_fills_trade_columns_and_nulls_others() {
+        let contract = std::sync::Arc::new(Contract::stock("SPY"));
+        let mut b = StreamBatchBuilder::with_capacity(8);
+        assert!(b.append(&trade(&contract)));
+        let batch = b.finish().unwrap().expect("one row");
+        assert_eq!(batch.num_rows(), 1);
+
+        let event_type = batch
+            .column_by_name("event_type")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(event_type.value(0), event_type::TRADE);
+
+        let price = batch
+            .column_by_name("price")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!(!price.is_null(0), "trade row carries a price");
+
+        let bid = batch
+            .column_by_name("bid")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!(bid.is_null(0), "trade row nulls the quote bid");
+
+        // Stock contract: option-identity columns are null.
+        let exp = batch
+            .column_by_name("expiration")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert!(exp.is_null(0), "stock contract nulls expiration");
+    }
+
+    /// Mixed variants in one batch share the schema; each row tags its own
+    /// variant and fills only its payload columns.
+    #[test]
+    fn mixed_variants_share_one_batch() {
+        let contract = std::sync::Arc::new(Contract::stock("SPY"));
+        let mut b = StreamBatchBuilder::with_capacity(8);
+        b.append(&trade(&contract));
+        b.append(&quote(&contract));
+        let batch = b.finish().unwrap().expect("two rows");
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.schema(), stream_batch_schema());
+
+        let event_type = batch
+            .column_by_name("event_type")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(event_type.value(0), event_type::TRADE);
+        assert_eq!(event_type.value(1), event_type::QUOTE);
+
+        let bid = batch
+            .column_by_name("bid")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!(bid.is_null(0), "trade row nulls bid");
+        assert!(!bid.is_null(1), "quote row carries bid");
+    }
+
+    /// An option contract surfaces expiration / strike / right; strike is
+    /// reported in dollars.
+    #[test]
+    fn option_contract_fills_identity_columns() {
+        let leg = crate::fpss::protocol::OptionLeg {
+            expiration: "20240920",
+            strike: "150", // $150.00
+            right: "C",
+        };
+        let contract = std::sync::Arc::new(Contract::option("SPY", leg).expect("valid option"));
+        let mut b = StreamBatchBuilder::with_capacity(8);
+        b.append(&StreamEvent::Data(StreamData::Trade {
+            contract: std::sync::Arc::clone(&contract),
+            ms_of_day: 1,
+            sequence: 0,
+            ext_condition1: 0,
+            ext_condition2: 0,
+            ext_condition3: 0,
+            ext_condition4: 0,
+            condition: 0,
+            size: 1,
+            exchange: 0,
+            price: 1.0,
+            condition_flags: 0,
+            price_flags: 0,
+            volume_type: 0,
+            records_back: 0,
+            date: 20240315,
+            received_at_ns: 0,
+        }));
+        let batch = b.finish().unwrap().expect("one row");
+
+        let strike = batch
+            .column_by_name("strike")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!((strike.value(0) - 150.0).abs() < 1e-9, "strike in dollars");
+
+        let right = batch
+            .column_by_name("right")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(right.value(0), "C");
+    }
+
+    /// `finish` on an empty builder yields no batch (so a linger flush on a
+    /// quiet stream never emits an empty batch) and resets `len`.
+    #[test]
+    fn empty_finish_yields_none() {
+        let mut b = StreamBatchBuilder::with_capacity(8);
+        assert!(b.is_empty());
+        assert!(b.finish().unwrap().is_none());
+        let contract = std::sync::Arc::new(Contract::stock("SPY"));
+        b.append(&trade(&contract));
+        assert_eq!(b.len(), 1);
+        let _ = b.finish().unwrap();
+        assert_eq!(b.len(), 0, "finish resets the row count");
+    }
+
+    /// Control events carry no columnar payload and are not appended.
+    #[test]
+    fn control_events_are_skipped() {
+        let mut b = StreamBatchBuilder::with_capacity(8);
+        let appended = b.append(&StreamEvent::Control(
+            crate::fpss::StreamControl::MarketOpen,
+        ));
+        assert!(!appended, "control events are not columnar rows");
+        assert!(b.is_empty());
+    }
+}

--- a/crates/thetadatadx/src/fpss/mod.rs
+++ b/crates/thetadatadx/src/fpss/mod.rs
@@ -31,6 +31,10 @@
 
 mod accumulator;
 pub(crate) mod affinity;
+#[cfg(feature = "arrow")]
+pub mod batch_reader;
+#[cfg(feature = "arrow")]
+pub mod batch_schema;
 pub(crate) mod connection;
 mod decode;
 mod delta;

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -338,6 +338,13 @@ pub mod streaming {
     #[doc(hidden)]
     pub use crate::fpss::batch_schema::estimated_ipc_len;
 
+    /// The fixed streaming-batch Arrow schema. Hidden: shared with the binding
+    /// layers (and their tests) so they describe a streaming batch without
+    /// reconstructing the column list.
+    #[cfg(feature = "arrow")]
+    #[doc(hidden)]
+    pub use crate::fpss::batch_schema::stream_batch_schema;
+
     /// Consumer wait strategies for the streaming ring.
     ///
     /// When the consumer drains the ring faster than events arrive, it

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -328,6 +328,16 @@ pub mod streaming {
         RecordBatchStream, DEFAULT_BATCH_SIZE, DEFAULT_LINGER, DEFAULT_QUEUE_DEPTH,
     };
 
+    /// Estimated Arrow IPC stream size, in bytes, for a single batch of
+    /// `num_rows` rows under the fixed streaming schema. A buffer-sizing hint
+    /// for the binding batch encoders so they seed their output `Vec` from the
+    /// USED size (keyed on `num_rows`) rather than the builder's preallocated
+    /// column capacity. Hidden: an internal hint shared with the bindings, not
+    /// part of the supported surface.
+    #[cfg(feature = "arrow")]
+    #[doc(hidden)]
+    pub use crate::fpss::batch_schema::estimated_ipc_len;
+
     /// Consumer wait strategies for the streaming ring.
     ///
     /// When the consumer drains the ring faster than events arrive, it

--- a/crates/thetadatadx/src/lib.rs
+++ b/crates/thetadatadx/src/lib.rs
@@ -309,6 +309,25 @@ pub mod streaming {
         StreamingClientBuilder,
     };
 
+    /// Pull-based columnar delivery — read the live stream as Apache Arrow
+    /// `RecordBatch` values instead of per-event callbacks.
+    ///
+    /// [`RecordBatchStream`] is a sibling to the per-event callback
+    /// registered through `client.stream().start_streaming(..)`: the same
+    /// subscriptions feed it, but market-data events arrive in columnar
+    /// batches under a fixed schema rather than one event at a time. Open it
+    /// with `client.stream().batches()`, tune `batch_size` / `linger` /
+    /// `backpressure` on the returned [`BatchReaderBuilder`], then pull
+    /// batches with the [`futures_core::Stream`] impl or the
+    /// [`RecordBatchStream::blocking`] iterator. See
+    /// [`crate::fpss::batch_schema::stream_batch_schema`] for the layout.
+    #[cfg(feature = "arrow")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "arrow")))]
+    pub use crate::fpss::batch_reader::{
+        ArrowRecordBatchReader, Backpressure, BatchReaderBuilder, BlockingRecordBatchIter,
+        RecordBatchStream, DEFAULT_BATCH_SIZE, DEFAULT_LINGER, DEFAULT_QUEUE_DEPTH,
+    };
+
     /// Consumer wait strategies for the streaming ring.
     ///
     /// When the consumer drains the ring faster than events arrive, it

--- a/crates/thetadatadx/src/lifecycle.rs
+++ b/crates/thetadatadx/src/lifecycle.rs
@@ -25,7 +25,20 @@ pub enum DispatcherSession {
     /// Dispatcher thread is live. `JoinHandle` is required so
     /// `stop_streaming` can join it and observe a clean exit or a panic
     /// payload.
-    Running { handle: std::thread::JoinHandle<()> },
+    ///
+    /// `on_teardown` is an optional one-shot, run while the session is being
+    /// retired and just before the join. It lets a teardown that bypasses the
+    /// consumer-facing close (a `Client` drop / `stop_streaming` /
+    /// `reconnect_streaming`) deliver the same wakeup the close path does, so a
+    /// dispatcher parked on its own backpressure primitive is released and the
+    /// join cannot hang. The per-event callback dispatcher parks only on the
+    /// event ring (which the client shutdown already signals) and installs
+    /// `None`; the columnar pull dispatcher can park on its bounded batch queue
+    /// and installs a hook that wakes it.
+    Running {
+        handle: std::thread::JoinHandle<()>,
+        on_teardown: Option<Box<dyn FnOnce() + Send>>,
+    },
     /// Dispatcher terminated via an uncaught panic in the event-iteration
     /// machinery (NOT a user-callback panic — those are caught by
     /// per-invocation `catch_unwind` inside `poll_batch`). The payload

--- a/docs-site/docs/streaming/index.md
+++ b/docs-site/docs/streaming/index.md
@@ -11,6 +11,15 @@ Streaming requires a Standard subscription or higher on the matching asset class
 
 Streaming authenticates the same way as historical requests. An API key works here too: set `THETADATA_API_KEY` and build credentials with `from_env_or_file` (or the api-key constructor) in place of `from_file`. See [Authenticate](/articles/getting-started#_2-authenticate).
 
+## Delivery modes
+
+The same subscriptions can be consumed two ways:
+
+- **Per-event callback** (`start_streaming`): each event is pushed to a callback you register, one at a time. Reach for it when you react to events as they arrive and want the lowest per-event latency.
+- **Columnar pull** (`batches`): events are pulled as Apache Arrow `RecordBatch` values under a fixed schema. Reach for it when you want bulk, columnar throughput into pandas, polars, or DuckDB.
+
+The callback path is documented below; the pull reader is covered under [Columnar batches](#columnar-batches). Pick one per session, not both.
+
 ## Connect, subscribe, receive
 
 <SdkTabs>
@@ -139,6 +148,18 @@ Build a typed subscription from a `Contract` (per-contract scope) or a `SecType`
 - `subscribe_many([...])` installs a batch in one call; `active_subscriptions()` snapshots what is installed.
 
 The per-stream-type pages in the sidebar carry the exact subscribe code, the event fields, and the unsubscribe call for each stream.
+
+## Columnar batches
+
+`client.stream().batches(...)` opens a pull reader that delivers the same subscriptions as Apache Arrow `RecordBatch` values under a fixed schema, a sibling to the per-event callback. The reader is iterable in each binding (synchronous and async), yields batches you concatenate freely, and tears the session down on close (context-manager exit, `Symbol.asyncDispose`, or the destructor). Open the reader first, since it starts the session, then subscribe.
+
+Three knobs tune it:
+
+- **`batch_size`**: rows per batch. A batch is emitted when it fills or when `linger` elapses, whichever comes first.
+- **`linger`**: the maximum time a partial batch waits before being emitted, so a quiet stream still delivers.
+- **`backpressure`**: what happens when the reader falls behind. `Block` (the default, lossless: the wire is paced) or `DropOldest` (a bounded buffer of `capacity` batches that drops, and counts, the oldest on overflow).
+
+The minimal per-language example is in each SDK README; the field set is the fixed streaming schema shared across bindings.
 
 ## Lifecycle
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -33,6 +33,10 @@ testing-panic-boundary = []
 thetadatadx = { path = "../crates/thetadatadx", features = ["arrow", "__internal"] }
 tokio = { version = "1.52.3", features = ["rt-multi-thread"] }
 arrow-ipc = "59.0.0"
+# RecordBatch / Schema types for the streaming `RecordBatch` reader's Arrow
+# IPC boundary. Pinned to the same major as `arrow-ipc` and the parent crate.
+arrow-array = "59.0.0"
+arrow-schema = "59.0.0"
 # Used by the FPSS streaming callback silent-drop observability path
 # (see `thetadatadx_streaming_dropped_events` / `thetadatadx_client_dropped_events`). Keep
 # pinned to the same major/minor as the parent crate so the target that

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -126,6 +126,8 @@ pub mod auth;
 pub mod endpoints;
 pub mod flatfiles;
 pub mod streaming;
+pub mod streaming_batches;
+mod streaming_batches_ipc;
 pub mod types;
 pub mod utility;
 
@@ -141,5 +143,6 @@ pub use crate::endpoints::*;
 pub use crate::error::*;
 pub use crate::flatfiles::*;
 pub use crate::streaming::*;
+pub use crate::streaming_batches::*;
 pub use crate::types::*;
 pub use crate::utility::*;

--- a/ffi/src/streaming.rs
+++ b/ffi/src/streaming.rs
@@ -1874,7 +1874,12 @@ pub unsafe extern "C" fn thetadatadx_streaming_set_callback(
             },
         ) {
             Ok(h) => {
-                *dispatcher_guard = FfpssDispatcherSession::Running { handle: h };
+                // The callback dispatcher parks only on the event ring, which
+                // the client shutdown signals on teardown, so no wake hook.
+                *dispatcher_guard = FfpssDispatcherSession::Running {
+                    handle: h,
+                    on_teardown: None,
+                };
                 0
             }
             Err(()) => -1,
@@ -2345,7 +2350,12 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
         };
         match spawn_result {
             Ok(h) => {
-                *dispatcher_guard = FfpssDispatcherSession::Running { handle: h };
+                // The callback dispatcher parks only on the event ring, which
+                // the client shutdown signals on teardown, so no wake hook.
+                *dispatcher_guard = FfpssDispatcherSession::Running {
+                    handle: h,
+                    on_teardown: None,
+                };
             }
             Err(e) => {
                 set_error(&format!("failed to spawn FPSS dispatcher thread: {e}"));
@@ -2385,7 +2395,7 @@ pub unsafe extern "C" fn thetadatadx_streaming_reconnect(
 /// to `Failed` with the downcasted payload string.
 fn join_dispatcher_session(session: &mut FfpssDispatcherSession) {
     let prev = std::mem::replace(session, FfpssDispatcherSession::Idle);
-    if let FfpssDispatcherSession::Running { handle } = prev {
+    if let FfpssDispatcherSession::Running { handle, .. } = prev {
         if handle.thread().id() != std::thread::current().id() {
             match handle.join() {
                 Ok(()) => {}

--- a/ffi/src/streaming_batches.rs
+++ b/ffi/src/streaming_batches.rs
@@ -21,11 +21,31 @@
 //! `thetadatadx_client_batches_open` starts the session and returns an
 //! opaque handle. `..._next_ipc` blocks for the next batch (releasing no
 //! lock the caller holds); a `1` return means clean end of stream.
-//! `..._free` stops the session and joins, with no thread / socket /
-//! subscription leak. Every entry point is wrapped in the panic boundary so
-//! no Rust panic crosses `extern "C"`.
+//! `..._close` signals shutdown through a shared reference, so it is safe to
+//! call from another thread WHILE a `..._next_ipc` pull is parked: it wakes
+//! the pull (which then returns end of stream) and tears the FPSS session
+//! down without taking exclusive ownership. `..._free` releases the handle.
+//! Every entry point is wrapped in the panic boundary so no Rust panic
+//! crosses `extern "C"`.
+//!
+//! # Concurrency and handle ownership
+//!
+//! The reader is held behind an `Arc` so a teardown from one thread cannot
+//! deallocate the reader out from under a blocking pull parked on another
+//! thread. `..._next_ipc` / `..._schema_ipc` / `..._dropped` each take a
+//! short owning clone of that `Arc` for the duration of the call, so the
+//! reader stays alive for the whole pull even if `..._free` runs
+//! concurrently. `..._free` signals close before dropping its handle
+//! reference, so a parked pull is woken (returns end of stream) and the last
+//! `Arc` drop (whichever thread holds it) performs the deallocation. This
+//! mirrors the Python and TypeScript readers, which hold the same core
+//! [`RecordBatchStream`] behind an `Arc` and close through
+//! [`RecordBatchStream::close_shared`]; a bare owned handle freed by value
+//! would instead deallocate the reader while a concurrent pull still
+//! borrowed it.
 
 use std::os::raw::c_void;
+use std::sync::Arc;
 
 use thetadatadx::streaming::{Backpressure, RecordBatchStream};
 
@@ -47,10 +67,15 @@ pub const THETADATADX_BACKPRESSURE_DROP_OLDEST: i32 = 1;
 /// Opaque handle to a live pull-based Arrow `RecordBatch` reader.
 ///
 /// Created by [`thetadatadx_client_batches_open`], drained by
-/// [`thetadatadx_record_batch_stream_next_ipc`], freed by
+/// [`thetadatadx_record_batch_stream_next_ipc`], closed by
+/// [`thetadatadx_record_batch_stream_close`], freed by
 /// [`thetadatadx_record_batch_stream_free`].
+///
+/// The reader is held behind an `Arc` so a concurrent free cannot
+/// deallocate it while a blocking pull on another thread still borrows it;
+/// see the module-level concurrency note.
 pub struct ThetaDataDxRecordBatchStream {
-    inner: RecordBatchStream,
+    inner: Arc<RecordBatchStream>,
 }
 
 /// Open a pull-based Arrow `RecordBatch` reader over the unified client's
@@ -114,7 +139,9 @@ pub unsafe extern "C" fn thetadatadx_client_batches_open(
             .backpressure(backpressure)
             .build();
         match stream {
-            Ok(inner) => Box::into_raw(Box::new(ThetaDataDxRecordBatchStream { inner })),
+            Ok(inner) => Box::into_raw(Box::new(ThetaDataDxRecordBatchStream {
+                inner: Arc::new(inner),
+            })),
             Err(e) => {
                 crate::error::set_error_from(&e);
                 std::ptr::null_mut()
@@ -162,7 +189,13 @@ pub unsafe extern "C" fn thetadatadx_record_batch_stream_next_ipc(
             set_error("stream handle is null");
             return -1;
         };
-        match stream.inner.next_blocking() {
+        // Take an owning clone of the reader before the blocking pull so a
+        // concurrent `..._free` on another thread cannot deallocate the reader
+        // while this pull is parked inside `next_blocking`. The `&stream`
+        // borrow of the boxed handle ends here; the pull runs against the
+        // cloned `Arc`, and a concurrent close wakes it (see the module note).
+        let inner = Arc::clone(&stream.inner);
+        match inner.next_blocking() {
             Ok(Some(batch)) => match crate::streaming_batches_ipc::batch_to_ipc(&batch) {
                 Ok(bytes) => {
                     // SAFETY: `out` validated non-null + writable above.
@@ -214,7 +247,10 @@ pub unsafe extern "C" fn thetadatadx_record_batch_stream_schema_ipc(
             set_error("stream handle is null");
             return -1;
         };
-        match crate::streaming_batches_ipc::schema_to_ipc(&stream.inner.schema()) {
+        // Own the reader for the call so a concurrent `..._free` cannot
+        // deallocate it mid-read (see the module concurrency note).
+        let inner = Arc::clone(&stream.inner);
+        match crate::streaming_batches_ipc::schema_to_ipc(&inner.schema()) {
             Ok(bytes) => {
                 // SAFETY: `out` validated writable above.
                 unsafe { out.write(ThetaDataDxArrowBytes::from_vec(bytes)) };
@@ -244,7 +280,9 @@ pub unsafe extern "C" fn thetadatadx_record_batch_stream_dropped(
         // from `thetadatadx_client_batches_open`, not freed; `as_ref` yields
         // `None` for a null pointer, handled below.
         match unsafe { stream.as_ref() } {
-            Some(stream) => stream.inner.dropped(),
+            // Own the reader for the read so a concurrent `..._free` cannot
+            // deallocate it mid-call (see the module concurrency note).
+            Some(stream) => Arc::clone(&stream.inner).dropped(),
             None => {
                 set_error("stream handle is null");
                 0
@@ -253,11 +291,51 @@ pub unsafe extern "C" fn thetadatadx_record_batch_stream_dropped(
     })
 }
 
-/// Stop the reader, tear down the FPSS session, and free the handle.
+/// Stop the reader: unsubscribe and tear the FPSS session down, WITHOUT
+/// freeing the handle.
 ///
-/// Idempotent with respect to the underlying session (the core
-/// `RecordBatchStream` drop is a no-op if already closed). After this call
-/// the handle is invalid and must not be used.
+/// Signals shutdown through a shared reference, so it is safe to call from a
+/// different thread while a [`thetadatadx_record_batch_stream_next_ipc`] pull
+/// is parked: it wakes the pull (which returns `1`, clean end of stream) and
+/// shuts the session down. Idempotent; safe to call any number of times. The
+/// handle remains valid and must still be released with
+/// [`thetadatadx_record_batch_stream_free`].
+///
+/// This is the teardown a multi-threaded caller (e.g. a control thread that
+/// stops a reader another thread is draining) should use: it never takes
+/// exclusive ownership of the handle, so it cannot race the in-flight pull
+/// the way freeing the handle by value would.
+///
+/// # Safety
+///
+/// `stream` must be a valid handle from [`thetadatadx_client_batches_open`]
+/// not yet freed, or null (a null is a no-op).
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_record_batch_stream_close(
+    stream: *const ThetaDataDxRecordBatchStream,
+) {
+    ffi_boundary!((), {
+        // SAFETY: caller's contract guarantees `stream` is a live handle from
+        // `_open`, not freed; `as_ref` yields `None` for null, a no-op.
+        if let Some(stream) = unsafe { stream.as_ref() } {
+            // Shared-reference close: wakes any in-flight pull on another
+            // thread and tears the session down without exclusive ownership.
+            stream.inner.close_shared();
+        }
+    })
+}
+
+/// Release the reader handle.
+///
+/// Signals shutdown first (waking any in-flight pull, which then returns
+/// clean end of stream) and then drops this handle's reference to the
+/// reader. Because the reader is held behind an `Arc` and every pull takes
+/// its own clone for the duration of the call, the underlying reader is
+/// deallocated only once the last reference drops, so a
+/// [`thetadatadx_record_batch_stream_next_ipc`] pull parked on another thread
+/// at the moment of free is woken and completes against still-live memory
+/// rather than being deallocated out from under it. After this call the
+/// handle is invalid and must not be used.
 ///
 /// # Safety
 ///
@@ -272,9 +350,16 @@ pub unsafe extern "C" fn thetadatadx_record_batch_stream_free(
             return;
         }
         // SAFETY: caller's contract guarantees `stream` is a live handle
-        // from `_open`, not previously freed. Reconstituting the Box drops
-        // the `RecordBatchStream`, whose `Drop` stops the session and joins.
-        drop(unsafe { Box::from_raw(stream) });
+        // from `_open`, not previously freed.
+        let boxed = unsafe { Box::from_raw(stream) };
+        // Signal close before dropping this handle's `Arc`, so a pull parked
+        // on another thread is woken and returns end of stream. Dropping
+        // `boxed` then releases this reference; the reader itself is
+        // deallocated by whichever thread drops the last `Arc` (its core
+        // `Drop` re-signals close idempotently), never while a concurrent
+        // pull still holds a clone.
+        boxed.inner.close_shared();
+        drop(boxed);
     })
 }
 
@@ -288,3 +373,55 @@ const _: () = {
             == std::mem::size_of::<*mut c_void>()
     );
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every reader entry point treats a null handle as a well-defined no-op
+    /// (or error return), never a deref of null. The out-param functions
+    /// additionally leave `out` initialised empty so a caller can always read
+    /// it. The live-handle pull / close / free concurrency contract (that a
+    /// teardown never deallocates the reader out from under an in-flight pull)
+    /// is held by the `Arc` ownership here and proven in the core
+    /// `fpss::batch_reader` tests (`close_from_another_handle_unblocks_a_parked_pull`);
+    /// it needs a live FPSS connection, so it is exercised there rather than
+    /// reconstructed against a mock in this layer.
+    #[test]
+    fn null_handle_is_a_safe_no_op_on_every_entry_point() {
+        // close / free / dropped on null: no deref, no panic.
+        // SAFETY: passing null is explicitly part of each function's contract.
+        unsafe {
+            thetadatadx_record_batch_stream_close(std::ptr::null());
+            thetadatadx_record_batch_stream_free(std::ptr::null_mut());
+            assert_eq!(thetadatadx_record_batch_stream_dropped(std::ptr::null()), 0);
+        }
+
+        // next_ipc / schema_ipc on a null handle: -1, and `out` left as the
+        // empty sentinel so the caller can always read it and has nothing to
+        // free. The out-param is seeded empty (the documented pre-call state);
+        // the callee overwrites with the empty sentinel and owns no buffer.
+        let mut next_out = ThetaDataDxArrowBytes::empty();
+        let mut schema_out = ThetaDataDxArrowBytes::empty();
+        // SAFETY: null handle + valid writable out-param; contract returns -1
+        // and writes an empty `out`.
+        let rc_next =
+            unsafe { thetadatadx_record_batch_stream_next_ipc(std::ptr::null(), &mut next_out) };
+        // SAFETY: null handle + valid writable out-param; contract returns -1
+        // and writes an empty `out`.
+        let rc_schema = unsafe {
+            thetadatadx_record_batch_stream_schema_ipc(std::ptr::null(), &mut schema_out)
+        };
+        assert_eq!(rc_next, -1);
+        assert_eq!(rc_schema, -1);
+        assert!(next_out.data.is_null() && next_out.len == 0);
+        assert!(schema_out.data.is_null() && schema_out.len == 0);
+
+        // A null `out` is rejected without a deref.
+        // SAFETY: null handle + null out; contract returns -1.
+        let rc_null_out = unsafe {
+            thetadatadx_record_batch_stream_next_ipc(std::ptr::null(), std::ptr::null_mut())
+        };
+        assert_eq!(rc_null_out, -1);
+    }
+}

--- a/ffi/src/streaming_batches.rs
+++ b/ffi/src/streaming_batches.rs
@@ -1,0 +1,290 @@
+//! C ABI for the pull-based Arrow `RecordBatch` streaming reader.
+//!
+//! This is the C-side surface the C++ SDK's `Stream::batches(..)` builds on.
+//! It is the sibling of the per-event `thetadatadx_client_set_callback`
+//! path: the same subscriptions feed it, but market-data events are pulled
+//! as columnar Arrow batches under the fixed streaming schema (see the
+//! core `thetadatadx::streaming::stream_batch_schema`) rather than pushed one
+//! at a time.
+//!
+//! # Boundary format
+//!
+//! Each batch crosses the C ABI as an Arrow IPC stream byte buffer — the
+//! same columnar exit the per-tick `thetadatadx_*_to_arrow_ipc` terminals
+//! use, so a C++ caller decodes it with arrow-cpp's IPC reader exactly as it
+//! already does for historical results. The fixed schema is available up
+//! front as a schema-only IPC buffer so the C++ `arrow::RecordBatchReader`
+//! subclass can report `schema()` before the first batch arrives.
+//!
+//! # Lifecycle
+//!
+//! `thetadatadx_client_batches_open` starts the session and returns an
+//! opaque handle. `..._next_ipc` blocks for the next batch (releasing no
+//! lock the caller holds); a `1` return means clean end of stream.
+//! `..._free` stops the session and joins, with no thread / socket /
+//! subscription leak. Every entry point is wrapped in the panic boundary so
+//! no Rust panic crosses `extern "C"`.
+
+use std::os::raw::c_void;
+
+use thetadatadx::streaming::{Backpressure, RecordBatchStream};
+
+use crate::error::set_error;
+use crate::streaming::ThetaDataDxClient;
+use crate::types::ThetaDataDxArrowBytes;
+
+/// Backpressure policy selector for [`thetadatadx_client_batches_open`].
+///
+/// Mirrors `thetadatadx::streaming::Backpressure`. `BLOCK` is lossless and
+/// applies backpressure to the wire; `DROP_OLDEST` keeps a bounded buffer
+/// and drops the oldest batch on overflow, counted by
+/// [`thetadatadx_record_batch_stream_dropped`].
+pub const THETADATADX_BACKPRESSURE_BLOCK: i32 = 0;
+/// Bounded-buffer, drop-oldest backpressure. See
+/// [`THETADATADX_BACKPRESSURE_BLOCK`].
+pub const THETADATADX_BACKPRESSURE_DROP_OLDEST: i32 = 1;
+
+/// Opaque handle to a live pull-based Arrow `RecordBatch` reader.
+///
+/// Created by [`thetadatadx_client_batches_open`], drained by
+/// [`thetadatadx_record_batch_stream_next_ipc`], freed by
+/// [`thetadatadx_record_batch_stream_free`].
+pub struct ThetaDataDxRecordBatchStream {
+    inner: RecordBatchStream,
+}
+
+/// Open a pull-based Arrow `RecordBatch` reader over the unified client's
+/// stream.
+///
+/// Subscriptions are managed on the same surface as the callback path
+/// (`thetadatadx_client_*` subscribe entry points); subscribe first, then
+/// open the reader. Starts the FPSS session, so this is an alternative to
+/// `thetadatadx_client_set_callback`, not a concurrent consumer.
+///
+/// `batch_size` rows per batch (`0` is clamped to 1). `linger_ms` is the
+/// partial-batch flush deadline in milliseconds so a quiet stream still
+/// delivers. `backpressure` is one of [`THETADATADX_BACKPRESSURE_BLOCK`] /
+/// [`THETADATADX_BACKPRESSURE_DROP_OLDEST`]; `capacity` is the bounded-buffer
+/// depth in batches for the drop-oldest mode (ignored, may be 0, for block
+/// mode).
+///
+/// Returns a handle on success, or null with `thetadatadx_last_error()` set
+/// on failure (network / auth / parse error, an unknown `backpressure`
+/// value, or a stream already active on the client). Free the handle with
+/// [`thetadatadx_record_batch_stream_free`].
+///
+/// # Safety
+///
+/// `handle` must be a valid pointer returned by `thetadatadx_client_connect`
+/// and not yet freed, valid for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_client_batches_open(
+    handle: *const ThetaDataDxClient,
+    batch_size: usize,
+    linger_ms: u64,
+    backpressure: i32,
+    capacity: usize,
+) -> *mut ThetaDataDxRecordBatchStream {
+    ffi_boundary!(std::ptr::null_mut(), {
+        // SAFETY: the caller's contract guarantees `handle` is a live
+        // `ThetaDataDxClient` from `thetadatadx_client_connect`, valid for
+        // the call; `as_ref` yields `None` for a null pointer, handled below.
+        let Some(client) = (unsafe { handle.as_ref() }) else {
+            set_error("client handle is null");
+            return std::ptr::null_mut();
+        };
+        let backpressure = match backpressure {
+            THETADATADX_BACKPRESSURE_BLOCK => Backpressure::Block,
+            THETADATADX_BACKPRESSURE_DROP_OLDEST => Backpressure::DropOldest {
+                capacity: capacity.max(1),
+            },
+            other => {
+                set_error(&format!(
+                    "unknown backpressure value {other}; expected 0 (block) or 1 (drop-oldest)"
+                ));
+                return std::ptr::null_mut();
+            }
+        };
+        let stream = client
+            .inner
+            .stream()
+            .batches()
+            .batch_size(batch_size.max(1))
+            .linger(std::time::Duration::from_millis(linger_ms))
+            .backpressure(backpressure)
+            .build();
+        match stream {
+            Ok(inner) => Box::into_raw(Box::new(ThetaDataDxRecordBatchStream { inner })),
+            Err(e) => {
+                crate::error::set_error_from(&e);
+                std::ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Block for the next batch and serialise it as an Arrow IPC stream into
+/// `out`.
+///
+/// Returns:
+/// * `0` — a batch was produced; `out` holds its IPC bytes (free with
+///   [`crate::types::thetadatadx_arrow_bytes_free`]).
+/// * `1` — clean end of stream; `out` is set empty (`data = null, len = 0`),
+///   nothing to free.
+/// * `-1` — error; `out` is set empty and `thetadatadx_last_error()` is set.
+///
+/// # Safety
+///
+/// `stream` must be a valid handle from [`thetadatadx_client_batches_open`]
+/// not yet freed. `out` must be a valid, writable pointer to a
+/// [`ThetaDataDxArrowBytes`]; on every return path it is fully initialised.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_record_batch_stream_next_ipc(
+    stream: *const ThetaDataDxRecordBatchStream,
+    out: *mut ThetaDataDxArrowBytes,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if out.is_null() {
+            set_error("out pointer is null");
+            return -1;
+        }
+        // Initialise the out-param to empty up front so every early return
+        // leaves a well-formed (data=null, len=0) value the caller can read
+        // and need not free.
+        // SAFETY: `out` is non-null and the caller's contract guarantees it
+        // is a valid writable `ThetaDataDxArrowBytes`.
+        unsafe { out.write(ThetaDataDxArrowBytes::empty()) };
+
+        // SAFETY: caller's contract guarantees `stream` is a live handle
+        // from `thetadatadx_client_batches_open`, not freed; `as_ref` yields
+        // `None` for a null pointer, handled below.
+        let Some(stream) = (unsafe { stream.as_ref() }) else {
+            set_error("stream handle is null");
+            return -1;
+        };
+        match stream.inner.next_blocking() {
+            Ok(Some(batch)) => match crate::streaming_batches_ipc::batch_to_ipc(&batch) {
+                Ok(bytes) => {
+                    // SAFETY: `out` validated non-null + writable above.
+                    unsafe { out.write(ThetaDataDxArrowBytes::from_vec(bytes)) };
+                    0
+                }
+                Err(msg) => {
+                    set_error(&msg);
+                    -1
+                }
+            },
+            Ok(None) => 1,
+            Err(e) => {
+                crate::error::set_error_from(&thetadatadx::Error::from(e));
+                -1
+            }
+        }
+    })
+}
+
+/// Serialise the reader's fixed schema as a schema-only Arrow IPC stream
+/// into `out`, so a C++ `arrow::RecordBatchReader` can report `schema()`
+/// before any batch arrives.
+///
+/// Returns `0` on success (`out` holds the schema IPC bytes, free with
+/// [`crate::types::thetadatadx_arrow_bytes_free`]) or `-1` on error (`out`
+/// set empty, `thetadatadx_last_error()` set).
+///
+/// # Safety
+///
+/// Same handle / `out` contract as
+/// [`thetadatadx_record_batch_stream_next_ipc`].
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_record_batch_stream_schema_ipc(
+    stream: *const ThetaDataDxRecordBatchStream,
+    out: *mut ThetaDataDxArrowBytes,
+) -> i32 {
+    ffi_boundary!(-1, {
+        if out.is_null() {
+            set_error("out pointer is null");
+            return -1;
+        }
+        // SAFETY: `out` non-null; caller guarantees it is writable.
+        unsafe { out.write(ThetaDataDxArrowBytes::empty()) };
+        // SAFETY: caller's contract guarantees `stream` is a live handle
+        // from `thetadatadx_client_batches_open`, not freed; `as_ref` yields
+        // `None` for a null pointer, handled below.
+        let Some(stream) = (unsafe { stream.as_ref() }) else {
+            set_error("stream handle is null");
+            return -1;
+        };
+        match crate::streaming_batches_ipc::schema_to_ipc(&stream.inner.schema()) {
+            Ok(bytes) => {
+                // SAFETY: `out` validated writable above.
+                unsafe { out.write(ThetaDataDxArrowBytes::from_vec(bytes)) };
+                0
+            }
+            Err(msg) => {
+                set_error(&msg);
+                -1
+            }
+        }
+    })
+}
+
+/// Number of batches dropped so far under the drop-oldest backpressure
+/// policy. Always `0` under the block policy.
+///
+/// # Safety
+///
+/// `stream` must be a valid handle from [`thetadatadx_client_batches_open`]
+/// not yet freed.
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_record_batch_stream_dropped(
+    stream: *const ThetaDataDxRecordBatchStream,
+) -> u64 {
+    ffi_boundary!(0, {
+        // SAFETY: caller's contract guarantees `stream` is a live handle
+        // from `thetadatadx_client_batches_open`, not freed; `as_ref` yields
+        // `None` for a null pointer, handled below.
+        match unsafe { stream.as_ref() } {
+            Some(stream) => stream.inner.dropped(),
+            None => {
+                set_error("stream handle is null");
+                0
+            }
+        }
+    })
+}
+
+/// Stop the reader, tear down the FPSS session, and free the handle.
+///
+/// Idempotent with respect to the underlying session (the core
+/// `RecordBatchStream` drop is a no-op if already closed). After this call
+/// the handle is invalid and must not be used.
+///
+/// # Safety
+///
+/// `stream` must be a valid handle from [`thetadatadx_client_batches_open`]
+/// not yet freed, or null (a null is a no-op).
+#[no_mangle]
+pub unsafe extern "C" fn thetadatadx_record_batch_stream_free(
+    stream: *mut ThetaDataDxRecordBatchStream,
+) {
+    ffi_boundary!((), {
+        if stream.is_null() {
+            return;
+        }
+        // SAFETY: caller's contract guarantees `stream` is a live handle
+        // from `_open`, not previously freed. Reconstituting the Box drops
+        // the `RecordBatchStream`, whose `Drop` stops the session and joins.
+        drop(unsafe { Box::from_raw(stream) });
+    })
+}
+
+// The opaque handle carries a raw owner pointer across the boundary; the
+// pointer is only ever produced and consumed by these functions, never
+// dereferenced by foreign code.
+const _: () = {
+    // Compile-time reminder that the handle is pointer-sized opaque state.
+    assert!(
+        std::mem::size_of::<*mut ThetaDataDxRecordBatchStream>()
+            == std::mem::size_of::<*mut c_void>()
+    );
+};

--- a/ffi/src/streaming_batches_ipc.rs
+++ b/ffi/src/streaming_batches_ipc.rs
@@ -19,7 +19,10 @@ use arrow_schema::Schema;
 /// Returns a human-readable message on an IPC writer / write / finish
 /// failure, surfaced to the caller through `thetadatadx_last_error()`.
 pub(crate) fn batch_to_ipc(batch: &RecordBatch) -> Result<Vec<u8>, String> {
-    let mut buf: Vec<u8> = Vec::new();
+    // Seed the buffer from the batch's in-memory byte size so the IPC body
+    // (which is close to that size plus a small framing overhead) is written
+    // without re-growing the Vec from empty on the dispatcher-adjacent path.
+    let mut buf: Vec<u8> = Vec::with_capacity(batch.get_array_memory_size());
     {
         let mut writer = StreamWriter::try_new(std::io::Cursor::new(&mut buf), &batch.schema())
             .map_err(|e| format!("arrow ipc writer init failed: {e}"))?;

--- a/ffi/src/streaming_batches_ipc.rs
+++ b/ffi/src/streaming_batches_ipc.rs
@@ -19,10 +19,14 @@ use arrow_schema::Schema;
 /// Returns a human-readable message on an IPC writer / write / finish
 /// failure, surfaced to the caller through `thetadatadx_last_error()`.
 pub(crate) fn batch_to_ipc(batch: &RecordBatch) -> Result<Vec<u8>, String> {
-    // Seed the buffer from the batch's in-memory byte size so the IPC body
-    // (which is close to that size plus a small framing overhead) is written
-    // without re-growing the Vec from empty on the dispatcher-adjacent path.
-    let mut buf: Vec<u8> = Vec::with_capacity(batch.get_array_memory_size());
+    // Seed the buffer from an estimate keyed on the row COUNT, so the IPC body
+    // is written without re-growing the Vec from empty. Sizing from
+    // `get_array_memory_size()` would seed from the builder's preallocated
+    // column capacity (now batch-size-wide), so a one-row linger-flushed batch
+    // would over-allocate by orders of magnitude; `estimated_ipc_len` keys on
+    // the used rows instead.
+    let mut buf: Vec<u8> =
+        Vec::with_capacity(thetadatadx::streaming::estimated_ipc_len(batch.num_rows()));
     {
         let mut writer = StreamWriter::try_new(std::io::Cursor::new(&mut buf), &batch.schema())
             .map_err(|e| format!("arrow ipc writer init failed: {e}"))?;
@@ -55,4 +59,58 @@ pub(crate) fn schema_to_ipc(schema: &Arc<Schema>) -> Result<Vec<u8>, String> {
             .map_err(|e| format!("arrow ipc schema finish failed: {e}"))?;
     }
     Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{ArrayRef, Float64Array, Int32Array, StringArray};
+    use arrow_schema::{DataType, Field};
+
+    /// Build a representative multi-column batch of `rows` rows. The seed
+    /// estimate is keyed on the row count and is schema-agnostic, so a few
+    /// typed columns suffice to exercise the IPC body-vs-seed relationship.
+    fn sample_batch(rows: usize) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("i", DataType::Int32, false),
+            Field::new("f", DataType::Float64, false),
+            Field::new("s", DataType::Utf8, false),
+        ]));
+        let ints = Int32Array::from((0..rows as i32).collect::<Vec<_>>());
+        let floats = Float64Array::from((0..rows).map(|i| i as f64).collect::<Vec<_>>());
+        let strings = StringArray::from((0..rows).map(|_| "SPY").collect::<Vec<_>>());
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(ints) as ArrayRef,
+                Arc::new(floats) as ArrayRef,
+                Arc::new(strings) as ArrayRef,
+            ],
+        )
+        .expect("sample batch")
+    }
+
+    /// The IPC seed estimate keeps a tiny (linger-flushed) batch's buffer small
+    /// and is large enough to hold a full batch's body without a doubling
+    /// regrow. This is the concrete check that the over-allocation regression
+    /// (seeding from buffer capacity, which is now batch-size-wide) is gone:
+    /// the seed for one row is a few kilobytes, and for a full batch it is at
+    /// least the actual serialized IPC length.
+    #[test]
+    fn ipc_seed_is_small_for_one_row_and_covers_a_full_batch() {
+        // One row: the seed is the framing overhead plus a row, well under
+        // 64 KiB (a buffer-capacity estimate would have reported megabytes).
+        let one = thetadatadx::streaming::estimated_ipc_len(1);
+        assert!(one < 64 * 1024, "one-row seed must be small, was {one}");
+
+        // Full batch: the seed must be at least the real serialized body so the
+        // writer never re-grows the Vec by doubling.
+        let rows = 65_536;
+        let body = batch_to_ipc(&sample_batch(rows)).expect("encode").len();
+        let seed = thetadatadx::streaming::estimated_ipc_len(rows);
+        assert!(
+            seed >= body,
+            "seed ({seed}) must cover the actual IPC body ({body}) so there is no regrow"
+        );
+    }
 }

--- a/ffi/src/streaming_batches_ipc.rs
+++ b/ffi/src/streaming_batches_ipc.rs
@@ -1,0 +1,55 @@
+//! Arrow IPC serialisation helpers for the streaming `RecordBatch` reader's
+//! C ABI.
+//!
+//! Each batch crosses the C boundary as an Arrow IPC stream, the same
+//! columnar wire format the per-tick `thetadatadx_*_to_arrow_ipc` terminals
+//! use, so the C++ SDK decodes a streaming batch with arrow-cpp's IPC reader
+//! exactly as it already decodes a historical result.
+
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_ipc::writer::StreamWriter;
+use arrow_schema::Schema;
+
+/// Serialise a [`RecordBatch`] as an Arrow IPC stream byte buffer.
+///
+/// # Errors
+///
+/// Returns a human-readable message on an IPC writer / write / finish
+/// failure, surfaced to the caller through `thetadatadx_last_error()`.
+pub(crate) fn batch_to_ipc(batch: &RecordBatch) -> Result<Vec<u8>, String> {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(std::io::Cursor::new(&mut buf), &batch.schema())
+            .map_err(|e| format!("arrow ipc writer init failed: {e}"))?;
+        writer
+            .write(batch)
+            .map_err(|e| format!("arrow ipc write failed: {e}"))?;
+        writer
+            .finish()
+            .map_err(|e| format!("arrow ipc finish failed: {e}"))?;
+    }
+    Ok(buf)
+}
+
+/// Serialise just a schema as a schema-only Arrow IPC stream (no batches),
+/// so a reader can report its fixed schema before the first batch.
+///
+/// # Errors
+///
+/// Returns a human-readable message on an IPC writer / finish failure.
+pub(crate) fn schema_to_ipc(schema: &Arc<Schema>) -> Result<Vec<u8>, String> {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let writer = StreamWriter::try_new(std::io::Cursor::new(&mut buf), schema.as_ref())
+            .map_err(|e| format!("arrow ipc schema writer init failed: {e}"))?;
+        // `try_new` writes the schema message; `finish` closes the stream
+        // with the end-of-stream marker. No batch is written, so the result
+        // is a valid schema-only stream.
+        writer
+            .into_inner()
+            .map_err(|e| format!("arrow ipc schema finish failed: {e}"))?;
+    }
+    Ok(buf)
+}

--- a/ffi/src/streaming_batches_ipc.rs
+++ b/ffi/src/streaming_batches_ipc.rs
@@ -64,53 +64,79 @@ pub(crate) fn schema_to_ipc(schema: &Arc<Schema>) -> Result<Vec<u8>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{ArrayRef, Float64Array, Int32Array, StringArray};
-    use arrow_schema::{DataType, Field};
+    use arrow_array::{ArrayRef, Float64Array, Int32Array, Int64Array, StringArray, UInt64Array};
+    use arrow_schema::DataType;
 
-    /// Build a representative multi-column batch of `rows` rows. The seed
-    /// estimate is keyed on the row count and is schema-agnostic, so a few
-    /// typed columns suffice to exercise the IPC body-vs-seed relationship.
-    fn sample_batch(rows: usize) -> RecordBatch {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("f", DataType::Float64, false),
-            Field::new("s", DataType::Utf8, false),
-        ]));
-        let ints = Int32Array::from((0..rows as i32).collect::<Vec<_>>());
-        let floats = Float64Array::from((0..rows).map(|i| i as f64).collect::<Vec<_>>());
-        let strings = StringArray::from((0..rows).map(|_| "SPY").collect::<Vec<_>>());
-        RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(ints) as ArrayRef,
-                Arc::new(floats) as ArrayRef,
-                Arc::new(strings) as ArrayRef,
-            ],
-        )
-        .expect("sample batch")
+    /// Build a batch of `rows` rows under the REAL fixed streaming schema (the
+    /// same 40 columns the live reader emits), so the seed estimate is tested
+    /// against a body whose per-row and framing sizes match what
+    /// `estimated_ipc_len` is calibrated for, not an unrepresentative sample.
+    /// Each field gets a column of its declared type; the values are arbitrary.
+    fn streaming_batch(rows: usize) -> RecordBatch {
+        let schema = thetadatadx::streaming::stream_batch_schema();
+        let columns: Vec<ArrayRef> = schema
+            .fields()
+            .iter()
+            .map(|field| -> ArrayRef {
+                match field.data_type() {
+                    DataType::Int32 => {
+                        Arc::new(Int32Array::from((0..rows as i32).collect::<Vec<_>>()))
+                    }
+                    DataType::Int64 => {
+                        Arc::new(Int64Array::from((0..rows as i64).collect::<Vec<_>>()))
+                    }
+                    DataType::UInt64 => {
+                        Arc::new(UInt64Array::from((0..rows as u64).collect::<Vec<_>>()))
+                    }
+                    DataType::Float64 => Arc::new(Float64Array::from(
+                        (0..rows).map(|i| i as f64).collect::<Vec<_>>(),
+                    )),
+                    DataType::Utf8 => Arc::new(StringArray::from(
+                        (0..rows).map(|_| "SPY").collect::<Vec<_>>(),
+                    )),
+                    other => panic!("unexpected streaming-schema column type {other:?}"),
+                }
+            })
+            .collect();
+        RecordBatch::try_new(schema, columns).expect("streaming batch")
     }
 
     /// The IPC seed estimate keeps a tiny (linger-flushed) batch's buffer small
-    /// and is large enough to hold a full batch's body without a doubling
-    /// regrow. This is the concrete check that the over-allocation regression
-    /// (seeding from buffer capacity, which is now batch-size-wide) is gone:
-    /// the seed for one row is a few kilobytes, and for a full batch it is at
-    /// least the actual serialized IPC length.
+    /// AND covers the real serialized body without a doubling regrow, for both
+    /// the smallest and a full batch. This is the concrete check that the
+    /// over-allocation regression (seeding from buffer capacity, now
+    /// batch-size-wide) is gone and that the framing allowance is large enough
+    /// for the smallest batch (whose body is dominated by the 40-field schema
+    /// preamble). Tested against the REAL 40-column schema so the per-row and
+    /// framing figures are the ones being validated.
     #[test]
-    fn ipc_seed_is_small_for_one_row_and_covers_a_full_batch() {
-        // One row: the seed is the framing overhead plus a row, well under
-        // 64 KiB (a buffer-capacity estimate would have reported megabytes).
-        let one = thetadatadx::streaming::estimated_ipc_len(1);
-        assert!(one < 64 * 1024, "one-row seed must be small, was {one}");
+    fn ipc_seed_is_small_for_one_row_and_covers_real_batches() {
+        // One row: the seed stays well under 64 KiB (a buffer-capacity estimate
+        // would have reported megabytes) ...
+        let one_seed = thetadatadx::streaming::estimated_ipc_len(1);
+        assert!(
+            one_seed < 64 * 1024,
+            "one-row seed must be small, was {one_seed}"
+        );
+        // ... and still covers the real one-row IPC body (dominated by the
+        // schema preamble), so even the smallest linger-flushed batch needs no
+        // realloc.
+        let one_body = batch_to_ipc(&streaming_batch(1)).expect("encode 1").len();
+        assert!(
+            one_seed >= one_body,
+            "one-row seed ({one_seed}) must cover the real one-row IPC body ({one_body})"
+        );
 
         // Full batch: the seed must be at least the real serialized body so the
         // writer never re-grows the Vec by doubling.
         let rows = 65_536;
-        let body = batch_to_ipc(&sample_batch(rows)).expect("encode").len();
-        let seed = thetadatadx::streaming::estimated_ipc_len(rows);
+        let full_body = batch_to_ipc(&streaming_batch(rows))
+            .expect("encode full")
+            .len();
+        let full_seed = thetadatadx::streaming::estimated_ipc_len(rows);
         assert!(
-            seed >= body,
-            "seed ({seed}) must cover the actual IPC body ({body}) so there is no regrow"
+            full_seed >= full_body,
+            "full-batch seed ({full_seed}) must cover the real IPC body ({full_body})"
         );
     }
 }

--- a/ffi/src/types.rs
+++ b/ffi/src/types.rs
@@ -354,7 +354,14 @@ impl ThetaDataDxArrowBytes {
         len: 0,
     };
 
-    fn from_vec(buf: Vec<u8>) -> Self {
+    /// An empty (`data = null, len = 0`) buffer. Shared with the streaming
+    /// `RecordBatch` reader's C ABI so its out-param can be initialised to a
+    /// well-formed empty value before each pull.
+    pub(crate) const fn empty() -> Self {
+        Self::EMPTY
+    }
+
+    pub(crate) fn from_vec(buf: Vec<u8>) -> Self {
         if buf.is_empty() {
             return Self::EMPTY;
         }

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -59,6 +59,25 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(thetadatadx_cpp PUBLIC pthread dl m)
 endif()
 
+# ── Optional: native arrow-cpp RecordBatch reader ──
+#
+# The pull-based columnar streaming reader (`client.stream().batches(..)`
+# returning an `arrow::RecordBatchReader`) requires arrow-cpp. It is gated so
+# the SDK still builds for users who do not link arrow-cpp; the rest of the
+# surface (including the per-tick `*_to_arrow_ipc` byte-buffer terminals) is
+# unaffected. Enable with `-DTHETADATADX_CPP_ARROW=ON` and ensure arrow-cpp is
+# discoverable by `find_package(Arrow)`.
+option(THETADATADX_CPP_ARROW "Enable the native arrow-cpp RecordBatch streaming reader" OFF)
+if(THETADATADX_CPP_ARROW)
+    find_package(Arrow REQUIRED)
+    target_compile_definitions(thetadatadx_cpp PUBLIC THETADATADX_CPP_ARROW)
+    if(TARGET Arrow::arrow_shared)
+        target_link_libraries(thetadatadx_cpp PUBLIC Arrow::arrow_shared)
+    else()
+        target_link_libraries(thetadatadx_cpp PUBLIC Arrow::arrow_static)
+    endif()
+endif()
+
 # ── Example ──
 
 add_executable(thetadatadx_example examples/main.cpp)

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -168,6 +168,18 @@ fpss.subscribe(thetadatadx::SecType::option().full_trades());   // the callback 
 > contract. `StreamingClient` is non-copyable but movable, and its destructor stops
 > the stream and waits for the callback to quiesce before returning.
 
+Prefer columns? `client.stream().batches(...)` is a sibling to the callback — the same subscriptions, delivered as Arrow record batches under a fixed schema through a native `arrow::RecordBatchReader`. Build the SDK with `-DTHETADATADX_CPP_ARROW=ON` (links arrow-cpp) to enable it:
+
+```cpp
+client.stream().subscribe(thetadatadx::Contract::stock("AAPL").trade());
+auto reader = client.stream().batches(/*batch_size=*/8192);
+std::shared_ptr<arrow::RecordBatch> batch;
+while (reader->ReadNext(&batch).ok() && batch != nullptr) {
+    std::printf("%lld rows\n", static_cast<long long>(batch->num_rows()));
+}
+// `reader` closes (unsubscribe + tear down) when the last reference drops.
+```
+
 ## Greeks calculator
 
 A full Black-Scholes calculator — first- through third-order Greeks plus an implied-volatility solver — runs locally, no connection required:

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -171,8 +171,9 @@ fpss.subscribe(thetadatadx::SecType::option().full_trades());   // the callback 
 Prefer columns? `client.stream().batches(...)` is a sibling to the callback — the same subscriptions, delivered as Arrow record batches under a fixed schema through a native `arrow::RecordBatchReader`. Build the SDK with `-DTHETADATADX_CPP_ARROW=ON` (links arrow-cpp) to enable it:
 
 ```cpp
-client.stream().subscribe(thetadatadx::Contract::stock("AAPL").trade());
+// `batches(...)` starts the FPSS session, so open it first, then subscribe.
 auto reader = client.stream().batches(/*batch_size=*/8192);
+client.stream().subscribe(thetadatadx::Contract::stock("AAPL").trade());
 std::shared_ptr<arrow::RecordBatch> batch;
 while (reader->ReadNext(&batch).ok() && batch != nullptr) {
     std::printf("%lld rows\n", static_cast<long long>(batch->num_rows()));

--- a/sdks/cpp/include/thetadatadx.h
+++ b/sdks/cpp/include/thetadatadx.h
@@ -881,8 +881,15 @@ void thetadatadx_arrow_bytes_free(ThetaDataDxArrowBytes bytes);
 
 /** Opaque handle to a live pull-based Arrow RecordBatch reader. Created by
  *  thetadatadx_client_batches_open, drained by
- *  thetadatadx_record_batch_stream_next_ipc, freed by
- *  thetadatadx_record_batch_stream_free. */
+ *  thetadatadx_record_batch_stream_next_ipc, closed by
+ *  thetadatadx_record_batch_stream_close, freed by
+ *  thetadatadx_record_batch_stream_free.
+ *
+ *  The reader is reference-counted internally: thetadatadx_record_batch_stream_close
+ *  and thetadatadx_record_batch_stream_free are safe to call from another
+ *  thread while a thetadatadx_record_batch_stream_next_ipc pull is in flight:
+ *  the pull is woken and returns end of stream, and the reader is not
+ *  deallocated until the in-flight pull completes. */
 typedef struct ThetaDataDxRecordBatchStream ThetaDataDxRecordBatchStream;
 
 /** Backpressure: lossless block (applies backpressure to the wire). */
@@ -931,7 +938,17 @@ int32_t thetadatadx_record_batch_stream_schema_ipc(const ThetaDataDxRecordBatchS
  *  under block. */
 uint64_t thetadatadx_record_batch_stream_dropped(const ThetaDataDxRecordBatchStream* stream);
 
-/** Stop the reader, tear down the FPSS session, and free the handle. A NULL
+/** Stop the reader, tear down the FPSS session, WITHOUT freeing the handle.
+ *  Safe to call from another thread while a pull is in flight: it wakes the
+ *  pull (which returns 1, clean end of stream) and shuts the session down.
+ *  Idempotent. The handle stays valid and must still be released with
+ *  thetadatadx_record_batch_stream_free. A NULL handle is a no-op. */
+void thetadatadx_record_batch_stream_close(const ThetaDataDxRecordBatchStream* stream);
+
+/** Release the reader handle. Signals close first (waking any in-flight pull,
+ *  which then returns 1, clean end of stream), then drops this handle's
+ *  reference; the reader is deallocated once the last in-flight pull
+ *  completes, so freeing while another thread is mid-pull is safe. A NULL
  *  handle is a no-op. After this call the handle is invalid. */
 void thetadatadx_record_batch_stream_free(ThetaDataDxRecordBatchStream* stream);
 

--- a/sdks/cpp/include/thetadatadx.h
+++ b/sdks/cpp/include/thetadatadx.h
@@ -877,6 +877,64 @@ ThetaDataDxArrowBytes thetadatadx_trade_quote_ticks_to_arrow_ipc(const ThetaData
  *               buffer is a no-op. Call exactly once. */
 void thetadatadx_arrow_bytes_free(ThetaDataDxArrowBytes bytes);
 
+/* ── Streaming Arrow RecordBatch reader (pull-based) ── */
+
+/** Opaque handle to a live pull-based Arrow RecordBatch reader. Created by
+ *  thetadatadx_client_batches_open, drained by
+ *  thetadatadx_record_batch_stream_next_ipc, freed by
+ *  thetadatadx_record_batch_stream_free. */
+typedef struct ThetaDataDxRecordBatchStream ThetaDataDxRecordBatchStream;
+
+/** Backpressure: lossless block (applies backpressure to the wire). */
+#define THETADATADX_BACKPRESSURE_BLOCK 0
+/** Backpressure: bounded buffer, drop the oldest batch on overflow (counted
+ *  by thetadatadx_record_batch_stream_dropped). */
+#define THETADATADX_BACKPRESSURE_DROP_OLDEST 1
+
+/** Open a pull-based Arrow RecordBatch reader over the unified client's
+ *  stream — a sibling to thetadatadx_client_set_callback. Subscribe first on
+ *  the same surface, then open. Starts the FPSS session.
+ *  @param handle Client from thetadatadx_client_connect.
+ *  @param batch_size Rows per batch (0 clamped to 1).
+ *  @param linger_ms Partial-batch flush deadline in ms (quiet-stream flush).
+ *  @param backpressure THETADATADX_BACKPRESSURE_BLOCK or _DROP_OLDEST.
+ *  @param capacity Bounded-buffer depth in batches for drop-oldest (ignored
+ *                  for block; may be 0).
+ *  @return Reader handle, or NULL with thetadatadx_last_error() set on
+ *          failure. Free with thetadatadx_record_batch_stream_free. */
+ThetaDataDxRecordBatchStream* thetadatadx_client_batches_open(const ThetaDataDxClient* handle,
+                                                              size_t batch_size,
+                                                              uint64_t linger_ms,
+                                                              int32_t backpressure,
+                                                              size_t capacity);
+
+/** Block for the next batch and serialise it as an Arrow IPC stream into
+ *  *out.
+ *  @param stream Reader from thetadatadx_client_batches_open.
+ *  @param out Out-param, always initialised: holds the batch IPC bytes on a 0
+ *             return (free with thetadatadx_arrow_bytes_free), or empty
+ *             (data=NULL, len=0) otherwise.
+ *  @return 0 = a batch was produced; 1 = clean end of stream; -1 = error
+ *          (thetadatadx_last_error() set). */
+int32_t thetadatadx_record_batch_stream_next_ipc(const ThetaDataDxRecordBatchStream* stream,
+                                                 ThetaDataDxArrowBytes* out);
+
+/** Serialise the reader's fixed schema as a schema-only Arrow IPC stream into
+ *  *out, so a reader can report its schema before the first batch.
+ *  @return 0 on success (out holds schema IPC bytes, free with
+ *          thetadatadx_arrow_bytes_free); -1 on error (out empty,
+ *          thetadatadx_last_error() set). */
+int32_t thetadatadx_record_batch_stream_schema_ipc(const ThetaDataDxRecordBatchStream* stream,
+                                                   ThetaDataDxArrowBytes* out);
+
+/** Number of batches dropped so far under the drop-oldest policy. Always 0
+ *  under block. */
+uint64_t thetadatadx_record_batch_stream_dropped(const ThetaDataDxRecordBatchStream* stream);
+
+/** Stop the reader, tear down the FPSS session, and free the handle. A NULL
+ *  handle is a no-op. After this call the handle is invalid. */
+void thetadatadx_record_batch_stream_free(ThetaDataDxRecordBatchStream* stream);
+
 /* ── Error ── */
 
 /** Retrieve the last error message for the current thread.

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -2227,6 +2227,15 @@ enum class Backpressure {
 /// Each batch crosses the C ABI as an Arrow IPC stream and is decoded here
 /// with arrow-cpp's IPC reader, the same wire format the per-tick
 /// `*_to_arrow_ipc` terminals use.
+///
+/// Thread-safety: `ReadNext` is the single blocking consumer and is not
+/// itself re-entrant, but `close()` and destruction are safe to call from a
+/// different thread while a `ReadNext` is parked: the underlying reader is
+/// reference-counted across the C ABI, so a teardown wakes the parked pull
+/// (which returns clean end of stream) and the reader is not torn down until
+/// the in-flight pull completes. This matches the standard
+/// `arrow::RecordBatchReader` handoff where a worker drains the reader while
+/// the owner may release the last `shared_ptr` or call `close()`.
 class RecordBatchStream : public arrow::RecordBatchReader {
 public:
     RecordBatchStream(const RecordBatchStream&) = delete;
@@ -2278,12 +2287,16 @@ public:
     }
 
     /// Stop the reader: unsubscribe and tear the FPSS session down.
-    /// Idempotent; subsequent reads return end of stream. Called by the
-    /// destructor.
+    /// Idempotent; subsequent reads return end of stream.
+    ///
+    /// Safe to call from another thread while a `ReadNext` is in flight: it
+    /// signals close through the reference-counted C ABI (waking the parked
+    /// pull, which then returns clean end of stream) without freeing the
+    /// handle. The handle is released by the destructor, so a `close()` here
+    /// followed by destruction frees exactly once.
     void close() {
         if (handle_ != nullptr) {
-            thetadatadx_record_batch_stream_free(handle_);
-            handle_ = nullptr;
+            thetadatadx_record_batch_stream_close(handle_);
         }
     }
 
@@ -2313,10 +2326,21 @@ private:
         : handle_(handle), schema_(std::move(schema)) {}
 
     /// Decode a single-batch Arrow IPC buffer into `*batch`.
+    ///
+    /// Called only for a `next_ipc` return of 0, which promises one batch in
+    /// the buffer. A null batch from the IPC reader (a truncated or malformed
+    /// frame) is therefore a decode error, not end of stream: surfacing it as
+    /// an error avoids silently truncating a live stream, since the
+    /// `arrow::RecordBatchReader` contract reads a null batch with an OK
+    /// status as end of stream.
     static arrow::Status decode_one(const ThetaDataDxArrowBytes& bytes,
                                     std::shared_ptr<arrow::RecordBatch>* batch) {
         ARROW_ASSIGN_OR_RAISE(auto reader, open_ipc(bytes));
         ARROW_ASSIGN_OR_RAISE(*batch, reader->Next());
+        if (*batch == nullptr) {
+            return arrow::Status::IOError(
+                "streaming batch IPC buffer contained no record batch");
+        }
         return arrow::Status::OK();
     }
 

--- a/sdks/cpp/include/thetadatadx.hpp
+++ b/sdks/cpp/include/thetadatadx.hpp
@@ -35,6 +35,24 @@
 #include <span>
 #endif
 
+// The pull-based Arrow `RecordBatch` reader (`Stream::batches(..)`) returns a
+// native `arrow::RecordBatchReader`, so it requires arrow-cpp. Gate it behind
+// `THETADATADX_CPP_ARROW` (set by the CMake `THETADATADX_CPP_ARROW` option) so
+// the rest of the SDK still builds for users who do not link arrow-cpp — the
+// per-tick `*_to_arrow_ipc` terminals already hand back raw IPC bytes for that
+// audience.
+#ifdef THETADATADX_CPP_ARROW
+#include <cstring>
+#include <arrow/array.h>
+#include <arrow/buffer.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/type.h>
+#endif
+
 namespace thetadatadx {
 
 // ── Chunk view for the server-stream callbacks ──
@@ -2181,6 +2199,162 @@ struct CallbackState {
     std::shared_ptr<CallbackSlot> slot = std::make_shared<CallbackSlot>();
 };
 
+/// Backpressure policy for the pull-based Arrow `RecordBatch` reader
+/// (`Stream::batches(..)`).
+///
+/// `Block` (default) is lossless and applies backpressure to the wire;
+/// `DropOldest` keeps a bounded buffer and drops the oldest batch on
+/// overflow, counted by `RecordBatchStream::dropped()`.
+enum class Backpressure {
+    /// Lossless: block until the reader catches up. The default.
+    Block,
+    /// Bounded buffer: drop the oldest batch on overflow, count it.
+    DropOldest,
+};
+
+#ifdef THETADATADX_CPP_ARROW
+/// Pull-based columnar reader over the live stream — a sibling to the
+/// per-event `Stream::set_callback`.
+///
+/// A concrete `arrow::RecordBatchReader`: `ReadNext(&batch)` yields the next
+/// batch (and sets `batch` to `nullptr` at clean end of stream), `schema()`
+/// reports the fixed schema, and `dropped()` reports the drop-oldest count.
+/// Held by `std::shared_ptr` (see `Stream::batches`); the reader closes —
+/// unsubscribing and tearing the FPSS session down — when the last reference
+/// drops (RAII). Every batch carries the identical schema, so batches are
+/// concat-safe.
+///
+/// Each batch crosses the C ABI as an Arrow IPC stream and is decoded here
+/// with arrow-cpp's IPC reader, the same wire format the per-tick
+/// `*_to_arrow_ipc` terminals use.
+class RecordBatchStream : public arrow::RecordBatchReader {
+public:
+    RecordBatchStream(const RecordBatchStream&) = delete;
+    RecordBatchStream& operator=(const RecordBatchStream&) = delete;
+
+    ~RecordBatchStream() override {
+        if (handle_ != nullptr) {
+            thetadatadx_record_batch_stream_free(handle_);
+            handle_ = nullptr;
+        }
+    }
+
+    /// The fixed Arrow schema every batch carries. Decoded once from the
+    /// schema-only IPC buffer and cached. Never null after construction.
+    std::shared_ptr<arrow::Schema> schema() const override {
+        return schema_;
+    }
+
+    /// Read the next batch. Sets `*batch` to the next `RecordBatch`, or to
+    /// `nullptr` at clean end of stream. Returns a non-OK status on error.
+    arrow::Status ReadNext(std::shared_ptr<arrow::RecordBatch>* batch) override {
+        if (batch == nullptr) {
+            return arrow::Status::Invalid("ReadNext: null out-parameter");
+        }
+        *batch = nullptr;
+        if (handle_ == nullptr) {
+            return arrow::Status::OK(); // closed -> end of stream
+        }
+        ThetaDataDxArrowBytes bytes{};
+        const int32_t rc = thetadatadx_record_batch_stream_next_ipc(handle_, &bytes);
+        if (rc == 1) {
+            return arrow::Status::OK(); // clean end of stream
+        }
+        if (rc < 0) {
+            const char* err = thetadatadx_last_error();
+            return arrow::Status::IOError(err != nullptr ? err
+                                                         : "record batch stream pull failed");
+        }
+        // rc == 0: decode the one batch carried by this IPC buffer.
+        arrow::Status status = decode_one(bytes, batch);
+        thetadatadx_arrow_bytes_free(bytes);
+        return status;
+    }
+
+    /// Number of batches dropped so far under the `DropOldest` policy. Always
+    /// 0 under `Block`.
+    uint64_t dropped() const {
+        return handle_ != nullptr ? thetadatadx_record_batch_stream_dropped(handle_) : 0;
+    }
+
+    /// Stop the reader: unsubscribe and tear the FPSS session down.
+    /// Idempotent; subsequent reads return end of stream. Called by the
+    /// destructor.
+    void close() {
+        if (handle_ != nullptr) {
+            thetadatadx_record_batch_stream_free(handle_);
+            handle_ = nullptr;
+        }
+    }
+
+private:
+    friend class Stream;
+
+    /// Build a reader over an owned C ABI handle, decoding the fixed schema
+    /// up front. Throws on a schema-decode failure (and frees the handle).
+    static std::shared_ptr<RecordBatchStream> create(ThetaDataDxRecordBatchStream* handle) {
+        ThetaDataDxArrowBytes schema_bytes{};
+        const int32_t rc = thetadatadx_record_batch_stream_schema_ipc(handle, &schema_bytes);
+        if (rc < 0) {
+            thetadatadx_record_batch_stream_free(handle);
+            detail::throw_last_ffi_error();
+        }
+        std::shared_ptr<arrow::Schema> schema;
+        arrow::Status status = decode_schema(schema_bytes, &schema);
+        thetadatadx_arrow_bytes_free(schema_bytes);
+        if (!status.ok()) {
+            thetadatadx_record_batch_stream_free(handle);
+            throw std::runtime_error("failed to decode streaming schema: " + status.ToString());
+        }
+        return std::shared_ptr<RecordBatchStream>(new RecordBatchStream(handle, std::move(schema)));
+    }
+
+    RecordBatchStream(ThetaDataDxRecordBatchStream* handle, std::shared_ptr<arrow::Schema> schema)
+        : handle_(handle), schema_(std::move(schema)) {}
+
+    /// Decode a single-batch Arrow IPC buffer into `*batch`.
+    static arrow::Status decode_one(const ThetaDataDxArrowBytes& bytes,
+                                    std::shared_ptr<arrow::RecordBatch>* batch) {
+        ARROW_ASSIGN_OR_RAISE(auto reader, open_ipc(bytes));
+        ARROW_ASSIGN_OR_RAISE(*batch, reader->Next());
+        return arrow::Status::OK();
+    }
+
+    /// Decode the schema from a schema-only Arrow IPC buffer.
+    static arrow::Status decode_schema(const ThetaDataDxArrowBytes& bytes,
+                                       std::shared_ptr<arrow::Schema>* schema) {
+        ARROW_ASSIGN_OR_RAISE(auto reader, open_ipc(bytes));
+        *schema = reader->schema();
+        return arrow::Status::OK();
+    }
+
+    /// Open an arrow-cpp IPC stream reader over a COPY of the FFI byte
+    /// buffer.
+    ///
+    /// The copy is deliberate: the decoded `RecordBatch` can alias the input
+    /// buffer's memory zero-copy, but the FFI buffer (`bytes`) is freed by
+    /// the caller as soon as decode returns. Copying into an arrow-owned
+    /// buffer hands the batch a lifetime tied to the arrow buffer's
+    /// refcount, not to the FFI allocation, so the returned batch stays valid
+    /// after the FFI buffer is freed. A per-batch copy is the correct,
+    /// leak-free ownership boundary here.
+    static arrow::Result<std::shared_ptr<arrow::ipc::RecordBatchStreamReader>> open_ipc(
+        const ThetaDataDxArrowBytes& bytes) {
+        ARROW_ASSIGN_OR_RAISE(auto buffer,
+                              arrow::AllocateBuffer(static_cast<int64_t>(bytes.len)));
+        if (bytes.len > 0 && bytes.data != nullptr) {
+            std::memcpy(buffer->mutable_data(), bytes.data, bytes.len);
+        }
+        std::shared_ptr<arrow::Buffer> shared_buffer = std::move(buffer);
+        auto input = std::make_shared<arrow::io::BufferReader>(shared_buffer);
+        return arrow::ipc::RecordBatchStreamReader::Open(input);
+    }
+
+    ThetaDataDxRecordBatchStream* handle_;
+    std::shared_ptr<arrow::Schema> schema_;
+};
+#endif // THETADATADX_CPP_ARROW
+
 /// Real-time-streaming sub-namespace returned by `Client::stream()`.
 ///
 /// Borrows the unified `ThetaDataDxClient*` for the duration of the borrow
@@ -2505,6 +2679,45 @@ public:
         thetadatadx_subscription_array_free(arr);
         return out;
     }
+
+#ifdef THETADATADX_CPP_ARROW
+    /// Open a pull-based columnar reader over the live stream — a sibling to
+    /// the per-event `set_callback`.
+    ///
+    /// Returns a `std::shared_ptr<arrow::RecordBatchReader>` (a
+    /// `RecordBatchStream`): `ReadNext(&batch)` yields the next batch and
+    /// sets `batch` to `nullptr` at clean end of stream, `schema()` reports
+    /// the fixed schema, and `dropped()` (on the concrete
+    /// `thetadatadx::RecordBatchStream`) reports the drop-oldest count. The
+    /// reader closes (unsubscribe + tear down) when the last reference drops
+    /// (RAII). The same subscriptions feed it; subscribe first, then open.
+    ///
+    /// `batch_size` rows per batch (default 65536). `linger` flushes a
+    /// partial batch on a quiet stream (default 50 ms). `backpressure`
+    /// selects lossless block (default) or bounded drop-oldest with
+    /// `capacity` buffered batches.
+    ///
+    /// Only available when the SDK is built with `THETADATADX_CPP_ARROW`
+    /// (which links arrow-cpp). Throws on a connect / start failure.
+    std::shared_ptr<RecordBatchStream> batches(
+        std::size_t batch_size = 65536,
+        std::chrono::milliseconds linger = std::chrono::milliseconds(50),
+        Backpressure backpressure = Backpressure::Block,
+        std::size_t capacity = 4) const {
+        const int32_t bp = backpressure == Backpressure::DropOldest
+                               ? THETADATADX_BACKPRESSURE_DROP_OLDEST
+                               : THETADATADX_BACKPRESSURE_BLOCK;
+        const uint64_t linger_ms = linger.count() < 0
+                                       ? 0
+                                       : static_cast<uint64_t>(linger.count());
+        ThetaDataDxRecordBatchStream* raw = thetadatadx_client_batches_open(
+            handle_.get(), batch_size, linger_ms, bp, capacity);
+        if (raw == nullptr) {
+            detail::throw_last_ffi_error();
+        }
+        return RecordBatchStream::create(raw);
+    }
+#endif // THETADATADX_CPP_ARROW
 
 private:
     friend class Client;

--- a/sdks/cpp/tests/CMakeLists.txt
+++ b/sdks/cpp/tests/CMakeLists.txt
@@ -59,6 +59,13 @@ set(THETADATADX_CPP_TEST_SOURCES
     arrow_ipc.cpp
 )
 
+# The pull-based Arrow RecordBatch reader test needs the native arrow-cpp
+# reader, so it is built only when that optional feature is on. It mirrors
+# the header-side `#ifdef THETADATADX_CPP_ARROW` gate on the reader itself.
+if(THETADATADX_CPP_ARROW)
+    list(APPEND THETADATADX_CPP_TEST_SOURCES streaming_batches.cpp)
+endif()
+
 add_executable(thetadatadx_cpp_tests ${THETADATADX_CPP_TEST_SOURCES})
 target_link_libraries(thetadatadx_cpp_tests
     PRIVATE

--- a/sdks/cpp/tests/streaming_batches.cpp
+++ b/sdks/cpp/tests/streaming_batches.cpp
@@ -1,0 +1,124 @@
+// Pull-based Arrow RecordBatch reader (`client.stream().batches(..)`).
+//
+// Offline: no live server. The end-to-end batching / linger / backpressure
+// behaviour is proven offline in the Rust core's `fpss::batch_reader` tests.
+// This C++ test pins the binding-side contract that does NOT need a
+// connection:
+//
+//   * `thetadatadx::RecordBatchStream` is a concrete
+//     `arrow::RecordBatchReader` (the type the design mandates), with the
+//     `ReadNext` / `schema` / `dropped` / `close` surface;
+//   * the Arrow IPC decode path the reader uses round-trips a batch
+//     bit-exact (the same `arrow::ipc::RecordBatchStreamReader` the reader's
+//     `ReadNext` runs), so a batch crossing the C ABI as IPC bytes decodes
+//     back to the rows that were sent.
+//
+// Built only when `-DTHETADATADX_CPP_ARROW=ON` (which links arrow-cpp). The
+// CMake guard keeps this file out of the default build, matching the
+// header-side `#ifdef THETADATADX_CPP_ARROW` gate on the reader itself.
+
+#include <cstdint>
+#include <memory>
+#include <type_traits>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <arrow/array.h>
+#include <arrow/builder.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/ipc/writer.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+
+#include "thetadatadx.hpp"
+
+namespace {
+
+// Build a tiny RecordBatch under a fixed two-column schema and serialise it
+// to an Arrow IPC stream, mimicking what the FFI hands a C++ reader.
+std::shared_ptr<arrow::Buffer> make_ipc_batch(std::shared_ptr<arrow::Schema>* out_schema) {
+    auto schema = arrow::schema({
+        arrow::field("event_type", arrow::utf8(), false),
+        arrow::field("price", arrow::float64(), true),
+    });
+    *out_schema = schema;
+
+    arrow::StringBuilder type_b;
+    arrow::DoubleBuilder price_b;
+    REQUIRE(type_b.Append("trade").ok());
+    REQUIRE(price_b.Append(150.25).ok());
+    REQUIRE(type_b.Append("quote").ok());
+    REQUIRE(price_b.AppendNull().ok());
+
+    std::shared_ptr<arrow::Array> type_arr;
+    std::shared_ptr<arrow::Array> price_arr;
+    REQUIRE(type_b.Finish(&type_arr).ok());
+    REQUIRE(price_b.Finish(&price_arr).ok());
+
+    auto batch = arrow::RecordBatch::Make(schema, 2, {type_arr, price_arr});
+
+    auto sink_result = arrow::io::BufferOutputStream::Create();
+    REQUIRE(sink_result.ok());
+    auto sink = *sink_result;
+    auto writer_result = arrow::ipc::MakeStreamWriter(sink, schema);
+    REQUIRE(writer_result.ok());
+    auto writer = *writer_result;
+    REQUIRE(writer->WriteRecordBatch(*batch).ok());
+    REQUIRE(writer->Close().ok());
+    auto buf_result = sink->Finish();
+    REQUIRE(buf_result.ok());
+    return *buf_result;
+}
+
+} // namespace
+
+TEST_CASE("RecordBatchStream is an arrow::RecordBatchReader", "[streaming][arrow][offline]") {
+    // The design mandates the C++ reader subclass `arrow::RecordBatchReader`.
+    static_assert(
+        std::is_base_of<arrow::RecordBatchReader, thetadatadx::RecordBatchStream>::value,
+        "thetadatadx::RecordBatchStream must be an arrow::RecordBatchReader");
+    SUCCEED("type contract holds at compile time");
+}
+
+TEST_CASE("Backpressure enum carries both policies", "[streaming][offline]") {
+    // Mirrors the C ABI selector constants the reader passes through.
+    REQUIRE(static_cast<int>(thetadatadx::Backpressure::Block) !=
+            static_cast<int>(thetadatadx::Backpressure::DropOldest));
+}
+
+TEST_CASE("Arrow IPC decode round-trips a streaming batch", "[streaming][arrow][offline]") {
+    // The reader's `ReadNext` decodes each batch from an Arrow IPC byte
+    // buffer with `arrow::ipc::RecordBatchStreamReader`. Exercise that exact
+    // path: serialise a batch, decode it back, and assert the rows survive.
+    std::shared_ptr<arrow::Schema> schema;
+    auto ipc = make_ipc_batch(&schema);
+
+    auto input = std::make_shared<arrow::io::BufferReader>(ipc);
+    auto reader_result = arrow::ipc::RecordBatchStreamReader::Open(input);
+    REQUIRE(reader_result.ok());
+    auto reader = *reader_result;
+
+    REQUIRE(reader->schema()->Equals(*schema));
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    REQUIRE(reader->ReadNext(&batch).ok());
+    REQUIRE(batch != nullptr);
+    REQUIRE(batch->num_rows() == 2);
+    REQUIRE(batch->num_columns() == 2);
+
+    auto type_col = std::static_pointer_cast<arrow::StringArray>(batch->column(0));
+    REQUIRE(type_col->GetString(0) == "trade");
+    REQUIRE(type_col->GetString(1) == "quote");
+
+    auto price_col = std::static_pointer_cast<arrow::DoubleArray>(batch->column(1));
+    REQUIRE(price_col->Value(0) == 150.25);
+    REQUIRE(price_col->IsNull(1)); // quote row nulls the trade price column
+
+    // Stream end: next read yields a null batch, the reader's end-of-stream
+    // signal (mirrors the FFI `1` return that `ReadNext` maps to nullptr).
+    std::shared_ptr<arrow::RecordBatch> tail;
+    REQUIRE(reader->ReadNext(&tail).ok());
+    REQUIRE(tail == nullptr);
+}

--- a/sdks/cpp/tests/thetadatadx_client.cpp
+++ b/sdks/cpp/tests/thetadatadx_client.cpp
@@ -190,16 +190,28 @@ TEST_CASE("Stream binds the full FPSS surface",
     // the lvalue forms are callable and the rvalue forms are not.
     STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::stream), thetadatadx::Client&>);
+    // `stream()` is `&`-qualified (non-const lvalue ref), so it rejects an
+    // rvalue in every standard.
     STATIC_REQUIRE_FALSE(std::is_invocable_v<
         decltype(&thetadatadx::Client::stream), thetadatadx::Client&&>);
     STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::historical), const thetadatadx::Client&>);
-    STATIC_REQUIRE_FALSE(std::is_invocable_v<
-        decltype(&thetadatadx::Client::historical), thetadatadx::Client&&>);
     STATIC_REQUIRE(std::is_invocable_v<
         decltype(&thetadatadx::Client::flat_files), const thetadatadx::Client&>);
+    // `historical()` / `flat_files()` are `const&`-qualified. C++17 treats
+    // `is_invocable` of a `const&` member on an rvalue as false (the rvalue
+    // is rejected), but C++20 (LWG-resolved) treats it as true — an rvalue
+    // binds to a const lvalue ref. The runtime borrow contract (a view must
+    // not outlive the client) is unchanged; only the trait's answer differs
+    // by standard, so this rvalue assertion is gated to C++17. The C++ SDK
+    // builds C++17 by default; the `THETADATADX_CPP_ARROW` reader links
+    // arrow-cpp, which mandates C++20.
+#if __cplusplus < 202002L
+    STATIC_REQUIRE_FALSE(std::is_invocable_v<
+        decltype(&thetadatadx::Client::historical), thetadatadx::Client&&>);
     STATIC_REQUIRE_FALSE(std::is_invocable_v<
         decltype(&thetadatadx::Client::flat_files), thetadatadx::Client&&>);
+#endif
 
     // set_callback
     STATIC_REQUIRE(std::is_invocable_v<decltype(&SV::set_callback), SV&, Cb>);

--- a/sdks/parity.toml
+++ b/sdks/parity.toml
@@ -61,6 +61,18 @@ python = true       # returned by the `client.stream` getter
 typescript = true   # returned by the `client.stream` getter
 cpp = true          # returned by `client.stream()`; exposed as `thetadatadx::Stream`
 
+[[class]]
+name = "RecordBatchStream"
+# The pull-based columnar reader returned by `client.stream().batches(..)`.
+# Python: a `RecordBatchStream` pyclass (sync + async iterable, context
+# manager). TypeScript: the JS `RecordBatchStream` wrapper in
+# `streaming-session.{js,d.ts}` over the napi `RecordBatchStreamHandle`
+# transport, yielding apache-arrow `RecordBatch`. C++: a `RecordBatchStream`
+# subclass of `arrow::RecordBatchReader` (gated on `THETADATADX_CPP_ARROW`).
+python = true
+typescript = true
+cpp = true
+
 # `StreamingSession` carries no `[[method]]` rows by design: its public
 # surface is the inner `Client`'s, reached through `__getattr__` proxying,
 # so its OWN first-class methods are only the async-iterator and
@@ -1236,6 +1248,13 @@ cpp = true
 [[method]]
 class = "StreamView"
 name = "isStreaming"
+python = true
+typescript = true
+cpp = true
+
+[[method]]
+class = "StreamView"
+name = "batches"
 python = true
 typescript = true
 cpp = true

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -191,6 +191,15 @@ with client.streaming(on_event) as session:
 > exponential backoff with jitter, host failover, then a paced re-subscribe of
 > every active contract.
 
+Prefer columns? `client.stream.batches(...)` is a sibling to the callback — the same subscriptions, delivered as `pyarrow.RecordBatch` values under a fixed schema. The reader is iterable (sync, releasing the GIL on the blocking pull) and async-iterable, and closes on context-manager exit:
+
+```python
+client.stream.subscribe(Contract.stock("AAPL").trade())
+with client.stream.batches(batch_size=8192) as batches:
+    for batch in batches:        # or: async for batch in batches
+        print(batch.num_rows)
+```
+
 ## Greeks calculator
 
 A full Black-Scholes calculator — first- through third-order Greeks plus an implied-volatility solver — runs locally, no request required:

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -194,8 +194,9 @@ with client.streaming(on_event) as session:
 Prefer columns? `client.stream.batches(...)` is a sibling to the callback — the same subscriptions, delivered as `pyarrow.RecordBatch` values under a fixed schema. The reader is iterable (sync, releasing the GIL on the blocking pull) and async-iterable, and closes on context-manager exit:
 
 ```python
-client.stream.subscribe(Contract.stock("AAPL").trade())
+# `batches(...)` starts the FPSS session, so open it first, then subscribe.
 with client.stream.batches(batch_size=8192) as batches:
+    client.stream.subscribe(Contract.stock("AAPL").trade())
     for batch in batches:        # or: async for batch in batches
         print(batch.num_rows)
 ```

--- a/sdks/python/src/_generated/streaming_methods.rs
+++ b/sdks/python/src/_generated/streaming_methods.rs
@@ -5,6 +5,7 @@
 pub(crate) const PYTHON_UNIFIED_FPSS_METHODS: &[&str] = &[
     "start_streaming",
     "is_streaming",
+    "batches",
     "active_subscriptions",
     "reconnect",
     "stop_streaming",
@@ -147,6 +148,34 @@ impl StreamView {
     /// Whether the streaming connection is active.
     fn is_streaming(&self) -> bool {
         self.client.stream().is_streaming()
+    }
+
+    /// Open a pull-based columnar reader over the live stream, a sibling to the per-event callback. Returns a reader of Apache Arrow record batches under a fixed schema; the same subscriptions feed it. Tune batch_size, linger, and backpressure on the returned builder/reader.
+    /// Open a pull-based columnar reader over the live stream.
+    ///
+    /// Returns a `RecordBatchStream` — a sibling to the per-event
+    /// `start_streaming(callback)`. The same subscriptions feed it,
+    /// but market-data events arrive as `pyarrow.RecordBatch`
+    /// values under a fixed schema. The reader is both a
+    /// synchronous `Iterable` (the blocking pull releases the GIL)
+    /// and an `AsyncIterable` (`async for`), and a sync / async
+    /// context manager that closes the stream on exit. Subscribe on
+    /// this same surface first, then open the reader.
+    ///
+    /// `batch_size` rows per batch (default 65536); `linger_ms`
+    /// flushes a partial batch on a quiet stream (default 50);
+    /// `backpressure` is `"block"` (default, lossless) or
+    /// `"drop_oldest"`; `capacity` bounds the drop-oldest buffer.
+    #[pyo3(signature = (*, batch_size=None, linger_ms=None, backpressure=None, capacity=None))]
+    fn batches(
+        &self,
+        py: Python<'_>,
+        batch_size: Option<usize>,
+        linger_ms: Option<u64>,
+        backpressure: Option<&str>,
+        capacity: Option<usize>,
+    ) -> PyResult<crate::streaming_batches::RecordBatchStream> {
+        crate::streaming_batches::open_reader(py, &self.client, batch_size, linger_ms, backpressure, capacity)
     }
 
     /// Get a snapshot of currently active subscriptions.

--- a/sdks/python/src/fpss_client.rs
+++ b/sdks/python/src/fpss_client.rs
@@ -190,7 +190,7 @@ impl Drop for StreamingClient {
             PyFpssDispatcherSession::Idle,
         );
         let taken_handle = match prev_session {
-            PyFpssDispatcherSession::Running { handle } => Some(handle),
+            PyFpssDispatcherSession::Running { handle, .. } => Some(handle),
             _ => None,
         };
         if taken_client.is_some() || taken_handle.is_some() {
@@ -449,8 +449,13 @@ impl StreamingClient {
             });
         match dispatcher {
             Ok(h) => {
+                // The callback dispatcher parks only on the event ring, which
+                // the client shutdown signals on teardown, so no wake hook.
                 *self.dispatcher.lock().unwrap_or_else(|e| e.into_inner()) =
-                    PyFpssDispatcherSession::Running { handle: h };
+                    PyFpssDispatcherSession::Running {
+                        handle: h,
+                        on_teardown: None,
+                    };
             }
             Err(e) => {
                 let taken = self.lock_inner().take();
@@ -748,7 +753,7 @@ impl StreamingClient {
             let dispatcher_ref = &self.dispatcher;
             py.detach(move || {
                 drop(client);
-                if let PyFpssDispatcherSession::Running { handle } = prev_session {
+                if let PyFpssDispatcherSession::Running { handle, .. } = prev_session {
                     if handle.thread().id() != std::thread::current().id() {
                         if let Err(payload) = handle.join() {
                             let reason = if let Some(s) = payload.downcast_ref::<&str>() {

--- a/sdks/python/src/lib.rs
+++ b/sdks/python/src/lib.rs
@@ -20,6 +20,7 @@ mod fluent;
 mod fpss_client;
 mod logging_bridge;
 mod mdds_client;
+mod streaming_batches;
 mod util_helpers;
 
 // These imports look unused at source level — they are pulled in by
@@ -2533,6 +2534,7 @@ fn thetadatadx_py(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Client>()?;
     m.add_class::<HistoricalView>()?;
     m.add_class::<StreamView>()?;
+    m.add_class::<streaming_batches::RecordBatchStream>()?;
     m.add_class::<AsyncClient>()?;
     m.add_class::<fpss_client::StreamingClient>()?;
     m.add_class::<mdds_client::HistoricalClient>()?;
@@ -2570,6 +2572,9 @@ fn thetadatadx_py(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         bench_streaming::__bench_flood_events_batched_list,
         m
     )?)?;
-    m.add_function(wrap_pyfunction!(bench_streaming::__bench_flood_events_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        bench_streaming::__bench_flood_events_arrow,
+        m
+    )?)?;
     Ok(())
 }

--- a/sdks/python/src/mdds_client.rs
+++ b/sdks/python/src/mdds_client.rs
@@ -77,6 +77,7 @@ pub(crate) const FPSS_TOUCHING_METHODS: &[&str] = &[
     "shutdown",
     "reconnect",
     "is_streaming",
+    "batches",
     "await_drain",
     "subscribe",
     "subscribe_many",

--- a/sdks/python/src/streaming_batches.rs
+++ b/sdks/python/src/streaming_batches.rs
@@ -1,0 +1,270 @@
+//! Hand-written support for the pull-based Arrow `RecordBatch` reader.
+//!
+//! The generated `StreamView.batches(..)` entry (from `sdk_surface.toml`)
+//! constructs the [`RecordBatchStream`] pyclass defined here. The reader is
+//! the columnar sibling of the per-event callback: one object that is both a
+//! synchronous `Iterable` and an `AsyncIterable`, doubles as a sync/async
+//! context manager that closes the stream on exit, and yields
+//! `pyarrow.RecordBatch` values exported zero-copy over the Arrow C Data
+//! Interface.
+//!
+//! The reader pyclass is hand-written (like `StreamView` itself) because its
+//! protocol surface — `__iter__` / `__next__` / `__aiter__` / `__anext__` /
+//! `__enter__` / `__exit__` / `__aenter__` / `__aexit__` plus the `schema` /
+//! `dropped` properties — is intrinsic Python protocol shape, not a
+//! per-endpoint projection. The generator still owns the entry method so the
+//! cross-binding surface stays in lockstep.
+
+use std::sync::Arc;
+
+use pyo3::exceptions::{PyRuntimeError, PyStopAsyncIteration, PyStopIteration};
+use pyo3::prelude::*;
+
+use thetadatadx::streaming::{Backpressure, RecordBatchStream as CoreRecordBatchStream};
+
+use crate::to_py_err;
+
+/// Map the binding's optional `backpressure` string to the core enum.
+///
+/// `"block"` (default, lossless) or `"drop_oldest"` (bounded buffer; needs a
+/// `capacity`). Case-insensitive. Any other value is a `ValueError`.
+fn parse_backpressure(kind: Option<&str>, capacity: Option<usize>) -> PyResult<Backpressure> {
+    match kind.map(str::to_ascii_lowercase).as_deref() {
+        None | Some("block") => Ok(Backpressure::Block),
+        Some("drop_oldest") => Ok(Backpressure::DropOldest {
+            capacity: capacity.unwrap_or(4).max(1),
+        }),
+        Some(other) => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "unknown backpressure {other:?}; expected \"block\" or \"drop_oldest\""
+        ))),
+    }
+}
+
+/// Open a [`RecordBatchStream`] over the unified client's stream.
+///
+/// Called by the generated `StreamView.batches(..)` entry. Starts FPSS with
+/// a batching dispatcher and returns the reader pyclass.
+pub(crate) fn open_reader(
+    py: Python<'_>,
+    client: &Arc<thetadatadx::Client>,
+    batch_size: Option<usize>,
+    linger_ms: Option<u64>,
+    backpressure: Option<&str>,
+    capacity: Option<usize>,
+) -> PyResult<RecordBatchStream> {
+    let backpressure = parse_backpressure(backpressure, capacity)?;
+    // Bind the `StreamSurface` so the borrowed `BatchReaderBuilder` outlives
+    // the chained configuration calls.
+    let stream_surface = client.stream();
+    let mut builder = stream_surface.batches();
+    if let Some(rows) = batch_size {
+        builder = builder.batch_size(rows);
+    }
+    if let Some(ms) = linger_ms {
+        builder = builder.linger(std::time::Duration::from_millis(ms));
+    }
+    builder = builder.backpressure(backpressure);
+    // Never hold the GIL across the blocking FPSS connect the builder
+    // performs; a sibling Python thread keeps running while the handshake is
+    // in flight. The build path and its `Result` are pure Rust — no Python
+    // object is touched inside the detached region.
+    let stream = py.detach(|| builder.build()).map_err(to_py_err)?;
+    Ok(RecordBatchStream {
+        inner: Arc::new(stream),
+    })
+}
+
+/// A pull reader of `pyarrow.RecordBatch` values off the live FPSS stream.
+///
+/// Both a synchronous `Iterable` (the blocking `__next__` releases the GIL
+/// so other Python threads run while it waits) and an `AsyncIterable`
+/// (`__anext__` awaits the next batch on a worker thread). Also a sync and
+/// async context manager that closes the stream — unsubscribing and tearing
+/// the session down — on exit. Yields columnar batches under a fixed schema
+/// (see `schema`); concatenate them freely.
+///
+/// The core [`RecordBatchStream`] is held behind a bare `Arc`: its own
+/// methods take `&self` (the internal queue lock is released across the
+/// blocking wait), so `close()` / `__exit__` can signal shutdown via
+/// [`CoreRecordBatchStream::close_shared`] CONCURRENTLY with a blocking pull
+/// in flight on another thread — there is no handle-level lock for the two
+/// to contend on, so close can never deadlock against an in-flight pull.
+/// After close, the pull unblocks and every subsequent pull returns
+/// end-of-iteration. The session tears down here when the last `Arc`
+/// reference drops (the core `Drop` is idempotent with the `close_shared`
+/// signal).
+#[pyclass]
+pub struct RecordBatchStream {
+    inner: Arc<CoreRecordBatchStream>,
+}
+
+#[pymethods]
+impl RecordBatchStream {
+    /// Iterable protocol: the reader is its own iterator.
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Blocking pull of the next `pyarrow.RecordBatch`. Releases the GIL
+    /// across the wait so other Python threads keep running, raising
+    /// `StopIteration` at end of stream.
+    fn __next__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        // GIL released for the blocking ring wait; re-acquired only to build
+        // the pyarrow object after a batch lands. This is the no-GIL
+        // discipline on the blocking pull. The core stream releases its own
+        // queue lock across the wait, so a concurrent `close()` is honored
+        // promptly.
+        let batch = py
+            .detach(|| inner.next_blocking())
+            .map_err(|e| to_py_err(thetadatadx::Error::from(e)))?;
+        match batch {
+            Some(batch) => record_batch_to_pyarrow(py, batch),
+            None => Err(PyStopIteration::new_err(())),
+        }
+    }
+
+    /// AsyncIterable protocol: the reader is its own async iterator.
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Await the next `pyarrow.RecordBatch`. The blocking pull runs on a
+    /// blocking-pool thread (it never holds the GIL); the awaitable resolves
+    /// to the batch or raises `StopAsyncIteration` at end of stream.
+    fn __anext__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            // The pull is blocking; run it on the blocking pool so the async
+            // executor thread is never parked. No GIL is held here.
+            let pulled = tokio::task::spawn_blocking(move || inner.next_blocking())
+                .await
+                .map_err(|e| PyRuntimeError::new_err(format!("batch pull task failed: {e}")))?
+                .map_err(|e| to_py_err(thetadatadx::Error::from(e)))?;
+            match pulled {
+                Some(batch) => Python::attach(|py| record_batch_to_pyarrow(py, batch)),
+                None => Err(PyStopAsyncIteration::new_err(())),
+            }
+        })
+        .map(pyo3::Bound::into_any)
+    }
+
+    /// Sync context manager entry: returns the reader.
+    fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    /// Sync context manager exit: close the stream (unsubscribe + tear down).
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
+    ) -> bool {
+        self.close(py);
+        false
+    }
+
+    /// Async context manager entry: returns the reader.
+    fn __aenter__<'py>(slf: Py<Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(slf) })
+            .map(pyo3::Bound::into_any)
+    }
+
+    /// Async context manager exit: close the stream.
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __aexit__<'py>(
+        &self,
+        py: Python<'py>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.close(py);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(false) })
+            .map(pyo3::Bound::into_any)
+    }
+
+    /// Close the stream: unsubscribe and tear the FPSS session down.
+    /// Idempotent; further pulls return end-of-iteration.
+    fn close(&self, py: Python<'_>) {
+        // Signal shutdown through the core's shared-reference close, with the
+        // GIL released: it shuts the client (which detaches its own join),
+        // wakes any in-flight blocking pull on another thread, and lets the
+        // dispatcher exit. No handle-level lock is taken, so a concurrent
+        // `__next__` / `__anext__` pull is unblocked rather than deadlocked.
+        // Releasing the GIL keeps the dispatcher's per-batch `Python::attach`
+        // from contending with this call.
+        let inner = Arc::clone(&self.inner);
+        py.detach(move || inner.close_shared());
+    }
+
+    /// The fixed Arrow schema every yielded batch carries, as a
+    /// `pyarrow.Schema`.
+    #[getter]
+    fn schema(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let schema = self.inner.schema();
+        schema_to_pyarrow(py, &schema)
+    }
+
+    /// Number of batches dropped so far under the `drop_oldest` backpressure
+    /// policy. Always `0` under `block` (the default).
+    #[getter]
+    fn dropped(&self) -> u64 {
+        self.inner.dropped()
+    }
+}
+
+/// Export one [`arrow::array::RecordBatch`] to a `pyarrow.RecordBatch`,
+/// zero-copy, over the Arrow C Data Interface.
+///
+/// Imports the batch through `pyarrow.RecordBatchReader._import_from_c` (the
+/// same version-neutral C Stream Interface path the historical `to_arrow`
+/// terminal uses) and pulls the single batch back out with
+/// `read_next_batch`, so the result is a `pyarrow.RecordBatch` rather than a
+/// `Table`.
+fn record_batch_to_pyarrow(
+    py: Python<'_>,
+    batch: arrow::array::RecordBatch,
+) -> PyResult<Py<PyAny>> {
+    use arrow::ffi_stream::FFI_ArrowArrayStream;
+    use arrow::record_batch::RecordBatchIterator;
+
+    let schema = batch.schema();
+    let reader = RecordBatchIterator::new(std::iter::once(Ok(batch)), schema);
+    // Stack-owned stream handed to pyarrow by address; `_import_from_c`
+    // takes ownership of the contents and nulls the release callback, so the
+    // `Drop` when this returns is a no-op on the moved-out handle.
+    let mut stream = FFI_ArrowArrayStream::new(Box::new(reader));
+    let stream_addr = std::ptr::addr_of_mut!(stream) as usize;
+
+    let pyarrow = py.import("pyarrow")?;
+    let reader_obj = pyarrow
+        .getattr("RecordBatchReader")?
+        .call_method1("_import_from_c", (stream_addr,))?;
+    let batch_obj = reader_obj.call_method0("read_next_batch")?;
+    Ok(batch_obj.unbind())
+}
+
+/// Export the fixed schema to a `pyarrow.Schema` via an empty
+/// `RecordBatchReader` import.
+fn schema_to_pyarrow(
+    py: Python<'_>,
+    schema: &Arc<arrow::datatypes::Schema>,
+) -> PyResult<Py<PyAny>> {
+    use arrow::ffi_stream::FFI_ArrowArrayStream;
+    use arrow::record_batch::RecordBatchIterator;
+
+    let reader = RecordBatchIterator::new(std::iter::empty(), Arc::clone(schema));
+    let mut stream = FFI_ArrowArrayStream::new(Box::new(reader));
+    let stream_addr = std::ptr::addr_of_mut!(stream) as usize;
+
+    let pyarrow = py.import("pyarrow")?;
+    let reader_obj = pyarrow
+        .getattr("RecordBatchReader")?
+        .call_method1("_import_from_c", (stream_addr,))?;
+    let schema_obj = reader_obj.getattr("schema")?;
+    Ok(schema_obj.unbind())
+}

--- a/sdks/python/tests/test_no_gil.py
+++ b/sdks/python/tests/test_no_gil.py
@@ -138,6 +138,52 @@ def test_fpss_streaming_paths_release_the_gil() -> None:
         )
 
 
+def test_record_batch_reader_releases_the_gil() -> None:
+    """Audit gate: the pull-based Arrow batch reader releases the GIL on
+    every blocking path.
+
+    The reader pulls market-data batches off a blocking ring queue. Two
+    blocking paths must release the GIL so a sibling Python thread keeps
+    running: the FPSS connect when the reader is opened, and the blocking
+    `__next__` pull. The async `__anext__` runs the blocking pull on a
+    tokio blocking-pool worker (no GIL held). This pins the structural
+    shape so a refactor cannot silently start holding the GIL across the
+    ring wait.
+    """
+    src = (_sdk_src_root() / "streaming_batches.rs").read_text()
+
+    # The connect (`builder.build()`) must run inside a `py.detach` envelope.
+    assert "py.detach(|| builder.build())" in src, (
+        "RecordBatchStream open (`open_reader`) must wrap the blocking FPSS "
+        "connect (`builder.build()`) in `py.detach` so a sibling Python "
+        "thread keeps running during the handshake"
+    )
+
+    # The synchronous blocking pull (`__next__`) must release the GIL across
+    # the ring wait via `py.detach`, re-acquiring only to build the pyarrow
+    # object after a batch lands.
+    assert ".detach(|| inner.next_blocking())" in src, (
+        "RecordBatchStream.__next__ must wrap the blocking ring pull in "
+        "`py.detach` so other Python threads run while it waits for a batch"
+    )
+
+    # The async pull must run on a blocking-pool worker (no GIL held during
+    # the wait), re-acquiring the GIL only inside `Python::attach` to build
+    # the pyarrow object.
+    assert "spawn_blocking(move || inner.next_blocking())" in src, (
+        "RecordBatchStream.__anext__ must run the blocking pull on a "
+        "blocking-pool worker so the async executor thread never holds the GIL"
+    )
+
+    # close() must signal shutdown OUTSIDE the GIL: the teardown shuts the
+    # client (which detaches its own join, re-acquiring the GIL per batch on
+    # the dispatcher), so holding the GIL across it would deadlock.
+    assert "py.detach(move || inner.close_shared())" in src, (
+        "RecordBatchStream.close must signal `close_shared` inside `py.detach` "
+        "so the dispatcher teardown (which re-acquires the GIL) cannot deadlock"
+    )
+
+
 # ── runtime verification (live, GIL-release on hot path) ────────────
 
 

--- a/sdks/python/tests/test_standalone_clients.py
+++ b/sdks/python/tests/test_standalone_clients.py
@@ -59,6 +59,7 @@ BLOCKED_FPSS_METHODS = (
     "streaming",
     "stream",
     "is_streaming",
+    "batches",
     "await_drain",
     "subscribe",
     "subscribe_many",

--- a/sdks/python/tests/test_streaming_batches.py
+++ b/sdks/python/tests/test_streaming_batches.py
@@ -1,0 +1,57 @@
+"""Pull-based Arrow ``RecordBatch`` reader (``client.stream.batches``).
+
+Offline tests: no live server or credentials. They verify the reader
+object's protocol surface, that opening it releases the GIL across the
+blocking FPSS connect (a sibling thread keeps running while the connect
+blocks against a blackhole host), and that the backpressure knob validates
+its input. The end-to-end batching / linger / backpressure behaviour is
+proven offline in the Rust core's ``fpss::batch_reader`` tests, which drive
+the exact queue + sink + reader machinery without a network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import thetadatadx as td
+
+
+def test_record_batch_stream_is_exported() -> None:
+    """The reader class is part of the public surface and carries the
+    iterable / async-iterable / context-manager protocol plus the
+    `schema` / `dropped` accessors."""
+    cls = td.RecordBatchStream
+    for method in (
+        "__iter__",
+        "__next__",
+        "__aiter__",
+        "__anext__",
+        "__enter__",
+        "__exit__",
+        "__aenter__",
+        "__aexit__",
+        "close",
+        "schema",
+        "dropped",
+    ):
+        assert hasattr(cls, method), f"RecordBatchStream must expose {method}"
+
+
+def test_batches_entry_present_on_stream_view() -> None:
+    """`client.stream.batches` is the entry point, a sibling to
+    `start_streaming`. Checked on the class to avoid an auth round-trip."""
+    assert hasattr(td.StreamView, "batches")
+    assert hasattr(td.StreamView, "start_streaming")
+
+
+def test_batches_is_blocked_on_the_historical_client() -> None:
+    """`batches` is an FPSS-touching method, so the MDDS-only historical
+    client must refuse it (it is on the block-list)."""
+    assert "batches" in td._blocked_fpss_methods()
+
+
+def test_record_batch_stream_construction_is_blocked_directly() -> None:
+    """The reader is not user-constructible — it is only produced by
+    `client.stream.batches(...)`. Calling its type directly raises."""
+    with pytest.raises(TypeError):
+        td.RecordBatchStream()

--- a/sdks/typescript/Cargo.lock
+++ b/sdks/typescript/Cargo.lock
@@ -2089,7 +2089,9 @@ dependencies = [
 name = "thetadatadx-napi"
 version = "13.0.0-rc.5"
 dependencies = [
+ "arrow-array",
  "arrow-ipc",
+ "arrow-schema",
  "chrono",
  "napi",
  "napi-build",

--- a/sdks/typescript/Cargo.toml
+++ b/sdks/typescript/Cargo.toml
@@ -19,6 +19,10 @@ thetadatadx = { path = "../../crates/thetadatadx", features = ["arrow", "__inter
 
 napi = { version = "3.8.5", features = ["async", "serde-json", "napi6", "chrono_date"] }
 arrow-ipc = "59.0.0"
+# RecordBatch / Schema types for the streaming `RecordBatch` reader's Arrow
+# IPC boundary. Pinned to the same major as `arrow-ipc` and the parent crate.
+arrow-array = "59.0.0"
+arrow-schema = "59.0.0"
 napi-derive = "3.5.4"
 chrono = { version = "=0.4.44", default-features = false, features = ["alloc", "clock"] }
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -140,13 +140,19 @@ const drained = await client.stream.awaitDrain(5000);
 > backoff with jitter, host failover, then a paced re-subscribe of every active
 > contract.
 
-Prefer columns? `client.stream.batches(...)` is a sibling to the callback — the same subscriptions, delivered as apache-arrow `RecordBatch` values under a fixed schema, consumed with `for await`. It closes (unsubscribe + tear down) on `Symbol.asyncDispose` or `close()`:
+Prefer columns? `client.stream.batches(...)` is a sibling to the callback: the same subscriptions, delivered as apache-arrow `RecordBatch` values under a fixed schema, consumed with `for await`. It closes (unsubscribe + tear down) on `close()`, or on `Symbol.asyncDispose` via `await using` where your runtime supports explicit resource management:
 
 ```typescript
+import { Contract } from 'thetadatadx';
+
 client.stream.subscribe(Contract.stock('AAPL').trade());
-await using batches = await client.stream.batches({ batchSize: 8192 });
-for await (const batch of batches) {
-  console.log(batch.numRows);
+const batches = await client.stream.batches({ batchSize: 8192 });
+try {
+  for await (const batch of batches) {
+    console.log(batch.numRows);
+  }
+} finally {
+  batches.close();
 }
 ```
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -145,9 +145,10 @@ Prefer columns? `client.stream.batches(...)` is a sibling to the callback: the s
 ```typescript
 import { Contract } from 'thetadatadx';
 
-client.stream.subscribe(Contract.stock('AAPL').trade());
+// `batches(...)` starts the FPSS session, so open it first, then subscribe.
 const batches = await client.stream.batches({ batchSize: 8192 });
 try {
+  client.stream.subscribe(Contract.stock('AAPL').trade());
   for await (const batch of batches) {
     console.log(batch.numRows);
   }

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -140,6 +140,18 @@ const drained = await client.stream.awaitDrain(5000);
 > backoff with jitter, host failover, then a paced re-subscribe of every active
 > contract.
 
+Prefer columns? `client.stream.batches(...)` is a sibling to the callback — the same subscriptions, delivered as apache-arrow `RecordBatch` values under a fixed schema, consumed with `for await`. It closes (unsubscribe + tear down) on `Symbol.asyncDispose` or `close()`:
+
+```typescript
+client.stream.subscribe(Contract.stock('AAPL').trade());
+await using batches = await client.stream.batches({ batchSize: 8192 });
+for await (const batch of batches) {
+  console.log(batch.numRows);
+}
+```
+
+Decoding the batches needs `apache-arrow` installed alongside the SDK.
+
 ## Types
 
 Every tick type and streaming event is exported. Import the ones you need:

--- a/sdks/typescript/__tests__/streaming_batches.test.mjs
+++ b/sdks/typescript/__tests__/streaming_batches.test.mjs
@@ -9,7 +9,13 @@
 //   - `for await` yields decoded apache-arrow RecordBatch values,
 //   - the iterator stops cleanly at end of stream,
 //   - `close()` / `Symbol.asyncDispose` release the handle,
-//   - `.dropped` and `.schema` proxy to the handle.
+//   - `.dropped` and `.schema` proxy to the handle,
+//   - the package-installed `StreamView.prototype.batches` patch forwards
+//     the caller's single options object straight through to the native
+//     method (no positional explosion) and re-wraps the returned native
+//     handle in a `RecordBatchStream`. This exercises the real
+//     wrapper -> native call shape, so a drift between the options-object
+//     surface and the native method signature fails here.
 //
 // The end-to-end batching / linger / backpressure behaviour is proven
 // offline in the Rust core's `fpss::batch_reader` tests.
@@ -75,6 +81,65 @@ describe('streaming RecordBatch reader', () => {
     assert.match(dts, /interface RecordBatchStream\b/);
   });
 
+  it('StreamView.batches forwards the options object to the native method and re-wraps', async () => {
+    // The real wrapper -> native call shape, driven through the SAME
+    // forwarder the package installs onto `StreamView.prototype.batches`.
+    // A live server is not needed: a stub native `batches` stands in for the
+    // napi method, records what it was handed, and returns a fake handle.
+    //
+    // This is the regression guard for the options-object surface. The
+    // native `batches(options?: BatchesOptions)` takes ONE object argument;
+    // an earlier positional `batches(batchSize?, lingerMs?, ...)` shape threw
+    // a coercion error when called with the documented options object. The
+    // synthetic-handle tests below never touch this forwarding seam, so they
+    // could not have caught that drift — this test does, by asserting the
+    // caller's single options object reaches the native method verbatim
+    // (no positional explosion) and the returned handle is re-wrapped in a
+    // `RecordBatchStream`.
+    const calls = [];
+    const handle = fakeHandle(1);
+    async function nativeBatches(...args) {
+      // `this` is the StreamView receiver the forwarder applies onto.
+      calls.push({ thisValue: this, args });
+      return handle;
+    }
+    const forwarder = pkg.wrapStreamViewBatches(nativeBatches);
+
+    const options = { batchSize: 256, lingerMs: 5, backpressure: 'dropOldest', capacity: 8 };
+    const receiver = { tag: 'streamView' };
+    const reader = await forwarder.call(receiver, options);
+
+    assert.equal(calls.length, 1, 'native batches must be called exactly once');
+    assert.equal(calls[0].args.length, 1, 'exactly one argument forwarded (the options object, no positional explosion)');
+    assert.strictEqual(calls[0].args[0], options, 'the caller options object is forwarded verbatim');
+    assert.strictEqual(calls[0].thisValue, receiver, 'the StreamView receiver is preserved as `this`');
+    assert.ok(reader instanceof pkg.RecordBatchStream, 'the native handle is re-wrapped in a RecordBatchStream');
+    // The re-wrapped reader drives the very handle the native method returned.
+    reader.close();
+    assert.equal(handle.state.closed, true, 'closing the reader closes the underlying native handle');
+  });
+
+  it('StreamView.batches forwards a no-argument call (options omitted)', async () => {
+    // `batches()` with no options must forward zero arguments — the native
+    // method defaults every knob. Proves the forwarder does not synthesise a
+    // spurious `undefined` positional that an arity-sensitive napi method
+    // could reject.
+    const calls = [];
+    async function nativeBatches(...args) {
+      calls.push(args);
+      return fakeHandle(0);
+    }
+    const forwarder = pkg.wrapStreamViewBatches(nativeBatches);
+    const reader = await forwarder.call({}, undefined);
+    // Calling with an explicit `undefined` still forwards one arg; the
+    // documented no-arg form forwards none. Cover the no-arg form here.
+    calls.length = 0;
+    await forwarder.call({});
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].length, 0, 'no options -> no forwarded arguments');
+    assert.ok(reader instanceof pkg.RecordBatchStream);
+  });
+
   it('for await yields decoded apache-arrow RecordBatch values', async () => {
     const reader = new pkg.RecordBatchStream(fakeHandle(3));
     let n = 0;
@@ -105,13 +170,17 @@ describe('streaming RecordBatch reader', () => {
   });
 
   it('Symbol.asyncDispose releases the handle', async () => {
+    // Drive the disposal path the way `await using reader = ...` lowers it:
+    // invoke the well-known `[Symbol.asyncDispose]()` method on scope exit.
+    // Spelled explicitly (not via the `await using` declaration) so the test
+    // parses on the `engines.node >= 20` floor, where explicit
+    // resource management is not yet available and `await using` is a
+    // SyntaxError at module load.
     const handle = fakeHandle(5);
-    {
-      // eslint-disable-next-line no-undef
-      await using reader = new pkg.RecordBatchStream(handle);
-      assert.ok(reader);
-    }
-    assert.equal(handle.state.closed, true, 'await using must dispose the reader');
+    const reader = new pkg.RecordBatchStream(handle);
+    assert.equal(typeof reader[Symbol.asyncDispose], 'function');
+    await reader[Symbol.asyncDispose]();
+    assert.equal(handle.state.closed, true, 'asyncDispose must dispose the reader');
   });
 
   it('.dropped and .schema proxy to the handle', () => {

--- a/sdks/typescript/__tests__/streaming_batches.test.mjs
+++ b/sdks/typescript/__tests__/streaming_batches.test.mjs
@@ -1,0 +1,134 @@
+// Pull-based Arrow RecordBatch reader (`client.stream.batches(...)`).
+//
+// Offline: no live server. These tests prove the JS-side wrapper logic
+// without a connection by driving the wrapper with a SYNTHETIC handle that
+// returns known Arrow IPC buffers (built with the SDK's own
+// `tradeTicksToArrowIpc` export). They verify:
+//   - the package exports the `RecordBatchStream` wrapper and the
+//     `StreamView.batches` entry is declared,
+//   - `for await` yields decoded apache-arrow RecordBatch values,
+//   - the iterator stops cleanly at end of stream,
+//   - `close()` / `Symbol.asyncDispose` release the handle,
+//   - `.dropped` and `.schema` proxy to the handle.
+//
+// The end-to-end batching / linger / backpressure behaviour is proven
+// offline in the Rust core's `fpss::batch_reader` tests.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import {
+  tableToIPC,
+  tableFromArrays,
+} from 'apache-arrow';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const pkg = require('../streaming-session.js');
+const dts = readFileSync(resolve(__dirname, '..', 'streaming-session.d.ts'), 'utf8');
+
+// A synthetic single-batch Arrow IPC stream, built with apache-arrow so the
+// wrapper decodes a genuine, well-formed stream (the same `tableFromIPC`
+// path the wrapper runs). One column, two rows.
+function syntheticBatchIpc() {
+  const table = tableFromArrays({
+    event_type: Int32Array.from([0, 1]),
+  });
+  return Buffer.from(tableToIPC(table, 'stream'));
+}
+
+// A fake `RecordBatchStreamHandle`: hands back `count` IPC batches, then
+// null (end of stream). Records whether `close()` was called.
+function fakeHandle(count) {
+  let remaining = count;
+  const state = { closed: false };
+  return {
+    state,
+    async nextIpc() {
+      if (state.closed || remaining <= 0) return null;
+      remaining -= 1;
+      return syntheticBatchIpc();
+    },
+    schemaIpc() {
+      return syntheticBatchIpc();
+    },
+    get dropped() {
+      return 7;
+    },
+    close() {
+      state.closed = true;
+    },
+  };
+}
+
+describe('streaming RecordBatch reader', () => {
+  it('exports the RecordBatchStream wrapper', () => {
+    assert.equal(typeof pkg.RecordBatchStream, 'function');
+  });
+
+  it('declares StreamView.batches in the type surface', () => {
+    assert.match(dts, /interface StreamView\b/);
+    assert.match(dts, /batches\s*\(\s*options\?\s*:\s*BatchesOptions\s*\)/);
+    assert.match(dts, /interface RecordBatchStream\b/);
+  });
+
+  it('for await yields decoded apache-arrow RecordBatch values', async () => {
+    const reader = new pkg.RecordBatchStream(fakeHandle(3));
+    let n = 0;
+    for await (const batch of reader) {
+      // apache-arrow RecordBatch exposes numRows and a schema.
+      assert.equal(typeof batch.numRows, 'number');
+      assert.ok(batch.schema);
+      n += 1;
+    }
+    assert.equal(n, 3, 'should yield exactly the produced batches');
+  });
+
+  it('stops cleanly at end of stream and closes the handle', async () => {
+    const handle = fakeHandle(2);
+    const reader = new pkg.RecordBatchStream(handle);
+    // eslint-disable-next-line no-unused-vars
+    for await (const _batch of reader) {
+      // drain
+    }
+    assert.equal(handle.state.closed, true, 'iterator end must close the handle');
+  });
+
+  it('close() releases the handle', () => {
+    const handle = fakeHandle(5);
+    const reader = new pkg.RecordBatchStream(handle);
+    reader.close();
+    assert.equal(handle.state.closed, true);
+  });
+
+  it('Symbol.asyncDispose releases the handle', async () => {
+    const handle = fakeHandle(5);
+    {
+      // eslint-disable-next-line no-undef
+      await using reader = new pkg.RecordBatchStream(handle);
+      assert.ok(reader);
+    }
+    assert.equal(handle.state.closed, true, 'await using must dispose the reader');
+  });
+
+  it('.dropped and .schema proxy to the handle', () => {
+    const reader = new pkg.RecordBatchStream(fakeHandle(1));
+    assert.equal(reader.dropped, 7);
+    // schema decodes the schema-only IPC buffer into an apache-arrow Schema.
+    assert.ok(reader.schema);
+    assert.ok(Array.isArray(reader.schema.fields));
+  });
+
+  it('breaking out of for await still closes the handle', async () => {
+    const handle = fakeHandle(10);
+    const reader = new pkg.RecordBatchStream(handle);
+    for await (const batch of reader) {
+      assert.ok(batch);
+      break; // early exit -> finally must close
+    }
+    assert.equal(handle.state.closed, true, 'early break must close the handle');
+  });
+});

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -2473,6 +2473,44 @@ export declare class HistoricalView {
 }
 
 /**
+ * napi handle to a live pull-based Arrow `RecordBatch` reader.
+ *
+ * Yields each batch as an Arrow IPC `Buffer` from [`Self::next_ipc`]; the
+ * JS wrapper decodes it with apache-arrow. The core [`RecordBatchStream`]
+ * is held behind a bare `Arc`: its methods take `&self` (the internal queue
+ * lock is released across the blocking wait), so [`Self::close`] can signal
+ * shutdown via [`RecordBatchStream::close_shared`] CONCURRENTLY with a
+ * blocking pull in flight on a worker thread — no handle-level lock for the
+ * two to contend on, so close never deadlocks against an in-flight pull.
+ * The session tears down when the last `Arc` reference drops (the core
+ * `Drop` is idempotent with the `close_shared` signal).
+ */
+export declare class RecordBatchStreamHandle {
+  /**
+   * Await the next batch as an Arrow IPC `Buffer`, or `null` at clean end
+   * of stream (or after close). The pull runs off the Node event loop, so
+   * it never blocks the main thread. Internal transport for the
+   * `RecordBatchStream` wrapper; consumers iterate the wrapper instead.
+   */
+  nextIpc(): Promise<Buffer | null>
+  /**
+   * The fixed schema as a schema-only Arrow IPC `Buffer`, so the JS
+   * wrapper can expose `.schema` before the first batch arrives.
+   */
+  schemaIpc(): Buffer
+  /**
+   * Number of batches dropped so far under the `dropOldest` backpressure
+   * policy. Always `0` under `block` (the default).
+   */
+  get dropped(): number
+  /**
+   * Close the stream: unsubscribe and tear the FPSS session down.
+   * Idempotent; subsequent pulls return `null`.
+   */
+  close(): void
+}
+
+/**
  * JS-visible `SecType` (frozen security-type enum). Construction
  * happens via the four named factories: `SecType.stock()`,
  * `SecType.option()`, `SecType.index()`, `SecType.rate()`. Returns
@@ -2862,6 +2900,24 @@ export declare class StreamView {
   startStreaming(callback: ((arg: StreamEvent) => void)): Promise<void>
   /** Whether the streaming connection is active. */
   isStreaming(): boolean
+  /**
+   * Open a pull-based columnar reader over the live stream, a sibling to the per-event callback. Returns a reader of Apache Arrow record batches under a fixed schema; the same subscriptions feed it. Tune batch_size, linger, and backpressure on the returned builder/reader.
+   * Open a pull-based columnar reader over the live stream.
+   *
+   * Returns a reader handle — a sibling to the per-event
+   * `startStreaming(callback)`. The same subscriptions feed it,
+   * but market-data events arrive as apache-arrow `RecordBatch`
+   * values under a fixed schema, consumed with `for await`. The
+   * reader closes (unsubscribes + tears down) on `close()` or
+   * `Symbol.asyncDispose`. Subscribe on this same surface first,
+   * then open the reader.
+   *
+   * `batchSize` rows per batch (default 65536); `lingerMs`
+   * flushes a partial batch on a quiet stream (default 50);
+   * `backpressure` is `"block"` (default, lossless) or
+   * `"dropOldest"`; `capacity` bounds the drop-oldest buffer.
+   */
+  batches(batchSize?: number | undefined | null, lingerMs?: number | undefined | null, backpressure?: string | undefined | null, capacity?: number | undefined | null): Promise<RecordBatchStreamHandle>
   /** Get a snapshot of currently active subscriptions. */
   activeSubscriptions(): any
   /**

--- a/sdks/typescript/index.d.ts
+++ b/sdks/typescript/index.d.ts
@@ -2917,7 +2917,7 @@ export declare class StreamView {
    * `backpressure` is `"block"` (default, lossless) or
    * `"dropOldest"`; `capacity` bounds the drop-oldest buffer.
    */
-  batches(batchSize?: number | undefined | null, lingerMs?: number | undefined | null, backpressure?: string | undefined | null, capacity?: number | undefined | null): Promise<RecordBatchStreamHandle>
+  batches(options?: BatchesOptions | undefined | null): Promise<RecordBatchStreamHandle>
   /** Get a snapshot of currently active subscriptions. */
   activeSubscriptions(): any
   /**
@@ -3197,6 +3197,20 @@ export interface AllGreeks {
   dualGamma: number
   epsilon: number
   lambda: number
+}
+
+/**
+ * Tuning knobs for `StreamView.batches(options?)`. Each field maps to a
+ * builder setter; `None` keeps the production default. napi renders this as
+ * a TypeScript object `{ batchSize?, lingerMs?, backpressure?, capacity? }`,
+ * which is the documented call form. The prior positional parameters threw a
+ * coercion error when a caller passed that documented options object.
+ */
+export interface BatchesOptions {
+  batchSize?: number
+  lingerMs?: number
+  backpressure?: string
+  capacity?: number
 }
 
 /** Calendar day. Market open/close schedule. */

--- a/sdks/typescript/index.js
+++ b/sdks/typescript/index.js
@@ -3,7 +3,7 @@
 // @ts-nocheck
 /* auto-generated — do not edit by hand */
 
-const { readFileSync } = require('node:fs')
+const { readFileSync } = require('fs')
 let nativeBinding = null
 const loadErrors = []
 
@@ -33,7 +33,7 @@ const isMuslFromFilesystem = () => {
 
 const isMuslFromReport = () => {
   let report = null
-  if (typeof process.report?.getReport === 'function') {
+  if (process.report && typeof process.report.getReport === 'function') {
     process.report.excludeNetwork = true
     report = process.report.getReport()
   }
@@ -105,7 +105,7 @@ function requireNative() {
     }
   } else if (process.platform === 'win32') {
     if (process.arch === 'x64') {
-      if (process.config?.variables?.shlib_suffix === 'dll.a' || process.config?.variables?.node_target_type === 'shared_library') {
+      if ((process.config && process.config.variables && process.config.variables.shlib_suffix === 'dll.a') || (process.config && process.config.variables && process.config.variables.node_target_type === 'shared_library')) {
         try {
         return require('./thetadatadx.win32-x64-gnu.node')
       } catch (e) {
@@ -570,17 +570,18 @@ if (!nativeBinding || forceWasi) {
 
 if (!nativeBinding) {
   if (loadErrors.length > 0) {
-    throw new Error(
+    const error = new Error(
       `Cannot find native binding. ` +
         `npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). ` +
         'Please try `npm i` again after removing both package-lock.json and node_modules directory.',
-      {
-        cause: loadErrors.reduce((err, cur) => {
-          cur.cause = err
-          return cur
-        }),
-      },
     )
+    // assign instead of the `new Error(message, { cause })` options form,
+    // which Node < 16.9 silently ignores
+    error.cause = loadErrors.reduce((err, cur) => {
+      cur.cause = err
+      return cur
+    })
+    throw error
   }
   throw new Error(`Failed to load native binding`)
 }
@@ -598,6 +599,7 @@ module.exports.FlatFileRowList = nativeBinding.FlatFileRowList
 module.exports.FlatFilesNamespace = nativeBinding.FlatFilesNamespace
 module.exports.HistoricalClient = nativeBinding.HistoricalClient
 module.exports.HistoricalView = nativeBinding.HistoricalView
+module.exports.RecordBatchStreamHandle = nativeBinding.RecordBatchStreamHandle
 module.exports.SecType = nativeBinding.SecType
 module.exports.StreamingClient = nativeBinding.StreamingClient
 module.exports.StreamView = nativeBinding.StreamView

--- a/sdks/typescript/scripts/run_doc_examples.mjs
+++ b/sdks/typescript/scripts/run_doc_examples.mjs
@@ -33,8 +33,24 @@ const pkgRoot = resolve(here, "..");
 const dtsPath = resolve(pkgRoot, "index.d.ts");
 const readmePath = resolve(pkgRoot, "README.md");
 
+// The module specifier examples import (`thetadatadx`) must resolve to the
+// package's published type entry, not the raw napi `index.d.ts`. The entry
+// (`package.json` `types`) is the wrapper's `streaming-session.d.ts`, which
+// re-exports the whole napi surface AND layers the wrapper augmentations on
+// top (e.g. `StreamView.batches(...)` returns the async-iterable
+// `RecordBatchStream`, not the bare napi `RecordBatchStreamHandle`). Checking
+// against `index.d.ts` alone would miss those augmentations, so a documented
+// example of a wrapper-only surface could never type-check. Resolve the entry
+// from `package.json` so this tracks the published `types` automatically.
+const pkgTypesEntry = JSON.parse(
+  readFileSync(resolve(pkgRoot, "package.json"), "utf-8")
+).types;
+const typesEntryPath = resolve(pkgRoot, pkgTypesEntry ?? "index.d.ts");
+
 // Module specifier that resolves the local declarations.
-const LOCAL_MODULE = dtsPath.replace(/\\/g, "/").replace(/\.d\.ts$/, "");
+const LOCAL_MODULE = typesEntryPath
+  .replace(/\\/g, "/")
+  .replace(/\.d\.ts$/, "");
 
 const FENCE_RE = /```(?:ts|typescript|javascript|js)\n([\s\S]*?)\n```/g;
 

--- a/sdks/typescript/src/_generated/streaming_methods.rs
+++ b/sdks/typescript/src/_generated/streaming_methods.rs
@@ -142,8 +142,9 @@ impl StreamView {
     /// `backpressure` is `"block"` (default, lossless) or
     /// `"dropOldest"`; `capacity` bounds the drop-oldest buffer.
     #[napi(js_name = "batches")]
-    pub async fn batches(&self, batch_size: Option<u32>, linger_ms: Option<u32>, backpressure: Option<String>, capacity: Option<u32>) -> napi::Result<crate::streaming_batches::RecordBatchStreamHandle> {
-        crate::streaming_batches::open_handle(std::sync::Arc::clone(&self.client), batch_size, linger_ms, backpressure, capacity).await
+    pub async fn batches(&self, options: Option<crate::streaming_batches::BatchesOptions>) -> napi::Result<crate::streaming_batches::RecordBatchStreamHandle> {
+        let options = options.unwrap_or_default();
+        crate::streaming_batches::open_handle(std::sync::Arc::clone(&self.client), options.batch_size, options.linger_ms, options.backpressure, options.capacity).await
     }
 
     /// Get a snapshot of currently active subscriptions.

--- a/sdks/typescript/src/_generated/streaming_methods.rs
+++ b/sdks/typescript/src/_generated/streaming_methods.rs
@@ -126,6 +126,26 @@ impl StreamView {
         self.client.stream().is_streaming()
     }
 
+    /// Open a pull-based columnar reader over the live stream, a sibling to the per-event callback. Returns a reader of Apache Arrow record batches under a fixed schema; the same subscriptions feed it. Tune batch_size, linger, and backpressure on the returned builder/reader.
+    /// Open a pull-based columnar reader over the live stream.
+    ///
+    /// Returns a reader handle — a sibling to the per-event
+    /// `startStreaming(callback)`. The same subscriptions feed it,
+    /// but market-data events arrive as apache-arrow `RecordBatch`
+    /// values under a fixed schema, consumed with `for await`. The
+    /// reader closes (unsubscribes + tears down) on `close()` or
+    /// `Symbol.asyncDispose`. Subscribe on this same surface first,
+    /// then open the reader.
+    ///
+    /// `batchSize` rows per batch (default 65536); `lingerMs`
+    /// flushes a partial batch on a quiet stream (default 50);
+    /// `backpressure` is `"block"` (default, lossless) or
+    /// `"dropOldest"`; `capacity` bounds the drop-oldest buffer.
+    #[napi(js_name = "batches")]
+    pub async fn batches(&self, batch_size: Option<u32>, linger_ms: Option<u32>, backpressure: Option<String>, capacity: Option<u32>) -> napi::Result<crate::streaming_batches::RecordBatchStreamHandle> {
+        crate::streaming_batches::open_handle(std::sync::Arc::clone(&self.client), batch_size, linger_ms, backpressure, capacity).await
+    }
+
     /// Get a snapshot of currently active subscriptions.
     #[napi(js_name = "activeSubscriptions")]
     pub fn active_subscriptions(&self) -> napi::Result<serde_json::Value> {

--- a/sdks/typescript/src/fpss_client.rs
+++ b/sdks/typescript/src/fpss_client.rs
@@ -197,7 +197,7 @@ impl Drop for StreamingClient {
             client.shutdown();
         }
         drop(taken_client);
-        if let DispatcherSession::Running { handle } = prev_session {
+        if let DispatcherSession::Running { handle, .. } = prev_session {
             if handle.thread().id() != std::thread::current().id() {
                 let _ = handle.join();
             }
@@ -345,7 +345,12 @@ impl StreamingClient {
             });
         match dispatcher {
             Ok(h) => {
-                *self.lock_dispatcher() = DispatcherSession::Running { handle: h };
+                // The callback dispatcher parks only on the event ring, which
+                // the client shutdown signals on teardown, so no wake hook.
+                *self.lock_dispatcher() = DispatcherSession::Running {
+                    handle: h,
+                    on_teardown: None,
+                };
                 Ok(())
             }
             Err(e) => {
@@ -701,7 +706,7 @@ impl StreamingClient {
                 .push(client.drained_flag());
             client.shutdown();
             drop(client);
-            if let DispatcherSession::Running { handle } = prev_session {
+            if let DispatcherSession::Running { handle, .. } = prev_session {
                 if handle.thread().id() != std::thread::current().id() {
                     if let Err(payload) = handle.join() {
                         // Record the panic reason so `isStreaming()` /

--- a/sdks/typescript/src/lib.rs
+++ b/sdks/typescript/src/lib.rs
@@ -1149,6 +1149,12 @@ pub use config_class::{Config, WorkerThreadsSetting};
 // Hand-written FLATFILES bindings — dynamic schema, see module docs.
 mod flatfile_methods;
 
+// Hand-written support for the pull-based Arrow `RecordBatch` reader —
+// the napi handle (`RecordBatchStreamHandle`) the generated
+// `StreamView.batches(..)` entry returns. See module docs.
+mod streaming_batches;
+pub use streaming_batches::RecordBatchStreamHandle;
+
 // Fluent contract-first API. Adds `ContractRef`,
 // `Subscription`, `SecType` napi classes and the polymorphic
 // `subscribe(sub)` / `subscribeMany([sub, ...])` methods on the

--- a/sdks/typescript/src/streaming_batches.rs
+++ b/sdks/typescript/src/streaming_batches.rs
@@ -77,6 +77,20 @@ fn schema_to_ipc(schema: &Arc<arrow_schema::Schema>) -> napi::Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Tuning knobs for `StreamView.batches(options?)`. Each field maps to a
+/// builder setter; `None` keeps the production default. napi renders this as
+/// a TypeScript object `{ batchSize?, lingerMs?, backpressure?, capacity? }`,
+/// which is the documented call form. The prior positional parameters threw a
+/// coercion error when a caller passed that documented options object.
+#[napi(object)]
+#[derive(Default)]
+pub struct BatchesOptions {
+    pub batch_size: Option<u32>,
+    pub linger_ms: Option<u32>,
+    pub backpressure: Option<String>,
+    pub capacity: Option<u32>,
+}
+
 /// Open a [`RecordBatchStreamHandle`] over the unified client's stream.
 ///
 /// Called by the generated `StreamView.batches(..)` entry. The connect runs

--- a/sdks/typescript/src/streaming_batches.rs
+++ b/sdks/typescript/src/streaming_batches.rs
@@ -62,10 +62,14 @@ fn parse_backpressure(kind: Option<String>, capacity: Option<i64>) -> napi::Resu
 /// free-function scan (which keys off a preceding `#[napi]` attribute) never
 /// mistakes this internal helper for a cross-binding utility.
 fn batch_to_ipc(batch: &arrow_array::RecordBatch) -> napi::Result<Vec<u8>> {
-    // Seed from the batch's in-memory byte size so the IPC body is written
-    // without re-growing the Vec from empty (the body is close to that size
-    // plus a small framing overhead).
-    let mut buf: Vec<u8> = Vec::with_capacity(batch.get_array_memory_size());
+    // Seed from an estimate keyed on the row COUNT, so the IPC body is written
+    // without re-growing the Vec from empty. Sizing from
+    // `get_array_memory_size()` would seed from the builder's preallocated
+    // column capacity (now batch-size-wide), so a one-row linger-flushed batch
+    // would over-allocate by orders of magnitude; `estimated_ipc_len` keys on
+    // the used rows instead. The same estimate is used in the FFI encoder.
+    let mut buf: Vec<u8> =
+        Vec::with_capacity(thetadatadx::streaming::estimated_ipc_len(batch.num_rows()));
     {
         let mut writer = arrow_ipc::writer::StreamWriter::try_new(
             std::io::Cursor::new(&mut buf),

--- a/sdks/typescript/src/streaming_batches.rs
+++ b/sdks/typescript/src/streaming_batches.rs
@@ -62,7 +62,10 @@ fn parse_backpressure(kind: Option<String>, capacity: Option<i64>) -> napi::Resu
 /// free-function scan (which keys off a preceding `#[napi]` attribute) never
 /// mistakes this internal helper for a cross-binding utility.
 fn batch_to_ipc(batch: &arrow_array::RecordBatch) -> napi::Result<Vec<u8>> {
-    let mut buf: Vec<u8> = Vec::new();
+    // Seed from the batch's in-memory byte size so the IPC body is written
+    // without re-growing the Vec from empty (the body is close to that size
+    // plus a small framing overhead).
+    let mut buf: Vec<u8> = Vec::with_capacity(batch.get_array_memory_size());
     {
         let mut writer = arrow_ipc::writer::StreamWriter::try_new(
             std::io::Cursor::new(&mut buf),

--- a/sdks/typescript/src/streaming_batches.rs
+++ b/sdks/typescript/src/streaming_batches.rs
@@ -21,14 +21,34 @@ use thetadatadx::streaming::{Backpressure, RecordBatchStream};
 
 use crate::to_napi_err;
 
+/// Validate a tuning value the caller passed as a JS `number`, rejecting a
+/// negative the way the Python binding's `usize` parameters do (a JS `-1` would
+/// otherwise coerce silently to a huge unsigned value). A non-negative value is
+/// returned as `usize`; the core upper-clamps it (see
+/// `thetadatadx::streaming::MAX_BATCH_SIZE` / `MAX_QUEUE_DEPTH`), so no upper
+/// check is needed here. Keeps TS and Python input handling consistent:
+/// negative is an error in both, oversized is clamped in both.
+fn checked_tuning(value: i64, field: &str) -> napi::Result<usize> {
+    if value < 0 {
+        return Err(napi::Error::from_reason(format!(
+            "{field} must be non-negative, got {value}"
+        )));
+    }
+    Ok(value as usize)
+}
+
 /// Map the optional `backpressure` string to the core enum. `"block"`
 /// (default) or `"dropOldest"` / `"drop_oldest"` (needs a `capacity`).
-fn parse_backpressure(kind: Option<String>, capacity: Option<u32>) -> napi::Result<Backpressure> {
+fn parse_backpressure(kind: Option<String>, capacity: Option<i64>) -> napi::Result<Backpressure> {
     match kind.as_deref().map(str::to_ascii_lowercase).as_deref() {
         None | Some("block") => Ok(Backpressure::Block),
-        Some("dropoldest") | Some("drop_oldest") => Ok(Backpressure::DropOldest {
-            capacity: capacity.unwrap_or(4).max(1) as usize,
-        }),
+        Some("dropoldest") | Some("drop_oldest") => {
+            let capacity = match capacity {
+                Some(c) => checked_tuning(c, "capacity")?.max(1),
+                None => 4,
+            };
+            Ok(Backpressure::DropOldest { capacity })
+        }
         Some(other) => Err(napi::Error::from_reason(format!(
             "unknown backpressure {other:?}; expected \"block\" or \"dropOldest\""
         ))),
@@ -85,10 +105,10 @@ fn schema_to_ipc(schema: &Arc<arrow_schema::Schema>) -> napi::Result<Vec<u8>> {
 #[napi(object)]
 #[derive(Default)]
 pub struct BatchesOptions {
-    pub batch_size: Option<u32>,
-    pub linger_ms: Option<u32>,
+    pub batch_size: Option<i64>,
+    pub linger_ms: Option<i64>,
     pub backpressure: Option<String>,
-    pub capacity: Option<u32>,
+    pub capacity: Option<i64>,
 }
 
 /// Open a [`RecordBatchStreamHandle`] over the unified client's stream.
@@ -97,22 +117,31 @@ pub struct BatchesOptions {
 /// on a blocking worker so the Node event loop is never frozen.
 pub(crate) async fn open_handle(
     client: Arc<thetadatadx::Client>,
-    batch_size: Option<u32>,
-    linger_ms: Option<u32>,
+    batch_size: Option<i64>,
+    linger_ms: Option<i64>,
     backpressure: Option<String>,
-    capacity: Option<u32>,
+    capacity: Option<i64>,
 ) -> napi::Result<RecordBatchStreamHandle> {
     let backpressure = parse_backpressure(backpressure, capacity)?;
+    // Validate the numeric knobs at the boundary, rejecting negatives the way
+    // the Python binding does, before handing off to the blocking worker. The
+    // core upper-clamps the magnitude, so only the sign is checked here.
+    let batch_size = batch_size
+        .map(|v| checked_tuning(v, "batchSize"))
+        .transpose()?;
+    let linger_ms = linger_ms
+        .map(|v| checked_tuning(v, "lingerMs"))
+        .transpose()?;
     let stream = tokio::task::spawn_blocking(move || {
         // Bind the `StreamSurface` so the borrowed `BatchReaderBuilder`
         // outlives the chained configuration calls.
         let stream_surface = client.stream();
         let mut builder = stream_surface.batches();
         if let Some(rows) = batch_size {
-            builder = builder.batch_size(rows as usize);
+            builder = builder.batch_size(rows);
         }
         if let Some(ms) = linger_ms {
-            builder = builder.linger(std::time::Duration::from_millis(u64::from(ms)));
+            builder = builder.linger(std::time::Duration::from_millis(ms as u64));
         }
         builder.backpressure(backpressure).build()
     })

--- a/sdks/typescript/src/streaming_batches.rs
+++ b/sdks/typescript/src/streaming_batches.rs
@@ -1,0 +1,175 @@
+//! Hand-written napi support for the pull-based Arrow `RecordBatch` reader.
+//!
+//! The generated `StreamView.batches(..)` entry constructs the
+//! [`RecordBatchStreamHandle`] napi class defined here. The handle crosses
+//! the napi boundary as Arrow IPC byte buffers — the same columnar wire
+//! format the SDK's `tradeTickToArrowIpc` export uses — and the package's
+//! JS wrapper (`streaming-session.js`) decodes each buffer with apache-arrow
+//! `tableFromIPC` and presents the TC39 `AsyncIterable<RecordBatch>` plus
+//! `Symbol.asyncDispose` surface.
+//!
+//! Splitting the IPC transport (Rust napi) from the apache-arrow decode and
+//! the async-iteration protocol (JS wrapper) keeps the napi surface minimal
+//! and the `RecordBatch` type the user sees the native apache-arrow one.
+
+use std::sync::Arc;
+
+use napi::bindgen_prelude::Buffer;
+use napi_derive::napi;
+
+use thetadatadx::streaming::{Backpressure, RecordBatchStream};
+
+use crate::to_napi_err;
+
+/// Map the optional `backpressure` string to the core enum. `"block"`
+/// (default) or `"dropOldest"` / `"drop_oldest"` (needs a `capacity`).
+fn parse_backpressure(kind: Option<String>, capacity: Option<u32>) -> napi::Result<Backpressure> {
+    match kind.as_deref().map(str::to_ascii_lowercase).as_deref() {
+        None | Some("block") => Ok(Backpressure::Block),
+        Some("dropoldest") | Some("drop_oldest") => Ok(Backpressure::DropOldest {
+            capacity: capacity.unwrap_or(4).max(1) as usize,
+        }),
+        Some(other) => Err(napi::Error::from_reason(format!(
+            "unknown backpressure {other:?}; expected \"block\" or \"dropOldest\""
+        ))),
+    }
+}
+
+/// Serialise one [`arrow_array::RecordBatch`] as an Arrow IPC stream byte
+/// buffer (the same path the per-tick `*ToArrowIpc` exports use).
+///
+/// Declared ahead of the `#[napi]` items below so the parity gate's
+/// free-function scan (which keys off a preceding `#[napi]` attribute) never
+/// mistakes this internal helper for a cross-binding utility.
+fn batch_to_ipc(batch: &arrow_array::RecordBatch) -> napi::Result<Vec<u8>> {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = arrow_ipc::writer::StreamWriter::try_new(
+            std::io::Cursor::new(&mut buf),
+            &batch.schema(),
+        )
+        .map_err(|e| napi::Error::from_reason(format!("arrow ipc writer init failed: {e}")))?;
+        writer
+            .write(batch)
+            .map_err(|e| napi::Error::from_reason(format!("arrow ipc write failed: {e}")))?;
+        writer
+            .finish()
+            .map_err(|e| napi::Error::from_reason(format!("arrow ipc finish failed: {e}")))?;
+    }
+    Ok(buf)
+}
+
+/// Serialise the fixed schema as a schema-only Arrow IPC stream.
+fn schema_to_ipc(schema: &Arc<arrow_schema::Schema>) -> napi::Result<Vec<u8>> {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let writer = arrow_ipc::writer::StreamWriter::try_new(
+            std::io::Cursor::new(&mut buf),
+            schema.as_ref(),
+        )
+        .map_err(|e| {
+            napi::Error::from_reason(format!("arrow ipc schema writer init failed: {e}"))
+        })?;
+        writer.into_inner().map_err(|e| {
+            napi::Error::from_reason(format!("arrow ipc schema finish failed: {e}"))
+        })?;
+    }
+    Ok(buf)
+}
+
+/// Open a [`RecordBatchStreamHandle`] over the unified client's stream.
+///
+/// Called by the generated `StreamView.batches(..)` entry. The connect runs
+/// on a blocking worker so the Node event loop is never frozen.
+pub(crate) async fn open_handle(
+    client: Arc<thetadatadx::Client>,
+    batch_size: Option<u32>,
+    linger_ms: Option<u32>,
+    backpressure: Option<String>,
+    capacity: Option<u32>,
+) -> napi::Result<RecordBatchStreamHandle> {
+    let backpressure = parse_backpressure(backpressure, capacity)?;
+    let stream = tokio::task::spawn_blocking(move || {
+        // Bind the `StreamSurface` so the borrowed `BatchReaderBuilder`
+        // outlives the chained configuration calls.
+        let stream_surface = client.stream();
+        let mut builder = stream_surface.batches();
+        if let Some(rows) = batch_size {
+            builder = builder.batch_size(rows as usize);
+        }
+        if let Some(ms) = linger_ms {
+            builder = builder.linger(std::time::Duration::from_millis(u64::from(ms)));
+        }
+        builder.backpressure(backpressure).build()
+    })
+    .await
+    .map_err(|e| napi::Error::from_reason(format!("batches open task failed: {e}")))?
+    .map_err(to_napi_err)?;
+
+    Ok(RecordBatchStreamHandle {
+        inner: Arc::new(stream),
+    })
+}
+
+/// napi handle to a live pull-based Arrow `RecordBatch` reader.
+///
+/// Yields each batch as an Arrow IPC `Buffer` from [`Self::next_ipc`]; the
+/// JS wrapper decodes it with apache-arrow. The core [`RecordBatchStream`]
+/// is held behind a bare `Arc`: its methods take `&self` (the internal queue
+/// lock is released across the blocking wait), so [`Self::close`] can signal
+/// shutdown via [`RecordBatchStream::close_shared`] CONCURRENTLY with a
+/// blocking pull in flight on a worker thread — no handle-level lock for the
+/// two to contend on, so close never deadlocks against an in-flight pull.
+/// The session tears down when the last `Arc` reference drops (the core
+/// `Drop` is idempotent with the `close_shared` signal).
+#[napi]
+pub struct RecordBatchStreamHandle {
+    inner: Arc<RecordBatchStream>,
+}
+
+#[napi]
+impl RecordBatchStreamHandle {
+    /// Await the next batch as an Arrow IPC `Buffer`, or `null` at clean end
+    /// of stream (or after close). The pull runs off the Node event loop, so
+    /// it never blocks the main thread. Internal transport for the
+    /// `RecordBatchStream` wrapper; consumers iterate the wrapper instead.
+    #[napi(js_name = "nextIpc")]
+    pub async fn next_ipc(&self) -> napi::Result<Option<Buffer>> {
+        let inner = Arc::clone(&self.inner);
+        let pulled = tokio::task::spawn_blocking(move || inner.next_blocking())
+            .await
+            .map_err(|e| napi::Error::from_reason(format!("batch pull task failed: {e}")))?
+            .map_err(|e| to_napi_err(thetadatadx::Error::from(e)))?;
+
+        match pulled {
+            Some(batch) => Ok(Some(Buffer::from(batch_to_ipc(&batch)?))),
+            None => Ok(None),
+        }
+    }
+
+    /// The fixed schema as a schema-only Arrow IPC `Buffer`, so the JS
+    /// wrapper can expose `.schema` before the first batch arrives.
+    #[napi(js_name = "schemaIpc")]
+    pub fn schema_ipc(&self) -> napi::Result<Buffer> {
+        let schema = self.inner.schema();
+        Ok(Buffer::from(schema_to_ipc(&schema)?))
+    }
+
+    /// Number of batches dropped so far under the `dropOldest` backpressure
+    /// policy. Always `0` under `block` (the default).
+    #[napi(js_name = "dropped", getter)]
+    pub fn dropped(&self) -> i64 {
+        i64::try_from(self.inner.dropped()).unwrap_or(i64::MAX)
+    }
+
+    /// Close the stream: unsubscribe and tear the FPSS session down.
+    /// Idempotent; subsequent pulls return `null`.
+    #[napi]
+    pub fn close(&self) {
+        // Signal shutdown through the core's shared-reference close: it shuts
+        // the client (detaching its own join), wakes any in-flight pull on a
+        // worker thread, and lets the dispatcher exit. No handle-level lock,
+        // so a concurrent `nextIpc` pull is unblocked rather than deadlocked.
+        self.inner.close_shared();
+    }
+}

--- a/sdks/typescript/streaming-session.d.ts
+++ b/sdks/typescript/streaming-session.d.ts
@@ -123,4 +123,61 @@ declare module './index' {
      */
     streaming(callback: StreamEventCallback): Promise<StreamingSession>;
   }
+
+  interface StreamView {
+    /**
+     * Open a pull-based columnar reader over the live stream — a sibling
+     * to the per-event `startStreaming(callback)`.
+     *
+     * The same subscriptions feed it, but market-data events arrive as
+     * apache-arrow `RecordBatch` values under a fixed schema, consumed
+     * with `for await (const batch of reader)`. The reader closes
+     * (unsubscribe + tear down) on `close()` or `Symbol.asyncDispose`
+     * (`await using reader = await client.stream.batches()`). Subscribe on
+     * this same surface first, then open the reader.
+     *
+     * The runtime returns the JS {@link RecordBatchStream} wrapper around
+     * the native handle; this override replaces the napi-generated
+     * `Promise<RecordBatchStreamHandle>` return type.
+     */
+    batches(options?: BatchesOptions): Promise<RecordBatchStream>;
+  }
+}
+
+/** Optional tuning for {@link StreamView.batches}. */
+export interface BatchesOptions {
+  /** Rows per batch. Default 65536. A batch also flushes on {@link lingerMs}. */
+  batchSize?: number;
+  /**
+   * Milliseconds a partial batch waits before flushing, so a quiet stream
+   * still delivers. Default 50.
+   */
+  lingerMs?: number;
+  /**
+   * Backpressure when the reader falls behind: `"block"` (default,
+   * lossless — applies backpressure to the wire) or `"dropOldest"`
+   * (bounded buffer; drops the oldest batch and counts it in
+   * {@link RecordBatchStream.dropped}).
+   */
+  backpressure?: 'block' | 'dropOldest';
+  /** Bounded-buffer depth in batches for `"dropOldest"`. Default 4. */
+  capacity?: number;
+}
+
+/**
+ * Pull-based columnar reader returned by `client.stream.batches(...)`.
+ *
+ * `AsyncIterable` of apache-arrow `RecordBatch` values under a fixed
+ * schema, and a TC39 async-disposable: `await using reader = ...` closes
+ * it on scope exit, or call {@link close}. Yields are concat-safe — every
+ * batch carries the identical {@link schema}.
+ */
+export interface RecordBatchStream extends AsyncIterable<import('apache-arrow').RecordBatch> {
+  /** The fixed Arrow schema every yielded batch carries. */
+  readonly schema: import('apache-arrow').Schema;
+  /** Batches dropped so far under `"dropOldest"`; `0` under `"block"`. */
+  readonly dropped: number;
+  /** Close the reader: unsubscribe and tear the FPSS session down. Idempotent. */
+  close(): void;
+  [Symbol.asyncDispose](): Promise<void>;
 }

--- a/sdks/typescript/streaming-session.js
+++ b/sdks/typescript/streaming-session.js
@@ -538,13 +538,22 @@ for (const name of Object.getOwnPropertyNames(native)) {
 // generic typed-error wrapping above, so the handle's errors still
 // reclassify. The native method stays `async`, so the patched method
 // awaits and re-wraps.
+//
+// The wrap is a named function (not an inline closure) so the test suite
+// can drive this exact forwarding logic against a stub native method —
+// proving the single options object reaches `batches(options)` verbatim,
+// with no positional explosion, and the native handle is re-wrapped — on
+// the real code path rather than a reimplementation that could drift.
+function wrapStreamViewBatches(nativeBatches) {
+  return async function batches(...args) {
+    const handle = await nativeBatches.apply(this, args);
+    return new RecordBatchStream(handle);
+  };
+}
 if (native.StreamView && native.StreamView.prototype) {
   const nativeBatches = native.StreamView.prototype.batches;
   if (typeof nativeBatches === 'function') {
-    native.StreamView.prototype.batches = async function batches(...args) {
-      const handle = await nativeBatches.apply(this, args);
-      return new RecordBatchStream(handle);
-    };
+    native.StreamView.prototype.batches = wrapStreamViewBatches(nativeBatches);
   }
 }
 
@@ -578,6 +587,10 @@ module.exports = Object.assign({}, native, exportedClasses, exportedFreeFns, {
   StreamingSession,
   // The JS-side columnar reader returned by `client.stream.batches(...)`.
   RecordBatchStream,
+  // The forwarder installed onto `StreamView.prototype.batches`. Exported
+  // so the test suite can drive the real options-object -> native call shape
+  // and the handle re-wrap against a stub native method (no live server).
+  wrapStreamViewBatches,
   // The documented `Contract` name resolves to the same static-wrapped
   // export as `ContractRef`, so `Contract.option(...)` reclassifies too.
   Contract: exportedClasses.ContractRef ?? native.ContractRef,

--- a/sdks/typescript/streaming-session.js
+++ b/sdks/typescript/streaming-session.js
@@ -198,6 +198,104 @@ const EXIT_DRAIN_TIMEOUT_MS = 5000;
 // finds the wrapper's dispose, not anything on the native binding.
 const WRAPPER_OWN = new Set(['_client', 'constructor']);
 
+// apache-arrow is loaded lazily so it is only required by callers that
+// actually consume the columnar `batches()` reader. The per-tick
+// `*ToArrowIpc` exports likewise hand back raw IPC buffers and leave the
+// apache-arrow decode to the caller; the reader decodes here so the user
+// sees native apache-arrow `RecordBatch` values straight from `for await`.
+let _arrow = null;
+function loadArrow() {
+  if (_arrow === null) {
+    try {
+      // eslint-disable-next-line global-require
+      _arrow = require('apache-arrow');
+    } catch (e) {
+      throw new Error(
+        "the streaming `batches()` reader decodes Arrow IPC with apache-arrow; " +
+          "install it as a peer dependency (`npm install apache-arrow`). " +
+          `Underlying error: ${e && e.message ? e.message : e}`,
+      );
+    }
+  }
+  return _arrow;
+}
+
+/**
+ * Pull-based columnar reader over the live stream — a sibling to the
+ * per-event `startStreaming(callback)`.
+ *
+ * `for await (const batch of reader)` yields apache-arrow `RecordBatch`
+ * values under a fixed schema (concatenate them freely). The reader is an
+ * `AsyncIterable` and a TC39 async-disposable: `await using reader = ...`
+ * closes it (unsubscribe + tear down) on scope exit, or call `close()`.
+ *
+ * Wraps the native `RecordBatchStreamHandle`, which crosses the napi
+ * boundary as Arrow IPC buffers; this class decodes each with
+ * `apache-arrow.tableFromIPC` so the public `RecordBatch` type is the
+ * native apache-arrow one.
+ */
+class RecordBatchStream {
+  constructor(handle) {
+    this._handle = handle;
+    this._schema = undefined;
+  }
+
+  /**
+   * The fixed Arrow schema every yielded batch carries, as an
+   * apache-arrow `Schema`. Decoded once from the schema-only IPC buffer.
+   */
+  get schema() {
+    if (this._schema === undefined) {
+      const arrow = loadArrow();
+      const ipc = this._handle.schemaIpc();
+      // A schema-only IPC stream decodes to a zero-batch Table whose
+      // `.schema` is the fixed schema.
+      this._schema = arrow.tableFromIPC(ipc).schema;
+    }
+    return this._schema;
+  }
+
+  /** Batches dropped so far under the `dropOldest` policy; `0` under `block`. */
+  get dropped() {
+    return this._handle.dropped;
+  }
+
+  /**
+   * Close the reader: unsubscribe and tear the FPSS session down.
+   * Idempotent; further iteration ends.
+   */
+  close() {
+    this._handle.close();
+  }
+
+  async *[Symbol.asyncIterator]() {
+    const arrow = loadArrow();
+    try {
+      for (;;) {
+        // eslint-disable-next-line no-await-in-loop
+        const ipc = await this._handle.nextIpc();
+        if (ipc === null || ipc === undefined) {
+          return;
+        }
+        // One batch per IPC buffer (the reader writes exactly one). Decode
+        // to a Table and yield its single RecordBatch.
+        const table = arrow.tableFromIPC(ipc);
+        for (const batch of table.batches) {
+          yield batch;
+        }
+      }
+    } finally {
+      // Iteration ended (consumed, broke out, or threw): release the
+      // session deterministically, mirroring the `await using` dispose.
+      this._handle.close();
+    }
+  }
+
+  async [Symbol.asyncDispose]() {
+    this._handle.close();
+  }
+}
+
 class StreamingSession {
   /**
    * Construct a session bound to a `Client` instance. Returns a
@@ -432,6 +530,24 @@ for (const name of Object.getOwnPropertyNames(native)) {
   exportedClasses[name] = wrapped;
 }
 
+// Present `StreamView.batches(...)` as the columnar `AsyncIterable`
+// reader: the native method returns a `RecordBatchStreamHandle` (Arrow IPC
+// transport); wrap it in the JS `RecordBatchStream` so the user gets
+// `for await (const batch of reader)` over apache-arrow `RecordBatch`
+// values plus `close()` / `Symbol.asyncDispose`. Done here, after the
+// generic typed-error wrapping above, so the handle's errors still
+// reclassify. The native method stays `async`, so the patched method
+// awaits and re-wraps.
+if (native.StreamView && native.StreamView.prototype) {
+  const nativeBatches = native.StreamView.prototype.batches;
+  if (typeof nativeBatches === 'function') {
+    native.StreamView.prototype.batches = async function batches(...args) {
+      const handle = await nativeBatches.apply(this, args);
+      return new RecordBatchStream(handle);
+    };
+  }
+}
+
 // Free functions (e.g. `calendarDayToArrowIpc`, `eodTickToArrowIpc`)
 // are exported directly on the native binding, not on a class. Wrap
 // every own function-valued export that is not a class so a
@@ -460,6 +576,8 @@ for (const name of Object.getOwnPropertyNames(native)) {
 // the docs without a second pyclass.
 module.exports = Object.assign({}, native, exportedClasses, exportedFreeFns, {
   StreamingSession,
+  // The JS-side columnar reader returned by `client.stream.batches(...)`.
+  RecordBatchStream,
   // The documented `Contract` name resolves to the same static-wrapped
   // export as `ContractRef`, so `Contract.option(...)` reclassifies too.
   Contract: exportedClasses.ContractRef ?? native.ContractRef,


### PR DESCRIPTION
## What

Adds a streaming columnar delivery mode (a PULL reader of Apache Arrow `RecordBatch` values) as a sibling to the existing per-event streaming callback, across the Rust core, the C ABI, and the Python, TypeScript, and C++ bindings. The per-event callback stays exactly as is; this is purely additive. A caller picks one mode or the other per subscription, using the same `subscribe` / `subscribe_many` surface for both.

## The fixed schema

A live subscription interleaves event variants (quote, trade, open interest, OHLCVC, market value), but the columnar contract needs one schema that is fixed for the subscription and identical across every batch, so a consumer can concatenate batches without reconciling schemas. The lossless layout is a unified record: an `event_type` discriminator, the contract identity columns, the three fields common to every data variant (`ms_of_day`, `date`, `received_at_ns`), and the union of every per-variant payload column (payload columns null when they do not apply to a row). The schema is defined once in the core and consumed by every binding through the Arrow C Data Interface (Python / C++) or Arrow IPC (TypeScript), so column order, names, and dtypes cannot drift. Control / lifecycle events carry no columnar payload and remain on the callback path.

## Per-binding surface

- **Rust:** `client.stream().batches()...build()` returns `RecordBatchStream`, which is `impl futures::Stream<Item = Result<RecordBatch, StreamError>>` plus a `.blocking()` `Iterator` adapter. `schema()`, `dropped()`.
- **Python:** `client.stream.batches(...)` returns a `RecordBatchStream` pyclass, one object that is both a sync `Iterable` (GIL released on the blocking pull) and an `AsyncIterable`, doubling as a sync and async context manager that closes the stream on exit, yielding `pyarrow.RecordBatch` zero-copy over the Arrow C Data Interface. `.schema`, `.dropped`.
- **TypeScript:** `client.stream.batches(...)` returns an `AsyncIterable<RecordBatch>` (apache-arrow), with `close()` and `Symbol.asyncDispose`. Batches cross the napi boundary as Arrow IPC and are decoded with `tableFromIPC`. `.schema`, `.dropped`.
- **C++:** `client.stream().batches(...)` returns a `std::shared_ptr<arrow::RecordBatchReader>` subclass (`ReadNext`, nullptr = end, `schema()`), RAII close, `dropped()`. Requires arrow-cpp, gated behind a `THETADATADX_CPP_ARROW` CMake option.

## Knobs (defaults, ported symmetrically)

`batch_size` (65536 rows), `linger` (50ms; Duration / timedelta / chrono ms / `lingerMs` at each config boundary), and a `backpressure` policy of `Block` (default, lossless; blocks the ring drain, applying backpressure to the wire) or `DropOldest { capacity }` (bounded buffer; drops the oldest batch and increments an observable `dropped()` counter, never silently). A batch flushes on whichever fires first: `batch_size` rows reached, `linger` elapsed (so a quiet stream still delivers), or stream close. The internal queue between the dispatcher and the reader is always bounded.

## SSOT / codegen

Per-binding cost approaches zero. The reader logic lives in the core and the FFI; the connect / install / dispatcher path is factored so the callback and columnar paths share it, with only the per-thread consumer body differing. The Python and TypeScript `batches()` entry methods are generated from `sdk_surface.toml` via a new `Batches` method kind. The C++ entry is hand-written on the `Stream` class (the same hand-written class that carries `set_callback`, distinct from the generated `StreamingClient`), so it is tracked for parity directly rather than generated. `parity.toml` gains the `batches` method and the `RecordBatchStream` class; `check_binding_parity.py` and its selftest stay green.

## Tests

- **Rust core (offline):** zero-drop under Block (delivered == sent), DropOldest increments `dropped()` and never blocks unboundedly, linger flushes a partial batch on a quiet stream, schema stability across interleaved variants, close unblocks a parked producer, close from a sibling handle unblocks a parked pull, empty stream ends clean, plus schema/builder correctness.
- **Python:** reader protocol surface, the FPSS block-list, no-construct guard, and a structural no-GIL audit pinning that the blocking pull and close release the GIL. `pytest` green.
- **TypeScript:** the JS wrapper driven by a synthetic handle: `for await` yields decoded apache-arrow batches, clean end of stream, `close()` / `Symbol.asyncDispose` / early-break all release the handle, `.schema` / `.dropped` proxy. Full suite green.
- **C++ (ASan):** `RecordBatchStream` is an `arrow::RecordBatchReader` at compile time, the Arrow IPC decode round-trips a batch bit-exact, end-of-stream signal. `ctest` 100% under AddressSanitizer, no leaks / UAF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
