### PR TITLE
ci: enforce the historical/streaming vocabulary on the client-facing prose surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,17 @@ jobs:
         run: |
           python3 scripts/ci/check_public_surface_leak.py --selftest
           python3 scripts/ci/check_public_surface_leak.py
+      # Prose complement to the symbol-leak gate above: the symbol gate
+      # guards the exported API identifiers, this one guards the
+      # client-facing documentation prose (READMEs, examples, published
+      # type declarations, docs site, OpenAPI, user config) against the
+      # internal transport vocabulary. `--selftest` is the in-process
+      # smoke check; the tests/ file drives the full fixture matrix.
+      - name: Client-facing vocabulary detector
+        run: |
+          python3 scripts/ci/check_client_facing_vocab.py --selftest
+          python3 scripts/ci/tests/test_check_client_facing_vocab.py
+          python3 scripts/ci/check_client_facing_vocab.py
 
   doc-defaults:
     name: Documented config defaults

--- a/scripts/ci/check_client_facing_vocab.py
+++ b/scripts/ci/check_client_facing_vocab.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Client-facing vocabulary gate: the prose surface says historical/streaming.
+
+The two server channels are named after the data they serve on every surface
+a user reads: the public API symbols, the CLI, the environment variables, the
+error strings, the published binding type declarations, the examples, the
+READMEs, the docs site, and the OpenAPI document. The internal transport
+vocabulary (`fpss` / `mdds`) is permitted only in places a user never reads:
+the transport source, the wire protocol, the proto package, generated-file
+provenance banners, the real DNS hostnames, and the operator metric namespace.
+
+`check_public_surface_leak.py` enforces the *symbol* surface (the exported API
+identifiers). This gate is its prose complement: it greps the client-facing
+*documentation* surface case-insensitively for `fpss` / `mdds` and fails on any
+hit outside the encoded allow-list. Without it the historical/streaming
+invariant on README / example / `.d.ts` prose is on the honor system, which is
+exactly where manual review (not CI) caught the regressions this gate prevents.
+
+Run::
+
+    python3 scripts/ci/check_client_facing_vocab.py            # gate
+    python3 scripts/ci/check_client_facing_vocab.py --selftest # in-process smoke test
+
+Exit 0 + "client-facing vocab: clean" when there are no non-exempt hits; exit 1
+plus a `file:line` list otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+import tempfile
+from typing import Iterable
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+SELF_NAME = pathlib.Path(__file__).name
+
+
+# ── The swept client-facing surface ────────────────────────────────────────
+#
+# Glob patterns (relative to the repo root) for every file a user reads as
+# product documentation. Listed explicitly rather than walked-by-extension
+# because the client-facing surface is a curated subset: a TS source file
+# under `sdks/typescript/src/` is internal and keeps its transport names,
+# while the published `index.d.ts` / `streaming-session.d.ts` it generates is
+# client-facing and must not. The exempt rules below carve the few internal
+# files that happen to match these globs.
+SWEEP_GLOBS = (
+    # READMEs the integrator reads.
+    "README.md",
+    "sdks/README.md",
+    "sdks/python/README.md",
+    "sdks/typescript/README.md",
+    "sdks/cpp/README.md",
+    "ffi/README.md",
+    "tools/cli/README.md",
+    "tools/mcp/README.md",
+    "tools/server/README.md",
+    # Published examples, every language.
+    "sdks/python/examples/**/*",
+    "sdks/typescript/examples/**/*",
+    "sdks/cpp/examples/**/*",
+    # Published type declarations (the IDE-hover surface).
+    "sdks/python/**/*.pyi",
+    "sdks/typescript/**/*.d.ts",
+    "sdks/cpp/include/**/*.h",
+    "sdks/cpp/include/**/*.hpp",
+    # User-facing docs site + the published OpenAPI contract.
+    "docs-site/docs/**/*.md",
+    "docs-site/docs/public/**/*.yaml",
+    # User-editable config + the developer helper scripts shipped in-tree.
+    "crates/thetadatadx/config.default.toml",
+    "scripts/dev/*.py",
+)
+
+
+# ── Path-level exemptions ───────────────────────────────────────────────────
+#
+# Files that match a sweep glob but are NOT the client-facing prose surface:
+# append-only history, contributor / internal docs, the wire/proto contract,
+# generated includes, CI config, internal source, and the guard scripts. A
+# substring match against `/<relpath>/` exempts the whole file.
+EXEMPT_PATH_FRAGMENTS = (
+    # Append-only history: the old names are the accurate record of a past
+    # release and must not be rewritten.
+    "/CHANGELOG.md",
+    "/docs-site/docs/changelog.md",
+    "/docs-site/docs/migration/",
+    "/.github/release-notes/",
+    # Contributor / internal documentation (not the product-usage surface).
+    "/CONTRIBUTING.md",
+    "/SECURITY.md",
+    "/crates/thetadatadx/proto/MAINTENANCE.md",
+    "/crates/thetadatadx/benches/README.md",
+    # CI config, internal source trees, generated wire includes, build output.
+    "/.github/workflows/",
+    "/src/",
+    "/_generated/",
+    "/node_modules/",
+    "/target/",
+    "/.git/",
+)
+
+
+# ── Line-level exemptions ───────────────────────────────────────────────────
+#
+# Within a swept file, a line whose only `fpss`/`mdds` occurrence is one of
+# these is not a leak: it names a real internal artifact a user may legitimately
+# encounter (a generated-file provenance banner, a wire-include filename, the
+# real DNS hosts, the operator metric namespace). Matched case-insensitively;
+# the line is cleared of these spans before the leak scan runs, so a real leak
+# sharing a line with an exempt token still trips.
+EXEMPT_LINE_PATTERNS = (
+    # Generated-file provenance banners cite the schema they are emitted from.
+    re.compile(r"@generated", re.IGNORECASE),
+    re.compile(r"fpss_event_schema\.toml", re.IGNORECASE),
+    # Wire-include filenames (the C/C++ event-struct includes).
+    re.compile(r"fpss_event_structs\.h(?:\.inc)?", re.IGNORECASE),
+    re.compile(r"fpss_layout_asserts\.hpp(?:\.inc)?", re.IGNORECASE),
+    re.compile(r"fpss\.hpp\.inc", re.IGNORECASE),
+    re.compile(r"fpss_event_classes", re.IGNORECASE),
+    # Real DNS hostnames (the actual production / staging endpoints).
+    re.compile(r"mdds-01\.thetadata\.us", re.IGNORECASE),
+    re.compile(r"mdds-stage\.thetadata\.us", re.IGNORECASE),
+    # Operator metric namespace (renaming breaks dashboards / alerts).
+    re.compile(r"thetadatadx\.fpss\.", re.IGNORECASE),
+)
+
+
+# The internal transport vocabulary forbidden on the client-facing surface.
+# Matched as a plain case-insensitive substring, NOT word-bounded: `\b` treats
+# `_` as a word character, so a `\bfpss\b` pattern would miss the very leaks
+# that matter most — `THETADATA_FPSS_TYPE`, `THETADATADX_FPSS_QUOTE`,
+# `MDDS_TYPE` — where the token is embedded in an underscore-delimited
+# identifier. `fpss` / `mdds` are distinctive enough that substring matching
+# does not collide with unrelated words.
+LEAK_PATTERN = re.compile(r"(?:fpss|mdds)", re.IGNORECASE)
+
+
+def _is_exempt_path(rel_path: pathlib.Path) -> bool:
+    parts = "/" + rel_path.as_posix() + "/"
+    if any(fragment in parts for fragment in EXEMPT_PATH_FRAGMENTS):
+        return True
+    return rel_path.name == SELF_NAME
+
+
+def _iter_swept_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
+    seen: set[pathlib.Path] = set()
+    for pattern in SWEEP_GLOBS:
+        for candidate in sorted(root.glob(pattern)):
+            if not candidate.is_file():
+                continue
+            rel = candidate.relative_to(root)
+            if rel in seen:
+                continue
+            if _is_exempt_path(rel):
+                continue
+            seen.add(rel)
+            yield candidate
+
+
+def _strip_exempt_spans(line: str) -> str:
+    """Blank every exempt span so a leak sharing the line still trips."""
+    residue = line
+    for pattern in EXEMPT_LINE_PATTERNS:
+        residue = pattern.sub(" ", residue)
+    return residue
+
+
+def _scan(root: pathlib.Path) -> list[tuple[pathlib.Path, int, str]]:
+    """Return (rel_path, lineno, line_text) for every non-exempt leak."""
+    hits: list[tuple[pathlib.Path, int, str]] = []
+    for path in _iter_swept_files(root):
+        rel = path.relative_to(root)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if LEAK_PATTERN.search(_strip_exempt_spans(line)):
+                hits.append((rel, lineno, line.strip()))
+    return hits
+
+
+def _run(root: pathlib.Path) -> int:
+    hits = _scan(root)
+    if hits:
+        print(
+            "client-facing vocab: FAIL — internal transport names (fpss/mdds) "
+            "found on the client-facing surface:",
+            file=sys.stderr,
+        )
+        for rel, lineno, line in hits:
+            print(f"  {rel}:{lineno}: {line}", file=sys.stderr)
+        print(
+            "\nThe client-facing surface says historical/streaming. If a hit is a "
+            "real internal artifact (generated-file banner, wire-include filename, "
+            "DNS host, metric namespace), add it to the exempt rules; otherwise "
+            "rename it to the channel vocabulary.",
+            file=sys.stderr,
+        )
+        return 1
+    print("client-facing vocab: clean")
+    return 0
+
+
+# ── In-process selftest ─────────────────────────────────────────────────────
+
+
+def _selftest() -> int:
+    """Plant synthetic files and confirm the gate fires on a leak, not on exempt.
+
+    Cases:
+      * a fake README carrying "FPSS event" prose -> must be flagged;
+      * a file whose only hits are exempt (DNS host, metric namespace,
+        @generated banner, a leak sharing a line with an exempt span) ->
+        must be clean, except the genuine leak sharing the exempt line.
+    """
+    failures = 0
+
+    def check(name: str, cond: bool) -> None:
+        nonlocal failures
+        if not cond:
+            failures += 1
+            print(f"  selftest FAIL: {name}", file=sys.stderr)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+
+        # Leak fixture: a README with client-facing FPSS prose.
+        (root / "README.md").write_text(
+            "# Demo\n\nThe SDK delivers every typed FPSS event to your callback.\n",
+            encoding="utf-8",
+        )
+        leak_hits = _scan(root)
+        check(
+            "client-facing FPSS prose in README is flagged",
+            any(rel.as_posix() == "README.md" for rel, _, _ in leak_hits),
+        )
+
+        # Exempt-only fixture: every hit is allow-listed -> clean.
+        (root / "README.md").write_text(
+            "# Demo\n"
+            "Historical host is mdds-01.thetadata.us; staging is "
+            "mdds-stage.thetadata.us.\n"
+            "Scrape the thetadatadx.fpss.reconnects counter.\n"
+            "<!-- @generated from fpss_event_schema.toml -->\n"
+            '#include "fpss_event_structs.h.inc"\n',
+            encoding="utf-8",
+        )
+        check("exempt-only README is clean", _scan(root) == [])
+
+        # Path-exempt fixture: a migration doc may carry the old names.
+        mig = root / "docs-site" / "docs" / "migration"
+        mig.mkdir(parents=True)
+        (mig / "v1.md").write_text("v12 used THETADATA_FPSS_TYPE.\n", encoding="utf-8")
+        check("migration history path is exempt", _scan(root) == [])
+
+        # Shared-line fixture: a real leak next to an exempt DNS host still trips.
+        (root / "README.md").write_text(
+            "Connect to mdds-01.thetadata.us over the FPSS stream.\n",
+            encoding="utf-8",
+        )
+        shared = _scan(root)
+        check(
+            "a leak sharing a line with an exempt span still trips",
+            any(rel.as_posix() == "README.md" for rel, _, _ in shared),
+        )
+
+    if failures:
+        print(f"client-facing vocab selftest: {failures} case(s) FAILED", file=sys.stderr)
+    else:
+        print("client-facing vocab selftest: all cases passed")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="run the in-process synthetic fixtures instead of scanning the repo",
+    )
+    parser.add_argument(
+        "--root",
+        type=pathlib.Path,
+        default=REPO_ROOT,
+        help="repository root to scan (defaults to the repo this script lives in)",
+    )
+    args = parser.parse_args()
+    if args.selftest:
+        return _selftest()
+    return _run(args.root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/tests/test_check_client_facing_vocab.py
+++ b/scripts/ci/tests/test_check_client_facing_vocab.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Test suite for `scripts/ci/check_client_facing_vocab.py`.
+
+Drives the production gate over synthetic tempdir trees and asserts:
+  * a would-be leak ("FPSS event" prose in a swept README / example / .d.ts) is
+    flagged;
+  * a tree whose only `fpss`/`mdds` occurrences are exempt (DNS hosts, the
+    metric namespace, generated-file banners, wire-include filenames, history /
+    migration / internal-source paths) is clean;
+  * a real leak that shares a line with an exempt span still trips;
+  * an internal `src/` file with the transport names is NOT swept.
+
+Runs as plain Python (no pytest) so CI can wire it into the same `ci.yml`
+invocation as the production gate. The exit code is the total failure count.
+
+Run::
+
+    python3 scripts/ci/tests/test_check_client_facing_vocab.py
+
+The production script's `--selftest` runs an in-process subset for a fast smoke
+check; this file is the fuller fixture matrix.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+# Import the production module so the suite exercises the gate's own code path.
+GATE_DIR = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(GATE_DIR))
+import check_client_facing_vocab as gate  # noqa: E402
+
+import tempfile  # noqa: E402
+
+_fails: list[str] = []
+_total = 0
+
+
+def _expect(name: str, cond: bool) -> None:
+    global _total
+    _total += 1
+    if not cond:
+        _fails.append(name)
+        print(f"FAIL: {name}", file=sys.stderr)
+
+
+def _write(root: pathlib.Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _hits(root: pathlib.Path) -> list[tuple[pathlib.Path, int, str]]:
+    return gate._scan(root)
+
+
+def _flagged(root: pathlib.Path, rel: str) -> bool:
+    return any(h[0].as_posix() == rel for h in _hits(root))
+
+
+# ── Negative cases: a leak in each swept surface is flagged ─────────────────
+
+
+def test_leak_in_readme_flagged() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(root, "ffi/README.md", "Reconnect FPSS, drain the previous generation.\n")
+        _expect("README leak flagged", _flagged(root, "ffi/README.md"))
+
+
+def test_leak_in_example_flagged() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(
+            root,
+            "sdks/python/examples/quote.py",
+            '"""Match-case dispatch on typed FPSS event classes."""\n',
+        )
+        _expect("example leak flagged", _flagged(root, "sdks/python/examples/quote.py"))
+
+
+def test_leak_in_dts_flagged() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(
+            root,
+            "sdks/typescript/streaming-session.d.ts",
+            "/** tear the FPSS session down. */\nexport declare class X {}\n",
+        )
+        _expect(
+            "published .d.ts leak flagged",
+            _flagged(root, "sdks/typescript/streaming-session.d.ts"),
+        )
+
+
+def test_leak_in_openapi_flagged() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(
+            root,
+            "docs-site/docs/public/openapi.yaml",
+            "paths:\n  /v3/system/fpss/status: {}\n",
+        )
+        _expect(
+            "OpenAPI leak flagged",
+            _flagged(root, "docs-site/docs/public/openapi.yaml"),
+        )
+
+
+def test_leak_in_config_default_flagged() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(
+            root,
+            "crates/thetadatadx/config.default.toml",
+            "# THETADATA_FPSS_TYPE = prod\n",
+        )
+        _expect(
+            "config.default.toml leak flagged",
+            _flagged(root, "crates/thetadatadx/config.default.toml"),
+        )
+
+
+# ── Positive cases: exempt-only trees are clean ─────────────────────────────
+
+
+def test_exempt_only_tokens_clean() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(
+            root,
+            "README.md",
+            "Historical host mdds-01.thetadata.us, staging mdds-stage.thetadata.us.\n"
+            "Scrape thetadatadx.fpss.dropped.\n"
+            "<!-- @generated from fpss_event_schema.toml -->\n"
+            '#include "fpss_event_structs.h.inc"\n',
+        )
+        _expect("exempt-only tokens clean", _hits(root) == [])
+
+
+def test_history_paths_exempt() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(root, "CHANGELOG.md", "Renamed THETADATA_FPSS_TYPE.\n")
+        _write(root, "docs-site/docs/changelog.md", "Renamed Error::Fpss.\n")
+        _write(
+            root,
+            "docs-site/docs/migration/v11-to-v12.md",
+            "v11 used the FpssEventPoller and THETADATADX_FPSS_QUOTE.\n",
+        )
+        _expect("history + migration paths exempt", _hits(root) == [])
+
+
+def test_contributor_and_internal_docs_exempt() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(root, "CONTRIBUTING.md", "Commit scope feat(fpss) / feat(mdds).\n")
+        _write(root, "SECURITY.md", "The FPSS TLS connection pins the SPKI.\n")
+        _write(
+            root,
+            "crates/thetadatadx/proto/MAINTENANCE.md",
+            "The mdds.proto wire contract.\n",
+        )
+        _write(
+            root,
+            "crates/thetadatadx/benches/README.md",
+            "FPSS Framing (`fpss/framing.rs`) benchmarks.\n",
+        )
+        _expect("contributor + internal docs exempt", _hits(root) == [])
+
+
+def test_internal_src_not_swept() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        # An internal binding-crate source file: keeps transport names, and is
+        # not part of the swept client-facing surface.
+        _write(
+            root,
+            "sdks/typescript/src/fpss_client.rs",
+            "/// Start the FPSS streaming connection.\n",
+        )
+        _expect("internal src/ not swept", _hits(root) == [])
+
+
+def test_generated_path_exempt() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(
+            root,
+            "sdks/typescript/src/_generated/fpss_event_classes.rs",
+            "/// FPSS Quote tick.\n",
+        )
+        _expect("_generated path exempt", _hits(root) == [])
+
+
+# ── Shared-line + clean-real-surface cases ──────────────────────────────────
+
+
+def test_leak_sharing_line_with_exempt_span_trips() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(
+            root,
+            "README.md",
+            "Connect to mdds-01.thetadata.us over the FPSS stream.\n",
+        )
+        _expect(
+            "leak sharing a line with an exempt span trips",
+            _flagged(root, "README.md"),
+        )
+
+
+def test_clean_channel_prose_passes() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write(
+            root,
+            "ffi/README.md",
+            "Reconnect streaming, drain the previous generation.\n"
+            "GET /v3/system/historical/status returns the historical status.\n",
+        )
+        _expect("clean channel prose passes", _hits(root) == [])
+
+
+def main() -> int:
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    if _fails:
+        print(
+            f"\ntest_check_client_facing_vocab: {len(_fails)}/{_total} cases FAILED",
+            file=sys.stderr,
+        )
+        return len(_fails)
+    print(f"test_check_client_facing_vocab: all {_total} cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/ci/check_client_facing_vocab.py`, a CI gate that machine-enforces the historical/streaming vocabulary across the client-facing **prose** surface so the zero-internal-transport-name invariant cannot silently regress.

## Why

`scripts/ci/check_public_surface_leak.py` enforces the exported API **symbol** surface, but the same invariant on documentation prose — READMEs, examples, published type declarations, the docs site, the OpenAPI document, and the user-editable config — had no gate. That honor-system gap is exactly where manual review (not CI) caught internal-transport-name regressions in READMEs, examples, and `.d.ts` files.

## What it checks

Greps a curated client-facing surface case-insensitively for the internal transport names and fails on any hit outside an encoded allow-list:

- **Swept:** root + SDK + FFI + CLI + MCP + server READMEs; `sdks/*/examples/**`; `sdks/python/**/*.pyi`; `sdks/typescript/**/*.d.ts`; `sdks/cpp/include/**/*.{h,hpp}`; `docs-site/docs/**/*.md`; `docs-site/docs/public/*.yaml`; `crates/thetadatadx/config.default.toml`; `scripts/dev/*.py`.
- **Path-exempt:** append-only history (CHANGELOG, docs-site changelog, migration guides, release notes); contributor/internal docs (CONTRIBUTING, SECURITY, proto MAINTENANCE, benches README); CI config; internal `src/` trees; generated files; the guard scripts.
- **Line-exempt:** generated-file provenance banners (`@generated` / `fpss_event_schema.toml`), the wire-include filenames, the real DNS hostnames (`mdds-01` / `mdds-stage`), and the operator metric namespace (`thetadatadx.fpss.*`). A real leak that shares a line with an exempt span still trips.

The leak match is a plain substring, not word-bounded: `\b` treats `_` as a word character, so a word-bounded pattern would miss the highest-value leaks (`THETADATA_FPSS_TYPE`, `THETADATADX_FPSS_QUOTE`) where the token is embedded in an underscore-delimited identifier.

## Output

Exit 0 + `client-facing vocab: clean` when there are no non-exempt hits; exit 1 + a `file:line` list otherwise.

## Test + CI

`scripts/ci/tests/test_check_client_facing_vocab.py` drives a synthetic-tempdir fixture matrix: a would-be leak in each swept surface (README / example / `.d.ts` / OpenAPI / config) is flagged; an exempt-only tree, the history/migration paths, contributor/internal docs, internal `src/`, and generated paths are clean; a leak sharing a line with an exempt span still trips. The gate runs `--selftest`, then the test file, then the production scan, as a step alongside the symbol-leak detector.

## Verification

Run on the current base (after #952 landed): `client-facing vocab: clean` — confirming the literal-zero is real. The test suite passes 12/12.

DO NOT MERGE pending review.