### PR TITLE
docs(readme): surface the columnar streaming mode and fix the backfill link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThetaDataDx
 
-High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Python, TypeScript, C++, and Rust** — one Rust engine under all four. Pull US stock, option, index, and rate data three ways: point-in-time **history**, real-time **streaming**, and whole-universe **flat files**, all from a single authenticated client. Connects straight to ThetaData — nothing to install and run locally.
+High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Python, TypeScript, C++, and Rust**. One Rust engine under all four. Pull US stock, option, index, and rate data three ways: point-in-time **history**, real-time **streaming**, and whole-universe **flat files**, all from a single authenticated client. Connects straight to ThetaData, with nothing to install and run locally.
 
 [![Rust CI](https://github.com/userFRM/ThetaDataDx/actions/workflows/ci.yml/badge.svg)](https://github.com/userFRM/ThetaDataDx/actions/workflows/ci.yml)
 [![Python SDK](https://github.com/userFRM/ThetaDataDx/actions/workflows/python.yml/badge.svg)](https://github.com/userFRM/ThetaDataDx/actions/workflows/python.yml)
@@ -25,12 +25,12 @@ High-performance market-data SDKs for [ThetaData](https://thetadata.us), in **Py
 
 ## Features
 
-- **Complete coverage** — stocks, options, indices, and rates across 65 typed endpoints.
-- **Three access modes, one client** — point-in-time history, real-time streaming, and bulk flat-file downloads.
-- **DataFrames built in** — every result chains straight to Polars, pandas, or Arrow over a zero-copy boundary.
-- **Greeks without a round-trip** — first- through third-order Black-Scholes Greeks and an implied-volatility solver, computed locally.
-- **The same surface in every language** — identical methods and identical typed errors, Python through Rust.
-- **No terminal to run** — a direct connection to ThetaData; nothing to install and babysit locally.
+- **Complete coverage**: stocks, options, indices, and rates across 65 typed endpoints.
+- **Three access modes, one client**: point-in-time history, real-time streaming, and bulk flat-file downloads.
+- **DataFrames built in**: every result chains straight to Polars, pandas, or Arrow over a zero-copy boundary.
+- **Greeks without a round-trip**: first- through third-order Black-Scholes Greeks and an implied-volatility solver, computed locally.
+- **The same surface in every language**: identical methods and identical typed errors, Python through Rust.
+- **No terminal to run**: a direct connection to ThetaData; nothing to install and babysit locally.
 
 ## Install
 
@@ -40,7 +40,7 @@ npm install thetadatadx        # TypeScript / Node.js
 cargo add thetadatadx          # Rust
 ```
 
-C++ ships as a header plus a small implementation file over a prebuilt library (a CMake target wires it up) — see the [C++ guide](sdks/cpp/).
+C++ ships as a header plus a small implementation file over a prebuilt library (a CMake target wires it up). See the [C++ guide](sdks/cpp/).
 
 ## Quick start
 
@@ -208,7 +208,7 @@ async fn main() -> Result<(), thetadatadx::Error> {
 
 ## DataFrames
 
-Every historical result is a typed list that converts directly to a dataframe —
+Every historical result is a typed list that converts directly to a dataframe:
 no row-by-row iteration:
 
 ```python
@@ -219,23 +219,32 @@ greeks.to_arrow()    # pyarrow.Table      (zero-copy)
 
 The same `.to_polars()` / `.to_pandas()` / `.to_arrow()` terminals are available
 on flat-file results. For multi-day backfills, stream the response in chunks
-instead of buffering it — see [Bulk backfill](https://userfrm.github.io/ThetaDataDx/examples/bulk-backfill).
+instead of buffering it. See [Request sizing](https://userfrm.github.io/ThetaDataDx/articles/request-sizing).
 
 ## Streaming
 
 One connection, one authentication. Historical queries work immediately; the
 streaming transport connects on the first subscription. Subscribe specific
-contracts with the fluent `Contract` API, or take a whole-market feed — every
+contracts with the fluent `Contract` API, or take a whole-market feed: every
 option trade across the universe, no per-contract setup:
 
 ```python
 with client.streaming(on_event) as session:
     session.subscribe(SecType.OPTION.full_trades())
-    time.sleep(60)   # the callback runs on the streaming thread — keep it fast
+    time.sleep(60)   # the callback runs on the streaming thread; keep it fast
 ```
 
 > [!TIP]
-> On an involuntary disconnect the client recovers on its own — exponential
+> The callback above is one of two delivery modes. It pushes one typed event at
+> a time for the lowest latency, ideal when you react to each trade or quote.
+> For bulk and analytics, `client.stream.batches(...)` delivers the same
+> subscriptions as Apache Arrow `RecordBatch` values under a fixed schema, ready
+> to pull into pandas, Polars, or DuckDB. Open the reader first, since it starts
+> the session, then subscribe. Every binding has both; the
+> [streaming guide](https://userfrm.github.io/ThetaDataDx/streaming/) covers them.
+
+> [!TIP]
+> On an involuntary disconnect the client recovers on its own: exponential
 > backoff with jitter, automatic host failover, then a paced re-subscribe of
 > every active contract. Read liveness directly off the stream with
 > `connection_status()` and the last-event timestamp; no separate health poll
@@ -260,7 +269,7 @@ The full per-language method list lives in the
 ## Errors
 
 Every binding raises the same typed hierarchy, so the same cases are catchable
-in any language — `AuthenticationError`, `RateLimitError`, `NotFoundError`,
+in any language: `AuthenticationError`, `RateLimitError`, `NotFoundError`,
 `DeadlineExceededError`, `InvalidParameterError`, and the rest, all under a
 common `ThetaDataError` base.
 
@@ -268,7 +277,7 @@ common `ThetaDataError` base.
 
 | Path | Package | Purpose |
 |---|---|---|
-| [`crates/thetadatadx`](crates/thetadatadx/) | `thetadatadx` (crates.io) | The Rust SDK — tick types, Greeks, price math, and the network client in one crate |
+| [`crates/thetadatadx`](crates/thetadatadx/) | `thetadatadx` (crates.io) | The Rust SDK: tick types, Greeks, price math, and the network client in one crate |
 | [`sdks/python`](sdks/python/) | `thetadatadx` (PyPI) | Python package with DataFrame adapters |
 | [`sdks/typescript`](sdks/typescript/) | `thetadatadx` (npm) | TypeScript / Node.js package, prebuilt binaries |
 | [`sdks/cpp`](sdks/cpp/) | header + prebuilt library | C++ wrapper over the C ABI |
@@ -280,7 +289,7 @@ common `ThetaDataError` base.
 
 ## Documentation
 
-- [Documentation site](https://userfrm.github.io/ThetaDataDx/) — getting started, API reference, streaming, server, and MCP
+- [Documentation site](https://userfrm.github.io/ThetaDataDx/): getting started, API reference, streaming, server, and MCP
 - [Changelog](CHANGELOG.md)
 
 ## Contributing

--- a/docs-site/docs/streaming/index.md
+++ b/docs-site/docs/streaming/index.md
@@ -159,7 +159,111 @@ Three knobs tune it:
 - **`linger`**: the maximum time a partial batch waits before being emitted, so a quiet stream still delivers.
 - **`backpressure`**: what happens when the reader falls behind. `Block` (the default, lossless: the wire is paced) or `DropOldest` (a bounded buffer of `capacity` batches that drops, and counts, the oldest on overflow).
 
-The minimal per-language example is in each SDK README; the field set is the fixed streaming schema shared across bindings.
+The field set is the fixed streaming schema, shared across bindings.
+
+<SdkTabs>
+
+<template #rust>
+
+```rust
+use thetadatadx::streaming::Contract;
+use thetadatadx::{Credentials, DirectConfig, Client};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), thetadatadx::Error> {
+    let creds = Credentials::from_file("creds.txt")?;
+    let client = Client::connect(&creds, DirectConfig::production()).await?;
+
+    // `batches()` starts the session, so open the reader first, then subscribe.
+    let mut batches = client.stream().batches().batch_size(8_192).build()?;
+    client.stream().subscribe(Contract::stock("AAPL").trade())?;
+
+    while let Some(batch) = batches.next().await {
+        println!("{} rows", batch?.num_rows());
+    }
+    Ok(())
+}
+```
+
+`build()` returns a `RecordBatchStream` that implements `futures::Stream`; call `.blocking()` for a synchronous `Iterator` instead. Dropping it (or `close()`) tears the session down.
+
+</template>
+
+<template #python>
+
+```python
+from thetadatadx import Config, Contract, Credentials, Client
+
+creds = Credentials.from_file("creds.txt")
+client = Client(creds, Config.production())
+
+# `batches(...)` starts the session, so open the reader first, then subscribe.
+with client.stream.batches(batch_size=8192) as batches:
+    client.stream.subscribe(Contract.stock("AAPL").trade())
+    for batch in batches:        # pyarrow.RecordBatch; or: async for batch in batches
+        print(batch.num_rows)
+```
+
+</template>
+
+<template #typescript>
+
+```typescript
+import { Contract, Client } from 'thetadatadx';
+
+const client = await Client.connectFromFile('creds.txt');
+
+// `batches(...)` starts the session, so open the reader first, then subscribe.
+const batches = await client.stream.batches({ batchSize: 8192 });
+try {
+  client.stream.subscribe(Contract.stock('AAPL').trade());
+  for await (const batch of batches) {
+    console.log(batch.numRows);
+  }
+} finally {
+  batches.close();
+}
+```
+
+Decoding the batches needs `apache-arrow` installed alongside the SDK.
+
+</template>
+
+<template #cpp>
+
+```cpp
+#include "thetadatadx.hpp"
+#include <arrow/api.h>
+#include <cstdio>
+
+int main() {
+    auto creds = thetadatadx::Credentials::from_file("creds.txt");
+    auto client = thetadatadx::Client::connect(creds, thetadatadx::Config::production());
+
+    // `batches(...)` starts the session, so open the reader first, then subscribe.
+    auto reader = client.stream().batches(/*batch_size=*/8192);
+    client.stream().subscribe(thetadatadx::Contract::stock("AAPL").trade());
+
+    std::shared_ptr<arrow::RecordBatch> batch;
+    while (reader->ReadNext(&batch).ok() && batch != nullptr) {
+        std::printf("%lld rows\n", static_cast<long long>(batch->num_rows()));
+    }
+    // RAII: `reader` closes when the last reference drops.
+}
+```
+
+Build the SDK with `-DTHETADATADX_CPP_ARROW=ON` (links arrow-cpp) to enable the reader.
+
+</template>
+
+<template #http>
+
+The columnar reader is an in-process SDK surface and is not bridged over the [server binary](/server/)'s WebSocket; use the per-event stream there ([WebSocket Streaming](/server/websocket)).
+
+</template>
+
+</SdkTabs>
 
 ## Lifecycle
 


### PR DESCRIPTION
## What

Surfaces both real-time streaming delivery modes in the main README and fixes a broken docs-site link.

- A tip in the Streaming section now shows the two modes: the existing per-event callback and the new columnar `batches()` Arrow reader (#950), with when to use each and a link to the streaming guide.
- The multi-day backfill reference pointed at `examples/bulk-backfill`, which does not exist on the docs site. Relinked to the `Request sizing` article, which already documents switching to the chunk-streaming variant for large responses.
- Replaced prose em-dashes with standard punctuation throughout (the table N/A placeholder is left as is), matching the house style.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)